### PR TITLE
Add itemLongPress event to ListView

### DIFF
--- a/ui/list-view/list-view-common.ts
+++ b/ui/list-view/list-view-common.ts
@@ -32,6 +32,7 @@ function onItemTemplatePropertyChanged(data: dependencyObservable.PropertyChange
 export class ListView extends view.View implements definition.ListView {
     public static itemLoadingEvent = "itemLoading";
     public static itemTapEvent = "itemTap";
+    public static itemLongPressEvent = "itemLongPress";
     public static loadMoreItemsEvent = "loadMoreItems";
 
     public static separatorColorProperty = new dependencyObservable.Property(

--- a/ui/list-view/list-view.android.ts
+++ b/ui/list-view/list-view.android.ts
@@ -12,6 +12,7 @@ import utils = require("utils/utils")
 var ITEMLOADING = common.ListView.itemLoadingEvent;
 var LOADMOREITEMS = common.ListView.loadMoreItemsEvent;
 var ITEMTAP = common.ListView.itemTapEvent;
+var ITEMLONGPRESS = common.ListView.itemLongPressEvent;
 var REALIZED_INDEX = "realizedIndex";
 
 global.moduleMerge(common, exports);
@@ -87,6 +88,16 @@ export class ListView extends common.ListView {
                 if (owner) {
                     owner.notify({ eventName: ITEMTAP, object: owner, index: index, view: owner._getRealizedView(convertView, index) });
                 }
+            }
+        }));
+        
+        this.android.setOnItemLongClickListener(new android.widget.AdapterView.OnItemLongClickListener({
+            onItemLongClick: function (parent, convertView, index, id) {
+                var owner = that.get();
+                if (owner) {
+                    owner.notify({ eventName: ITEMLONGPRESS, object: owner, index: index, view: owner._getRealizedView(convertView, index) });
+                }
+                return true;
             }
         }));
     }


### PR DESCRIPTION
In my application i needed to show an array of items in a listview and when user longpresses listview item a popup menu would show. 
I have searched this feature, but couldn't locate it, so i changed the source code as simple as possible.

After this change user can reference itemLongPress event in xml like this:
```xml
<ListView items="{{ TaskList }}" itemLongPress="TaskListAction">
```

Codebehind would be:
```javascript
exports.TaskListAction = function(args) {
    var Task = viewModel.TaskList.getItem(args.index);
}
```

This change is android only, i really dont know the ios equivalent so i was unable to type it.


Note this is my first time using github (yes i was living under a rock last 5 years) so if i am doing something wrong please imform me.