### PR TITLE
Add the __decorate function

### DIFF
--- a/globals/globals.ts
+++ b/globals/globals.ts
@@ -17,6 +17,15 @@ global.clearTimeout = timer.clearTimeout;
 global.setInterval = timer.setInterval;
 global.clearInterval = timer.clearInterval;
 
+if (typeof global.__decorate !== "function") global.__decorate = function (decorators, target, key, desc) {
+    if (typeof global.Reflect === "object" && typeof global.Reflect.decorate === "function") return global.Reflect.decorate(decorators, target, key, desc);
+    switch (arguments.length) {
+        case 2: return decorators.reduceRight(function(o, d) { return (d && d(o)) || o; }, target);
+        case 3: return decorators.reduceRight(function(o, d) { return (d && d(target, key)), void 0; }, void 0);
+        case 4: return decorators.reduceRight(function(o, d) { return (d && d(target, key, o)) || o; }, desc);
+    }
+};
+
 // Temporary workaround for console in iOS. We will use runtime console instead our implementation.
 if (types.isUndefined(global.NSObject)) {
     global.console = new consoleModule.Console();


### PR DESCRIPTION
Removing __extends function generation by setting the
noEmitHelpers flag we removed the __decorate as well.
While the __extends exists in the runtimes, __decorate
is an EcmaScript-related functionality, hence its place
is in the modules.