### PR TITLE
Link click detection

### DIFF
--- a/ui/html-view/html-view.android.ts
+++ b/ui/html-view/html-view.android.ts
@@ -30,5 +30,7 @@ export class HtmlView extends common.HtmlView {
 
     public _createUI() {
         this._android = new android.widget.TextView(this._context);
+        this._android.setAutoLinkMask(15); // 15 (0x0f) = Linkify All
     }
+
 }

--- a/ui/html-view/html-view.android.ts
+++ b/ui/html-view/html-view.android.ts
@@ -10,6 +10,13 @@ function onHtmlPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     }
 
     if (types.isString(data.newValue)) {
+        // If the data.newValue actually has a <a...> in it; we need to disable auto-linking
+        // as it internally disables anyways; and then links won't work..
+        if (data.newValue.toLowerCase().indexOf("<a ") > 0) {
+            view.android.setAutoLinkMask(0);
+        } else {
+            view.android.setAutoLinkMask(15); // 15 (0x0f) = Linkify All text links
+        }
         view.android.setText(<any>android.text.Html.fromHtml(data.newValue));
     } else {
         view.android.setText("");
@@ -30,7 +37,10 @@ export class HtmlView extends common.HtmlView {
 
     public _createUI() {
         this._android = new android.widget.TextView(this._context);
-        this._android.setAutoLinkMask(15); // 15 (0x0f) = Linkify All
+        // This makes the <a href...> work
+        this._android.setLinksClickable(true);
+        this._android.setMovementMethod(android.text.method.LinkMovementMethod.getInstance());
+
     }
 
 }

--- a/ui/html-view/html-view.android.ts
+++ b/ui/html-view/html-view.android.ts
@@ -10,13 +10,14 @@ function onHtmlPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     }
 
     if (types.isString(data.newValue)) {
-        // If the data.newValue actually has a <a...> in it; we need to disable auto-linking
-        // as it internally disables anyways; and then links won't work..
-        if (data.newValue.toLowerCase().indexOf("<a ") > 0) {
-            view.android.setAutoLinkMask(0);
-        } else {
-            view.android.setAutoLinkMask(15); // 15 (0x0f) = Linkify All text links
+        // If the data.newValue actually has a <a...> in it; we need to disable autolink mask
+        // it internally disables the coloring, but then the <a> links won't work..  So to support both
+        // styles of links (html and just text based) we have to manually enable/disable the autolink mask
+        var mask = 15;
+        if (data.newValue.search(/<a\s/i) >= 0) {
+            mask = 0;
         }
+        view.android.setAutoLinkMask(mask);
         view.android.setText(<any>android.text.Html.fromHtml(data.newValue));
     } else {
         view.android.setText("");
@@ -37,7 +38,7 @@ export class HtmlView extends common.HtmlView {
 
     public _createUI() {
         this._android = new android.widget.TextView(this._context);
-        // This makes the <a href...> work
+        // This makes the html <a href...> vwork
         this._android.setLinksClickable(true);
         this._android.setMovementMethod(android.text.method.LinkMovementMethod.getInstance());
 

--- a/ui/html-view/html-view.ios.ts
+++ b/ui/html-view/html-view.ios.ts
@@ -27,21 +27,24 @@ function onHtmlPropertyChanged(data: dependencyObservable.PropertyChangeData) {
 global.moduleMerge(common, exports);
 
 export class HtmlView extends common.HtmlView {
-    private _ios: UILabel;
+    private _ios: UITextView;
 
     constructor(options?: definition.Options) {
         super(options);
+        this._ios = UITextView.new();
 
-        this._ios = new UILabel();
-        this._ios.userInteractionEnabled = true;
-        this._ios.numberOfLines = 0;
+        this._ios.scrollEnabled = false;
+        this._ios.editable = false;
+        this._ios.selectable = true;
+        this._ios.userInteractionEnabled  = true;
+        this._ios.dataDetectorTypes = 255; // Future Proof this; valid max in iOS is currently 15; however ALL = MAX UNSIGNED INT which isn't valid in JavaScript
     }
 
-    get ios(): UILabel {
+    get ios(): UITextView {
         return this._ios;
     }
 
-    get _nativeView(): UILabel {
+    get _nativeView(): UITextView {
         return this._ios;
     }
 

--- a/ui/html-view/html-view.ios.ts
+++ b/ui/html-view/html-view.ios.ts
@@ -37,7 +37,7 @@ export class HtmlView extends common.HtmlView {
         this._ios.editable = false;
         this._ios.selectable = true;
         this._ios.userInteractionEnabled  = true;
-        this._ios.dataDetectorTypes = 255; // Future Proof this; valid max in iOS is currently 15; however ALL = MAX UNSIGNED INT which isn't valid in JavaScript
+        this._ios.dataDetectorTypes = UIDataDetectorTypes.UIDataDetectorTypeAll;
     }
 
     get ios(): UITextView {


### PR DESCRIPTION
This makes the <HtmlView> clickable and automatic parsing.

Please note; their is one **possible negative** to this code; on iOS to allow the clicking ability the label has to allow selection, so the user can actually select text (i.e. you can actually select & copy the "Go to") in the label.   However, for the minor drawback; you can now do:

\<HtmlView html="Go to http://www.master-technology.com or email me at me@somewhere"/> and both links will just work.   :grinning:  (And \<a href="...">Link Text\</a> now also works... on both platforms)