### PR TITLE
Fix originX/Y not applied when set before layout in android

### DIFF
--- a/org.nativescript.widgets.d.ts
+++ b/org.nativescript.widgets.d.ts
@@ -65,6 +65,11 @@
                 horizontal,
                 vertical
             }
+            
+            export class OriginPoint {
+                public static setX(view: android.view.View, value: number);
+                public static setY(view: android.view.View, value: number);
+            }
 
             export class LayoutBase extends android.view.ViewGroup {
                 constructor(context: android.content.Context);

--- a/ui/core/view.android.ts
+++ b/ui/core/view.android.ts
@@ -50,16 +50,12 @@ function onScaleYPropertyChanged(data: dependencyObservable.PropertyChangeData) 
 (<proxy.PropertyMetadata>viewCommon.View.scaleYProperty.metadata).onSetNativeValue = onScaleYPropertyChanged;
 
 function onOriginXPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    var width = view._nativeView.getWidth();
-    view._nativeView.setPivotX(data.newValue * width);
+    org.nativescript.widgets.OriginPoint.setX((<View>data.object)._nativeView, data.newValue);
 }
 (<proxy.PropertyMetadata>viewCommon.View.originXProperty.metadata).onSetNativeValue = onOriginXPropertyChanged;
 
 function onOriginYPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    var height = view._nativeView.getHeight();
-    view._nativeView.setPivotY(data.newValue * height);
+    org.nativescript.widgets.OriginPoint.setY((<View>data.object)._nativeView, data.newValue);
 }
 (<proxy.PropertyMetadata>viewCommon.View.originYProperty.metadata).onSetNativeValue = onOriginYPropertyChanged;
 


### PR DESCRIPTION
Use the OriginPoint class in android widgets for the originX/Y implementation.
It will listen for layout events and recalculate the pivot point in pixels based on the origin point that is relative to the view size.