### PR TITLE
Created a new event to allow blocking of navigation.

### DIFF
--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -130,6 +130,9 @@ export class Frame extends view.CustomLayoutView implements definition.Frame {
             // TODO: Do we need to throw an error?
             return;
         }
+        if (!this._onCanNavigateFrom()) {
+            return;
+        }
 
         var backstackEntry = this._backStack.pop();
         var navigationContext: NavigationContext = {
@@ -149,6 +152,9 @@ export class Frame extends view.CustomLayoutView implements definition.Frame {
 
     public navigate(param: any) {
         trace.write(this._getTraceId() + ".navigate();", trace.categories.Navigation);
+        if (!this._onCanNavigateFrom()) {
+            return;
+        }
 
         var entry = buildEntryFromArgs(param);
         var page = resolvePageFromEntry(entry);
@@ -230,6 +236,13 @@ export class Frame extends view.CustomLayoutView implements definition.Frame {
 
     public _navigateCore(backstackEntry: definition.BackstackEntry) {
         //
+    }
+
+    public _onCanNavigateFrom() {
+        if (this.currentPage) {
+            return this.currentPage.onCanNavigateFrom();
+        }
+        return true;
     }
 
     public _onNavigatingTo(backstackEntry: definition.BackstackEntry) {

--- a/ui/page/page-common.ts
+++ b/ui/page/page-common.ts
@@ -27,6 +27,7 @@ function onActionBarHiddenPropertyChanged(data: dependencyObservable.PropertyCha
 
 export class Page extends contentView.ContentView implements dts.Page {
     public static actionBarHiddenProperty = actionBarHiddenProperty;
+    public static canNavigateFromEvent = "canNavigateFrom";
     public static navigatingToEvent = "navigatingTo";
     public static navigatedToEvent = "navigatedTo";
     public static navigatingFromEvent = "navigatingFrom";
@@ -182,6 +183,16 @@ export class Page extends contentView.ContentView implements dts.Page {
         });
 
         this._navigationContext = undefined;
+    }
+
+    public onCanNavigateFrom(): boolean {
+        var event = {
+            eventName: Page.canNavigateFromEvent,
+            object: this,
+            canNavigate: true
+        }
+        this.notify(event);
+        return !!event.canNavigate;
     }
 
     public showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean) {

--- a/ui/page/page.d.ts
+++ b/ui/page/page.d.ts
@@ -23,6 +23,13 @@ declare module "ui/page" {
         context: any;
     }
 
+    export interface CanNavigateFromData extends observable.EventData {
+        /**
+         * The can Navigate Value
+         */
+        canNavigate: boolean;
+    }
+
     /**
      * Defines the data for the Page.shownModally event.
      */
@@ -50,6 +57,11 @@ declare module "ui/page" {
          * Dependency property used to hide the Navigation Bar in iOS and the Action Bar in Android.
          */
         public static actionBarHiddenProperty: dependencyObservable.Property;
+
+        /**
+         * String value used when hooking to canNavigateFrom event.
+         */
+        public static canNavigateFromEvent: string;
 
         /**
          * String value used when hooking to shownModally event.
@@ -134,6 +146,11 @@ declare module "ui/page" {
         on(event: "navigatedTo", callback: (args: NavigatedData) => void, thisArg?: any);
 
         /**
+         * Raised when checking to see if we can navigate from.
+         */
+        on(event: "canNavigateFrom", callback: (args: CanNavigateFromData) => void, thisArg?: any);
+
+        /**
          * Raised when navigation from the page has started.
          */
         on(event: "navigatingFrom", callback: (args: NavigatedData) => void, thisArg?: any);
@@ -169,6 +186,11 @@ declare module "ui/page" {
          * A method called after navigated to the page.
          */
         onNavigatedTo(): void;
+
+        /**
+         * A method called to check if navigation from this page is allowed
+         */
+        onCanNavigateFrom(): boolean;
 
         /**
          * A method called before navigating from the page.


### PR DESCRIPTION
This creates an event that gets ran before navigation is even tried.  This allows a page to cancel navigating from a page. Fix for #583 

Example:
Page.on('canNavigateFrom', function(args) {   args.canNavigate = false; });
