### PR TITLE
Upgrade tslint to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "shelljs": "0.5.3",
     "chai": "3.2.0",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
@@ -27,11 +26,12 @@
     "grunt-shell": "1.1.2",
     "grunt-simple-mocha": "0.4.0",
     "grunt-ts": "5.0.0-beta.5",
-    "grunt-tslint": "2.5.0",
-    "tslint": "2.5.1",
     "grunt-typedoc": "0.2.3",
     "grunt-untar": "0.0.1",
     "mocha": "2.2.5",
+    "shelljs": "0.5.3",
+    "grunt-tslint": "3.0.0",
+    "tslint": "3.1.1",
     "typescript": "1.7.3"
   },
   "typings": "tns-core-modules.d.ts"


### PR DESCRIPTION
Still crashing with stack overflow when enabling the unused variables check, but at least it's newer :disappointed_relieved: 