### PR TITLE
Transformations such as scale, translate, rotate won't be incorrectly affected by the layout

### DIFF
--- a/ui/core/view.ios.ts
+++ b/ui/core/view.ios.ts
@@ -251,6 +251,8 @@ export class View extends viewCommon.View {
         if (!CGRectEqualToRect(nativeView.frame, frame)) {
             trace.write(this + ", Native setFrame: = " + NSStringFromCGRect(frame), trace.categories.Layout);
             nativeView.frame = frame;
+            var boundsOrigin = nativeView.bounds.origin;
+            nativeView.bounds = CGRectMake(boundsOrigin.x, boundsOrigin.y, frame.size.width, frame.size.height);
         }
     }
 


### PR DESCRIPTION
In iOS we now set `bound` along the `frame` property on the native views.

The easiest way to reproduce this is to display an UI similar to:
```
<GridLayout width="50" height="50">
    <Image src="res://img" rotate="25" backgroundColor="red" />
</GridLayout>
```
The image will be rotated but will also somewhat scale since the transform was not reapplied after the frame was set. After applying this fix, the image will appear correctly rotated.