### PR TITLE
use isNullOrUndefined instead of isUndefined

### DIFF
--- a/file-system/file-system-access.android.ts
+++ b/file-system/file-system-access.android.ts
@@ -210,7 +210,7 @@ export class FileSystemAccess {
             var result = "";
             while (true) {
                 line = bufferedReader.readLine();
-                if (types.isUndefined(line)) {
+                if (types.isNullOrUndefined(line)) {
                     break;
                 }
 


### PR DESCRIPTION
Due a bug in the Android runtime when a Java method returns `null` value it was propagated as `undefined` in JavaScript. This is no longer the case. As a result, the current loop check never holds `true`. The proposed workaround is to use `isNullOrUndefined` instead of `isUndefined`. Another, yet simpler solution is to use `line === null` check.