### PR TITLE
RefreshableListView inherits ListView

### DIFF
--- a/ui/builder/component-builder.ts
+++ b/ui/builder/component-builder.ts
@@ -16,6 +16,7 @@ var UI_PATH = "ui/";
 var MODULES = {
     "ActivityIndicator": "ui/activity-indicator",
     "ListView": "ui/list-view",
+    "RefreshableListView": "ui/refreshable-list-view",
     "GridLayout": "ui/layouts/grid-layout",
     "DockLayout": "ui/layouts/dock-layout",
     "WrapLayout": "ui/layouts/wrap-layout",

--- a/ui/list-view/list-view-common.ts
+++ b/ui/list-view/list-view-common.ts
@@ -29,7 +29,7 @@ function onItemTemplatePropertyChanged(data: dependencyObservable.PropertyChange
     listView.refresh();
 }
 
-export class ListView extends view.View implements definition.ListView {
+export class AbstractListView extends view.View implements definition.AbstractListView {
     public static itemLoadingEvent = "itemLoading";
     public static itemTapEvent = "itemTap";
     public static loadMoreItemsEvent = "loadMoreItems";
@@ -145,4 +145,8 @@ export class ListView extends view.View implements definition.ListView {
     private _onItemsChanged(args: observable.EventData) {
         this.refresh();
     }
+}
+
+export class ListView extends AbstractListView implements definition.ListView {
+    
 }

--- a/ui/list-view/list-view.android.ts
+++ b/ui/list-view/list-view.android.ts
@@ -19,13 +19,13 @@ require("utils/module-merge").merge(common, exports);
 
 function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var bar = <ListView>data.object;
-    if (!bar.android) {
+    if (!bar._android) {
         return;
     }
 
     if (data.newValue instanceof color.Color) {
-        bar.android.setDivider(new android.graphics.drawable.ColorDrawable((<color.Color>data.newValue).android));
-        bar.android.setDividerHeight(1);
+        bar._android.setDivider(new android.graphics.drawable.ColorDrawable((<color.Color>data.newValue)._android));
+        bar._android.setDividerHeight(1);
     }
 }
 
@@ -37,22 +37,18 @@ export class ListView extends common.ListView {
     public _realizedItems = {};
     private _androidViewId: number;
 
-    public _createUI() {
-        this._android = new android.widget.ListView(this._context);
+    public _createListView(): android.widget.ListView {
+        listview = new android.widget.ListView(this._context);
 
         // Fixes issue with black random black items when scrolling
-        this._android.setCacheColorHint(android.graphics.Color.TRANSPARENT);
-        if (!this._androidViewId) {
-            this._androidViewId = android.view.View.generateViewId();
-        }
-        this._android.setId(this._androidViewId);
+        listview.setCacheColorHint(android.graphics.Color.TRANSPARENT);
 
-        this.android.setAdapter(new ListViewAdapter(this));
+        listview.setAdapter(new ListViewAdapter(this));
 
         var that = new WeakRef(this);
 
         // TODO: This causes many marshalling calls, rewrite in Java and generate bindings
-        this.android.setOnScrollListener(new android.widget.AbsListView.OnScrollListener({
+        listview.setOnScrollListener(new android.widget.AbsListView.OnScrollListener({
             onScrollStateChanged: function (view: android.widget.AbsListView, scrollState: number) {
                 var owner: ListView = this.owner;
                 if (!owner) {
@@ -82,7 +78,7 @@ export class ListView extends common.ListView {
             }
         }));
 
-        this.android.setOnItemClickListener(new android.widget.AdapterView.OnItemClickListener({
+        listview.setOnItemClickListener(new android.widget.AdapterView.OnItemClickListener({
             onItemClick: function (parent: any, convertView: android.view.View, index: number, id: number) {
                 var owner = that.get();
                 if (owner) {
@@ -90,6 +86,16 @@ export class ListView extends common.ListView {
                 }
             }
         }));
+        return listview;
+    }
+
+    public _createUI() {
+        if (!this._androidViewId) {
+            this._androidViewId = android.view.View.generateViewId();
+        }
+        var listview = this._createListView();
+        listview.setId(this._androidViewId);
+        this._android = listview;
     }
 
     get android(): android.widget.ListView {
@@ -101,7 +107,7 @@ export class ListView extends common.ListView {
             return;
         }
 
-        (<ListViewAdapter>this.android.getAdapter()).notifyDataSetChanged();
+        (<ListViewAdapter>this._android.getAdapter()).notifyDataSetChanged();
     }
 
     public _onDetached(force?: boolean) {

--- a/ui/list-view/list-view.d.ts
+++ b/ui/list-view/list-view.d.ts
@@ -20,7 +20,7 @@ declare module "ui/list-view" {
     /**
      * Represents a view that shows items in a vertically scrolling list.
      */
-    export class ListView extends view.View {
+    export class AbstractListView extends view.View {
         /**
          * String value used when hooking to itemLoading event.
          */
@@ -50,9 +50,9 @@ declare module "ui/list-view" {
         public static isScrollingProperty: dependencyObservable.Property;
 
         /**
-         * Gets the native [android widget](http://developer.android.com/reference/android/widget/ListView.html) that represents the user interface for this component. Valid only when running on Android OS.
+         * Abstract attribute, will be overide by ListView or RefreshableListView
          */
-        android: android.widget.ListView;
+        android: any;
 
         /**
          * Gets the native [iOS view](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITableView_Class/) that represents the user interface for this component. Valid only when running on iOS.
@@ -110,6 +110,13 @@ declare module "ui/list-view" {
          * Raised when the ListView is scrolled so that its last item is visible.
          */
         on(event: "loadMoreItems", callback: (args: observable.EventData) => void, thisArg?: any);
+    }
+
+    export class ListView extends AbstractListView {
+        /**
+         * Gets the native [android widget](http://developer.android.com/reference/android/widget/ListView.html) that represents the user interface for this component. Valid only when running on Android OS.
+         */
+        android: android.widget.ListView;
     }
 
     /**

--- a/ui/refreshable-list-view/Readme.md
+++ b/ui/refreshable-list-view/Readme.md
@@ -1,0 +1,56 @@
+﻿RefreshableListView module. 
+```js
+    var lm  = require("ui/label");
+    var lvm = require("ui/refreshable-list-view");
+
+    var data = [];
+    for(var i = 0, l = 1000; i < l; i++) {
+       data.push(i);
+    }
+
+    var lv = new lvm.ListView();
+    lv.items = data;
+    lv.on(lvm.ListView.itemLoadingEvent, function(args){
+        var label = args.view;
+        if(!label) {
+            label = new lm.Label();
+            args.view = label;
+        }
+        label.text = "Item " + args.index;
+    });
+```
+
+Just replace `ListView` in your XML file with `RefreshableListView` and add attribute `refresh="yourRefreshHandler"`
+(while keep `ListView.itemTemplate` the same).
+
+Example:
+```xml
+<!-- main-page.xml -->
+<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded">
+    <StackLayout>
+        <RefreshableListView
+            items="{{ postList }}"
+            isScrolling="{{ isScrolling }}"
+            loadMoreItems="listViewLoadMoreItems"
+            refresh="myRefreshFunction"
+            >
+            <ListView.itemTemplate>
+                <!-- truncated -->
+            </ListView.itemTemplate>
+        </RefreshableListView>
+    </StackLayout>
+</Page>
+```
+```ts
+// main-page.ts
+export function myRefreshFunction(args: RefreshEventData) {
+  mainViewModel.refresh()
+  .then(()=>{
+    args.done();
+    })
+  .catch(function(e) {
+    setTimeout(function() { throw e; });
+  });
+  ;
+}
+```

--- a/ui/refreshable-list-view/package.json
+++ b/ui/refreshable-list-view/package.json
@@ -1,0 +1,2 @@
+﻿{ "name" : "refreshable-list-view",
+  "main" : "refreshable-list-view.js" }

--- a/ui/refreshable-list-view/refreshable-list-view-common.ts
+++ b/ui/refreshable-list-view/refreshable-list-view-common.ts
@@ -1,0 +1,3 @@
+﻿export class RefreshableListViewMixin {
+    public static refreshEvent = "refresh";
+}

--- a/ui/refreshable-list-view/refreshable-list-view.android.ts
+++ b/ui/refreshable-list-view/refreshable-list-view.android.ts
@@ -1,4 +1,9 @@
-﻿import parent = require("ui/list-view/list-view");
+﻿/* *
+// error: `tns_modules/ui/refreshable-list-view/refreshable-list-view.android.ts(1,25): error TS2306: File 'tns_modules/ui/list-view/list-view.d.ts' is not an external module.
+import parent = require("ui/list-view/list-view");
+/* */
+import parent = require("ui/list-view/list-view.android");
+import definition = require("ui/refreshable-list-view");
 import common = require("ui/refreshable-list-view/refreshable-list-view-common");
 
 var REFRESH = common.RefreshableListViewMixin.refreshEvent;
@@ -6,24 +11,21 @@ var REFRESH = common.RefreshableListViewMixin.refreshEvent;
 declare var exports;
 require("utils/module-merge").merge(parent, exports);
 
-export class RefreshableListView extends parent.ListView implements common.RefreshableListViewMixin {
+export class RefreshableListView extends parent.AbstractListView implements common.RefreshableListViewMixin {
     public static refreshEvent = REFRESH;
-    private _android: android.widget.ListView;
+    public _android: android.widget.ListView;
     private _refreshableView: definition.AndroidListView;
-    private _androidViewId: number;
 
     public _createUI() {
-        if (!this._androidViewId) {
-            this._androidViewId = android.view.View.generateViewId();
-        }
+        var androidViewId = this._createViewId();
         var listview = this._createListView();
-        var refreshLayout;
+        let refreshLayout;
         //Init SwipeRefreshLayout if there is refresh event
         if (this.hasListeners(common.RefreshableListViewMixin.refreshEvent)) {
             refreshLayout = this._createRefreshLayout(listview);
-            refreshLayout.setId(this._androidViewId);
+            refreshLayout.setId(androidViewId);
         } else {
-            listview.setId(this._androidViewId);
+            listview.setId(androidViewId);
         }
         
         this._android = listview;
@@ -36,7 +38,7 @@ export class RefreshableListView extends parent.ListView implements common.Refre
     // this._listview
     public _createRefreshLayout(listview: android.widget.ListView): android.support.v4.widget.SwipeRefreshLayout {
         var that = new WeakRef(this);
-        var refreshLayout = new android.support.v4.widget.SwipeRefreshLayout(this._context);
+        let refreshLayout = new android.support.v4.widget.SwipeRefreshLayout(this._context);
         refreshLayout.addView(listview);
         refreshLayout.setOnRefreshListener(new android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener({
             onRefresh: function() {

--- a/ui/refreshable-list-view/refreshable-list-view.android.ts
+++ b/ui/refreshable-list-view/refreshable-list-view.android.ts
@@ -1,0 +1,65 @@
+﻿import parent = require("ui/list-view/list-view");
+import common = require("ui/refreshable-list-view/refreshable-list-view-common");
+
+var REFRESH = common.RefreshableListViewMixin.refreshEvent;
+// merge the exports of the parent file with the exports of this file
+declare var exports;
+require("utils/module-merge").merge(parent, exports);
+
+export class RefreshableListView extends parent.ListView implements common.RefreshableListViewMixin {
+    public static refreshEvent = REFRESH;
+    private _android: android.widget.ListView;
+    private _refreshableView: definition.AndroidListView;
+    private _androidViewId: number;
+
+    public _createUI() {
+        if (!this._androidViewId) {
+            this._androidViewId = android.view.View.generateViewId();
+        }
+        var listview = this._createListView();
+        var refreshLayout;
+        //Init SwipeRefreshLayout if there is refresh event
+        if (this.hasListeners(common.RefreshableListViewMixin.refreshEvent)) {
+            refreshLayout = this._createRefreshLayout(listview);
+            refreshLayout.setId(this._androidViewId);
+        } else {
+            listview.setId(this._androidViewId);
+        }
+        
+        this._android = listview;
+        this._refreshableView = <definition.AndroidListView> {
+            RefreshLayout: refreshLayout,
+            ListView: listview,
+        }
+    }
+    
+    // this._listview
+    public _createRefreshLayout(listview: android.widget.ListView): android.support.v4.widget.SwipeRefreshLayout {
+        var that = new WeakRef(this);
+        var refreshLayout = new android.support.v4.widget.SwipeRefreshLayout(this._context);
+        refreshLayout.addView(listview);
+        refreshLayout.setOnRefreshListener(new android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener({
+            onRefresh: function() {
+                var owner = that.get();
+                if (owner) {
+                    owner.notify(<definition.RefreshEventData>{
+                        eventName: REFRESH,
+                        object: owner,
+                        done: function() { refreshLayout.setRefreshing(false) }
+                    });
+                }
+            }
+        }));
+        return refreshLayout;
+    }
+    get android(): definition.AndroidListView {
+        return this._refreshableView;
+    }
+    get _nativeView(): android.view.View {
+        var r = this._refreshableView && this._refreshableView.RefreshLayout;
+        if (r) {
+            return r;
+        }
+        return this._android;
+    }
+}

--- a/ui/refreshable-list-view/refreshable-list-view.d.ts
+++ b/ui/refreshable-list-view/refreshable-list-view.d.ts
@@ -7,7 +7,7 @@ declare module "ui/refreshable-list-view" {
     /**
      * Represents a view that shows items in a vertically refreshable scrolling list.
      */
-    export class RefreshableListView extends parent.ListView {
+    export class RefreshableListView extends parent.AbstractListView {
         /**
          * String value used when hooking to refresh event.
          */

--- a/ui/refreshable-list-view/refreshable-list-view.d.ts
+++ b/ui/refreshable-list-view/refreshable-list-view.d.ts
@@ -1,0 +1,42 @@
+﻿/**
+ * Contains the RefreshableListView class, which represents a standard refreshable list view widget.
+ */
+declare module "ui/refreshable-list-view" {
+    import observable = require("data/observable");
+    import parent = require("ui/list-view");
+    /**
+     * Represents a view that shows items in a vertically refreshable scrolling list.
+     */
+    export class RefreshableListView extends parent.ListView {
+        /**
+         * String value used when hooking to refresh event.
+         */
+        public static refreshEvent: string;
+        /**
+         * Get the wrapped object of native Android ListView and SwipeRefreshLayout. Valid only when running on Android OS.
+         */
+        android: AndroidListView;
+    }
+    /**
+     * Represents a wrapped object of native Android ListView and SwipeRefreshLayout
+     */
+    export interface AndroidListView {
+        /**
+         * Native [android widget](http://developer.android.com/reference/android/support/v4/widget/SwipeRefreshLayout.html).
+         */
+        RefreshLayout: android.support.v4.widget.SwipeRefreshLayout;
+        /**
+         * Native [android widget](http://developer.android.com/reference/android/widget/ListView.html).
+         */
+        ListView: android.widget.ListView;
+    }
+    /**
+     * Event data containing information for "refresh" with done callback
+     */
+    export interface RefreshEventData extends observable.EventData {
+        /**
+         * Callback when refresh is done to hide the loading icon
+         */
+        done: () => void;
+    }
+}

--- a/ui/refreshable-list-view/refreshable-list-view.ios.ts
+++ b/ui/refreshable-list-view/refreshable-list-view.ios.ts
@@ -1,5 +1,9 @@
-﻿import definition = require("ui/refreshable-list-view");
+﻿/* *
+// error: `tns_modules/ui/refreshable-list-view/refreshable-list-view.ios.ts(1,25): error TS2306: File 'tns_modules/ui/list-view/list-view.d.ts' is not an external module.
 import parent = require("ui/list-view/list-view");
+/* */
+import parent = require("ui/list-view/list-view.ios");
+import definition = require("ui/refreshable-list-view");
 import common = require("ui/refreshable-list-view/refreshable-list-view-common");
 
 var REFRESH = common.RefreshableListViewMixin.refreshEvent;
@@ -9,10 +13,10 @@ class RefreshHandlerImpl extends NSObject {
         return <RefreshHandlerImpl>super.new();
     }
 
-    private _owner: ListView;
+    private _owner: RefreshableListView;
     private _UIRefreshControl: UIRefreshControl;
 
-    public initWithOwner(owner: ListView): RefreshHandlerImpl {
+    public initWithOwner(owner: RefreshableListView): RefreshHandlerImpl {
         this._owner = owner;
         this._UIRefreshControl = new UIRefreshControl();
         owner.ios.addSubview(this._UIRefreshControl);
@@ -42,11 +46,7 @@ export class RefreshableListView extends parent.ListView implements common.Refre
     private _refreshHandler: RefreshHandlerImpl;
 
     public onLoaded() {
-        /*
-        // cannot use
         super.onLoaded();
-        */
-        super.prototype.onLoaded.call(this);
         if (this.hasListeners(REFRESH)) {
             this._refreshHandler = RefreshHandlerImpl.new().initWithOwner(this);
         }
@@ -54,11 +54,7 @@ export class RefreshableListView extends parent.ListView implements common.Refre
 
     public onUnloaded() {
         this._refreshHandler = null;
-        /*
-        // cannot use
         super.onUnloaded();
-        */
-        super.prototype.onUnloaded.call(this);
     }
 
 }

--- a/ui/refreshable-list-view/refreshable-list-view.ios.ts
+++ b/ui/refreshable-list-view/refreshable-list-view.ios.ts
@@ -1,0 +1,64 @@
+﻿import definition = require("ui/refreshable-list-view");
+import parent = require("ui/list-view/list-view");
+import common = require("ui/refreshable-list-view/refreshable-list-view-common");
+
+var REFRESH = common.RefreshableListViewMixin.refreshEvent;
+
+class RefreshHandlerImpl extends NSObject {
+    static new(): RefreshHandlerImpl {
+        return <RefreshHandlerImpl>super.new();
+    }
+
+    private _owner: ListView;
+    private _UIRefreshControl: UIRefreshControl;
+
+    public initWithOwner(owner: ListView): RefreshHandlerImpl {
+        this._owner = owner;
+        this._UIRefreshControl = new UIRefreshControl();
+        owner.ios.addSubview(this._UIRefreshControl);
+        this._UIRefreshControl.addTargetActionForControlEvents(this, "refresh", UIControlEvents.UIControlEventValueChanged);
+        return this;
+    }
+
+    public refresh(sender: UIRefreshControl) {
+        this._owner.notify(<definition.RefreshEventData>{
+            eventName: REFRESH,
+            object: this._owner,
+            done: sender.endRefreshing.bind(sender)
+        });
+    }
+
+    public static ObjCExposedMethods = {
+        'refresh': { returns: interop.types.void, params: [UIRefreshControl] }
+    };
+}
+
+// merge the exports of the common file with the exports of this file
+declare var exports;
+require("utils/module-merge").merge(parent, exports);
+
+export class RefreshableListView extends parent.ListView implements common.RefreshableListViewMixin {
+    public static refreshEvent = REFRESH;
+    private _refreshHandler: RefreshHandlerImpl;
+
+    public onLoaded() {
+        /*
+        // cannot use
+        super.onLoaded();
+        */
+        super.prototype.onLoaded.call(this);
+        if (this.hasListeners(REFRESH)) {
+            this._refreshHandler = RefreshHandlerImpl.new().initWithOwner(this);
+        }
+    }
+
+    public onUnloaded() {
+        this._refreshHandler = null;
+        /*
+        // cannot use
+        super.onUnloaded();
+        */
+        super.prototype.onUnloaded.call(this);
+    }
+
+}


### PR DESCRIPTION
Successor PR of #231
Issue #51
optional pull-to-refresh feature for iOS and Android.
When defining `RefreshableListView` (instead of `ListView`) XML, if there is xml attribute `refresh`, `RefreshableListView ` automatically add `UIRefreshControl` view and handler for iOS, or `SwipeRefreshLayout` for Android.
Example:
```xml
<!-- main-page.xml -->
<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded">
	<StackLayout>
		<RefreshableListView
			items="{{ postList }}"
			isScrolling="{{ isScrolling }}"
			loadMoreItems="listViewLoadMoreItems"
			refresh="myRefreshFunction"
			>
			<ListView.itemTemplate>
				<!-- truncated -->
			</ListView.itemTemplate>
		</RefreshableListView >
	</StackLayout>
</Page>
```
```ts
// main-page.ts
export function myRefreshFunction(args: RefreshEventData) {
  mainViewModel.refresh()
  .then(()=>{
    args.done();
    })
  .catch(function(e) {
    setTimeout(function() { throw e; });
  });
  ;
}
```