### PR TITLE
Android animations flicker when interrupted by a second animation

### DIFF
--- a/es6.d.ts
+++ b/es6.d.ts
@@ -1,0 +1,1 @@
+declare var Symbol: any;


### PR DESCRIPTION
When android animation is interrupted by a second animation, the first animation will not try to set the animated properties on the view.

Currently the first animation sets the properties on the view while the second animation is still playing causing a flickering.