### PR TITLE
Expose the response property on XMLHttpRequest in the d.ts file

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -36,6 +36,7 @@ declare class XMLHttpRequest {
     getResponseHeader(header: string): string;
     overrideMimeType(mime: string): void;
     readyState: number;
+    response: any;
     responseText: string;
     responseType: string;
     status: number;


### PR DESCRIPTION
The Angular http service needs it, and we already have it implemented.