### PR TITLE
Typescript 1.6

### DIFF
--- a/apps/tests/layouts/dock-layout-tests.ts
+++ b/apps/tests/layouts/dock-layout-tests.ts
@@ -50,9 +50,9 @@ export function setUpModule() {
 
 export function tearDownModule() {
     navHelper.goBack();
-    delete testPage;
-    delete rootLayout;
-    delete tmp;
+    testPage = null;
+    rootLayout = null;
+    tmp = null;
 }
 
 export function setUp() {

--- a/apps/tests/layouts/grid-layout-tests.ts
+++ b/apps/tests/layouts/grid-layout-tests.ts
@@ -52,9 +52,9 @@ export function setUpModule() {
 export function tearDownModule() {
     navHelper.goBack();
 
-    delete tmp;
-    delete newPage;
-    delete rootLayout;
+    tmp = null;
+    newPage = null;
+    rootLayout = null;
 }
 
 export function setUp() {

--- a/apps/tests/layouts/stack-layout-tests.ts
+++ b/apps/tests/layouts/stack-layout-tests.ts
@@ -29,11 +29,11 @@ export function setUpModule() {
 
 export function tearDownModule() {
     navHelper.goBack();
-    delete tmp;
-    delete newPage;
-    delete rootLayout;
-    delete btn1;
-    delete btn2;
+    tmp = null;
+    newPage = null;
+    rootLayout = null;
+    btn1 = null;
+    btn2 = null;
 }
 
 export function setUp() {

--- a/apps/tests/ui/scroll-view/scroll-view-tests.ts
+++ b/apps/tests/ui/scroll-view/scroll-view-tests.ts
@@ -49,9 +49,9 @@ export function setUpModule() {
 
 export function tearDownModule() {
     helper.goBack();
-    delete tmp;
-    delete newPage;
-    delete scrollView;
+    tmp = null;
+    newPage = null;
+    scrollView = null;
 }
 
 export function setUp() {

--- a/apps/tests/ui/style/style-properties-tests.ts
+++ b/apps/tests/ui/style/style-properties-tests.ts
@@ -25,8 +25,8 @@ export function setUpModule() {
 
 export function tearDownModule() {
     helper.goBack();
-    delete testBtn;
-    delete testPage;
+    testBtn = null;
+    testPage = null;
 }
 
 export function tearDown() {

--- a/data/observable/observable.d.ts
+++ b/data/observable/observable.d.ts
@@ -97,7 +97,7 @@ declare module "data/observable" {
          * Notifies all the registered listeners for the event provided in the data.eventName.
          * @param data The data associated with the event.
          */
-        notify(data: EventData): void;
+        notify<T extends EventData>(data: T): void;
 
         /**
          * Notifies all the registered listeners for the property change event.

--- a/data/observable/observable.ts
+++ b/data/observable/observable.ts
@@ -118,7 +118,7 @@ export class Observable implements definition.Observable {
         this[data.propertyName] = data.value;
     }
 
-    public notify(data: definition.EventData) {
+    public notify<T extends definition.EventData>(data: T) {
         var observers = this._getEventList(data.eventName);
         if (!observers) {
             return;

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -309,6 +309,12 @@ module.exports = function(grunt) {
                 outDir: localCfg.outModulesDir,
                 options: {
                     fast: 'never',
+
+                    // Resolve non-relative modules like "ui/styling/style"
+                    // based on the project root (not on node_modules which
+                    // is the typescript 1.6+ default)
+                    additionalFlags: '--moduleResolution classic',
+
                     module: "commonjs",
                     target: "es5",
                     sourceMap: false,

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "grunt-exec": "0.4.6",
     "grunt-multi-dest": "1.0.0",
     "grunt-shell": "1.1.2",
-    "grunt-ts": "4.2.0",
+    "grunt-ts": "5.0.0-beta.5",
     "grunt-tslint": "2.4.0",
     "mocha": "2.2.5",
     "grunt-simple-mocha": "0.4.0",
     "grunt-env": "0.4.4",
     "chai": "3.2.0",
-    "typescript": "1.5.3"
+    "typescript": "1.6.2"
   }
 }

--- a/ui/animation/animation.ios.ts
+++ b/ui/animation/animation.ios.ts
@@ -272,8 +272,7 @@ export class Animation extends common.Animation implements definition.Animation 
                         value: Animation._affineTransform(CGAffineTransformIdentity, propertyAnimations[i].property, propertyAnimations[i].value),
                         duration: propertyAnimations[i].duration,
                         delay: propertyAnimations[i].delay,
-                        iterations: propertyAnimations[i].iterations,
-                        iosUIViewAnimationCurve: propertyAnimations[i].curve
+                        iterations: propertyAnimations[i].iterations
                     };
                     trace.write("Created new transform animation: " + common.Animation._getAnimationInfo(newTransformAnimation), trace.categories.Animation);
 

--- a/ui/builder/component-builder.ts
+++ b/ui/builder/component-builder.ts
@@ -1,5 +1,4 @@
 ﻿import view = require("ui/core/view");
-import bindable = require("ui/core/bindable");
 import types = require("utils/types");
 import definition = require("ui/builder/component-builder");
 import fs = require("file-system");

--- a/ui/builder/component-builder.ts
+++ b/ui/builder/component-builder.ts
@@ -101,8 +101,6 @@ export function getComponentModule(elementName: string, namespace: string, attri
     }
 
     if (instance && instanceModule) {
-        var bindings = new Array<bindable.BindingOptions>();
-
         for (var attr in attributes) {
 
             var attrValue = <string>attributes[attr];
@@ -136,7 +134,7 @@ export function getComponentModule(elementName: string, namespace: string, attri
             }
         }
 
-        componentModule = { component: instance, exports: instanceModule, bindings: bindings };
+        componentModule = {component: instance, exports: instanceModule};
     }
 
     return componentModule;

--- a/ui/button/button.android.ts
+++ b/ui/button/button.android.ts
@@ -1,10 +1,7 @@
 ﻿import common = require("ui/button/button-common");
+import utils = require("utils/utils")
 
 global.moduleMerge(common, exports);
-
-interface Owned {
-    owner: any;
-}
 
 export class Button extends common.Button {
     private _android: android.widget.Button;
@@ -27,7 +24,7 @@ export class Button extends common.Button {
         this._android = new android.widget.Button(this._context);
 
         this._android.setOnClickListener(new android.view.View.OnClickListener(
-            <Owned & android.view.View.IOnClickListener>{
+            <utils.Owned & android.view.View.IOnClickListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/button/button.android.ts
+++ b/ui/button/button.android.ts
@@ -2,6 +2,10 @@
 
 global.moduleMerge(common, exports);
 
+interface Owned {
+    owner: any;
+}
+
 export class Button extends common.Button {
     private _android: android.widget.Button;
     private _isPressed: boolean;
@@ -22,7 +26,8 @@ export class Button extends common.Button {
 
         this._android = new android.widget.Button(this._context);
 
-        this._android.setOnClickListener(new android.view.View.OnClickListener({
+        this._android.setOnClickListener(new android.view.View.OnClickListener(
+            <Owned & android.view.View.IOnClickListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/date-picker/date-picker.android.ts
+++ b/ui/date-picker/date-picker.android.ts
@@ -2,6 +2,7 @@
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
 import types = require("utils/types");
+import utils = require("utils/utils")
 
 function onYearPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var picker = <DatePicker>data.object;
@@ -65,10 +66,6 @@ function onMinDatePropertyChanged(data: dependencyObservable.PropertyChangeData)
 
 global.moduleMerge(common, exports);
 
-interface Owned {
-    owner: any;
-}
-
 export class DatePicker extends common.DatePicker {
     private _android: android.widget.DatePicker;
     public _listener: android.widget.DatePicker.OnDateChangedListener;
@@ -83,7 +80,7 @@ export class DatePicker extends common.DatePicker {
         var that = new WeakRef(this);
 
         this._listener = new android.widget.DatePicker.OnDateChangedListener(
-            <Owned & android.widget.DatePicker.IOnDateChangedListener>{
+            <utils.Owned & android.widget.DatePicker.IOnDateChangedListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/date-picker/date-picker.android.ts
+++ b/ui/date-picker/date-picker.android.ts
@@ -65,6 +65,10 @@ function onMinDatePropertyChanged(data: dependencyObservable.PropertyChangeData)
 
 global.moduleMerge(common, exports);
 
+interface Owned {
+    owner: any;
+}
+
 export class DatePicker extends common.DatePicker {
     private _android: android.widget.DatePicker;
     public _listener: android.widget.DatePicker.OnDateChangedListener;
@@ -78,7 +82,8 @@ export class DatePicker extends common.DatePicker {
 
         var that = new WeakRef(this);
 
-        this._listener = new android.widget.DatePicker.OnDateChangedListener({
+        this._listener = new android.widget.DatePicker.OnDateChangedListener(
+            <Owned & android.widget.DatePicker.IOnDateChangedListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/list-picker/list-picker.android.ts
+++ b/ui/list-picker/list-picker.android.ts
@@ -1,12 +1,9 @@
 ﻿import common = require("ui/list-picker/list-picker-common");
 import dependencyObservable = require("ui/core/dependency-observable");
 import types = require("utils/types");
+import utils = require("utils/utils")
 
 global.moduleMerge(common, exports);
-
-interface Owned {
-    owner: any;
-}
 
 export class ListPicker extends common.ListPicker {
     private _android: android.widget.NumberPicker;
@@ -33,7 +30,7 @@ export class ListPicker extends common.ListPicker {
         var that = new WeakRef(this);
 
         this._formatter = new android.widget.NumberPicker.Formatter(
-            <Owned & android.widget.NumberPicker.IFormatter>{
+            <utils.Owned & android.widget.NumberPicker.IFormatter>{
             get owner(): ListPicker {
                 return that.get();
             },
@@ -48,7 +45,7 @@ export class ListPicker extends common.ListPicker {
         });
         this._android.setFormatter(this._formatter);
 
-        this._valueChangedListener = new android.widget.NumberPicker.OnValueChangeListener(<Owned & android.widget.NumberPicker.IOnValueChangeListener>{
+        this._valueChangedListener = new android.widget.NumberPicker.OnValueChangeListener(<utils.Owned & android.widget.NumberPicker.IOnValueChangeListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/list-picker/list-picker.android.ts
+++ b/ui/list-picker/list-picker.android.ts
@@ -4,6 +4,10 @@ import types = require("utils/types");
 
 global.moduleMerge(common, exports);
 
+interface Owned {
+    owner: any;
+}
+
 export class ListPicker extends common.ListPicker {
     private _android: android.widget.NumberPicker;
     private _valueChangedListener: android.widget.NumberPicker.OnValueChangeListener;
@@ -28,7 +32,8 @@ export class ListPicker extends common.ListPicker {
 
         var that = new WeakRef(this);
 
-        this._formatter = new android.widget.NumberPicker.Formatter({
+        this._formatter = new android.widget.NumberPicker.Formatter(
+            <Owned & android.widget.NumberPicker.IFormatter>{
             get owner(): ListPicker {
                 return that.get();
             },
@@ -43,7 +48,7 @@ export class ListPicker extends common.ListPicker {
         });
         this._android.setFormatter(this._formatter);
 
-        this._valueChangedListener = new android.widget.NumberPicker.OnValueChangeListener({
+        this._valueChangedListener = new android.widget.NumberPicker.OnValueChangeListener(<Owned & android.widget.NumberPicker.IOnValueChangeListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/list-view/list-view.android.ts
+++ b/ui/list-view/list-view.android.ts
@@ -7,6 +7,7 @@ import proxy = require("ui/core/proxy");
 import dependencyObservable = require("ui/core/dependency-observable");
 import color = require("color");
 import definition = require("ui/list-view");
+import utils = require("utils/utils")
 
 var ITEMLOADING = common.ListView.itemLoadingEvent;
 var LOADMOREITEMS = common.ListView.loadMoreItemsEvent;
@@ -25,10 +26,6 @@ function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChan
         bar.android.setDivider(new android.graphics.drawable.ColorDrawable((<color.Color>data.newValue).android));
         bar.android.setDividerHeight(1);
     }
-}
-
-interface Owned {
-    owner: any;
 }
 
 // register the setNativeValue callbacks
@@ -54,7 +51,7 @@ export class ListView extends common.ListView {
         var that = new WeakRef(this);
 
         // TODO: This causes many marshalling calls, rewrite in Java and generate bindings
-        this.android.setOnScrollListener(new android.widget.AbsListView.OnScrollListener(<Owned & android.widget.AbsListView.IOnScrollListener>{
+        this.android.setOnScrollListener(new android.widget.AbsListView.OnScrollListener(<utils.Owned & android.widget.AbsListView.IOnScrollListener>{
             onScrollStateChanged: function (view: android.widget.AbsListView, scrollState: number) {
                 var owner: ListView = this.owner;
                 if (!owner) {

--- a/ui/list-view/list-view.android.ts
+++ b/ui/list-view/list-view.android.ts
@@ -27,6 +27,10 @@ function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChan
     }
 }
 
+interface Owned {
+    owner: any;
+}
+
 // register the setNativeValue callbacks
 (<proxy.PropertyMetadata>common.ListView.separatorColorProperty.metadata).onSetNativeValue = onSeparatorColorPropertyChanged;
 
@@ -50,7 +54,7 @@ export class ListView extends common.ListView {
         var that = new WeakRef(this);
 
         // TODO: This causes many marshalling calls, rewrite in Java and generate bindings
-        this.android.setOnScrollListener(new android.widget.AbsListView.OnScrollListener({
+        this.android.setOnScrollListener(new android.widget.AbsListView.OnScrollListener(<Owned & android.widget.AbsListView.IOnScrollListener>{
             onScrollStateChanged: function (view: android.widget.AbsListView, scrollState: number) {
                 var owner: ListView = this.owner;
                 if (!owner) {

--- a/ui/search-bar/search-bar.android.ts
+++ b/ui/search-bar/search-bar.android.ts
@@ -3,6 +3,7 @@ import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
 import color = require("color");
 import types = require("utils/types");
+import utils = require("utils/utils")
 
 var SEARCHTEXT = "searchText";
 var QUERY = "query";
@@ -92,10 +93,6 @@ function _changeSearchViewHintColor(bar: android.widget.SearchView, color: numbe
 
 global.moduleMerge(common, exports);
 
-interface Owned {
-    owner: any;
-}
-
 export class SearchBar extends common.SearchBar {
     private _android: android.widget.SearchView;
 
@@ -105,7 +102,7 @@ export class SearchBar extends common.SearchBar {
         this._android.setIconified(false);
 
         var that = new WeakRef(this);
-        this._android.setOnQueryTextListener(new android.widget.SearchView.OnQueryTextListener(<Owned & android.widget.SearchView.IOnQueryTextListener>{
+        this._android.setOnQueryTextListener(new android.widget.SearchView.OnQueryTextListener(<utils.Owned & android.widget.SearchView.IOnQueryTextListener>{
             get owner() {
                 return that.get();
             },
@@ -136,7 +133,7 @@ export class SearchBar extends common.SearchBar {
             }
         }));
 
-        this._android.setOnCloseListener(new android.widget.SearchView.OnCloseListener(<Owned & android.widget.SearchView.IOnCloseListener>{
+        this._android.setOnCloseListener(new android.widget.SearchView.OnCloseListener(<utils.Owned & android.widget.SearchView.IOnCloseListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/search-bar/search-bar.android.ts
+++ b/ui/search-bar/search-bar.android.ts
@@ -92,6 +92,10 @@ function _changeSearchViewHintColor(bar: android.widget.SearchView, color: numbe
 
 global.moduleMerge(common, exports);
 
+interface Owned {
+    owner: any;
+}
+
 export class SearchBar extends common.SearchBar {
     private _android: android.widget.SearchView;
 
@@ -101,7 +105,7 @@ export class SearchBar extends common.SearchBar {
         this._android.setIconified(false);
 
         var that = new WeakRef(this);
-        this._android.setOnQueryTextListener(new android.widget.SearchView.OnQueryTextListener({
+        this._android.setOnQueryTextListener(new android.widget.SearchView.OnQueryTextListener(<Owned & android.widget.SearchView.IOnQueryTextListener>{
             get owner() {
                 return that.get();
             },
@@ -132,7 +136,7 @@ export class SearchBar extends common.SearchBar {
             }
         }));
 
-        this._android.setOnCloseListener(new android.widget.SearchView.OnCloseListener({
+        this._android.setOnCloseListener(new android.widget.SearchView.OnCloseListener(<Owned & android.widget.SearchView.IOnCloseListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/switch/switch.android.ts
+++ b/ui/switch/switch.android.ts
@@ -16,6 +16,10 @@ function onCheckedPropertyChanged(data: dependencyObservable.PropertyChangeData)
 
 global.moduleMerge(common, exports);
 
+interface Owned {
+    owner: any;
+}
+
 export class Switch extends common.Switch {
     private _android: android.widget.Switch;
 
@@ -28,7 +32,7 @@ export class Switch extends common.Switch {
 
         var that = new WeakRef(this);
 
-        this._android.setOnCheckedChangeListener(new android.widget.CompoundButton.OnCheckedChangeListener({
+        this._android.setOnCheckedChangeListener(new android.widget.CompoundButton.OnCheckedChangeListener(<Owned & android.widget.CompoundButton.IOnCheckedChangeListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/switch/switch.android.ts
+++ b/ui/switch/switch.android.ts
@@ -1,6 +1,7 @@
 ﻿import common = require("ui/switch/switch-common");
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
+import utils = require("utils/utils")
 
 function onCheckedPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var swtch = <Switch>data.object;
@@ -16,10 +17,6 @@ function onCheckedPropertyChanged(data: dependencyObservable.PropertyChangeData)
 
 global.moduleMerge(common, exports);
 
-interface Owned {
-    owner: any;
-}
-
 export class Switch extends common.Switch {
     private _android: android.widget.Switch;
 
@@ -32,7 +29,7 @@ export class Switch extends common.Switch {
 
         var that = new WeakRef(this);
 
-        this._android.setOnCheckedChangeListener(new android.widget.CompoundButton.OnCheckedChangeListener(<Owned & android.widget.CompoundButton.IOnCheckedChangeListener>{
+        this._android.setOnCheckedChangeListener(new android.widget.CompoundButton.OnCheckedChangeListener(<utils.Owned & android.widget.CompoundButton.IOnCheckedChangeListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/time-picker/time-picker.android.ts
+++ b/ui/time-picker/time-picker.android.ts
@@ -1,6 +1,7 @@
 ﻿import common = require("ui/time-picker/time-picker-common");
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
+import utils = require("utils/utils")
 
 function onHourPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var picker = <TimePicker>data.object;
@@ -18,10 +19,6 @@ function onMinutePropertyChanged(data: dependencyObservable.PropertyChangeData) 
 
 global.moduleMerge(common, exports);
 
-interface Owned {
-    owner: any;
-}
-
 export class TimePicker extends common.TimePicker {
     private _android: android.widget.TimePicker;
     private _listener: android.widget.TimePicker.OnTimeChangedListener;
@@ -37,7 +34,7 @@ export class TimePicker extends common.TimePicker {
         var that = new WeakRef(this);
 
         this._listener = new android.widget.TimePicker.OnTimeChangedListener(
-            <Owned & android.widget.TimePicker.IOnTimeChangedListener>{
+            <utils.Owned & android.widget.TimePicker.IOnTimeChangedListener>{
             get owner() {
                 return that.get();
             },

--- a/ui/time-picker/time-picker.android.ts
+++ b/ui/time-picker/time-picker.android.ts
@@ -18,6 +18,10 @@ function onMinutePropertyChanged(data: dependencyObservable.PropertyChangeData) 
 
 global.moduleMerge(common, exports);
 
+interface Owned {
+    owner: any;
+}
+
 export class TimePicker extends common.TimePicker {
     private _android: android.widget.TimePicker;
     private _listener: android.widget.TimePicker.OnTimeChangedListener;
@@ -32,7 +36,8 @@ export class TimePicker extends common.TimePicker {
 
         var that = new WeakRef(this);
 
-        this._listener = new android.widget.TimePicker.OnTimeChangedListener({
+        this._listener = new android.widget.TimePicker.OnTimeChangedListener(
+            <Owned & android.widget.TimePicker.IOnTimeChangedListener>{
             get owner() {
                 return that.get();
             },

--- a/utils/utils.d.ts
+++ b/utils/utils.d.ts
@@ -3,6 +3,15 @@
 
     export var RESOURCE_PREFIX: string;
 
+    //@private
+    /**
+     * Used by various android event listener implementations
+     */
+    interface Owned {
+        owner: any;
+    }
+    //@endprivate
+
     /**
      * Utility module related to layout.
      */


### PR DESCRIPTION
Fixed a bunch of errors all over the place:

- not using extra properties in object literals
- not using `delete` on module level vars.

------

We are also using the `--moduleResolution classic` compiler option to avoid the Node.js-like behavior of looking in `node_modules` instead of the current dir. Ideally (in the future) we should use only relative imports like `../ui/builder/...` instead of `ui/builder/...` and remove that compiler option.