### PR TITLE
Adding "hint" color to the searchBar code.

### DIFF
--- a/ui/search-bar/search-bar-common.ts
+++ b/ui/search-bar/search-bar-common.ts
@@ -9,6 +9,9 @@ export class SearchBar extends view.View implements definition.SearchBar {
     public static clearEvent = "clear";
 
     public static textFieldBackgroundColorProperty = new dependencyObservable.Property("textFieldBackgroundColor", "SearchBar", new proxy.PropertyMetadata(undefined))
+
+    public static textFieldHintColorProperty = new dependencyObservable.Property("textFieldHintColor", "SearchBar", new proxy.PropertyMetadata(undefined))
+	
     public static hintProperty = new dependencyObservable.Property("hint", "SearchBar", new proxy.PropertyMetadata(""))
 
     public static textProperty = new dependencyObservable.Property(
@@ -38,4 +41,13 @@ export class SearchBar extends view.View implements definition.SearchBar {
         this._setValue(SearchBar.textFieldBackgroundColorProperty,
             value instanceof color.Color ? value : new color.Color(<any>value));
     }
+	
+	get textFieldHintColor(): color.Color {
+        return this._getValue(SearchBar.textFieldHintColorProperty);
+    }
+    set textFieldHintColor(value: color.Color) {
+        this._setValue(SearchBar.textFieldHintColorProperty,
+            value instanceof color.Color ? value : new color.Color(<any>value));
+    }
+	
 } 

--- a/ui/search-bar/search-bar.android.ts
+++ b/ui/search-bar/search-bar.android.ts
@@ -34,6 +34,20 @@ function onTextFieldBackgroundColorPropertyChanged(data: dependencyObservable.Pr
 // register the setNativeValue callbacks
 (<proxy.PropertyMetadata>common.SearchBar.textFieldBackgroundColorProperty.metadata).onSetNativeValue = onTextFieldBackgroundColorPropertyChanged;
 
+function onTextFieldHintColorPropertyChanged(data: dependencyObservable.PropertyChangeData) {
+    var bar = <SearchBar>data.object;
+    if (!bar.android) {
+        return;
+    }
+
+    if (data.newValue instanceof color.Color) {
+        _changeSearchViewHintColor(bar.android, (<color.Color>data.newValue).android);
+    }
+}
+
+// register the setNativeValue callbacks
+(<proxy.PropertyMetadata>common.SearchBar.textFieldHintColorProperty.metadata).onSetNativeValue = onTextFieldHintColorPropertyChanged;
+
 function onHintPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var bar = <SearchBar>data.object;
     if (!bar.android) {
@@ -65,6 +79,14 @@ function _changeSearchViewBackgroundColor(bar: android.widget.SearchView, color:
 
     if (textView) {
         textView.setBackgroundColor(color);
+    }
+}
+
+function _changeSearchViewHintColor(bar: android.widget.SearchView, color: number) {
+    var textView = getTextView(bar);
+
+    if (textView) {
+        textView.setHintTextColor(color);
     }
 }
 

--- a/ui/search-bar/search-bar.android.ts
+++ b/ui/search-bar/search-bar.android.ts
@@ -150,6 +150,9 @@ export class SearchBar extends common.SearchBar {
         if (this.textFieldBackgroundColor instanceof color.Color) {
             _changeSearchViewBackgroundColor(this._android, this.textFieldBackgroundColor.android);
         }
+        if (this.textFieldHintColor instanceof color.Color) {
+            _changeSearchViewHintColor(this._android, this.textFieldHintColor.android);
+        }
     }
 
     get android(): android.widget.SearchView {

--- a/ui/search-bar/search-bar.d.ts
+++ b/ui/search-bar/search-bar.d.ts
@@ -57,6 +57,11 @@ declare module "ui/search-bar" {
         textFieldBackgroundColor: color.Color;
 
         /**
+         * Gets or sets the TextField Hint color of the SearchBar component.
+         */
+        textFieldHintColor: color.Color;
+				
+        /**
          * A basic method signature to hook an event listener (shortcut alias to the addEventListener method).
          * @param eventNames - String corresponding to events (e.g. "propertyChange"). Optionally could be used more events separated by `,` (e.g. "propertyChange", "change"). 
          * @param callback - Callback function which will be executed when event is raised.

--- a/ui/search-bar/search-bar.ios.ts
+++ b/ui/search-bar/search-bar.ios.ts
@@ -23,6 +23,20 @@ function onTextFieldBackgroundColorPropertyChanged(data: dependencyObservable.Pr
 
 (<proxy.PropertyMetadata>common.SearchBar.textFieldBackgroundColorProperty.metadata).onSetNativeValue = onTextFieldBackgroundColorPropertyChanged;
 
+function onTextFieldHintColorPropertyChanged(data: dependencyObservable.PropertyChangeData) {
+  // This should be in a Try Catch in case Apple eliminates which ever method in the future; 
+  try {
+		// TODO; convert this code into NativeScript Code		
+		/* if ([textField respondsToSelector:@selector(setAttributedPlaceholder:)]) {
+			textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:textField.placeholder attributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]}];
+		} */
+  } catch (Err) {
+	// Do Nothing 
+  }
+}
+
+(<proxy.PropertyMetadata>common.SearchBar.textFieldHintColorProperty.metadata).onSetNativeValue = onTextFieldHintColorPropertyChanged;
+
 function onHintPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var bar = <SearchBar>data.object;
     if (!bar.ios) {


### PR DESCRIPTION
Adding Search Hint/placeholder text color; since this is not accessible from the standard android style/theming xml files.

Please note; only the ANDROID side of this works; I put in notes for the IOS side including the IOS code; but at this moment I'm not sure how to convert it to NativeScript code.     If someone wants to give me some pointers on how to convert the tiny snippit of code into NativeScript IOS code; I can amend this patch with code that works for both platforms.