### PR TITLE
Break a circular import view-application-view.

### DIFF
--- a/ui/core/bindable.ts
+++ b/ui/core/bindable.ts
@@ -2,12 +2,21 @@
 import definition = require("ui/core/bindable");
 import dependencyObservable = require("ui/core/dependency-observable");
 import weakEvents = require("ui/core/weak-event-listener");
-import appModule = require("application");
 import types = require("utils/types");
 import trace = require("trace");
 import polymerExpressions = require("js-libs/polymer-expressions");
 import bindingBuilder = require("../builder/binding-builder");
 import viewModule = require("ui/core/view");
+
+//late import
+var _appModule = null;
+
+function appModule() {
+    if (!_appModule) {
+        _appModule = require("application");
+    }
+    return _appModule;
+}
 
 var bindingContextProperty = new dependencyObservable.Property(
     "bindingContext",
@@ -359,9 +368,9 @@ export class Binding {
             if (exp) {
                 var context = this.source && this.source.get && this.source.get() || global;
                 var model = {};
-                for (var prop in appModule.resources) {
-                    if (appModule.resources.hasOwnProperty(prop) && !context.hasOwnProperty(prop)) {
-                        context[prop] = appModule.resources[prop];
+                for (var prop in appModule().resources) {
+                    if (appModule().resources.hasOwnProperty(prop) && !context.hasOwnProperty(prop)) {
+                        context[prop] = appModule().resources[prop];
                     }
                 }
 

--- a/ui/styling/stylers-common.ts
+++ b/ui/styling/stylers-common.ts
@@ -1,7 +1,16 @@
 ﻿import view = require("ui/core/view");
-import application = require("application");
 import dependencyObservable = require("ui/core/dependency-observable");
 import types = require("utils/types");
+
+//late import
+var _appModule = null;
+
+function appModule() {
+    if (!_appModule) {
+        _appModule = require("application");
+    }
+    return _appModule;
+}
 
 var _defaultNativeValuesCache = {};
 
@@ -26,10 +35,9 @@ export class StylePropertyChangedHandler {
             _defaultNativeValuesCache[className + property.id] = this._getNativeValue(view);
         }
 
-        if (application.android) {
+        if (appModule().android) {
             newValue = newValue.android ? newValue.android : newValue;
-        }
-        else if (application.ios) {
+        } else if (appModule().ios) {
             newValue = newValue.ios ? newValue.ios : newValue;
         }
 


### PR DESCRIPTION
By late-importing `application` in `bindable` and `stylers-common`.

It all started in [this issue](https://github.com/NativeScript/NativeScript/issues/948).

Note that requiring `ui/core/view` early on may still break if "globals" hasn't been imported since it requires that the `moduleMerge` function be available.