### PR TITLE
Frame reload fix

### DIFF
--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -13,6 +13,9 @@ function createAlertDialog(options?: dialogs.DialogOptions): android.app.AlertDi
     var alert = new android.app.AlertDialog.Builder(appmodule.android.foregroundActivity);
     alert.setTitle(options && types.isString(options.title) ? options.title : "");
     alert.setMessage(options && types.isString(options.message) ? options.message : "");
+    if (options && (options.cancelable === false || options.cancelable === 0)) {
+        alert.setCancelable(false);
+    }
     return alert;
 }
 
@@ -72,6 +75,11 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
             }
         }));
     }
+    alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
+        onDismiss: function() {
+            callback(false);
+        }
+    }));
 }
 
 export function alert(arg: any): Promise<void> {
@@ -84,6 +92,11 @@ export function alert(arg: any): Promise<void> {
             alert.setPositiveButton(options.okButtonText, new android.content.DialogInterface.OnClickListener({
                 onClick: function (dialog: android.content.DialogInterface, id: number) {
                     dialog.cancel();
+                    resolve();
+                }
+            }));
+            alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
+                onDismiss: function() {
                     resolve();
                 }
             }));
@@ -262,6 +275,9 @@ export function action(arg: any): Promise<string> {
             var alert = new android.app.AlertDialog.Builder(activity);
             var message = options && types.isString(options.message) ? options.message : "";
             var title = options && types.isString(options.title) ? options.title : "";
+            if (options && (options.cancelable === false || options.cancelable === 0)) {
+                alert.setCancelable(false);
+            }
 
             if (title) {
                 alert.setTitle(title);
@@ -289,6 +305,17 @@ export function action(arg: any): Promise<string> {
                     }
                 }));
             }
+
+            alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
+                onDismiss: function() {
+                    if (types.isString(options.cancelButtonText)) {
+                        resolve(options.cancelButtonText);
+                    } else {
+                        resolve("");
+                    }
+                }
+            }));
+
             showDialog(alert);
 
         } catch (ex) {

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -34,11 +34,11 @@ export function reloadPage(): void {
         let currentEntry = frame._currentEntry.entry;
         let newEntry: definition.NavigationEntry = {
             animated: false,
-            clearHistory: true,
+            clearHistory: false,
             context: currentEntry.context,
             create: currentEntry.create,
             moduleName: currentEntry.moduleName,
-            backstackVisible: currentEntry.backstackVisible
+            backstackVisible: false
         }
 
         frame.navigate(newEntry);


### PR DESCRIPTION
I'm not sure why the existing code is the way it is; but if I call "reload" to reload the current page, I really don't want my history nuked, and I really don't need two copies of the current page in the page history...

This patch eliminates the history nuking, and sets it so that the reload'd page is not included in the page history a second time...