### PR TITLE
FIX: Platform specific _addViewCore, ignoring index parameter

### DIFF
--- a/ui/core/view.android.ts
+++ b/ui/core/view.android.ts
@@ -163,12 +163,12 @@ export class View extends viewCommon.View {
         }
     }
 
-    public _addViewCore(view: viewCommon.View) {
+    public _addViewCore(view: viewCommon.View, atIndex?: number) {
         if (this._context) {
             view._onAttached(this._context);
         }
 
-        super._addViewCore(view);
+        super._addViewCore(view, atIndex);
     }
 
     public _removeViewCore(view: viewCommon.View) {

--- a/ui/core/view.ios.ts
+++ b/ui/core/view.ios.ts
@@ -72,8 +72,8 @@ export class View extends viewCommon.View {
         this._privateFlags = PFLAG_LAYOUT_REQUIRED | PFLAG_FORCE_LAYOUT;
     }
 
-    public _addViewCore(view: viewCommon.View) {
-        super._addViewCore(view);
+    public _addViewCore(view: viewCommon.View, atIndex?: number) {
+        super._addViewCore(view, atIndex);
         this.requestLayout();
     }
 


### PR DESCRIPTION
`_addViewCommon` accepts index param in [view-common.ts](https://github.com/NativeScript/NativeScript/blob/master/ui/core/view-common.ts#L985) but it is ignored in ios/android implementations.