### PR TITLE
XHR events and an Android bugfix

### DIFF
--- a/apps/tests/testRunner.ts
+++ b/apps/tests/testRunner.ts
@@ -1,11 +1,12 @@
 ﻿/* tslint:disable */
-import TKUnit = require("./TKUnit");
-import trace = require("trace");
-import frameModule = require("ui/frame");
-import platform = require("platform");
-import uiTestModule = require("./ui-test");
+import * as TKUnit from"./TKUnit";
+import {messageType} from "trace";
+import {topmost, Frame} from "ui/frame";
+import {TextView} from "ui/text-view";
+import * as platform from "platform";
+import "./ui-test";
 
-frameModule.Frame.defaultAnimatedNavigation = false;
+Frame.defaultAnimatedNavigation = false;
 
 export function isRunningOnEmulator(): boolean {
     // This checks are not good enough to be added to modules but keeps unittests green.
@@ -123,22 +124,29 @@ function printRunTestStats() {
             }
         }
     }
-    TKUnit.write("=== ALL TESTS COMPLETE === " + (testsCount - failedTestCount) + " OK, " + failedTestCount + " failed", trace.messageType.info);
+    let finalMessage = "=== ALL TESTS COMPLETE === \n" + (testsCount - failedTestCount) + " OK, " + failedTestCount + " failed" + "\n";
+    TKUnit.write(finalMessage, messageType.info);
     for (j = 0; j < failedTestInfo.length; j++) {
-        TKUnit.write(failedTestInfo[j], trace.messageType.error);
+        let failureMessage = failedTestInfo[j];
+        TKUnit.write(failureMessage, messageType.error);
+        finalMessage += "\n" + failureMessage;
     }
+
+    let messageContainer = new TextView();
+    messageContainer.text = finalMessage;
+    topmost().currentPage.content = messageContainer;
 }
 
 function startLog(): void {
     let testsName: string = this.name;
-    TKUnit.write("START " + testsName + " TESTS.", trace.messageType.info);
+    TKUnit.write("START " + testsName + " TESTS.", messageType.info);
     this.start = TKUnit.time();
 }
 
 function log(): void {
     let testsName: string = this.name;
     let duration = TKUnit.time() - this.start;
-    TKUnit.write(testsName + " COMPLETED for " + duration, trace.messageType.info);
+    TKUnit.write(testsName + " COMPLETED for " + duration, messageType.info);
 }
 
 export var runAll = function (moduleName?: string) {

--- a/apps/tests/xhr-tests.ts
+++ b/apps/tests/xhr-tests.ts
@@ -212,12 +212,11 @@ export var test_XMLHttpRequest_requestShouldBePossibleAfterAbort = function (don
     xhr.send(JSON.stringify({ MyVariableOne: "ValueOne", MyVariableTwo: "ValueTwo" }));
 };
 
-export function test_ignore_zero_length_request_body(done) {
+export function test_ignore_zero_length_request_body() {
     let xhr = new XMLHttpRequest();
     xhr.open("GET", "https://httpbin.org/get");
 
     xhr.send('');
-    done(null);
 }
 
 export function test_raises_onload_Event(done) {
@@ -229,7 +228,7 @@ export function test_raises_onload_Event(done) {
     xhr.send();
 }
 
-export function test_xhr_events(done) {
+export function test_xhr_events() {
     let xhr = <any>new XMLHttpRequest();
 
     let loadCallbackFired = false, loadEventFired = false;
@@ -254,8 +253,6 @@ export function test_xhr_events(done) {
     xhr._setReadyState(xhr.DONE, 'error data');
     TKUnit.assertEqual(errorCallbackData, 'error data');
     TKUnit.assertEqual(errorEventData, 'error data');
-
-    done(null);
 }
 
 export function test_sets_status_and_statusText(done) {

--- a/apps/tests/xhr-tests.ts
+++ b/apps/tests/xhr-tests.ts
@@ -221,6 +221,35 @@ export function test_raises_onload_Event(done) {
     xhr.send();
 }
 
+export function test_xhr_events(done) {
+    let xhr = <any>new XMLHttpRequest();
+
+    let loadCallbackFired = false, loadEventFired = false;
+    xhr.onload = () => loadCallbackFired = true;
+    let badEvent = () => { throw new Error("Shouldn't call me") }
+    xhr.addEventListener('load', () => loadEventFired = true);
+    xhr.addEventListener('load', badEvent);
+    xhr.removeEventListener('load', badEvent);
+
+    xhr._errorFlag = false;
+    xhr._setReadyState(xhr.DONE);
+    TKUnit.assertTrue(loadCallbackFired);
+    TKUnit.assertTrue(loadEventFired);
+
+    let errorCallbackData = null, errorEventData = null;
+    xhr.onerror = (e) => errorCallbackData = e;
+    xhr.addEventListener('error', (e) => errorEventData = e);
+    xhr.addEventListener('error', badEvent);
+    xhr.removeEventListener('error', badEvent);
+
+    xhr._errorFlag = true;
+    xhr._setReadyState(xhr.DONE, 'error data');
+    TKUnit.assertEqual(errorCallbackData, 'error data');
+    TKUnit.assertEqual(errorEventData, 'error data');
+
+    done(null);
+}
+
 export function test_sets_status_and_statusText(done) {
     let xhr = new XMLHttpRequest();
     xhr.onreadystatechange = () => {

--- a/apps/tests/xhr-tests.ts
+++ b/apps/tests/xhr-tests.ts
@@ -212,6 +212,14 @@ export var test_XMLHttpRequest_requestShouldBePossibleAfterAbort = function (don
     xhr.send(JSON.stringify({ MyVariableOne: "ValueOne", MyVariableTwo: "ValueTwo" }));
 };
 
+export function test_ignore_zero_length_request_body(done) {
+    let xhr = new XMLHttpRequest();
+    xhr.open("GET", "https://httpbin.org/get");
+
+    xhr.send('');
+    done(null);
+}
+
 export function test_raises_onload_Event(done) {
     let xhr = new XMLHttpRequest();
     xhr.onload = () => {

--- a/xhr/xhr.ts
+++ b/xhr/xhr.ts
@@ -72,7 +72,10 @@ export class XMLHttpRequest {
         this._status = null;
 
         if (types.isDefined(this._options)) {
-            if (types.isString(data)) {
+            if (types.isString(data) && this._options.method !== 'GET') {
+                //The Android Java HTTP lib throws an exception if we provide a
+                //a request body for GET requests, so we avoid doing that.
+                //Browser implementations silently ignore it as well.
                 this._options.content = data;
             } else if (data instanceof FormData) {
                 this._options.content = (<FormData>data).toString();


### PR DESCRIPTION
Fixing problems I'd stumbled upon while building an HTTP demo with Angular:

- Add `addEventListener`/`removeEventListener` methods for `load` and `error` events only. Raise events accordingly.
- Ignore request body in `send()` if the method is a `GET` since that causes an error on Android. Browsers seem to ignore it too.