### PR TITLE
The Frame.reloadPage function is wrong.  ;-)

### DIFF
--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -34,11 +34,11 @@ export function reloadPage(): void {
         let currentEntry = frame._currentEntry.entry;
         let newEntry: definition.NavigationEntry = {
             animated: false,
-            clearHistory: true,
+            clearHistory: false,
             context: currentEntry.context,
             create: currentEntry.create,
             moduleName: currentEntry.moduleName,
-            backstackVisible: currentEntry.backstackVisible
+            backstackVisible: true
         }
 
         frame.navigate(newEntry);


### PR DESCRIPTION
The way the Frame.reloadPage works is wrong.  If I am trying to reload the current page; I don't want the entire application history nuked.  And since I don't want the history nuked; I don't need an extra copy of this page in the history.   This fixes both those bad defaults.