### PR TITLE
Add an option to build the test app only

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "shelljs": "0.5.3",
     "chai": "3.2.0",
     "grunt": "0.4.5",
     "grunt-bom-removal": "0.2.0",


### PR DESCRIPTION
Skip the rest of the apps and finish ~20 seconds faster.

```bash
$ time grunt --stack --test-app-only=1 --runtslint=0
...
21.52user 1.19system 0:19.81elapsed 114%CPU (0avgtext+0avgdata 655360maxresident)k
0inputs+36632outputs (0major+567166minor)pagefaults 0swaps

$ time grunt --stack --test-app-only=0 --runtslint=0
...
44.02user 2.99system 0:42.32elapsed 111%CPU (0avgtext+0avgdata 656340maxresident)k
0inputs+52440outputs (0major+1281229minor)pagefaults 0swaps
```

ping @ErjanGavalji

