### PR TITLE
This will now allow the dialog to call the resolve function when cancelled by clicking outside.

### DIFF
--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -13,7 +13,7 @@ function createAlertDialog(options?: dialogs.DialogOptions): android.app.AlertDi
     var alert = new android.app.AlertDialog.Builder(appmodule.android.foregroundActivity);
     alert.setTitle(options && types.isString(options.title) ? options.title : "");
     alert.setMessage(options && types.isString(options.message) ? options.message : "");
-    if (options && (options.cancelable === false || options.cancelable === 0)) {
+    if (options && options.cancelable === false) {
         alert.setCancelable(false);
     }
     return alert;

--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -275,7 +275,7 @@ export function action(arg: any): Promise<string> {
             var alert = new android.app.AlertDialog.Builder(activity);
             var message = options && types.isString(options.message) ? options.message : "";
             var title = options && types.isString(options.title) ? options.title : "";
-            if (options && (options.cancelable === false || options.cancelable === 0)) {
+            if (options && options.cancelable === false) {
                 alert.setCancelable(false);
             }
 

--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -13,6 +13,9 @@ function createAlertDialog(options?: dialogs.DialogOptions): android.app.AlertDi
     var alert = new android.app.AlertDialog.Builder(appmodule.android.foregroundActivity);
     alert.setTitle(options && types.isString(options.title) ? options.title : "");
     alert.setMessage(options && types.isString(options.message) ? options.message : "");
+    if (options && (options.cancelable === false || options.cancelable === 0)) {
+        alert.setCancelable(false);
+    }
     return alert;
 }
 
@@ -72,6 +75,11 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
             }
         }));
     }
+    alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
+        onDismiss: function() {
+            callback(false);
+        }
+    }));
 }
 
 export function alert(arg: any): Promise<void> {
@@ -84,6 +92,11 @@ export function alert(arg: any): Promise<void> {
             alert.setPositiveButton(options.okButtonText, new android.content.DialogInterface.OnClickListener({
                 onClick: function (dialog: android.content.DialogInterface, id: number) {
                     dialog.cancel();
+                    resolve();
+                }
+            }));
+            alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
+                onDismiss: function() {
                     resolve();
                 }
             }));
@@ -262,6 +275,9 @@ export function action(arg: any): Promise<string> {
             var alert = new android.app.AlertDialog.Builder(activity);
             var message = options && types.isString(options.message) ? options.message : "";
             var title = options && types.isString(options.title) ? options.title : "";
+            if (options && (options.cancelable === false || options.cancelable === 0)) {
+                alert.setCancelable(false);
+            }
 
             if (title) {
                 alert.setTitle(title);
@@ -289,6 +305,17 @@ export function action(arg: any): Promise<string> {
                     }
                 }));
             }
+
+            alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
+                onDismiss: function() {
+                    if (types.isString(options.cancelButtonText)) {
+                        resolve(options.cancelButtonText);
+                    } else {
+                        resolve("");
+                    }
+                }
+            }));
+
             showDialog(alert);
 
         } catch (ex) {

--- a/ui/dialogs/dialogs.d.ts
+++ b/ui/dialogs/dialogs.d.ts
@@ -120,6 +120,12 @@ declare module "ui/dialogs" {
          * Gets or sets the dialog message.
          */
         message?: string;
+		
+		/**
+		 * Sets if the Android dialog can be canceled via clicking outside of it
+		 * defaults to true.
+		 */
+		cancelable?: boolean;
     }
 
     /**

--- a/ui/dialogs/dialogs.d.ts
+++ b/ui/dialogs/dialogs.d.ts
@@ -81,11 +81,21 @@ declare module "ui/dialogs" {
      * @param options The options for the dialog box. 
      */
     export function action(options: ActionOptions): Promise<string>;
+    
+    /**
+     * Provides options for the dialog.
+     */
+    export interface CancelableOptions {
+        /**
+         * [Android only] Gets or sets if the dialog can be canceled by taping outside of the dialog.
+         */
+        cancelable?: boolean;
+    }
 
     /**
      * Provides options for the dialog.
      */
-    export interface ActionOptions {
+    export interface ActionOptions extends CancelableOptions {
         /**
          * Gets or sets the dialog title.
          */
@@ -110,7 +120,7 @@ declare module "ui/dialogs" {
     /**
      * Provides options for the dialog.
      */
-    export interface DialogOptions {
+    export interface DialogOptions extends CancelableOptions {
         /**
          * Gets or sets the dialog title.
          */
@@ -120,12 +130,7 @@ declare module "ui/dialogs" {
          * Gets or sets the dialog message.
          */
         message?: string;
-		
-		/**
-		 * Sets if the Android dialog can be canceled via clicking outside of it
-		 * defaults to true.
-		 */
-		cancelable?: boolean;
+
     }
 
     /**


### PR DESCRIPTION
All the dialogs also suffer on Android from the click outside and then not having the promise resolved or rejected.   
This code does two different things:
1. The promises to be resolved if clicked outside of dialog.
2. The ability to disable the click outside to cancel.  (This might be worth setting as default on the login dialog)