### PR TITLE
Rename the tns-core package to tns-core-modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tns-core",
-  "description": "Telerik NativeScript Core",
+  "name": "tns-core-modules",
+  "description": "Telerik NativeScript Core Modules",
   "version": "1.3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
That will make its name easily understandable. It will be used as a plugin in the future.