### PR TITLE
Fix XHR statusText property to return just the text

### DIFF
--- a/apps/tests/xhr-tests.ts
+++ b/apps/tests/xhr-tests.ts
@@ -221,6 +221,24 @@ export function test_raises_onload_Event(done) {
     xhr.send();
 }
 
+export function test_sets_status_and_statusText(done) {
+    let xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = () => {
+        if (xhr.readyState > 3) {
+            try {
+                TKUnit.assertEqual(xhr.status, 200);
+                TKUnit.assertEqual(xhr.statusText, 'OK');
+                done(null);
+            }
+            catch (err) {
+                done(err);
+            }
+        }
+    };
+    xhr.open("GET", "https://httpbin.org/get");
+    xhr.send();
+}
+
 export function test_raises_onerror_Event(done) {
     let xhr = new XMLHttpRequest();
     xhr.onerror = () => {

--- a/xhr/xhr.ts
+++ b/xhr/xhr.ts
@@ -197,7 +197,7 @@ export class XMLHttpRequest {
         if (this._readyState === this.UNSENT || this._readyState === this.OPENED || this._errorFlag) {
             return "";
         }
-        return this._status + " " + statuses[this._status];
+        return statuses[this._status];
     }
 }
 


### PR DESCRIPTION
In order to follow the spec the XHR statusText property should
return just the status text without the status code. Adding
tests to guard this behavior.