### PR TITLE
Set grunt to break on all TypeScript compilation errors

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -291,14 +291,15 @@ module.exports = function(grunt) {
         ts: {
             build: {
                 src: localCfg.typeScriptSrc,
-                outDir: [localCfg.outModulesDir],
+                outDir: localCfg.outModulesDir,
                 options: {
                     module: "commonjs",
                     target: "es5",
                     sourceMap: false,
                     declaration: false,
                     removeComments: "<%= !grunt.option('leavecomments') || '' %>",
-                    compiler: "node_modules/typescript/bin/tsc"
+                    compiler: "node_modules/typescript/bin/tsc",
+                    noEmitOnError: true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-exec": "0.4.5",
     "grunt-multi-dest": "1.0.0",
     "grunt-shell": "1.1.2",
-    "grunt-ts": "1.12.1",
+    "grunt-ts": "4.0.1",
     "grunt-tslint": "0.4.2",
     "typescript": "1.4.1"
   }


### PR DESCRIPTION
When there are errors that are not breaking the typescript compilation, the grunt build passes making these errors hard to find in the output.