### PR TITLE
Stop __extends function output

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -231,6 +231,7 @@ module.exports = function(grunt) {
                 }
             },
             modulesPackageDef: {
+                expand: true,
                 src: localCfg.packageJsonFilePath,
                 dest: localCfg.outModulesDir + "/",
                 options: {
@@ -254,6 +255,7 @@ module.exports = function(grunt) {
                 }
             },
             childPackageFiles: {
+                expand: true,
                 src: [
                     localCfg.srcDir + "/**/package.json",
                     "!./package.json",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -312,7 +312,8 @@ module.exports = function(grunt) {
                     removeComments: "<%= !grunt.option('leavecomments') || '' %>",
                     compiler: "node_modules/typescript/bin/tsc",
                     noEmitOnError: true,
-                    experimentalDecorators: true
+                    experimentalDecorators: true,
+                    noEmitHelpers: true
                 }
             },
             buildNodeTests: {


### PR DESCRIPTION
The __extends function is declared in the runtimes. Thus, the one
that the TypeScript compiler generates is reduntant and only
causes unnecessary marshaling delay.