### PR TITLE
Fix the 9 misspellings of _detach in the two Gestures files.

### DIFF
--- a/ui/gestures/gestures.android.ts
+++ b/ui/gestures/gestures.android.ts
@@ -28,7 +28,7 @@ export class GesturesObserver extends common.GesturesObserver {
             };
             this._onTargetUnloaded = args => {
                 trace.write(this.target + ".target unloaded. android:" + this.target._nativeView, "gestures");
-                this._dettach();
+                this._detach();
             };
 
             this.target.on(view.View.loadedEvent, this._onTargetLoaded);
@@ -41,7 +41,7 @@ export class GesturesObserver extends common.GesturesObserver {
     }
 
     public disconnect() {
-        this._dettach();
+        this._detach();
 
         if (this.target) {
             this.target.off(view.View.loadedEvent, this._onTargetLoaded);
@@ -54,7 +54,7 @@ export class GesturesObserver extends common.GesturesObserver {
         super.disconnect();
     }
 
-    private _dettach() {
+    private _detach() {
         trace.write(this.target + "._detach() android:" + this.target._nativeView, "gestures");
 
         this._onTouchListener = null;
@@ -66,7 +66,7 @@ export class GesturesObserver extends common.GesturesObserver {
 
     private _attach(target: view.View, type: definition.GestureTypes) {
         trace.write(this.target + "._attach() android:" + this.target._nativeView, "gestures");
-        this._dettach();
+        this._detach();
 
         if (type & definition.GestureTypes.tap || type & definition.GestureTypes.doubleTap || type & definition.GestureTypes.longPress) {
             this._simpleGestureDetector = new android.support.v4.view.GestureDetectorCompat(target._context, new TapAndDoubleTapGestureListener(this, this.target, type));

--- a/ui/gestures/gestures.ios.ts
+++ b/ui/gestures/gestures.ios.ts
@@ -73,7 +73,7 @@ export class GesturesObserver extends common.GesturesObserver {
             };
             this._onTargetUnloaded = args => {
                 trace.write(this.target + ".target unloaded. _nativeView:" + this.target._nativeView, "gestures");
-                this._dettach();
+                this._detach();
             };
 
             this.target.on(view.View.loadedEvent, this._onTargetLoaded);
@@ -87,7 +87,7 @@ export class GesturesObserver extends common.GesturesObserver {
 
     private _attach(target: view.View, type: definition.GestureTypes) {
         trace.write(target + "._attach() _nativeView:" + target._nativeView, "gestures");
-        this._dettach();
+        this._detach();
 
         if (target && target._nativeView && target._nativeView.addGestureRecognizer) {
             var nativeView = <UIView>target._nativeView;
@@ -145,8 +145,8 @@ export class GesturesObserver extends common.GesturesObserver {
         }
     }
 
-    private _dettach() {
-        trace.write(this.target + "._dettach() _nativeView:" + this.target._nativeView, "gestures");
+    private _detach() {
+        trace.write(this.target + "._detach() _nativeView:" + this.target._nativeView, "gestures");
         if (this.target && this.target._nativeView) {
             for (var name in this._recognizers) {
                 if (this._recognizers.hasOwnProperty(name)) {
@@ -162,7 +162,7 @@ export class GesturesObserver extends common.GesturesObserver {
     }
 
     public disconnect() {
-        this._dettach();
+        this._detach();
 
         if (this.target) {
             this.target.off(view.View.loadedEvent, this._onTargetLoaded);


### PR DESCRIPTION
Nothing major; While perusing the source code I found this simple misspelling in the _detach function in the gestures files.    Would be worth fixing before it becomes a fixed point in time and space.  