### PR TITLE
Pull-to-refresh ListView

### DIFF
--- a/apps/tests/ui/list-view/list-view-tests.ts
+++ b/apps/tests/ui/list-view/list-view-tests.ts
@@ -566,7 +566,7 @@ function loadViewWithItemNumber(args: listViewModule.ItemEventData) {
 
 function getTextFromNativeElementAt(listView: listViewModule.ListView, index: number): any {
     if (listView.android) {
-        var nativeElement = listView.android.getChildAt(index);
+        var nativeElement = listView.android.ListView.getChildAt(index);
         if (nativeElement instanceof android.view.ViewGroup) {
             return (<android.widget.TextView>((<any>nativeElement).getChildAt(0))).getText();
         }
@@ -579,7 +579,7 @@ function getTextFromNativeElementAt(listView: listViewModule.ListView, index: nu
 
 function getNativeViewCount(listView: listViewModule.ListView): number {
     if (listView.android) {
-        return listView.android.getChildCount();
+        return listView.android.ListView.getChildCount();
     }
     else if (listView.ios) {
         return listView.ios.visibleCells().count;
@@ -591,7 +591,7 @@ function getNativeViewCount(listView: listViewModule.ListView): number {
 
 function performNativeItemTap(listView: listViewModule.ListView, index: number): void {
     if (listView.android) {
-        listView.android.performItemClick(listView.android.getChildAt(index), index, listView.android.getAdapter().getItemId(index));
+        listView.android.ListView.performItemClick(listView.android.ListView.getChildAt(index), index, listView.android.ListView.getAdapter().getItemId(index));
     }
     else if (listView.ios) {
         // Calling selectRowAtIndexPathAnimatedScrollPosition will not tiger [Will|Did]SelectRowAtIndexPath callbacks.

--- a/ui/list-view/list-view-common.ts
+++ b/ui/list-view/list-view-common.ts
@@ -33,6 +33,7 @@ export class ListView extends view.View implements definition.ListView {
     public static itemLoadingEvent = "itemLoading";
     public static itemTapEvent = "itemTap";
     public static loadMoreItemsEvent = "loadMoreItems";
+    public static refreshEvent = "refresh";
 
     public static separatorColorProperty = new dependencyObservable.Property(
         SEPARATORCOLOR,

--- a/ui/list-view/list-view.d.ts
+++ b/ui/list-view/list-view.d.ts
@@ -50,9 +50,9 @@ declare module "ui/list-view" {
         public static isScrollingProperty: dependencyObservable.Property;
 
         /**
-         * Gets the native [android widget](http://developer.android.com/reference/android/widget/ListView.html) that represents the user interface for this component. Valid only when running on Android OS.
+         * Get the wrapped object of native Android ListView and SwipeRefreshLayout
          */
-        android: android.widget.ListView;
+        android: AndroidListView;
 
         /**
          * Gets the native [iOS view](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITableView_Class/) that represents the user interface for this component. Valid only when running on iOS.
@@ -135,6 +135,18 @@ declare module "ui/list-view" {
          * Gets the native [android widget](http://developer.android.com/reference/android/view/ViewGroup.html) that represents the user interface where the view is hosted. Valid only when running on Android OS.
          */
         android: android.view.ViewGroup;
+    }
+
+    /**
+     * Represents a wrapped object of native Android ListView and SwipeRefreshLayout
+     */
+    export interface AndroidListView {
+        RefreshLayout: android.support.v4.widget.SwipeRefreshLayout;
+
+        /**
+         * Native [android widget](http://developer.android.com/reference/android/widget/ListView.html) that represents the user interface for this component. Valid only when running on Android OS.
+         */
+        ListView: android.widget.ListView;
     }
 
     /**

--- a/ui/list-view/list-view.d.ts
+++ b/ui/list-view/list-view.d.ts
@@ -136,4 +136,14 @@ declare module "ui/list-view" {
          */
         android: android.view.ViewGroup;
     }
+
+    /**
+     * Event data containing information for "refresh" with done callback
+     */
+    export interface RefreshEventData extends observable.EventData {
+        /**
+         * Callback when refresh is done to hide the loading icon
+         */
+        done: () => void;
+    }
 }


### PR DESCRIPTION
Successor PR of #126
Issue #51
optional pull-to-refresh feature for iOS and Android.
When defining `ListView` XML, if there is xml attribute `refresh`, `ListView` automatically add `UIRefreshControl` view and handler for iOS, or `SwipeRefreshLayout` for Android.
Example:
```xml
<!-- main-page.xml -->
<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded">
	<StackLayout>
		<ListView
			items="{{ postList }}"
			isScrolling="{{ isScrolling }}"
			loadMoreItems="listViewLoadMoreItems"
			refresh="myRefreshFunction"
			>
			<ListView.itemTemplate>
				<!-- truncated -->
			</ListView.itemTemplate>
		</ListView>
	</StackLayout>
</Page>
```
```ts
// main-page.ts
export function myRefreshFunction(args: RefreshEventData) {
  mainViewModel.refresh()
  .then(()=>{
    args.done();
    })
  .catch(function(e) {
    setTimeout(function() { throw e; });
  });
  ;
}
```

**Warning**: this is breaking change for `ListView.android`. In previous PR, we were discussing inheriting `ListView` to make `RefreshableListView`, but I find that approach too much complicated. Please fell free to suggest/improve to minimize/eliminate the threat from breaking change.