### PR TITLE
frame-common.ts is missing the code to automagically load the page.css

### DIFF
--- a/apps/tests/ui/page/page-tests-common.ts
+++ b/apps/tests/ui/page/page-tests-common.ts
@@ -247,8 +247,37 @@ export function test_LoadPageFromModule() {
     try {
         var topFrame = FrameModule.topmost();
         TKUnit.assert(topFrame.currentPage.content instanceof LabelModule.Label, "Content of the test page should be a Label created within test-page-module.");
-        var testLabel = <LabelModule.Label>topFrame.currentPage.content
+        var testLabel = <LabelModule.Label>topFrame.currentPage.content;
         TKUnit.assert(testLabel.text === "Label created within a page module.");
+    }
+    finally {
+        helper.goBack();
+    }
+}
+
+export function test_LoadPageFromDeclarativeWithCSS() {
+    helper.navigateToModule("ui/page/test-page-declarative-css");
+    try {
+        var topFrame = FrameModule.topmost();
+        TKUnit.assert(topFrame.currentPage.content instanceof LabelModule.Label, "Content of the test page should be a Label created within test-page-module-css.");
+        var testLabel = <LabelModule.Label>topFrame.currentPage.content;
+        TKUnit.assert(testLabel.text === "Label created within a page declarative file with css.");
+        TKUnit.assert(testLabel.style.backgroundColor.hex === "#ff00ff00", "Expected: #ff00ff00, Actual: " + testLabel.style.backgroundColor.hex);
+    }
+    finally {
+        helper.goBack();
+    }
+
+}
+
+export function test_LoadPageFromModuleWithCSS() {
+    helper.navigateToModule("ui/page/test-page-module-css");
+    try {
+        var topFrame = FrameModule.topmost();
+        TKUnit.assert(topFrame.currentPage.content instanceof LabelModule.Label, "Content of the test page should be a Label created within test-page-module-css.");
+        var testLabel = <LabelModule.Label>topFrame.currentPage.content;
+        TKUnit.assert(testLabel.text === "Label created within a page module css.");
+        TKUnit.assert(testLabel.style.backgroundColor.hex === "#ff00ff00", "Expected: #ff00ff00, Actual: " + testLabel.style.backgroundColor.hex);
     }
     finally {
         helper.goBack();

--- a/apps/tests/ui/page/test-page-declarative-css.css
+++ b/apps/tests/ui/page/test-page-declarative-css.css
@@ -1,0 +1,3 @@
+Label {
+    background-color: #ff00ff00;
+}

--- a/apps/tests/ui/page/test-page-declarative-css.xml
+++ b/apps/tests/ui/page/test-page-declarative-css.xml
@@ -1,0 +1,3 @@
+﻿<Page>
+    <Label text="Label created within a page declarative file with css."/>
+</Page>

--- a/apps/tests/ui/page/test-page-module-css.css
+++ b/apps/tests/ui/page/test-page-module-css.css
@@ -1,0 +1,3 @@
+Label {
+    background-color: #ff00ff00;
+}

--- a/apps/tests/ui/page/test-page-module-css.ts
+++ b/apps/tests/ui/page/test-page-module-css.ts
@@ -1,0 +1,19 @@
+﻿import PageModule = require("ui/page");
+import LabelModule = require("ui/label");
+
+export class TestPageModule extends PageModule.Page {
+    constructor() {
+        super();
+
+        var label = new LabelModule.Label();
+        label.text = "Label created within a page module css.";
+
+        this.content = label;
+    }
+}
+
+export function createPage() {
+    return new TestPageModule();
+}
+
+//export var Page = new TestPageModule();

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -58,7 +58,7 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): pages.P
             trace.write("Calling createPage()", trace.categories.Navigation);
             page = moduleExports.createPage();
             var cssFileName = fileResolverModule.resolveFileName(moduleNamePath, "css");
-            if (cssFileName) {
+            if (cssFileName && page && page.addCssFile) {
                 page.addCssFile(cssFileName);
             }
         }

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -57,10 +57,6 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): pages.P
         if (moduleExports && moduleExports.createPage) {
             trace.write("Calling createPage()", trace.categories.Navigation);
             page = moduleExports.createPage();
-            var cssFileName = fileResolverModule.resolveFileName(moduleNamePath, "css");
-            if (cssFileName && page && page.addCssFile) {
-                page.addCssFile(cssFileName);
-            }
         }
         else {
             page = pageFromBuilder(moduleNamePath, moduleExports);
@@ -68,6 +64,12 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): pages.P
 
         if (!(page && page instanceof pages.Page)) {
             throw new Error("Failed to load Page from entry.moduleName: " + entry.moduleName);
+        }
+
+        // Possible CSS file path.
+        var cssFileName = fileResolverModule.resolveFileName(moduleNamePath, "css");
+        if (cssFileName) {
+            page.addCssFile(cssFileName);
         }
     }
 
@@ -87,12 +89,6 @@ function pageFromBuilder(moduleNamePath: string, moduleExports: any): pages.Page
         element = builder.load(fileName, moduleExports);
         if (element instanceof pages.Page) {
             page = <pages.Page>element;
-
-            // Possible CSS file path.
-            var cssFileName = fileResolverModule.resolveFileName(moduleNamePath, "css");
-            if (cssFileName) {
-                page.addCssFile(cssFileName);
-            }
         }
     }
 

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -57,6 +57,10 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): pages.P
         if (moduleExports && moduleExports.createPage) {
             trace.write("Calling createPage()", trace.categories.Navigation);
             page = moduleExports.createPage();
+            var cssFileName = fileResolverModule.resolveFileName(moduleNamePath, "css");
+            if (cssFileName) {
+                page.addCssFile(cssFileName);
+            }
         }
         else {
             page = pageFromBuilder(moduleNamePath, moduleExports);


### PR DESCRIPTION
frame-common.ts is missing the code to automagically load the page.css file if it exists on a page that is created via the JavaScript createPage() function.  The expected behavior is that the page.css file is always loaded if it exists, no matter how the page is created.