### PR TITLE
Refer to current _map, not most recent _map in Observable

### DIFF
--- a/apps/tests/observable-tests.ts
+++ b/apps/tests/observable-tests.ts
@@ -1,0 +1,26 @@
+import TKUnit = require("./TKUnit");
+require("globals");
+
+// <snippet module="data/observable" title="observable">
+// # Observable module
+// ``` JavaScript
+import observableModule = require("data/observable");
+// ```
+// </snippet>
+
+require("globals");
+
+export var test_Observable_shouldDistinguishSeparateObjects = function () {
+    // <snippet module="data/observable" title="observable">
+    // ### Create two Observables from different objects.
+    // ``` JavaScript
+    var obj1 = {val: 1};
+    var obj2 = {val: 2};
+    var observable1 = new observableModule.Observable(obj1);
+    var observable2 = new observableModule.Observable(obj2);
+    // ```
+    // </snippet>
+
+    TKUnit.assert(false, "Is this even being run");
+    TKUnit.assert(observable1.get('val') === 1 && observable2.get('val') === 2, "Observable should keep separate objects separate!");
+};

--- a/apps/tests/testRunner.ts
+++ b/apps/tests/testRunner.ts
@@ -42,6 +42,7 @@ allTests["APPLICATION SETTINGS"] = require("./application-settings-tests");
 allTests["IMAGE SOURCE"] = require("./image-source-tests");
 allTests["TIMER"] = require("./timer-tests");
 allTests["COLOR"] = require("./color-tests");
+allTests["OBSERVABLE"] = require("./observable-tests");
 allTests["OBSERVABLE-ARRAY"] = require("./observable-array-tests");
 allTests["VIRTUAL-ARRAY"] = require("./virtual-array-tests");
 allTests["OBSERVABLE"] = require("./ui/observable-tests");

--- a/data/observable/observable.ts
+++ b/data/observable/observable.ts
@@ -15,16 +15,15 @@ export class Observable implements definition.Observable {
     constructor(json?: any) {
         if (json) {
             this._map = new Map<string, Object>();
-            var that = this;
 
             var definePropertyFunc = function definePropertyFunc(propertyName) {
                 Object.defineProperty(Observable.prototype, propertyName, {
                     get: function () {
-                        return that._map.get(propertyName);
+                        return this._map.get(propertyName);
                     },
                     set: function (value) {
-                        that._map.set(propertyName, value);
-                        that.notify(that._createPropertyChangeData(propertyName, value));
+                        this._map.set(propertyName, value);
+                        this.notify(this._createPropertyChangeData(propertyName, value));
                     },
                     enumerable: true,
                     configurable: true


### PR DESCRIPTION
The `Observable` module uses `defineProperty` every time a new `Observable` is made, and the get/set methods refer to the `that` variable in the closure.  The result is that If you call `new Observable()` multiple times on objects that have identical properties (like `Observables` in an `ObservableArray`, as in [this StackOverflow question](http://stackoverflow.com/questions/31898061/observable-in-listview-binds-elements-incorrectly)), all the `Observables` will access/update only the last object's properties.

I changed the get/set methods to use `this`, which solves the immediate problem.  It still seems inefficient to redefine the get/set methods every time an `Observable` is created.  Also, every `Observable` will have every observable property from any other `Observable` defined for it, which seems odd, but not the worst possible problem, I suppose.