### PR TITLE
Move layout special properties sets out of the component builder.

### DIFF
--- a/ui/builder/special-properties.ts
+++ b/ui/builder/special-properties.ts
@@ -1,0 +1,23 @@
+import view = require("ui/core/view");
+
+export type PropertySetter = (instance: view.View, propertyValue: string) => void;
+
+var specialProperties: Map<string, PropertySetter> = new Map<string, PropertySetter>();
+
+function specialPropertyKey(name: string) {
+    return name.toLowerCase();
+}
+
+export function registerSpecialProperty(name: string, setter: PropertySetter) {
+    let propertyKey = specialPropertyKey(name);
+    if (specialProperties.has(propertyKey)) {
+        throw new Error(`Property for ${propertyKey} already registered`);
+    } else {
+        specialProperties.set(propertyKey, setter);
+    }
+}
+
+export function getSpecialPropertySetter(name: string): PropertySetter {
+    let propertyKey = specialPropertyKey(name);
+    return specialProperties.get(propertyKey);
+}

--- a/ui/layouts/absolute-layout/absolute-layout-common.ts
+++ b/ui/layouts/absolute-layout/absolute-layout-common.ts
@@ -3,6 +3,7 @@ import definition = require("ui/layouts/absolute-layout");
 import dependencyObservable = require("ui/core/dependency-observable");
 import view = require("ui/core/view");
 import proxy = require("ui/core/proxy");
+import {registerSpecialProperty} from "ui/builder/special-properties";
 
 function validateArgs(element: view.View): view.View {
     if (!element) {
@@ -10,6 +11,13 @@ function validateArgs(element: view.View): view.View {
     }
     return element;
 }
+
+registerSpecialProperty("left", (instance, propertyValue) => {
+    AbsoluteLayout.setLeft(instance, !isNaN(+propertyValue) && +propertyValue);
+});
+registerSpecialProperty("top", (instance, propertyValue) => {
+    AbsoluteLayout.setTop(instance, !isNaN(+propertyValue) && +propertyValue);
+});
 
 export class AbsoluteLayout extends layouts.LayoutBase implements definition.AbsoluteLayout {
 

--- a/ui/layouts/dock-layout/dock-layout-common.ts
+++ b/ui/layouts/dock-layout/dock-layout-common.ts
@@ -4,6 +4,7 @@ import dependencyObservable = require("ui/core/dependency-observable");
 import view = require("ui/core/view");
 import enums = require("ui/enums");
 import proxy = require("ui/core/proxy");
+import {registerSpecialProperty} from "ui/builder/special-properties";
 
 // on Android we explicitly set propertySettings to None because android will invalidate its layout (skip unnecessary native call).
 var AffectsLayout = global.android ? dependencyObservable.PropertyMetadataSettings.None : dependencyObservable.PropertyMetadataSettings.AffectsLayout;
@@ -18,6 +19,10 @@ function validateArgs(element: view.View): view.View {
     }
     return element;
 }
+
+registerSpecialProperty("dock", (instance, propertyValue) => {
+    DockLayout.setDock(instance, propertyValue);
+});
 
 export class DockLayout extends layouts.LayoutBase implements definition.DockLayout {
 

--- a/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/ui/layouts/grid-layout/grid-layout-common.ts
@@ -6,6 +6,7 @@ import bindable = require("ui/core/bindable");
 import types = require("utils/types");
 import numberUtils = require("utils/number-utils");
 import proxy = require("ui/core/proxy");
+import {registerSpecialProperty} from "ui/builder/special-properties";
 
 function validateArgs(element: view.View): view.View {
     if (!element) {
@@ -19,6 +20,19 @@ export module GridUnitType {
     export var pixel: string = "pixel";
     export var star: string = "star";
 }
+
+registerSpecialProperty("row", (instance, propertyValue) => {
+    GridLayout.setRow(instance, !isNaN(+propertyValue) && +propertyValue);
+});
+registerSpecialProperty("col", (instance, propertyValue) => {
+    GridLayout.setColumn(instance, !isNaN(+propertyValue) && +propertyValue);
+});
+registerSpecialProperty("colSpan", (instance, propertyValue) => {
+    GridLayout.setColumnSpan(instance, !isNaN(+propertyValue) && +propertyValue);
+});
+registerSpecialProperty("rowSpan", (instance, propertyValue) => {
+    GridLayout.setRowSpan(instance, !isNaN(+propertyValue) && +propertyValue);
+});
 
 export class ItemSpec extends bindable.Bindable implements definition.ItemSpec {
 


### PR DESCRIPTION
Setters registered by the respective modules on import.

As requested by @ligaz [here](https://github.com/NativeScript/NativeScript/pull/702#issuecomment-139123742). 
@enchev's [PR](https://github.com/NativeScript/NativeScript/pull/706) needs to be merged first