### PR TITLE
Changed createSelectorsFromSyntaxTree to use a loop rather than filter.

### DIFF
--- a/apps/tests/ui/style/style-tests.ts
+++ b/apps/tests/ui/style/style-tests.ts
@@ -816,6 +816,26 @@ export function test_set_invalid_CSS_values_dont_cause_crash() {
     }, invalidCSS);
 }
 
+// Check Mixed, Upper and lower case properties
+var casedCSS = ".cased {" +
+    "cOlOr: blue; " +
+    "FONT-SIZE: 30; " +
+    "background-color: red; " +
+    "}";
+
+export function test_set_mixed_CSS_cases_works() {
+    var testButton = new buttonModule.Button();
+    testButton.text = "Test";
+    testButton.cssClass = "cased";
+
+    helper.buildUIAndRunTest(testButton, function (views: Array<viewModule.View>) {
+        TKUnit.assertEqual(30, testButton.style.fontSize);
+        helper.assertViewBackgroundColor(testButton, "#FF0000");
+        helper.assertViewColor(testButton, "#0000FF");
+    }, casedCSS);
+}
+
+
 // <snippet module="ui/styling" title="styling">
 // For information and example how to use style properties please refer to special [**Styling**](../../../styling.md) topic. 
 // </snippet>

--- a/apps/tests/ui/style/style-tests.ts
+++ b/apps/tests/ui/style/style-tests.ts
@@ -835,7 +835,6 @@ export function test_set_mixed_CSS_cases_works() {
     }, casedCSS);
 }
 
-
 // <snippet module="ui/styling" title="styling">
 // For information and example how to use style properties please refer to special [**Styling**](../../../styling.md) topic. 
 // </snippet>

--- a/ui/styling/style-scope.ts
+++ b/ui/styling/style-scope.ts
@@ -200,7 +200,6 @@ export class StyleScope {
 
         var rules = ast.stylesheet.rules;
         var rule: cssParser.Rule;
-        var filteredDeclarations: cssParser.Declaration[];
         var i;
         var j;
 
@@ -209,11 +208,25 @@ export class StyleScope {
             rule = rules[i];
             // Skip comment nodes.
             if (rule.type === "rule") {
+
                 // Filter comment nodes.
-                filteredDeclarations = rule.declarations.filter((val, i, arr) => { return val.type === "declaration" });
-                for (j = 0; j < rule.selectors.length; j++) {
-                    result.push(cssSelector.createSelector(rule.selectors[j], filteredDeclarations));
+                var filteredDeclarations = [];
+                if (rule.declarations) {
+                    for (j = 0; j < rule.declarations.length; j++) {
+                        var declaration = rule.declarations[j];
+                        if (declaration.type === "declaration") {
+                            filteredDeclarations.push({
+                                property: declaration.property.toLowerCase(),
+                                value: declaration.value
+                            });
+                        }
+                    }
                 }
+
+                    for (j = 0; j < rule.selectors.length; j++) {
+                        result.push(cssSelector.createSelector(rule.selectors[j], filteredDeclarations));
+                    }
+                //}
             }
         }
 


### PR DESCRIPTION
1. Changed code to lowercase the declaration property
2. Minimize the data pushed to each rule (by about half)

Benchmark on v8 shows this new code is about a 1/3 faster than the original code.  (Not to mention it should cause less memory pressure as it saves memory per css rule).

This is to fix #623 