### PR TITLE
Add the typings hint to nativescript-dev-typescript.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "grunt-untar": "0.0.1",
     "mocha": "2.2.5",
     "typescript": "1.6.2"
-  }
+  },
+  "typings": "tns-core-modules.d.ts"
 }


### PR DESCRIPTION
I forgot it in my previous PR. `nativescript-dev-typescript` works without it, but it would be best if we keep it in our `package.json`.