### PR TITLE
Added method setError to the textfield && Added the options passwordHint and userNameHint

### DIFF
--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -176,10 +176,12 @@ export function login(arg: any): Promise<dialogs.LoginResult> {
 
             var userNameInput = new android.widget.EditText(context);
             userNameInput.setText(options.userName ? options.userName : "");
+            userNameInput.setHint(options.userNameHint ? options.userNameHint : "");
 
             var passwordInput = new android.widget.EditText(context);
             passwordInput.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
             passwordInput.setText(options.password ? options.password : "");
+            passwordInput.setHint(options.passwordHint ? options.passwordHint : "");
 
             var layout = new android.widget.LinearLayout(context);
             layout.setOrientation(1);

--- a/ui/text-field/text-field.android.ts
+++ b/ui/text-field/text-field.android.ts
@@ -49,4 +49,8 @@ export class TextField extends common.TextField {
         this.android.setMaxLines(1);
         this.android.setHorizontallyScrolling(true);
     }
+    
+    public setError(errString) {
+        this.android.setError(errString==""?null:errString);
+    }
 }


### PR DESCRIPTION
Hi,
i've added on the android branch of the text-field the method setError,
in android this method is used to validate the fields
i don't know the equivalent on ios, but i found that simple script that can be implemented https://github.com/tomkowz/TSValidatedTextField


Edit :

I've discovered that the options password and userName in the Login Dialog, set the defaults values for this fields.

I've added this two options to help the user to understand what the fields mean
