### PR TITLE
web-view loads local data with UTF-8

### DIFF
--- a/ui/web-view/web-view.android.ts
+++ b/ui/web-view/web-view.android.ts
@@ -91,13 +91,13 @@ export class WebView extends common.WebView {
             if (file) {
                 var baseUrl = `file:///${src.substring(0, src.lastIndexOf('/') + 1)}`;
                 file.readText().then(r => {
-                    this._android.loadDataWithBaseURL(baseUrl, r, "text/html", null, null);
+                    this._android.loadDataWithBaseURL(baseUrl, r, "text/html; charset=utf-8", "utf-8", null);
                 });
             }
         } else if (src.indexOf("http://") === 0 || src.indexOf("https://") === 0) {
             this._android.loadUrl(src);
         } else {
-            this._android.loadData(src, "text/html", null);
+            this._android.loadData(src, "text/html; charset=utf-8", "utf-8");
         }
     }
 


### PR DESCRIPTION
This PR fixes that UTF-8 characters (such as the Nordic `åäöæø`) does not show correctly in a Web-view, if content is loaded from local file or local html string.

content-type is changed from `text/html` to `text/html; charset=utf-8` as this is needed for newer Android (where older just rely on the mime-type `utf-8`)