### PR TITLE
tns-core-modules + d.ts = ☺☺☺

### DIFF
--- a/css/package.json
+++ b/css/package.json
@@ -3,10 +3,6 @@
   "version": "2.2.1",
   "description": "CSS parser / stringifier",
   "main": "index",
-  "files": [
-    "index.js",
-    "lib"
-  ],
   "dependencies": {
     "source-map": "^0.1.38",
     "source-map-resolve": "^0.3.0",

--- a/js-libs/easysax/package.json
+++ b/js-libs/easysax/package.json
@@ -17,11 +17,6 @@
     "email": "flash.vkv@gmail.com",
     "url": "http://vflash.ru"
   },
-  "files": [
-    "easysax.js",
-    "LICENSE",
-    "README.md"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/vflash/easysax"

--- a/js-libs/esprima/package.json
+++ b/js-libs/esprima/package.json
@@ -8,15 +8,6 @@
         "esvalidate": "./bin/esvalidate.js"
     },
     "version": "2.0.0-dev",
-    "files": [
-        "bin",
-        "test/run.js",
-        "test/runner.js",
-        "test/test.js",
-        "test/compat.js",
-        "test/reflect.js",
-        "esprima.js"
-    ],
     "engines": {
         "node": ">=0.4.0"
     },


### PR DESCRIPTION
Include d.ts files in tns-core-modules package.
    
- Generate a combined tns-core-modules.d.ts file for user projects. (Will
be included in tsconfig.json files by the `tns` tool automagically.)
- Test the integrity of the generated combined file by compiling it.
- Remove all traces of the obsoleted tns-definitions package.

/cc @ErjanGavalji @tailsu @ligaz 