### PR TITLE
Remove class override of ListViewCell

### DIFF
--- a/ui/list-view/list-view.ios.ts
+++ b/ui/list-view/list-view.ios.ts
@@ -23,9 +23,6 @@ class ListViewCell extends UITableViewCell {
     static new(): ListViewCell {
         return <ListViewCell>super.new();
     }
-    static class(): any {
-        return ListViewCell;
-    }
 }
 
 function notifyForItemAtIndex(listView: definition.ListView, cell: any, eventName: string, indexPath: NSIndexPath) {


### PR DESCRIPTION
This is broken and unneeded in the new ios runtime.

Related: https://github.com/NativeScript/ios-runtime/issues/178