### PR TITLE
XHR compatibility updates

### DIFF
--- a/apps/tests/TKUnit.ts
+++ b/apps/tests/TKUnit.ts
@@ -120,12 +120,15 @@ function runAsync(testInfo: TestInfoEntry, recursiveIndex: number, testTimeout?:
         }
     }
 
-    if (testInfo.instance) {
-        testInfo.testFunc.apply(testInfo.instance, [doneCallback]);
-    }
-    else {
-        var func: any = testInfo.testFunc;
-        func(doneCallback);
+    try {
+        if (testInfo.instance) {
+            testInfo.testFunc.apply(testInfo.instance, [doneCallback]);
+        } else {
+            var func: any = testInfo.testFunc;
+            func(doneCallback);
+        }
+    } catch (e) {
+        doneCallback(e);
     }
 
     setTimeout(checkFinished, 0);

--- a/apps/tests/http-tests.ts
+++ b/apps/tests/http-tests.ts
@@ -616,3 +616,16 @@ export function test_raises_onerror_Event(done) {
     xhr.open("GET", "https://no-such-domain-httpbin.org");
     xhr.send();
 }
+
+export function test_responseType(done) {
+    let xhr = new XMLHttpRequest();
+    xhr.responseType = "";
+    xhr.responseType = "text";
+
+    TKUnit.assertThrows(
+        () => xhr.responseType = "json",
+        "Didn't raise on unsupported type.",
+        "Response type of 'json' not supported."
+    );
+    done(null);
+}

--- a/apps/tests/http-tests.ts
+++ b/apps/tests/http-tests.ts
@@ -598,3 +598,21 @@ export var test_XMLHttpRequest_requestShouldBePossibleAfterAbort = function (don
 
     xhr.send(JSON.stringify({ MyVariableOne: "ValueOne", MyVariableTwo: "ValueTwo" }));
 };
+
+export function test_raises_onload_Event(done) {
+    let xhr = new XMLHttpRequest();
+    xhr.onload = () => {
+        done(null);
+    }
+    xhr.open("GET", "https://httpbin.org/get");
+    xhr.send();
+}
+
+export function test_raises_onerror_Event(done) {
+    let xhr = new XMLHttpRequest();
+    xhr.onerror = () => {
+        done(null);
+    }
+    xhr.open("GET", "https://no-such-domain-httpbin.org");
+    xhr.send();
+}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -37,6 +37,7 @@ declare class XMLHttpRequest {
     overrideMimeType(mime: string): void;
     readyState: number;
     responseText: string;
+    responseType: string;
     status: number;
 
     onload: () => void;

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -38,6 +38,9 @@ declare class XMLHttpRequest {
     readyState: number;
     responseText: string;
     status: number;
+
+    onload: () => void;
+    onerror: () => void;
 }
 
 /**

--- a/http/http.ts
+++ b/http/http.ts
@@ -49,6 +49,7 @@ export class XMLHttpRequest {
     private _responseText: string = "";
     private _headers: any;
     private _errorFlag: boolean;
+    private _responseType: string;
 
     public onreadystatechange: Function;
 
@@ -161,6 +162,18 @@ export class XMLHttpRequest {
 
     get readyState(): number {
         return this._readyState;
+    }
+
+    public get responseType(): string {
+        return this._responseType;
+    }
+
+    public set responseType(value: string) {
+        if (value === "" || value === "text") {
+            this._responseType = value;
+        } else {
+            throw new Error(`Response type of '${value}' not supported.`);
+        }
     }
 
     private _setReadyState(value: number) {

--- a/http/http.ts
+++ b/http/http.ts
@@ -39,6 +39,9 @@ export class XMLHttpRequest {
     public LOADING = 3;
     public DONE = 4;
 
+    public onload: () => void;
+    public onerror: () => void;
+
     private _options: definition.HttpRequestOptions;
     private _readyState: number;
     private _status: number;
@@ -112,8 +115,9 @@ export class XMLHttpRequest {
                 }
 
             }).catch(e => {
-                    this._errorFlag = true;
-                });
+                this._errorFlag = true;
+                this._setReadyState(this.DONE);
+            });
         }
     }
 
@@ -165,6 +169,15 @@ export class XMLHttpRequest {
 
             if (types.isFunction(this.onreadystatechange)) {
                 this.onreadystatechange();
+            }
+        }
+
+        if (this._readyState === this.DONE) {
+            if (this._errorFlag && types.isFunction(this.onerror)) {
+                this.onerror();
+            }
+            if (!this._errorFlag && types.isFunction(this.onload)) {
+                this.onload();
             }
         }
     }


### PR DESCRIPTION
The angular 2 code uses the `onload`/`onerror` events and explicitly sets `responseType`, so I added support for those. `responseType` is a pretty complex feature, so right now we only support `text` and raise an error if the user sets something else.

Bonus: modified TKUnit and wrapped test functions in a try/catch block thus failing the tests on exceptions instead of crashing the app.