### PR TITLE
This fixes the issue with the android Dialogs 

### DIFF
--- a/ui/page/page-common.ts
+++ b/ui/page/page-common.ts
@@ -33,9 +33,10 @@ export class Page extends contentView.ContentView implements dts.Page {
     public static navigatedFromEvent = "navigatedFrom";
     public static shownModallyEvent = "shownModally";
 
+    protected _closeModalCallback: Function;
+
     private _navigationContext: any;
 
-    private _closeDialogCallback: Function;
     private _cssApplied: boolean;
     private _styleScope: styleScope.StyleScope = new styleScope.StyleScope();
     private _actionBar: actionBar.ActionBar;
@@ -190,9 +191,9 @@ export class Page extends contentView.ContentView implements dts.Page {
         (<Page>page)._showNativeModalView(this, context, closeCallback, fullscreen);
     }
 
-    public closeDialog() {
-        if (this._closeDialogCallback) {
-            this._closeDialogCallback.apply(undefined, arguments);
+    public closeModal() {
+        if (this._closeModalCallback) {
+            this._closeModalCallback.apply(undefined, arguments);
         }
     }
 
@@ -207,9 +208,9 @@ export class Page extends contentView.ContentView implements dts.Page {
 
     protected _showNativeModalView(parent: Page, context: any, closeCallback: Function, fullscreen?: boolean) {
         var that = this;
-        this._closeDialogCallback = function () {
-            if (that._closeDialogCallback) {
-                that._closeDialogCallback = null;
+        this._closeModalCallback = function () {
+            if (that._closeModalCallback) {
+                that._closeModalCallback = null;
                 that._hideNativeModalView(parent);
                 if (typeof closeCallback === "function") {
                     closeCallback.apply(undefined, arguments);
@@ -227,7 +228,7 @@ export class Page extends contentView.ContentView implements dts.Page {
             eventName: Page.shownModallyEvent,
             object: this,
             context: context,
-            closeCallback: this._closeDialogCallback
+            closeCallback: this._closeModalCallback
         });
     }
 

--- a/ui/page/page.android.ts
+++ b/ui/page/page.android.ts
@@ -12,12 +12,14 @@ global.moduleMerge(pageCommon, exports);
 class DialogFragmentClass extends android.app.DialogFragment {
     private _owner: Page;
     private _fullscreen: boolean;
+    private _dismissCallback: Function;
 
-    constructor(owner: Page, fullscreen?: boolean) {
+    constructor(owner: Page, fullscreen?: boolean, dismissCallback?: Function) {
         super();
 
         this._owner = owner;
         this._fullscreen = fullscreen;
+        this._dismissCallback = dismissCallback;
         return global.__native(this);
     }
 
@@ -29,11 +31,18 @@ class DialogFragmentClass extends android.app.DialogFragment {
         window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
 
         if (this._fullscreen) {
-        window.setLayout(android.view.ViewGroup.LayoutParams.FILL_PARENT, android.view.ViewGroup.LayoutParams.FILL_PARENT);
+            window.setLayout(android.view.ViewGroup.LayoutParams.FILL_PARENT, android.view.ViewGroup.LayoutParams.FILL_PARENT);
         }
         
         return dialog;
     }
+
+    public onDismiss() {
+        if (typeof this._dismissCallback === "function") {
+            this._dismissCallback();
+        }
+    }
+
 };
 
 export class Page extends pageCommon.Page {
@@ -96,6 +105,7 @@ export class Page extends pageCommon.Page {
     private _dialogFragment: DialogFragmentClass;
     /* tslint:enable */
     protected _showNativeModalView(parent: Page, context: any, closeCallback: Function, fullscreen?: boolean) {
+        super._showNativeModalView(parent, context, closeCallback, fullscreen);
         if (!this.backgroundColor) {
             this.backgroundColor = new color.Color("White");
         }
@@ -104,7 +114,10 @@ export class Page extends pageCommon.Page {
         this._isAddedToNativeVisualTree = true;
         this.onLoaded();
 
-        this._dialogFragment = new DialogFragmentClass(this, fullscreen);
+        var that = this;
+        this._dialogFragment = new DialogFragmentClass(this, fullscreen, function() {
+            that.closeDialog();
+        });
         this._dialogFragment.show(parent.frame.android.activity.getFragmentManager(), "dialog");        
         
         super._raiseShownModallyEvent(parent, context, closeCallback);

--- a/ui/page/page.android.ts
+++ b/ui/page/page.android.ts
@@ -65,7 +65,11 @@ export class Page extends pageCommon.Page {
     public _createUI() {
         this._grid = new org.nativescript.widgets.GridLayout(this._context);
         this._grid.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
-        this._grid.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+        var gridUnitType = org.nativescript.widgets.GridUnitType.star
+        if (this._closeModalCallback) {
+            gridUnitType = org.nativescript.widgets.GridUnitType.auto;
+        }
+        this._grid.addRow(new org.nativescript.widgets.ItemSpec(1, gridUnitType));
     }
 
     public _addViewToNativeVisualTree(child: view.View, atIndex?: number): boolean {
@@ -116,7 +120,7 @@ export class Page extends pageCommon.Page {
 
         var that = this;
         this._dialogFragment = new DialogFragmentClass(this, fullscreen, function() {
-            that.closeDialog();
+            that.closeModal();
         });
         this._dialogFragment.show(parent.frame.android.activity.getFragmentManager(), "dialog");        
         

--- a/ui/page/page.ios.ts
+++ b/ui/page/page.ios.ts
@@ -129,6 +129,7 @@ export class Page extends pageCommon.Page {
     }
 
     protected _showNativeModalView(parent: Page, context: any, closeCallback: Function, fullscreen?: boolean) {
+        super._showNativeModalView(parent, context, closeCallback, fullscreen);
         this._isModal = true;
 
         if (!parent.ios.view.window) {


### PR DESCRIPTION
On Android either the dialogs can be dismissed by clicking anywhere elsewhere on the screen on Android.  (Also a couple other things can cause the OS to auto-dismiss the dialog) In all these cases the dialog will now call the callback with a null value as the first parameter (and finish calling the unloaded and other code that is supposed to be ran when the dialog is closed).   

This patch also adds the convenience function; closeDialog, that you can call from the dialog screen page component which will also do all the same cleanup and call the close callback for you.  (i.e. var page = object.args;  page.closeDialog("Value1", "Value2"...);  