### PR TITLE
Override addChild/removeChild on contentView

### DIFF
--- a/apps/tests/ui/scroll-view/scroll-view-tests.ts
+++ b/apps/tests/ui/scroll-view/scroll-view-tests.ts
@@ -313,5 +313,5 @@ export function test_scrollView_addChild_removeChild() {
     TKUnit.assertEqual(scrollView.content, btn, "scrollView.content addChild");
 
     scrollView.removeChild();
-    TKUnit.assertEqual(scrollView.content, null, "scrollView.content removeChild");
+    TKUnit.assertNull(scrollView.content, "scrollView.content removeChild");
 }

--- a/apps/tests/ui/scroll-view/scroll-view-tests.ts
+++ b/apps/tests/ui/scroll-view/scroll-view-tests.ts
@@ -75,7 +75,7 @@ export function test_default_TNS_values() {
     TKUnit.assertEqual(scrollView.horizontalOffset, 0, "Default scrollView.horizontalOffset");
 }
 
-export function test_vertical_oriantation_creates_correct_native_view() {
+export function test_vertical_orientation_creates_correct_native_view() {
     scrollView.orientation = enums.Orientation.vertical;
 
     if (app.android) {
@@ -86,7 +86,7 @@ export function test_vertical_oriantation_creates_correct_native_view() {
     }
 }
 
-export function test_horizontal_oriantation_creates_correct_native_view() {
+export function test_horizontal_orientation_creates_correct_native_view() {
     scrollView.orientation = enums.Orientation.horizontal;
 
     if (app.android) {
@@ -97,7 +97,7 @@ export function test_horizontal_oriantation_creates_correct_native_view() {
     }
 }
 
-export function test_scrollabeHeight_vertical_orientation_when_content_is_small() {
+export function test_scrollableHeight_vertical_orientation_when_content_is_small() {
     scrollView.orientation = enums.Orientation.vertical;
     scrollView.width = 200;
     scrollView.height = 300;
@@ -112,7 +112,7 @@ export function test_scrollabeHeight_vertical_orientation_when_content_is_small(
     TKUnit.assertEqual(scrollView.scrollableWidth, 0, "scrollView.scrollableWidth");
 }
 
-export function test_scrollabeHeight_vertical_orientation_when_content_is_big() {
+export function test_scrollableHeight_vertical_orientation_when_content_is_big() {
     scrollView.orientation = enums.Orientation.vertical;
 
     scrollView.width = 200;
@@ -129,7 +129,7 @@ export function test_scrollabeHeight_vertical_orientation_when_content_is_big() 
 
 }
 
-export function test_scrollabeWidth_horizontal_orientation_when_content_is_small() {
+export function test_scrollableWidth_horizontal_orientation_when_content_is_small() {
     scrollView.orientation = enums.Orientation.vertical;
     scrollView.width = 200;
     scrollView.height = 300;
@@ -144,7 +144,7 @@ export function test_scrollabeWidth_horizontal_orientation_when_content_is_small
     TKUnit.assertEqual(scrollView.scrollableWidth, 0, "scrollView.scrollableWidth");
 }
 
-export function test_scrollabeWidth_horizontal_orientation_when_content_is_big() {
+export function test_scrollableWidth_horizontal_orientation_when_content_is_big() {
     scrollView.orientation = enums.Orientation.horizontal;
 
     scrollView.width = 200;
@@ -298,4 +298,20 @@ export function test_scrollView_persistsState_horizontal() {
 
     // Check verticalOffset after navigation
     TKUnit.assertEqual(scrollView.horizontalOffset, 100, "scrollView.horizontalOffset after navigation");
+}
+
+export function test_scrollView_addChild_removeChild() {
+    scrollView.orientation = enums.Orientation.horizontal;
+
+    scrollView.width = 100;
+    scrollView.height = 100;
+
+    var btn = new button.Button();
+    btn.text = "test";
+    scrollView.addChild(btn);
+
+    TKUnit.assertEqual(scrollView.content, btn, "scrollView.content addChild");
+
+    scrollView.removeChild();
+    TKUnit.assertEqual(scrollView.content, null, "scrollView.content removeChild");
 }

--- a/ui/content-view/content-view.d.ts
+++ b/ui/content-view/content-view.d.ts
@@ -14,6 +14,17 @@ declare module "ui/content-view" {
          */
         content: view.View;
 
+        /**
+         * Changes the only child to be the value.
+         * @param value
+         */
+        addChild(value: view.View);
+
+        /**
+         * Removes the only Child, in this case it sets content = null
+         */
+        removeChild();
+
         //@private
         /**
          * Called when the content property has changed.

--- a/ui/content-view/content-view.ts
+++ b/ui/content-view/content-view.ts
@@ -69,4 +69,12 @@ export class ContentView extends view.CustomLayoutView implements definition.Con
     public onLayout(left: number, top: number, right: number, bottom: number): void {
         view.View.layoutChild(this, this.content, 0, 0, right - left, bottom - top);
     }
+
+    public addChild(value: view.View): void {
+        this.content = value;
+    }
+
+    public removeChild(): void {
+        this.content = null;
+    }
 }


### PR DESCRIPTION
This overrides the addChild/removeChild to fix a issue where addChild / removeChild is called on a contentView or a CV descendant it will then crash the client.   This basically adds a wrapper to override the native implementation so that it won't crash.   addChild will basically set the new child as the primary content.   removeChild will basically set the content to null.
