### PR TITLE
css-value parse fix to match the new parse function export.

### DIFF
--- a/css-value/reworkcss-value.d.ts
+++ b/css-value/reworkcss-value.d.ts
@@ -1,10 +1,13 @@
 declare module "css-value" {
-    export interface CSSValue {
+    interface CSSValue {
         type: string;
         string: string;
         unit: string;
         value: number;
     }
 
-    export function parse(cssValue: string): Array<CSSValue>;
+    interface ParserFunction {
+        (cssValue: string): Array<CSSValue>;
+    }
+    export = ParserFunction;
 }

--- a/ui/styling/background-common.ts
+++ b/ui/styling/background-common.ts
@@ -3,7 +3,7 @@ import colorModule = require("color");
 import types = require("utils/types");
 import enums = require("ui/enums");
 import dts = require("ui/styling/background");
-import cssValue = require("css-value");
+var cssValue = require("css-value");
 
 export class Background implements dts.Background {
     public static default = new Background(undefined, undefined, undefined, undefined, undefined);
@@ -83,7 +83,7 @@ export class Background implements dts.Background {
 
         // size
         if (this.size) {
-            let values = cssValue.parse(this.size);
+            let values = cssValue(this.size);
 
             if (values.length === 2) {
                 let vx = values[0];
@@ -126,7 +126,7 @@ export class Background implements dts.Background {
 
         // position
         if (this.position) {
-            let values = cssValue.parse(this.position);
+            let values = cssValue(this.position);
             let spaceX = width - imageWidth;
             let spaceY = height - imageHeight;
 


### PR DESCRIPTION
Using a JS hack. I got beat by the TS compiler `export =` feature