### PR TITLE
fix the issue that an iOS animation promise may never be resolved nor rejected

### DIFF
--- a/ui/animation/animation.ios.ts
+++ b/ui/animation/animation.ios.ts
@@ -96,7 +96,7 @@ export class Animation extends common.Animation implements definition.Animation 
                     that._finishedAnimations++;
                 }
 
-                if (that._cancelledAnimations === that._mergedPropertyAnimations.length) {
+                if (that._cancelledAnimations > 0 && (that._cancelledAnimations + that._finishedAnimations) === that._mergedPropertyAnimations.length) {
                     trace.write(that._cancelledAnimations + " animations cancelled.", trace.categories.Animation);
                     that._rejectAnimationFinishedPromise();
                 }


### PR DESCRIPTION
Before the fix, if an iOS animation object has some of its animations finished and some cancelled, that._cancelledAnimations and that._finishedAnimations will both be smaller than that._mergedPropertyAnimations.length and thus _animationFinishedPromise will never be resolved nor rejected. This PR tries to fix this bug.