### PR TITLE
separator is no longer forced to the edge

### DIFF
--- a/ui/list-view/list-view.ios.ts
+++ b/ui/list-view/list-view.ios.ts
@@ -89,18 +89,6 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
         if (indexPath.row === this._owner.items.length - 1) {
             this._owner.notify(<observable.EventData>{ eventName: LOADMOREITEMS, object: this._owner });
         }
-
-        if (cell.separatorInset) {
-            cell.separatorInset = UIEdgeInsetsZero;
-        }
-
-        if (cell.preservesSuperviewLayoutMargins) {
-            cell.preservesSuperviewLayoutMargins = false;
-        }
-
-        if (cell.layoutMargins) {
-            cell.layoutMargins = UIEdgeInsetsZero;
-        }
     }
 
     public tableViewWillSelectRowAtIndexPath(tableView: UITableView, indexPath: NSIndexPath): NSIndexPath {


### PR DESCRIPTION
Use this code in ListView.itemLoading event if you want to control the
inset:
```JavaScript
function listViewItemLoading(args) {
if (args.ios) {
   args.ios.separatorInset = UIEdgeInsetsZero;
   args.ios.preservesSuperviewLayoutMargins = false;
   args.ios.layoutMargins = UIEdgeInsetsZero;
 }
}
```