### PR TITLE
Make the modules correct NativeScript plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,11 @@
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
     "tns-core-modules-widgets": "1.6.0"
+  },
+  "nativescript": {
+    "platforms": {
+      "ios": "1.3.0",
+      "android": "1.3.0"
+    }
   }
 }


### PR DESCRIPTION
By definition NativeScript plugins have "nativescript" key in their `package.json`.
When there's such key, CLI allows you to execute `tns plugin add tns-core-modules`.
Also this gives you the ability to specify minimum required runtime version.
I've set it to 1.3.0 as I couldn't find any information which is the current supported runtimes version.