### PR TITLE
Fixed issue with two way binding update.

### DIFF
--- a/data/observable/observable.ts
+++ b/data/observable/observable.ts
@@ -121,16 +121,17 @@ export class Observable implements definition.Observable {
         return this[name];
     }
 
-    private disableNotifications = false;
+    //private disableNotifications = false;
+    private disableNotifications = {};
 
     public _setCore(data: definition.PropertyChangeData) {
-        this.disableNotifications = true;
+        this.disableNotifications[data.propertyName] = true;
         this[data.propertyName] = data.value;
-        this.disableNotifications = false;
+        delete this.disableNotifications[data.propertyName];
     }
 
     public notify<T extends definition.EventData>(data: T) {
-        if (this.disableNotifications) {
+        if (this.disableNotifications[(<any>data).propertyName]) {
             return;
         }
 


### PR DESCRIPTION
Fixes issue with updating another property within a property setter.

set value1(value) {
    if (this._value1 !== value) {
        this._value1 = value;
        this.value2 = value + " something";
        this.notifyPropertyChange("value1", value);
    }
}

set value2 (value) {
...
}

The problem is that notification of `value2` is not raised.