### PR TITLE
added simple showModal() overload

### DIFF
--- a/ui/page/page-common.ts
+++ b/ui/page/page-common.ts
@@ -197,9 +197,18 @@ export class Page extends ContentView implements dts.Page {
         this._navigationContext = undefined;
     }
 
-    public showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean) {
-        var page = frameCommon.resolvePageFromEntry({ moduleName: moduleName });
-        (<Page>page)._showNativeModalView(this, context, closeCallback, fullscreen);
+    public showModal() {
+        if (arguments.length === 0) {
+            this._showNativeModalView(<any>frame.topmost().currentPage, undefined, undefined, true);
+        } else {
+            var moduleName: string = arguments[0];
+            var context: any = arguments[1];
+            var closeCallback: Function = arguments[2];
+            var fullscreen: boolean = arguments[3];
+
+            var page = frameCommon.resolvePageFromEntry({ moduleName: moduleName });
+            (<Page>page)._showNativeModalView(this, context, closeCallback, fullscreen);
+        }
     }
 
     public closeModal() {

--- a/ui/page/page.d.ts
+++ b/ui/page/page.d.ts
@@ -168,6 +168,11 @@ declare module "ui/page" {
         showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean);
 
         /**
+         * Shows the page as a modal view.
+         */
+        showModal();
+
+        /**
          * Closes the current modal dialog that this page is showing.
          */
         closeModal();


### PR DESCRIPTION
Now you can do:
```JavaScript
        var p = new Page();
        var ai = new ActivityIndicator();
        ai.busy = true
        p.content = ai;
        p.showModal();
        
        setTimeout(function () { p.closeModal(); }, 1000);
```