### PR TITLE
CSS and XML code files now can be specified in XML

### DIFF
--- a/CrossPlatformModules.csproj
+++ b/CrossPlatformModules.csproj
@@ -79,6 +79,7 @@
     <TypeScriptCompile Include="apps\action-bar-demo\pages\data-binding.ts">
       <DependentUpon>data-binding.xml</DependentUpon>
     </TypeScriptCompile>
+    <TypeScriptCompile Include="apps\tests\xml-declaration\custom-code-file.ts" />
     <TypeScriptCompile Include="apps\transforms\app.ts" />
     <TypeScriptCompile Include="apps\transforms\main-page.ts" />
     <TypeScriptCompile Include="apps\transforms\model.ts" />
@@ -110,6 +111,7 @@
     <Content Include="apps\action-bar-demo\pages\center-view-segmented.xml" />
     <Content Include="apps\action-bar-demo\pages\center-view.xml" />
     <Content Include="apps\action-bar-demo\pages\data-binding.xml" />
+    <Content Include="apps\tests\xml-declaration\custom-css-file.css" />
     <Content Include="apps\transforms\main-page.xml">
       <SubType>Designer</SubType>
     </Content>
@@ -1982,8 +1984,6 @@
           <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>
-      <UserProperties ui_2scroll-view_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2editable-text-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2absolute-layout-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2gallery-app_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2content-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2web-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2absolute-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2dock-layout_2package_1json__JSONSchema="" ui_2layouts_2grid-layout_2package_1json__JSONSchema="" ui_2layouts_2wrap-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" />
-      <UserProperties ui_2scroll-view_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2editable-text-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2absolute-layout-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2gallery-app_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2content-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2web-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2linear-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2absolute-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2dock-layout_2package_1json__JSONSchema="" ui_2layouts_2grid-layout_2package_1json__JSONSchema="" ui_2layouts_2wrap-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" />
       <UserProperties ui_2layouts_2wrap-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2grid-layout_2package_1json__JSONSchema="" ui_2layouts_2dock-layout_2package_1json__JSONSchema="" ui_2layouts_2absolute-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2web-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2content-view_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2gallery-app_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2absolute-layout-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2editable-text-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2scroll-view_2package_1json__JSONSchema="http://json.schemastore.org/package" />
     </VisualStudio>
   </ProjectExtensions>

--- a/apps/tests/xml-declaration/custom-code-file.ts
+++ b/apps/tests/xml-declaration/custom-code-file.ts
@@ -1,0 +1,3 @@
+﻿export function loaded(args) {
+    args.object.customCodeLoaded = true;
+}

--- a/apps/tests/xml-declaration/custom-css-file.css
+++ b/apps/tests/xml-declaration/custom-css-file.css
@@ -1,0 +1,3 @@
+﻿.MyClass {
+    background-color: green;
+}

--- a/apps/tests/xml-declaration/xml-declaration-tests.ts
+++ b/apps/tests/xml-declaration/xml-declaration-tests.ts
@@ -215,6 +215,25 @@ export function test_parse_ShouldApplyCssFromCssFile() {
     }
 };
 
+export function test_parse_ShouldResolveExportsFromCodeFileAndApplyCssFile() {
+    var newPage: Page;
+    var pageFactory = function (): Page {
+        newPage = <Page>builder.parse("<Page codeFile='~/xml-declaration/custom-code-file' cssFile='~/xml-declaration/custom-css-file.css' loaded='loaded'><Label cssClass='MyClass' /></Page>");
+        return newPage;
+    };
+
+    helper.navigate(pageFactory);
+    TKUnit.assert(newPage.isLoaded, "The page should be loaded here.");
+    TKUnit.assert((<any>newPage).customCodeLoaded, "Parse should resolve exports from custom code file.");
+    try {
+        helper.assertViewBackgroundColor(newPage.content, "#008000");
+    }
+    finally {
+        helper.goBack();
+    }
+};
+
+
 export function test_parse_ShouldFindEventHandlersInExports() {
     var loaded;
     var page = builder.parse("<Page loaded='myLoaded'></Page>", {

--- a/apps/tests/xml-declaration/xml-declaration-tests.ts
+++ b/apps/tests/xml-declaration/xml-declaration-tests.ts
@@ -233,7 +233,6 @@ export function test_parse_ShouldResolveExportsFromCodeFileAndApplyCssFile() {
     }
 };
 
-
 export function test_parse_ShouldFindEventHandlersInExports() {
     var loaded;
     var page = builder.parse("<Page loaded='myLoaded'></Page>", {

--- a/ui/builder/component-builder.ts
+++ b/ui/builder/component-builder.ts
@@ -99,7 +99,9 @@ export function getComponentModule(elementName: string, namespace: string, attri
             } else {
                 throw new Error("Code file atribute is valid only for pages!");
             }
-        } else if (attributes[CSSFILE]) {
+        }
+
+        if (attributes[CSSFILE]) {
             if (instance instanceof pages.Page) {
                 var cssFilePath = attributes[CSSFILE].trim();
                 if (cssFilePath.indexOf("~/") === 0) {

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -66,9 +66,9 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): pages.P
             throw new Error("Failed to load Page from entry.moduleName: " + entry.moduleName);
         }
 
-        // Possible CSS file path.
+        // Possible CSS file path. Add it only if CSS not already specified and loaded from cssFile Page attribute in XML.
         var cssFileName = fileResolverModule.resolveFileName(moduleNamePath, "css");
-        if (cssFileName) {
+        if (cssFileName && !page["cssFile"]) {
             page.addCssFile(cssFileName);
         }
     }


### PR DESCRIPTION
Implemented #675

Example:
#### XML
```XML
<Page codeFile="~/custom-code-file"
           cssFile="~/custom-css-file.css" loaded="loaded">
  <Label cssClass='MyClass' />
</Page>
```
#### Code
```TypeScript
export function loaded(args) {
    console.log("Custom code file loaded!")
}
```
#### CSS
```CSS
.MyClass {
    background-color: green;
}
```