### PR TITLE
pull-to-refresh feature for iOS

### DIFF
--- a/ui/list-view/list-view-common.ts
+++ b/ui/list-view/list-view-common.ts
@@ -43,6 +43,7 @@ export class ListView extends view.View implements definition.ListView {
     public static itemLoadingEvent = "itemLoading";
     public static itemTapEvent = "itemTap";
     public static loadMoreItemsEvent = "loadMoreItems";
+    public static refreshEvent = "refresh";
 
     public static separatorColorProperty = new dependencyObservable.Property(
         SEPARATORCOLOR,

--- a/ui/list-view/list-view.d.ts
+++ b/ui/list-view/list-view.d.ts
@@ -126,4 +126,14 @@ declare module "ui/list-view" {
          */
         view: view.View;
     }
+
+    /**
+     * Event data containing information for "refresh" with done callback
+     */
+    export interface RefreshEventData extends observable.EventData {
+        /**
+         * Callback when refresh is done to hide the loading icon
+         */
+        done: () => void;
+    }
 }

--- a/ui/list-view/list-view.ios.ts
+++ b/ui/list-view/list-view.ios.ts
@@ -10,6 +10,7 @@ import color = require("color");
 var CELLIDENTIFIER = "cell";
 var ITEMLOADING = common.ListView.itemLoadingEvent;
 var LOADMOREITEMS = common.ListView.loadMoreItemsEvent;
+var REFRESH = common.ListView.refreshEvent;
 var ITEMTAP = common.ListView.itemTapEvent;
 var DEFAULT_HEIGHT = 80;
 
@@ -131,6 +132,35 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
     }
 }
 
+class RefreshHandlerImpl extends NSObject {
+    static new(): RefreshHandlerImpl {
+        return <RefreshHandlerImpl>super.new();
+    }
+
+    private _owner: ListView;
+    private _UIRefreshControl: UIRefreshControl;
+
+    public initWithOwner(owner: ListView): RefreshHandlerImpl {
+        this._owner = owner;
+        this._UIRefreshControl = new UIRefreshControl();
+        owner.ios.addSubview(this._UIRefreshControl);
+        this._UIRefreshControl.addTargetActionForControlEvents(this, "refresh", UIControlEvents.UIControlEventValueChanged);
+        return this;
+    }
+
+    public refresh(sender: UIRefreshControl) {
+        this._owner.notify(<definition.RefreshEventData>{
+          eventName: REFRESH,
+          object: this._owner,
+          done: sender.endRefreshing.bind(sender)
+        });
+    }
+
+    public static ObjCExposedMethods = {
+        'refresh': { returns: interop.types.void, params: [UIRefreshControl] }
+    };
+}
+
 function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var bar = <ListView>data.object;
     if (!bar.ios) {
@@ -147,6 +177,7 @@ function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChan
 
 export class ListView extends common.ListView {
     private _ios: UITableView;
+    private _refreshHandler: RefreshHandlerImpl;
     private _dataSource;
     private _delegate;
     private _heights: Array<number>;
@@ -173,10 +204,14 @@ export class ListView extends common.ListView {
     public onLoaded() {
         super.onLoaded();
         this._ios.delegate = this._delegate;
+        if (this.hasListeners(common.ListView.refreshEvent)) {
+            this._refreshHandler = RefreshHandlerImpl.new().initWithOwner(this);
+        }
     }
 
     public onUnloaded() {
         this._ios.delegate = null;
+        this._refreshHandler = null;
         super.onUnloaded();
     }
 


### PR DESCRIPTION
https://github.com/NativeScript/NativeScript/issues/51
optional pull-to-refresh feature for iOS (those for Android is being developed).
When defining `ListView` XML, if there is xml attribute `refresh`, `ListView` automatically add `UIRefreshControl` view and handler.
Example:
```xml
<!-- main-page.xml -->
<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded">
	<StackLayout>
		<ListView
			items="{{ postList }}"
			isScrolling="{{ isScrolling }}"
			loadMoreItems="listViewLoadMoreItems"
			refresh="myRefreshFunction"
			>
			<ListView.itemTemplate>
				<!-- truncated -->
			</ListView.itemTemplate>
		</ListView>
	</StackLayout>
</Page>
```
```ts
// main-page.ts
export function myRefreshFunction(args: RefreshEventData) {
  mainViewModel.refresh()
  .then(()=>{
    args.done();
    })
  .catch(function(e) {
    setTimeout(function() { throw e; });
  });
  ;
}
```