### PR TITLE
Move View._applyXmlAttribute outside @private block.

### DIFF
--- a/timer/timer.android.ts
+++ b/timer/timer.android.ts
@@ -3,24 +3,26 @@
  */
 var timeoutHandler;
 var timeoutCallbacks = {};
+var timerId = 0;
 
-function createHadlerAndGetId(): number {
+function createHandlerAndGetId(): number {
     if (!timeoutHandler) {
         timeoutHandler = new android.os.Handler(android.os.Looper.getMainLooper());
     }
 
-    return new Date().getUTCMilliseconds();
+    timerId++;
+    return timerId;
 }
 
 export function setTimeout(callback: Function, milliseconds = 0): number {
-    var id = createHadlerAndGetId();
+    var id = createHandlerAndGetId();
 
     var runnable = new java.lang.Runnable({
         run: () => {
             callback();
 
-            if (timeoutCallbacks && timeoutCallbacks[id]) {
-                timeoutCallbacks[id] = null;
+            if (timeoutCallbacks[id]) {
+                delete timeoutCallbacks[id];
             }
         }
     });
@@ -37,12 +39,12 @@ export function setTimeout(callback: Function, milliseconds = 0): number {
 export function clearTimeout(id: number): void {
     if (timeoutCallbacks[id]) {
         timeoutHandler.removeCallbacks(timeoutCallbacks[id]);
-        timeoutCallbacks[id] = null;
+        delete timeoutCallbacks[id];
     }
 }
 
 export function setInterval(callback: Function, milliseconds = 0): number {
-    var id = createHadlerAndGetId();
+    var id = createHandlerAndGetId();
     var handler = timeoutHandler;
 
     var runnable = new java.lang.Runnable({

--- a/timer/timer.ios.ts
+++ b/timer/timer.ios.ts
@@ -2,6 +2,7 @@
  * iOS specific timer functions implementation.
  */
 var timeoutCallbacks = {};
+var timerId = 0;
 
 class TimerTargetImpl extends NSObject {
     static new(): TimerTargetImpl {
@@ -25,7 +26,8 @@ class TimerTargetImpl extends NSObject {
 }
 
 function createTimerAndGetId(callback: Function, milliseconds: number, shouldRepeat: boolean): number {
-    var id = new Date().getUTCMilliseconds();
+    timerId++;
+    var id = timerId;
 
     var timerTarget = TimerTargetImpl.new().initWithCallback(callback);
     var timer = NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(milliseconds / 1000, timerTarget, "tick", null, shouldRepeat);
@@ -44,7 +46,7 @@ export function setTimeout(callback: Function, milliseconds = 0): number {
 export function clearTimeout(id: number): void {
     if (timeoutCallbacks[id]) {
         timeoutCallbacks[id].invalidate();
-        timeoutCallbacks[id] = null;
+        delete timeoutCallbacks[id];
     }
 }
 

--- a/ui/core/view.d.ts
+++ b/ui/core/view.d.ts
@@ -412,6 +412,8 @@ declare module "ui/core/view" {
         _removeView(view: View);
         _context: android.content.Context;
 
+        public _applyXmlAttribute(attribute: string, value: any): boolean;
+
         // TODO: Implement logic for stripping these lines out
         //@private
         _gestureObservers: Map<number, Array<gestures.GesturesObserver>>;
@@ -441,7 +443,6 @@ declare module "ui/core/view" {
 
         _updateLayout(): void;
 
-        _applyXmlAttribute(attribute, value): boolean;
 
         /**
          * Called my measure method to cache measureSpecs.

--- a/ui/core/view.d.ts
+++ b/ui/core/view.d.ts
@@ -443,7 +443,6 @@ declare module "ui/core/view" {
 
         _updateLayout(): void;
 
-
         /**
          * Called my measure method to cache measureSpecs.
          */


### PR DESCRIPTION
Fixes a broken interface implementation error in the public d.ts.