### PR TITLE
Dialog action fix

### DIFF
--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -209,7 +209,7 @@ export function action(arg: any): Promise<string> {
 
     var options: dialogs.ActionOptions;
 
-    var defaultOptions = { cancelButtonText: dialogsCommon.CANCEL };
+    var defaultOptions = { title: null, cancelButtonText: dialogsCommon.CANCEL };
 
     if (arguments.length === 1) {
         if (types.isString(arguments[0])) {
@@ -236,7 +236,16 @@ export function action(arg: any): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         try {
             var alert = new android.app.AlertDialog.Builder(appmodule.android.foregroundActivity);
-            alert.setTitle(options && types.isString(options.message) ? options.message : "");
+            var message = options && types.isString(options.message) ? options.message : "";
+            var title = options && types.isString(options.title) ? options.title : "";
+            
+            if (title) {
+                alert.setTitle(title);
+                alert.setMessage(message);
+            }
+            else {
+                alert.setTitle(message);
+            }
 
             if (options.actions) {
                 alert.setItems(options.actions, new android.content.DialogInterface.OnClickListener({

--- a/ui/dialogs/dialogs.d.ts
+++ b/ui/dialogs/dialogs.d.ts
@@ -87,6 +87,11 @@ declare module "ui/dialogs" {
      */
     export interface ActionOptions {
         /**
+         * Gets or sets the dialog title.
+         */
+        title?: string;
+
+        /**
          * Gets or sets the dialog message.
          */
         message?: string;

--- a/ui/dialogs/dialogs.ios.ts
+++ b/ui/dialogs/dialogs.ios.ts
@@ -387,7 +387,7 @@ function showUIAlertController(alertController: UIAlertController) {
 export function action(arg: any): Promise<string> {
     var options: dialogs.ActionOptions;
 
-    var defaultOptions = { cancelButtonText: dialogsCommon.CANCEL };
+    var defaultOptions = { title: null, cancelButtonText: dialogsCommon.CANCEL };
 
     if (arguments.length === 1) {
         if (types.isString(arguments[0])) {
@@ -445,7 +445,7 @@ export function action(arg: any): Promise<string> {
                 actionSheet.delegate = delegate;
                 actionSheet.showInView(UIApplication.sharedApplication().keyWindow);
             } else {
-                var alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.message, null, UIAlertControllerStyle.UIAlertControllerStyleActionSheet);
+                var alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.UIAlertControllerStyleActionSheet);
 
                 if (options.actions) {
                     for (i = 0; i < options.actions.length; i++) {

--- a/ui/dialogs/dialogs.ios.ts
+++ b/ui/dialogs/dialogs.ios.ts
@@ -445,7 +445,7 @@ export function action(arg: any): Promise<string> {
                 actionSheet.delegate = delegate;
                 actionSheet.showInView(UIApplication.sharedApplication().keyWindow);
             } else {
-                var alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.message, "", UIAlertControllerStyle.UIAlertControllerStyleActionSheet);
+                var alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.message, null, UIAlertControllerStyle.UIAlertControllerStyleActionSheet);
 
                 if (options.actions) {
                     for (i = 0; i < options.actions.length; i++) {


### PR DESCRIPTION
If the user wants to display only action sheet buttons w/o any text and
he sends null as message, the empty string causes an empty title to be
shown above the buttons. Having null instead, completely eliminates the
empty space.