### PR TITLE
Revisit lazy require routine

### DIFF
--- a/application/application.ios.ts
+++ b/application/application.ios.ts
@@ -1,13 +1,15 @@
 ﻿import common = require("./application-common");
 import frame = require("ui/frame");
 import definition = require("application");
-import * as uiUtilsModule from "ui/utils";
+import * as uiUtils from "ui/utils";
 import * as typesModule from "utils/types";
 import * as fileResolverModule  from "file-system/file-name-resolver";
 import * as enumsModule from "ui/enums";
 
 global.moduleMerge(common, exports);
 var typedExports: typeof definition = exports;
+
+var enums: typeof enumsModule
 
 class Responder extends UIResponder {
     //
@@ -33,8 +35,6 @@ class Window extends UIWindow {
     }
 
     public layoutSubviews(): void {
-        var uiUtils: typeof uiUtilsModule = require("ui/utils");
-
         uiUtils.ios._layoutRootView(this._content, UIScreen.mainScreen().bounds);
     }
 }

--- a/camera/camera.ios.ts
+++ b/camera/camera.ios.ts
@@ -1,4 +1,4 @@
-﻿var types = require("utils/types");
+﻿import types = require("utils/types");
 import * as cameraCommonModule from "./camera-common";
 import * as imageSourceModule from "image-source";
 import * as frameModule from "ui/frame";

--- a/http/http-request.android.ts
+++ b/http/http-request.android.ts
@@ -12,6 +12,27 @@ import http = require("http");
 var requestIdCounter = 0;
 var pendingRequests = {};
 
+var utils: typeof utilsModule;
+function ensureUtils() {
+    if (!utils) {
+        utils = require("utils/utils");
+    }
+}
+
+var imageSource: typeof imageSourceModule;
+function ensureImageSource() {
+    if (!imageSource) {
+        imageSource = require("image-source");
+    }
+}
+
+var platform: typeof platformModule;
+function ensurePlatform() {
+    if (!platform) {
+        platform = require("platform");
+    }
+}
+
 var completeCallback: com.tns.Async.CompleteCallback;
 function ensureCompleteCallback() {
     if (completeCallback) {
@@ -59,12 +80,11 @@ function onRequestComplete(requestId: number, result: com.tns.Async.Http.Request
                 }
             },
             toJSON: () => {
-                var utils: typeof utilsModule = require("utils/utils");
-
+                ensureUtils();
                 return utils.parseJSON(result.responseAsString);
             },
             toImage: () => {
-                var imageSource: typeof imageSourceModule = require("image-source");
+                ensureImageSource();
 
                 return new Promise<any>((resolveImage, rejectImage) => {
                     if (result.responseAsImage != null) {
@@ -111,7 +131,7 @@ function buildJavaOptions(options: http.HttpRequestOptions) {
         javaOptions.headers = arrayList;
     }
 
-    var platform: typeof platformModule = require("platform");
+    ensurePlatform();
 
     // pass the maximum available image size to the request options in case we need a bitmap conversion
     var screen = platform.screen.mainScreen;

--- a/http/http-request.ios.ts
+++ b/http/http-request.ios.ts
@@ -2,7 +2,7 @@
  * iOS specific http request implementation.
  */
 import http = require("http");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 import * as imageSourceModule from "image-source";
 import * as utilsModule from "utils/utils";
 
@@ -10,12 +10,24 @@ var GET = "GET";
 var USER_AGENT_HEADER = "User-Agent";
 var USER_AGENT = "Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25";
 
+var utils: typeof utilsModule;
+function ensureUtils() {
+    if (!utils) {
+        utils = require("utils/utils");
+    }
+}
+
+var imageSource: typeof imageSourceModule;
+function ensureImageSource() {
+    if (!imageSource) {
+        imageSource = require("image-source");
+    }
+}
+
 export function request(options: http.HttpRequestOptions): Promise<http.HttpResponse> {
     return new Promise<http.HttpResponse>((resolve, reject) => {
 
         try {
-            var types: typeof typesModule = require("utils/types");
-
             var sessionConfig = NSURLSessionConfiguration.defaultSessionConfiguration();
             var queue = NSOperationQueue.mainQueue();
             var session = NSURLSession.sessionWithConfigurationDelegateDelegateQueue(
@@ -63,13 +75,11 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
                                 raw: data,
                                 toString: () => { return NSDataToString(data); },
                                 toJSON: () => {
-                                    var utils: typeof utilsModule = require("utils/utils");
-
+                                    ensureUtils();
                                     return utils.parseJSON(NSDataToString(data));
                                 },
                                 toImage: () => {
-                                    var imageSource: typeof imageSourceModule = require("image-source");
-
+                                    ensureImageSource();
                                     if (UIImage.imageWithData["async"]) {
                                         return UIImage.imageWithData["async"](UIImage, [data])
                                                       .then(image => {

--- a/image-source/image-source-common.ts
+++ b/image-source/image-source-common.ts
@@ -1,6 +1,13 @@
 ﻿import utils = require("utils/utils");
 import * as httpModule from "http";
 
+var http: typeof httpModule;
+function ensureHttp() {
+    if (!http) {
+        http = require("http");
+    }
+}
+
 // This is used for definition purposes only, it does not generate JavaScript for it.
 import definition = require("image-source");
 
@@ -30,7 +37,7 @@ export function fromNativeSource(source: any): definition.ImageSource {
 }
 
 export function fromUrl(url: string): Promise<definition.ImageSource> {
-    var http: typeof httpModule = require("http");
+    ensureHttp();
     return http.getImage(url);
 }
 

--- a/image-source/image-source.android.ts
+++ b/image-source/image-source.android.ts
@@ -7,6 +7,27 @@ import * as enumsModule from "ui/enums";
 
 global.moduleMerge(common, exports);
 
+var utils: typeof utilsModule;
+function ensureUtils() {
+    if (!utils) {
+        utils = require("utils/utils");
+    }
+}
+
+var fs: typeof fileSystemModule;
+function ensureFS() {
+    if (!fs) {
+        fs = require("file-system");
+    }
+}
+
+var enums: typeof enumsModule;
+function ensureEnums() {
+    if (!enums) {
+        enums = require("ui/enums");
+    }
+}
+
 export class ImageSource implements definition.ImageSource {
     public android: android.graphics.Bitmap;
     public ios: UIImage;
@@ -14,7 +35,7 @@ export class ImageSource implements definition.ImageSource {
     public loadFromResource(name: string): boolean {
         this.android = null;
 
-        var utils: typeof utilsModule = require("utils/utils");
+        ensureUtils();
 
         var res = utils.ad.getApplicationContext().getResources();
         if (res) {
@@ -32,7 +53,7 @@ export class ImageSource implements definition.ImageSource {
     }
 
     public loadFromFile(path: string): boolean {
-        var fs: typeof fileSystemModule = require("file-system");
+        ensureFS();
 
         var fileName = types.isString(path) ? path.trim() : "";
         if (fileName.indexOf("~/") === 0) {
@@ -112,7 +133,7 @@ export class ImageSource implements definition.ImageSource {
 }
 
 function getTargetFromat(format: string): android.graphics.Bitmap.CompressFormat {
-    var enums: typeof enumsModule = require("ui/enums");
+    ensureEnums();
 
     switch (format) {
         case enums.ImageFormat.jpeg:

--- a/trace/trace.ts
+++ b/trace/trace.ts
@@ -1,5 +1,5 @@
 ﻿import definition = require("trace");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 var _enabled = false;
 var _categories = {};
@@ -136,8 +136,6 @@ class ConsoleWriter implements definition.TraceWriter {
         if (!console) {
             return;
         }
-
-        var types: typeof typesModule = require("utils/types");
 
         var msgType;
         if (types.isUndefined(type)) {

--- a/ui/action-bar/action-bar-common.ts
+++ b/ui/action-bar/action-bar-common.ts
@@ -6,9 +6,15 @@ import enums = require("ui/enums");
 import proxy = require("ui/core/proxy");
 import view = require("ui/core/view");
 import * as styleModule from "../styling/style";
-import * as dependencyObservableModule from "ui/core/dependency-observable";
 
 var ACTION_ITEMS = "actionItems";
+
+var style: typeof styleModule;
+function ensureStyle() {
+    if (!style) {
+        style = require("../styling/style");
+    }
+}
 
 export module knownCollections {
     export var actionItems = "actionItems";
@@ -65,20 +71,18 @@ export class ActionBar extends view.View implements dts.ActionBar {
     }
     set titleView(value: view.View) {
         if (this._titleView !== value) {
-            var style: typeof styleModule = require("../styling/style");
-            var observable: typeof dependencyObservableModule = require("ui/core/dependency-observable");
-
+            ensureStyle();
             if (this._titleView) {
                 this._removeView(this._titleView);
-                this._titleView.style._resetValue(style.horizontalAlignmentProperty, observable.ValueSource.Inherited);
-                this._titleView.style._resetValue(style.verticalAlignmentProperty, observable.ValueSource.Inherited);
+                this._titleView.style._resetValue(style.horizontalAlignmentProperty, dependencyObservable.ValueSource.Inherited);
+                this._titleView.style._resetValue(style.verticalAlignmentProperty, dependencyObservable.ValueSource.Inherited);
             }
 
             this._titleView = value;
 
             if (this._titleView) {
-                this._titleView.style._setValue(style.horizontalAlignmentProperty, enums.HorizontalAlignment.center, observable.ValueSource.Inherited);
-                this._titleView.style._setValue(style.verticalAlignmentProperty, enums.VerticalAlignment.center, observable.ValueSource.Inherited);
+                this._titleView.style._setValue(style.horizontalAlignmentProperty, enums.HorizontalAlignment.center, dependencyObservable.ValueSource.Inherited);
+                this._titleView.style._setValue(style.verticalAlignmentProperty, enums.VerticalAlignment.center, dependencyObservable.ValueSource.Inherited);
                 this._addView(this._titleView);
             }
 

--- a/ui/action-bar/action-bar.android.ts
+++ b/ui/action-bar/action-bar.android.ts
@@ -17,6 +17,27 @@ const ACTION_ITEM_ID_OFFSET = 1000;
 
 global.moduleMerge(common, exports);
 
+var trace: typeof traceModule;
+function ensureTrace() {
+    if (!trace) {
+        trace = require("trace");
+    }
+}
+
+var utils: typeof utilsModule;
+function ensureUtils() {
+    if (!utils) {
+        utils = require("utils/utils");
+    }
+}
+
+var imageSource: typeof imageSourceModule;
+function ensureImageSource() {
+    if (!imageSource) {
+        imageSource = require("image-source");
+    }
+}
+
 var actionItemIdGenerator = ACTION_ITEM_ID_OFFSET;
 function generateItemId(): number {
     actionItemIdGenerator++;
@@ -309,7 +330,7 @@ export class ActionBar extends common.ActionBar {
         if (this._toolbar && child._nativeView) {
             this._toolbar.removeView(child._nativeView);
 
-            var trace: typeof traceModule = require("trace");
+            ensureTrace();
 
             trace.notifyEvent(child, "childInLayoutRemovedFromNativeVisualTree");
         }
@@ -321,7 +342,7 @@ function getDrawableOrResourceId(icon: string, resources: android.content.res.Re
         return undefined;
     }
 
-    var utils: typeof utilsModule = require("utils/utils");
+    ensureUtils();
 
     if (icon.indexOf(utils.RESOURCE_PREFIX) === 0) {
         var resourceId: number = resources.getIdentifier(icon.substr(utils.RESOURCE_PREFIX.length), 'drawable', application.android.packageName);
@@ -332,7 +353,7 @@ function getDrawableOrResourceId(icon: string, resources: android.content.res.Re
     else {
         var drawable: android.graphics.drawable.BitmapDrawable;
 
-        var imageSource: typeof imageSourceModule = require("image-source");
+        ensureImageSource();
 
         var is = imageSource.fromFileOrResource(icon);
         if (is) {

--- a/ui/animation/animation-common.ts
+++ b/ui/animation/animation-common.ts
@@ -2,6 +2,13 @@
 import viewModule = require("ui/core/view");
 import * as traceModule from "trace";
 
+var trace: typeof traceModule;
+function ensureTrace() {
+    if (!trace) {
+        trace = require("trace");
+    }
+}
+
 export module Properties {
     export var opacity = "opacity";
     export var backgroundColor = "backgroundColor";
@@ -56,7 +63,7 @@ export class Animation implements definition.Animation {
             throw new Error("No animation definitions specified");
         }
 
-        var trace : typeof traceModule = require("trace");
+        ensureTrace();
 
         trace.write("Analyzing " + animationDefinitions.length + " animation definitions...", trace.categories.Animation);
         this._propertyAnimations = new Array<PropertyAnimation>();

--- a/ui/builder/builder.ts
+++ b/ui/builder/builder.ts
@@ -1,5 +1,4 @@
-﻿import * as trace from "trace";
-import {debug, ScopeError, SourceError, Source} from "utils/debug";
+﻿import {debug, ScopeError, SourceError, Source} from "utils/debug";
 import * as xml from "xml";
 import {View, Template} from "ui/core/view";
 import {File, path, knownFolders} from "file-system";
@@ -12,6 +11,13 @@ import {resolveFileName} from "file-system/file-name-resolver";
 import * as traceModule from "trace";
 
 const defaultNameSpaceMatcher = /tns\.xsd$/i;
+
+var trace: typeof traceModule;
+function ensureTrace() {
+    if (!trace) {
+        trace = require("trace");
+    }
+}
 
 export function parse(value: string | Template, context: any): View {
     if (isString(value)) {
@@ -90,7 +96,7 @@ function loadCustomComponent(componentPath: string, componentName?: string, attr
         if (parentPage) {
             parentPage.addCssFile(cssFilePath);
         } else {
-            var trace: typeof traceModule = require("trace");
+            ensureTrace();
 
             trace.write("CSS file found but no page specified. Please specify page in the options!", trace.categories.Error, trace.messageType.error);
         }

--- a/ui/builder/component-builder.ts
+++ b/ui/builder/component-builder.ts
@@ -27,6 +27,13 @@ var MODULES = {
 var CODEFILE = "codeFile";
 var CSSFILE = "cssFile";
 
+var platform: typeof platformModule;
+function ensurePlatform() {
+    if (!platform) {
+        platform = require("platform");
+    }
+}
+
 export function getComponentModule(elementName: string, namespace: string, attributes: Object, exports: Object): ComponentModule {
     var instance: View;
     var instanceModule: Object;
@@ -109,7 +116,7 @@ export function getComponentModule(elementName: string, namespace: string, attri
             if (attr.indexOf(":") !== -1) {
                 var platformName = attr.split(":")[0].trim();
 
-                var platform: typeof platformModule = require("platform");
+                ensurePlatform();
 
                 if (platformName.toLowerCase() === platform.device.os.toLowerCase()) {
                     attr = attr.split(":")[1].trim();

--- a/ui/button/button-common.ts
+++ b/ui/button/button-common.ts
@@ -7,6 +7,20 @@ import observable = require("data/observable");
 import * as weakEventListenerModule from "ui/core/weak-event-listener";
 import * as enumsModule from "ui/enums";
 
+var weakEvents: typeof weakEventListenerModule;
+function ensureWeakEvents() {
+    if (!weakEvents) {
+        weakEvents = require("ui/core/weak-event-listener");
+    }
+}
+
+var enums: typeof enumsModule;
+function ensureEnums() {
+    if (!enums) {
+        enums = require("ui/enums");
+    }
+}
+
 var textProperty = new dependencyObservable.Property(
     "text",
     "Button",
@@ -65,7 +79,7 @@ export class Button extends view.View implements definition.Button {
 
     set formattedText(value: formattedString.FormattedString) {
         if (this.formattedText !== value) {
-            var weakEvents: typeof weakEventListenerModule = require("ui/core/weak-event-listener");
+            ensureWeakEvents();
 
             if (this.formattedText) {
                 weakEvents.removeWeakEventListener(this.formattedText, observable.Observable.propertyChangeEvent, this.onFormattedTextChanged, this);
@@ -129,7 +143,7 @@ export class Button extends view.View implements definition.Button {
 
 function onTextWrapPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var v = <view.View>data.object;
-    var enums : typeof enumsModule = require("ui/enums");
+    ensureEnums();
 
     v.style.whiteSpace = data.newValue ? enums.WhiteSpace.normal : enums.WhiteSpace.nowrap;
 }

--- a/ui/content-view/content-view.ts
+++ b/ui/content-view/content-view.ts
@@ -1,6 +1,6 @@
 ﻿import definition = require("ui/content-view");
 import view = require("ui/core/view");
-import * as utilsModule from "utils/utils";
+import * as utils from "utils/utils";
 
 export class ContentView extends view.CustomLayoutView implements definition.ContentView, view.AddChildFromBuilder {
     private _content: view.View;
@@ -50,7 +50,6 @@ export class ContentView extends view.CustomLayoutView implements definition.Con
     // This method won't be called in Android because we use the native android layout.
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
         var result = view.View.measureChild(this, this.content, widthMeasureSpec, heightMeasureSpec);
-        var utils: typeof utilsModule = require("utils/utils");
 
         var width = utils.layout.getMeasureSpecSize(widthMeasureSpec);
         var widthMode = utils.layout.getMeasureSpecMode(widthMeasureSpec);

--- a/ui/core/bindable.ts
+++ b/ui/core/bindable.ts
@@ -11,13 +11,25 @@ import * as polymerExpressionsModule from "js-libs/polymer-expressions";
 import * as specialPropertiesModule from "ui/builder/special-properties";
 
 //late import
-var _appModule: typeof applicationModule = null;
-
-function appModule() {
-    if (!_appModule) {
-        _appModule = require("application");
+var application: typeof applicationModule;
+function ensureApplication() {
+    if (!application) {
+        application = require("application");
     }
-    return _appModule;
+}
+
+var expressions: typeof polymerExpressionsModule;
+function ensureExpressions() {
+    if (!expressions) {
+        expressions = require("js-libs/polymer-expressions");
+    }
+}
+
+var specialProperties: typeof specialPropertiesModule;
+function ensureSpecialProperties() {
+    if (!specialProperties) {
+        specialProperties = require("ui/builder/special-properties");
+    }
 }
 
 var bindingContextProperty = new dependencyObservable.Property(
@@ -364,15 +376,16 @@ export class Binding {
 
     private _getExpressionValue(expression: string, isBackConvert: boolean, changedModel: any): any {
         try {
-            var polymerExpressions: typeof polymerExpressionsModule = require("js-libs/polymer-expressions");
+            ensureExpressions();
 
-            var exp = polymerExpressions.PolymerExpressions.getExpression(expression);
+            var exp = expressions.PolymerExpressions.getExpression(expression);
             if (exp) {
                 var context = this.source && this.source.get && this.source.get() || global;
                 var model = {};
-                for (var prop in appModule().resources) {
-                    if (appModule().resources.hasOwnProperty(prop) && !context.hasOwnProperty(prop)) {
-                        context[prop] = appModule().resources[prop];
+                ensureApplication();
+                for (var prop in application.resources) {
+                    if (application.resources.hasOwnProperty(prop) && !context.hasOwnProperty(prop)) {
+                        context[prop] = application.resources[prop];
                     }
                 }
 
@@ -593,9 +606,9 @@ export class Binding {
                 optionsInstance.off(options.property, null, optionsInstance.bindingContext);
                 optionsInstance.on(options.property, value, optionsInstance.bindingContext);
             } else {
-                var sp: typeof specialPropertiesModule = require("ui/builder/special-properties");
+                ensureSpecialProperties();
 
-                let specialSetter = sp.getSpecialPropertySetter(options.property);
+                let specialSetter = specialProperties.getSpecialPropertySetter(options.property);
                 if (specialSetter) {
                     specialSetter(optionsInstance, value);
                 } else {

--- a/ui/core/control-state-change.ios.ts
+++ b/ui/core/control-state-change.ios.ts
@@ -1,6 +1,6 @@
 ﻿/* tslint:disable:no-unused-variable */
 import definition = require("ui/core/control-state-change");
-import * as visualStateConstantsModule from "ui/styling/visual-state-constants";
+import * as visualStateConstants from "ui/styling/visual-state-constants";
 
 var ObserverClass = NSObject.extend(
     {
@@ -50,8 +50,6 @@ export class ControlStateChangeListener implements definition.ControlStateChange
     }
 
     private _updateState() {
-        var visualStateConstants: typeof visualStateConstantsModule = require("ui/styling/visual-state-constants");
-
         var state = visualStateConstants.Normal;
         if (this._control.highlighted) {
             state = visualStateConstants.Pressed;

--- a/ui/core/proxy.ts
+++ b/ui/core/proxy.ts
@@ -1,9 +1,9 @@
 ﻿import bindable = require("ui/core/bindable");
 import dependencyObservable = require("ui/core/dependency-observable");
 import definition = require("ui/core/proxy");
-import * as platformModule from "platform";
-import * as typesModule from "utils/types";
-import * as observableModule from "data/observable";
+import * as platform from "platform";
+import * as types from "utils/types";
+import * as observable from "data/observable";
 
 export class PropertyMetadata extends dependencyObservable.PropertyMetadata implements definition.PropertyMetadata {
     private _onSetNativeValue: dependencyObservable.PropertyChangedCallback;
@@ -77,8 +77,6 @@ export class ProxyObject extends bindable.Bindable implements definition.ProxyOb
             return;
         }
 
-        var platform: typeof platformModule = require("platform");
-
         if (platform.device.os === platform.platformNames.android && !this.android) {
             // in android we have lazy loading and we do not have a native widget created yet, do not call the onSetNativeValue callback
             // properties will be synced when the widget is created
@@ -92,13 +90,9 @@ export class ProxyObject extends bindable.Bindable implements definition.ProxyOb
 
         var proxyMetadata = <PropertyMetadata>metadata;
         if (proxyMetadata.onSetNativeValue) {
-            var types: typeof typesModule = require("utils/types");
-
             if (types.isUndefined(newValue)) {
                 newValue = this._getValue(property);
             }
-
-            var observable: typeof observableModule = require("data/observable"); 
 
             proxyMetadata.onSetNativeValue({
                 object: this,

--- a/ui/core/view-common.ts
+++ b/ui/core/view-common.ts
@@ -14,9 +14,23 @@ import {PropertyMetadata, ProxyObject} from "ui/core/proxy";
 import {PropertyMetadataSettings, PropertyChangeData, Property, ValueSource, PropertyMetadata as doPropertyMetadata} from "ui/core/dependency-observable";
 import {registerSpecialProperty} from "ui/builder/special-properties";
 import {CommonLayoutParams, nativeLayoutParamsProperty} from "ui/styling/style";
-import * as visualStateConstantsModule from "ui/styling/visual-state-constants";
+import * as visualStateConstants from "ui/styling/visual-state-constants";
 import * as bindableModule from "ui/core/bindable";
 import * as visualStateModule from "../styling/visual-state";
+
+var bindable: typeof bindableModule;
+function ensureBindable() {
+    if (!bindable) {
+        bindable = require("ui/core/bindable");
+    }
+}
+
+var visualState: typeof visualStateModule;
+function ensureVisualState() {
+    if (!visualState) {
+        visualState = require("../styling/visual-state");
+    }
+}
 
 registerSpecialProperty("class", (instance: definition.View, propertyValue: string) => {
     instance.className = propertyValue;
@@ -181,9 +195,6 @@ export class View extends ProxyObject implements definition.View {
 
         this._style = new style.Style(this);
         this._domId = viewIdCounter++;
-
-        var visualStateConstants: typeof visualStateConstantsModule = require("ui/styling/visual-state-constants");
-
         this._visualState = visualStateConstants.Normal;
     }
 
@@ -1009,7 +1020,7 @@ export class View extends ProxyObject implements definition.View {
             view.onUnloaded();
         }
 
-        var bindable: typeof bindableModule = require("ui/core/bindable");
+        ensureBindable();
 
         view._setValue(bindable.Bindable.bindingContextProperty, undefined, ValueSource.Inherited);
         var inheritablePropertiesSetCallback = function (property: Property) {
@@ -1056,8 +1067,8 @@ export class View extends ProxyObject implements definition.View {
             return;
         }
         // we use lazy require to prevent cyclic dependencies issues
-        var vsm: typeof visualStateModule = require("ui/styling/visual-state");
-        this._visualState = vsm.goToState(this, state);
+        ensureVisualState();
+        this._visualState = visualState.goToState(this, state);
 
         // TODO: What state should we set here - the requested or the actual one?
         this._requestedVisualState = state;

--- a/ui/core/view.android.ts
+++ b/ui/core/view.android.ts
@@ -5,7 +5,7 @@ import utils = require("utils/utils");
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
 import gestures = require("ui/gestures");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 import style = require("ui/styling/style");
 import styling = require("ui/styling");
 import enums = require("ui/enums");
@@ -403,8 +403,6 @@ export class CustomLayoutView extends View implements viewDefinition.CustomLayou
         super._addViewToNativeVisualTree(child);
 
         if (this._nativeView && child._nativeView) {
-            var types: typeof typesModule = require("utils/types");
-
             if (types.isNullOrUndefined(atIndex) || atIndex >= this._nativeView.getChildCount()) {
                 this._nativeView.addView(child._nativeView);
             }

--- a/ui/core/view.ios.ts
+++ b/ui/core/view.ios.ts
@@ -8,6 +8,13 @@ import styling = require("ui/styling");
 import enums = require("ui/enums");
 import * as backgroundModule from "ui/styling/background";
 
+var background: typeof backgroundModule;
+function ensureBackground() {
+    if (!background) {
+        background = require("ui/styling/background");
+    }
+}
+
 global.moduleMerge(viewCommon, exports);
 
 function onAutomationTextPropertyChanged(data: dependencyObservable.PropertyChangeData) {
@@ -322,7 +329,7 @@ export class ViewStyler implements style.Styler {
     private static setBackgroundInternalProperty(view: View, newValue: any) {
         var nativeView: UIView = <UIView>view._nativeView;
         if (nativeView) {
-            var background: typeof backgroundModule = require("ui/styling/background");
+            ensureBackground();
             nativeView.backgroundColor = background.ios.createBackgroundUIColor(view);
         }
     }

--- a/ui/core/weak-event-listener.ts
+++ b/ui/core/weak-event-listener.ts
@@ -1,5 +1,5 @@
 ﻿import observable = require("data/observable");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 var handlersForEventName = new Map<string,(eventData: observable.EventData) => void>();
 var sourcesMap = new WeakMap<observable.Observable, Map<string, Array<TargetHandlerPair>>>();
@@ -62,8 +62,6 @@ function getHandlerForEventName(eventName: string): (eventData: observable.Event
 }
 
 function validateArgs(source: observable.Observable, eventName: string, handler: (eventData: observable.EventData) => void, target: any) {
-    var types: typeof typesModule = require("utils/types");
-
     if (types.isNullOrUndefined(source)) {
         throw new Error("source is null or undefined");
     }

--- a/ui/date-picker/date-picker.android.ts
+++ b/ui/date-picker/date-picker.android.ts
@@ -2,7 +2,7 @@
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
 import utils = require("utils/utils")
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 function onYearPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var picker = <DatePicker>data.object;
@@ -35,8 +35,6 @@ function onDayPropertyChanged(data: dependencyObservable.PropertyChangeData) {
 (<proxy.PropertyMetadata>common.DatePicker.dayProperty.metadata).onSetNativeValue = onDayPropertyChanged;
 
 function updateNativeDate(picker: DatePicker) {
-    var types: typeof typesModule = require("utils/types");
-
     var year = types.isNumber(picker.year) ? picker.year : picker.android.getYear();
     var month = types.isNumber(picker.month) ? (picker.month - 1) : picker.android.getMonth();
     var day = types.isNumber(picker.day) ? picker.day : picker.android.getDayOfMonth();

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -3,11 +3,16 @@ import {View, CustomLayoutView} from "ui/core/view";
 import {Page} from "ui/page";
 import {isString, isFunction, isDefined} from "utils/types";
 import * as trace from "trace";
-import {load as buildModule} from "ui/builder";
-import {knownFolders, path} from "file-system";
 import {resolveFileName} from "file-system/file-name-resolver";
-import * as fileSystemModule from "file-system";
+import * as fs from "file-system";
 import * as builderModule from "ui/builder";
+
+var builder: typeof builderModule;
+function ensureBuilder() {
+    if (!builder) {
+        builder = require("ui/builder");
+    }
+}
 
 var frameStack: Array<Frame> = [];
 
@@ -58,12 +63,10 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): Page {
         }
     }
     else if (entry.moduleName) {
-        var fs: typeof fileSystemModule = require("file-system");
-
         // Current app full path.
-        var currentAppPath = knownFolders.currentApp().path;
+        var currentAppPath = fs.knownFolders.currentApp().path;
         //Full path of the module = current app full path + module name.
-        var moduleNamePath = path.join(currentAppPath, entry.moduleName);
+        var moduleNamePath = fs.path.join(currentAppPath, entry.moduleName);
 
         var moduleExports;
         if (global.moduleExists(entry.moduleName)) {
@@ -111,10 +114,10 @@ function pageFromBuilder(moduleNamePath: string, moduleExports: any): Page {
     if (fileName) {
         trace.write("Loading XML file: " + fileName, trace.categories.Navigation);
 
-        var builder: typeof builderModule = require("ui/builder");
+        ensureBuilder();
 
         // Or check if the file exists in the app modules and load the page from XML.
-        element = buildModule(fileName, moduleExports);
+        element = builder.load(fileName, moduleExports);
         if (element instanceof Page) {
             page = <Page>element;
         }

--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -4,7 +4,7 @@ import pages = require("ui/page");
 import trace = require("trace");
 import observable = require("data/observable");
 import application = require("application");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 import * as utilsModule from "utils/utils";
 
 global.moduleMerge(frameCommon, exports);
@@ -366,8 +366,6 @@ export class Frame extends frameCommon.Frame {
     }
 
     public _getNavBarVisible(page: pages.Page): boolean {
-        var types : typeof typesModule = require("utils/types");
-
         if (types.isDefined(page.actionBarHidden)) {
             return !page.actionBarHidden;
         }

--- a/ui/frame/frame.d.ts
+++ b/ui/frame/frame.d.ts
@@ -248,6 +248,7 @@ declare module "ui/frame" {
     }
 
     //@private
-    export function reloadPage(): void;
+    function reloadPage(): void;
+    function resolvePageFromEntry(entry: NavigationEntry): pages.Page;
     //@endprivate
 }

--- a/ui/frame/frame.ios.ts
+++ b/ui/frame/frame.ios.ts
@@ -6,7 +6,7 @@ import enums = require("ui/enums");
 import utils = require("utils/utils");
 import view = require("ui/core/view");
 import uiUtils = require("ui/utils");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 global.moduleMerge(frameCommon, exports);
 
@@ -146,8 +146,6 @@ export class Frame extends frameCommon.Frame {
 
             case enums.NavigationBarVisibility.auto:
                 let newValue: boolean;
-
-                var types: typeof typesModule = require("utils/types");
 
                 if (page && types.isDefined(page.actionBarHidden)) {
                     newValue = !page.actionBarHidden;

--- a/ui/html-view/html-view.ios.ts
+++ b/ui/html-view/html-view.ios.ts
@@ -2,8 +2,8 @@
 import definition = require("ui/html-view");
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
-import * as utilsModule from "utils/utils";
-import * as viewModule from "ui/core/view";
+import * as utils from "utils/utils";
+import * as view from "ui/core/view";
 
 function onHtmlPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var view = <HtmlView>data.object;
@@ -53,8 +53,6 @@ export class HtmlView extends common.HtmlView {
         var nativeView = this._nativeView;
         if (nativeView) {
 
-            var utils: typeof utilsModule = require("utils/utils");
-
             var width = utils.layout.getMeasureSpecSize(widthMeasureSpec);
             var widthMode = utils.layout.getMeasureSpecMode(widthMeasureSpec);
 
@@ -76,8 +74,6 @@ export class HtmlView extends common.HtmlView {
 
             var measureWidth = Math.max(labelWidth, this.minWidth);
             var measureHeight = Math.max(nativeSize.height, this.minHeight);
-
-            var view: typeof viewModule = require("ui/core/view");
 
             var widthAndState = view.View.resolveSizeAndState(measureWidth, width, widthMode, 0);
             var heightAndState = view.View.resolveSizeAndState(measureHeight, height, heightMode, 0);

--- a/ui/image-cache/image-cache.ios.ts
+++ b/ui/image-cache/image-cache.ios.ts
@@ -3,6 +3,13 @@ import utils = require("utils/utils");
 import trace = require("trace");
 import * as httpRequestModule from "http/http-request";
 
+var httpRequest: typeof httpRequestModule;
+function ensureHttpRequest() {
+    if (!httpRequest) {
+        httpRequest = require("http/http-request");
+    }
+}
+
 //class NSCacheDelegateImpl extends NSObject implements NSCacheDelegate {
 //    public static ObjCProtocols = [NSCacheDelegate];
 
@@ -65,7 +72,7 @@ export class Cache extends common.Cache {
     }
 
     public _downloadCore(request: common.DownloadRequest) {
-        var httpRequest: typeof httpRequestModule = require("http/http-request");
+        ensureHttpRequest();
 
         var that = this;
         httpRequest.request({ url: request.url, method: "GET" })

--- a/ui/image/image-common.ts
+++ b/ui/image/image-common.ts
@@ -7,7 +7,7 @@ import enums = require("ui/enums");
 import platform = require("platform");
 import utils = require("utils/utils");
 
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 var SRC = "src";
 var IMAGE_SOURCE = "imageSource";
@@ -22,8 +22,6 @@ var AffectsLayout = platform.device.os === platform.platformNames.android ? depe
 function onSrcPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var image = <Image>data.object;
     var value = data.newValue;
-
-    var types: typeof typesModule = require("utils/types");
 
     if (types.isString(value)) {
         value = value.trim();

--- a/ui/image/image.android.ts
+++ b/ui/image/image.android.ts
@@ -11,13 +11,20 @@ import utils = require("utils/utils");
 
 global.moduleMerge(imageCommon, exports);
 
+var enums: typeof enumsModule;
+function ensureEnums() {
+    if (!enums) {
+        enums = require("ui/enums");
+    }
+}
+
 function onStretchPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var image = <Image>data.object;
     if (!image.android) {
         return;
     }
 
-    var enums: typeof enumsModule = require("ui/enums");
+    ensureEnums();
 
     switch (data.newValue) {
         case enums.Stretch.aspectFit:

--- a/ui/label/label-common.ts
+++ b/ui/label/label-common.ts
@@ -5,6 +5,13 @@ import textBase = require("ui/text-base");
 import view = require("ui/core/view");
 import * as enumsModule from "ui/enums";
 
+var enums: typeof enumsModule;
+function ensureEnums() {
+    if (!enums) {
+        enums = require("ui/enums");
+    }
+}
+
 export class Label extends textBase.TextBase implements definition.Label {
     public static textWrapProperty = new dependencyObservable.Property(
         "textWrap",
@@ -26,7 +33,7 @@ export class Label extends textBase.TextBase implements definition.Label {
 
 function onTextWrapPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var v = <view.View>data.object;
-    var enums: typeof enumsModule = require("ui/enums");
+    ensureEnums();
 
     v.style.whiteSpace = data.newValue ? enums.WhiteSpace.normal : enums.WhiteSpace.nowrap;
 }

--- a/ui/label/label.ios.ts
+++ b/ui/label/label.ios.ts
@@ -1,13 +1,20 @@
 ﻿import common = require("./label-common");
 import definition = require("ui/label");
-import * as enumsModule from "ui/enums";
-import * as utilsModule from "utils/utils";
+import * as enums from "ui/enums";
+import * as utils from "utils/utils";
 import * as backgroundModule from "ui/styling/background";
 import view = require("ui/core/view");
 import style = require("ui/styling/style");
 import styling = require("ui/styling");
 
 global.moduleMerge(common, exports);
+
+var background: typeof backgroundModule;
+function ensureBackground() {
+    if (!background) {
+        background = require("ui/styling/background");
+    }
+}
 
 class UILabelImpl extends UILabel {
 
@@ -73,8 +80,6 @@ export class Label extends common.Label {
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
         var nativeView = this._nativeView;
         if (nativeView) {
-            var utils: typeof utilsModule = require("utils/utils");
-
             var width = utils.layout.getMeasureSpecSize(widthMeasureSpec);
             var widthMode = utils.layout.getMeasureSpecMode(widthMeasureSpec);
 
@@ -91,8 +96,6 @@ export class Label extends common.Label {
 
             var nativeSize = nativeView.sizeThatFits(CGSizeMake(width, height));
             var labelWidth = nativeSize.width;
-
-            var enums: typeof enumsModule = require("ui/enums");
 
             if (!this.textWrap && this.style.whiteSpace !== enums.WhiteSpace.nowrap) {
                 labelWidth = Math.min(labelWidth, width);
@@ -115,7 +118,7 @@ export class LabelStyler implements style.Styler {
         var uiLabel: UILabel = <UILabel>view._nativeView;
         if (uiLabel && uiLabel.layer) {
             var flipImage = true;
-            var background: typeof backgroundModule = require("ui/styling/background");
+            ensureBackground();
             var uiColor = <UIColor>background.ios.createBackgroundUIColor(view, flipImage);
             var cgColor = uiColor ? uiColor.CGColor : null;
             uiLabel.layer.backgroundColor = cgColor;

--- a/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/ui/layouts/grid-layout/grid-layout-common.ts
@@ -8,6 +8,13 @@ import {registerSpecialProperty} from "ui/builder/special-properties";
 import numberUtils = require("../../../utils/number-utils");
 import * as typesModule from "utils/types";
 
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
 function validateArgs(element: View): View {
     if (!element) {
         throw new Error("element cannot be null or undefinied.");
@@ -47,7 +54,7 @@ export class ItemSpec extends Bindable implements definition.ItemSpec {
 
         }
         else if (arguments.length === 2) {
-            var types: typeof typesModule = require("utils/types");
+            ensureTypes();
 
             if (types.isNumber(arguments[0]) && types.isString(arguments[1])) {
                 if (arguments[0] < 0 || (arguments[1] !== GridUnitType.auto && arguments[1] !== GridUnitType.star && arguments[1] !== GridUnitType.pixel)) {

--- a/ui/layouts/layout.android.ts
+++ b/ui/layouts/layout.android.ts
@@ -2,7 +2,7 @@
 import view = require("ui/core/view");
 import layoutBase = require("ui/layouts/layout-base");
 import trace = require("trace");
-import * as utilsModule from "utils/utils";
+import * as utils from "utils/utils";
 
 var OWNER = "_owner";
 
@@ -52,8 +52,6 @@ export class Layout extends layoutBase.LayoutBase implements definition.Layout {
 
         var view = this._nativeView;
         if (view) {
-            var utils: typeof utilsModule = require("utils/utils");
-
             var width = utils.layout.getMeasureSpecSize(widthMeasureSpec);
             var widthMode = utils.layout.getMeasureSpecMode(widthMeasureSpec);
 

--- a/ui/list-picker/list-picker.android.ts
+++ b/ui/list-picker/list-picker.android.ts
@@ -1,7 +1,7 @@
 ﻿import common = require("./list-picker-common");
 import dependencyObservable = require("ui/core/dependency-observable");
 import utils = require("utils/utils")
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 global.moduleMerge(common, exports);
 
@@ -71,8 +71,6 @@ export class ListPicker extends common.ListPicker {
 
     public _onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChangeData) {
         super._onSelectedIndexPropertyChanged(data);
-        var types: typeof typesModule = require("utils/types");
-
         if (this.android && types.isNumber(data.newValue)) {
             this.android.setValue(data.newValue);
         }

--- a/ui/list-picker/list-picker.ios.ts
+++ b/ui/list-picker/list-picker.ios.ts
@@ -1,6 +1,6 @@
 ﻿import common = require("./list-picker-common");
 import dependencyObservable = require("ui/core/dependency-observable");
-import * as typesModule from "utils/types";
+import * as types from "utils/types";
 
 global.moduleMerge(common, exports);
 
@@ -33,8 +33,6 @@ export class ListPicker extends common.ListPicker {
 
     public _onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChangeData) {
         super._onSelectedIndexPropertyChanged(data);
-        var types: typeof typesModule = require("utils/types");
-
         if (this.ios && types.isNumber(data.newValue)) {
             this.ios.selectRowInComponentAnimated(data.newValue, 0, false);
         }

--- a/ui/list-view/list-view-common.ts
+++ b/ui/list-view/list-view-common.ts
@@ -9,6 +9,34 @@ import * as labelModule from "ui/label";
 import * as observableArrayModule from "data/observable-array";
 import * as weakEventsModule from "ui/core/weak-event-listener";
 
+var builder: typeof builderModule;
+function ensureBuilder() {
+    if (!builder) {
+        builder = require("ui/builder");
+    }
+}
+
+var label: typeof labelModule;
+function ensureLabel() {
+    if (!label) {
+        label = require("ui/label");
+    }
+}
+
+var observableArray: typeof observableArrayModule;
+function ensureObservableArray() {
+    if (!observableArray) {
+        observableArray = require("data/observable-array");
+    }
+}
+
+var weakEvents: typeof weakEventsModule;
+function ensureWeakEvents() {
+    if (!weakEvents) {
+        weakEvents = require("ui/core/weak-event-listener");
+    }
+}
+
 var ITEMS = "items";
 var ITEMTEMPLATE = "itemTemplate";
 var ISSCROLLING = "isScrolling";
@@ -129,11 +157,10 @@ export class ListView extends view.View implements definition.ListView {
     }
 
     public _getItemTemplateContent(index: number): view.View {
+        ensureBuilder();
+
         var v;
-
         if (this.itemTemplate && this.items) {
-            var builder : typeof builderModule = require("ui/builder");
-
             v = builder.parse(this.itemTemplate, this);
         }
 
@@ -156,7 +183,7 @@ export class ListView extends view.View implements definition.ListView {
     }
 
     public _getDefaultItemContent(index: number): view.View {
-        var label: typeof labelModule = require("ui/label");
+        ensureLabel();
 
         var lbl = new label.Label();
         lbl.bind({
@@ -167,8 +194,8 @@ export class ListView extends view.View implements definition.ListView {
     }
 
     public _onItemsPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-        var observableArray: typeof observableArrayModule = require("data/observable-array");
-        var weakEvents: typeof weakEventsModule = require("ui/core/weak-event-listener");
+        ensureObservableArray();
+        ensureWeakEvents();
 
         if (data.oldValue instanceof observable.Observable) {
             weakEvents.removeWeakEventListener(data.oldValue, observableArray.ObservableArray.changeEvent, this._onItemsChanged, this);

--- a/ui/list-view/list-view.android.ts
+++ b/ui/list-view/list-view.android.ts
@@ -6,8 +6,15 @@ import proxy = require("ui/core/proxy");
 import dependencyObservable = require("ui/core/dependency-observable");
 import definition = require("ui/list-view");
 import utils = require("utils/utils")
-import * as layoutBaseModule from "ui/layouts/layout-base";
+import * as layoutBase from "ui/layouts/layout-base";
 import * as colorModule from "color";
+
+var color: typeof colorModule;
+function ensureColor() {
+    if (!color) {
+        color = require("color");
+    }
+}
 
 var ITEMLOADING = common.ListView.itemLoadingEvent;
 var LOADMOREITEMS = common.ListView.loadMoreItemsEvent;
@@ -22,7 +29,7 @@ function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChan
         return;
     }
 
-    var color: typeof colorModule = require("color");
+    ensureColor();
 
     if (data.newValue instanceof color.Color) {
         bar.android.setDivider(new android.graphics.drawable.ColorDrawable(data.newValue.android));
@@ -222,8 +229,6 @@ function ensureListViewAdapterClass() {
                 }
                 this._listView._prepareItem(args.view, index);
                 if (!args.view.parent) {
-                    var layoutBase: typeof layoutBaseModule = require("ui/layouts/layout-base");
-
                     if (args.view instanceof layoutBase.LayoutBase) {
                         this._listView._addView(args.view);
                         convertView = args.view.android;

--- a/ui/list-view/list-view.ios.ts
+++ b/ui/list-view/list-view.ios.ts
@@ -7,6 +7,13 @@ import proxy = require("ui/core/proxy");
 import dependencyObservable = require("ui/core/dependency-observable");
 import * as colorModule from "color";
 
+var color: typeof colorModule;
+function ensureColor() {
+    if (!color) {
+        color = require("color");
+    }
+}
+
 var CELLIDENTIFIER = "cell";
 var ITEMLOADING = common.ListView.itemLoadingEvent;
 var LOADMOREITEMS = common.ListView.loadMoreItemsEvent;
@@ -181,7 +188,7 @@ function onSeparatorColorPropertyChanged(data: dependencyObservable.PropertyChan
         return;
     }
 
-    var color: typeof colorModule = require("color");
+    ensureColor();
 
     if (data.newValue instanceof color.Color) {
         bar.ios.separatorColor = data.newValue.ios;

--- a/ui/page/page.android.ts
+++ b/ui/page/page.android.ts
@@ -2,12 +2,26 @@
 import definition = require("ui/page");
 import view = require("ui/core/view");
 import enums = require("ui/enums");
-import * as actionBarModule from "ui/action-bar";
-import * as gridLayoutModule from "ui/layouts/grid-layout";
+import * as actionBar from "ui/action-bar";
+import * as gridLayout from "ui/layouts/grid-layout";
 import * as traceModule from "trace";
 import * as colorModule from "color";
 
 global.moduleMerge(pageCommon, exports);
+
+var trace: typeof traceModule;
+function ensureTrace() {
+    if (!trace) {
+        trace = require("trace");
+    }
+}
+
+var color: typeof colorModule;
+function ensureColor() {
+    if (!color) {
+        color = require("color");
+    }
+}
 
 var DialogFragmentClass;
 function ensureDialogFragmentClass() {
@@ -87,16 +101,13 @@ export class Page extends pageCommon.Page {
     public _addViewToNativeVisualTree(child: view.View, atIndex?: number): boolean {
         // Set the row property for the child 
         if (this._nativeView && child._nativeView) {
-            var actionBar: typeof actionBarModule = require("ui/action-bar");
-            var grid: typeof gridLayoutModule = require("ui/layouts/grid-layout");
-
             if (child instanceof actionBar.ActionBar) {
-                grid.GridLayout.setRow(child, 0);
+                gridLayout.GridLayout.setRow(child, 0);
                 child.horizontalAlignment = enums.HorizontalAlignment.stretch;
                 child.verticalAlignment = enums.VerticalAlignment.top;
             }
             else {
-                grid.GridLayout.setRow(child, 1);
+                gridLayout.GridLayout.setRow(child, 1);
             }
         }
 
@@ -107,8 +118,7 @@ export class Page extends pageCommon.Page {
         var skipDetached = !force && this.frame.android.cachePagesOnNavigate && !this._isBackNavigation;
 
         if (skipDetached) {
-            var trace: typeof traceModule = require("trace");
-
+            ensureTrace();
             // Do not detach the context and android reference.
             trace.write("Caching Page " + this._domId, trace.categories.NativeLifecycle);
         }
@@ -128,8 +138,7 @@ export class Page extends pageCommon.Page {
     protected _showNativeModalView(parent: Page, context: any, closeCallback: Function, fullscreen?: boolean) {
         super._showNativeModalView(parent, context, closeCallback, fullscreen);
         if (!this.backgroundColor) {
-            var color: typeof colorModule = require("color");
-
+            ensureColor();
             this.backgroundColor = new color.Color("White");
         }
 

--- a/ui/repeater/repeater.ts
+++ b/ui/repeater/repeater.ts
@@ -6,13 +6,20 @@ import observable = require("data/observable");
 import layoutBaseModule = require("ui/layouts/layout-base");
 import utils = require("utils/utils");
 import trace = require("trace");
-import * as platformModule from "platform";
-import * as stackLayoutModule from "ui/layouts/stack-layout";
-import * as typesModule from "utils/types";
-import * as builderModule from "ui/builder";
+import * as platform from "platform";
+import * as stackLayout from "ui/layouts/stack-layout";
+import * as types from "utils/types";
+import * as builder from "ui/builder";
 import * as labelModule from "ui/label";
-import * as observableArrayModule from "data/observable-array";
-import * as weakEventListenerModule from "ui/core/weak-event-listener";
+import * as observableArray from "data/observable-array";
+import * as weakEvents from "ui/core/weak-event-listener";
+
+var label: typeof labelModule;
+function ensureLabel() {
+    if (!label) {
+        label = require("ui/label");
+    }
+}
 
 var ITEMS = "items";
 var ITEMTEMPLATE = "itemTemplate";
@@ -46,13 +53,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     constructor() {
         super();
 
-        var platform: typeof platformModule = require("platform");
-
         if (platform.device.os === platform.platformNames.ios) {
             this._ios = UIView.new();
         }
-
-        var stackLayout: typeof stackLayoutModule = require("ui/layouts/stack-layout");
 
         this.itemsLayout = new stackLayout.StackLayout();
     }
@@ -131,13 +134,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
             this.itemsLayout.removeChildren();
         }
 
-        var types : typeof typesModule = require("utils/types");
-
         if (types.isNullOrUndefined(this.items) || !types.isNumber(this.items.length)) {
             return;
         }
-
-        var builder: typeof builderModule = require("ui/builder");
 
         var length = this.items.length;
         for (let i = 0; i < length; i++) {
@@ -153,9 +152,6 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     public _onItemsPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-        var observableArray: typeof observableArrayModule = require("data/observable-array");
-        var weakEvents: typeof weakEventListenerModule = require("ui/core/weak-event-listener");
-
         trace.write(`Repeater._onItemsPropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
         if (data.oldValue instanceof observableArray.ObservableArray) {
             weakEvents.removeWeakEventListener(data.oldValue, observableArray.ObservableArray.changeEvent, this._onItemsChanged, this);
@@ -192,7 +188,7 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     public _getDefaultItemContent(index: number): viewModule.View {
-        var label: typeof labelModule = require("ui/label");
+        ensureLabel();
 
         var lbl = new label.Label();
         lbl.bind({

--- a/ui/search-bar/search-bar.android.ts
+++ b/ui/search-bar/search-bar.android.ts
@@ -9,6 +9,13 @@ import style = require("ui/styling/style");
 import view = require("ui/core/view");
 import font = require("ui/styling/font");
 
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
 var SEARCHTEXT = "searchText";
 var QUERY = "query";
 var EMPTY = "";
@@ -60,7 +67,7 @@ function onHintPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     }
 
     var newValue = data.newValue;
-    var types: typeof typesModule = require("utils/types");
+    ensureTypes();
 
     if (types.isString(newValue)) {
         bar.android.setQueryHint(newValue);

--- a/ui/search-bar/search-bar.ios.ts
+++ b/ui/search-bar/search-bar.ios.ts
@@ -7,6 +7,13 @@ import style = require("ui/styling/style");
 import view = require("ui/core/view");
 import font = require("ui/styling/font");
 
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
 function onTextPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var bar = <SearchBar>data.object;
     bar.ios.text = data.newValue;
@@ -48,7 +55,7 @@ function onHintPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     }
 
     var newValue = data.newValue;
-    var types: typeof typesModule = require("utils/types");
+    ensureTypes();
 
     if (types.isString(newValue)) {
         bar.ios.placeholder = newValue;

--- a/ui/segmented-bar/segmented-bar-common.ts
+++ b/ui/segmented-bar/segmented-bar-common.ts
@@ -6,6 +6,13 @@ import color = require("color");
 import bindable = require("ui/core/bindable");
 import * as typesModule from "utils/types";
 
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
 export module knownCollections {
     export var items = "items";
 }
@@ -40,7 +47,7 @@ export class SegmentedBar extends view.View implements definition.SegmentedBar {
     public _adjustSelectedIndex(items: Array<definition.SegmentedBarItem>) {
         if (this.items) {
             if (this.items.length > 0) {
-                var types: typeof typesModule = require("utils/types");
+                ensureTypes();
 
                 if (types.isUndefined(this.selectedIndex) || (this.selectedIndex > this.items.length - 1)) {
                     this._setValue(SegmentedBar.selectedIndexProperty, 0);

--- a/ui/segmented-bar/segmented-bar.ios.ts
+++ b/ui/segmented-bar/segmented-bar.ios.ts
@@ -11,6 +11,13 @@ import view = require("ui/core/view");
 
 global.moduleMerge(common, exports);
 
+var color: typeof colorModule;
+function ensureColor() {
+    if (!color) {
+        color = require("color");
+    }
+}
+
 function onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var view = <SegmentedBar>data.object;
     if (!view.ios || !view.items) {
@@ -67,7 +74,7 @@ function onSelectedBackgroundColorPropertyChanged(data: dependencyObservable.Pro
         return;
     }
 
-    var color: typeof colorModule = require("color");
+    ensureColor();
 
     if (data.newValue instanceof color.Color) {
         view.ios.tintColor = data.newValue.ios;

--- a/ui/styling/background-common.ts
+++ b/ui/styling/background-common.ts
@@ -5,6 +5,13 @@ import definition = require("ui/styling/background");
 import cssValue = require("css-value");
 import * as typesModule from "utils/types";
 
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
 interface CSSValue {
     type: string;
     string: string;
@@ -213,7 +220,7 @@ export class Background implements definition.Background {
     };
 
     public isEmpty(): boolean {
-        var types: typeof typesModule = require("utils/types");
+        ensureTypes();
 
         return types.isNullOrUndefined(this.image) && types.isNullOrUndefined(this.color);
     }

--- a/ui/styling/background.android.ts
+++ b/ui/styling/background.android.ts
@@ -6,7 +6,18 @@ import types = require("utils/types");
 import * as styleModule from "./style";
 import * as buttonModule from "ui/button";
 
-var btn: typeof buttonModule;
+var button: typeof buttonModule;
+var style: typeof styleModule;
+
+function ensureLazyRequires() {
+    if (!button) {
+        button = require("ui/button");
+    }
+
+    if (!style) {
+        style = require("./style");
+    }
+}
 
 global.moduleMerge(common, exports);
 
@@ -164,24 +175,19 @@ export module ad {
     var _defaultBackgrounds = new Map<string, android.graphics.drawable.Drawable>();
 
     export function onBackgroundOrBorderPropertyChanged(v: view.View) {
-        if (!btn) {
-            btn = require("ui/button");
-        }
-
         var nativeView = <android.view.View>v._nativeView;
         if (!nativeView) {
             return;
         }
 
         ensureBorderDrawable();
-
-        var style: typeof styleModule = require("./style");
+        ensureLazyRequires();
 
         var backgroundValue = v.style._getValue(style.backgroundInternalProperty);
         var borderWidth = v.borderWidth;
         var bkg = <any>nativeView.getBackground();
 
-        if (v instanceof btn.Button && !types.isNullOrUndefined(bkg) && types.isFunction(bkg.setColorFilter) &&
+        if (v instanceof button.Button && !types.isNullOrUndefined(bkg) && types.isFunction(bkg.setColorFilter) &&
             v.borderWidth === 0 && v.borderRadius === 0 &&
             types.isNullOrUndefined(v.style._getValue(style.backgroundImageProperty)) &&
             !types.isNullOrUndefined(v.style._getValue(style.backgroundColorProperty))) {
@@ -193,7 +199,7 @@ export module ad {
             if (!(bkg instanceof BorderDrawableClass)) {
                 bkg = new BorderDrawableClass();
                 let viewClass = types.getClass(v);
-                if (!(v instanceof btn.Button) && !_defaultBackgrounds.has(viewClass)) {
+                if (!(v instanceof button.Button) && !_defaultBackgrounds.has(viewClass)) {
                     _defaultBackgrounds.set(viewClass, nativeView.getBackground());
                 }
 
@@ -216,7 +222,7 @@ export module ad {
         }
         else {
             // reset the value with the default native value
-            if (v instanceof btn.Button) {
+            if (v instanceof button.Button) {
                 var nativeButton = new android.widget.Button(nativeView.getContext());
                 nativeView.setBackground(nativeButton.getBackground());
             }

--- a/ui/styling/background.ios.ts
+++ b/ui/styling/background.ios.ts
@@ -16,7 +16,7 @@ export module ios {
         if(!view._nativeView){
             return undefined;
         }
-
+        ensureStyle();
         var background = <common.Background> view.style._getValue(style.backgroundInternalProperty);
 
         if (!background || background.isEmpty()) {

--- a/ui/styling/background.ios.ts
+++ b/ui/styling/background.ios.ts
@@ -4,13 +4,18 @@ import * as styleModule from "./style";
 
 global.moduleMerge(common, exports);
 
+var style: typeof styleModule;
+function ensureStyle() {
+    if (!style) {
+        style = require("./style");
+    }
+}
+
 export module ios {
     export function createBackgroundUIColor(view: viewModule.View, flip?: boolean): UIColor {
         if(!view._nativeView){
             return undefined;
         }
-
-        var style: typeof styleModule = require("./style");
 
         var background = <common.Background> view.style._getValue(style.backgroundInternalProperty);
 

--- a/ui/styling/css-selector.ts
+++ b/ui/styling/css-selector.ts
@@ -1,8 +1,8 @@
 ﻿import view = require("ui/core/view");
 import observable = require("ui/core/dependency-observable");
 import cssParser = require("css");
-import * as traceModule from "trace";
-import * as stylePropertyModule from "ui/styling/style-property";
+import * as trace from "trace";
+import * as styleProperty from "ui/styling/style-property";
 
 var ID_SPECIFICITY = 10000;
 var CLASS_SPECIFICITY = 100;
@@ -39,8 +39,6 @@ export class CssSelector {
                 view.style._setValue(property, value, observable.ValueSource.Css);
             }
             catch (ex) {
-                var trace : typeof traceModule = require("trace");
-
                 trace.write("Error setting property: " + property.name + " view: " + view + " value: " + value + " " + ex, trace.categories.Style, trace.messageType.error);
             }
         });
@@ -51,8 +49,6 @@ export class CssSelector {
             let declaration = this._declarations[i];
             let name = declaration.property;
             let resolvedValue = declaration.value;
-
-            var styleProperty: typeof stylePropertyModule = require("ui/styling/style-property");
 
             let property = styleProperty.getPropertyByCssName(name);
 

--- a/ui/styling/font-common.ts
+++ b/ui/styling/font-common.ts
@@ -1,6 +1,6 @@
 ﻿import enums = require("ui/enums");
 import definitios = require("ui/styling/font");
-import * as convertersModule from "./converters";
+import * as converters from "./converters";
 
 export class Font implements definitios.Font {
     public static default = undefined;
@@ -102,7 +102,6 @@ export class Font implements definitios.Font {
 
     public static parse(cssValue: string): Font {
         var parsed = parseFont(cssValue);
-        var converters: typeof convertersModule = require("./converters");
 
         var size = converters.fontSizeConverter(parsed.fontSize);
         size = !!size ? size : undefined;

--- a/ui/styling/font.android.ts
+++ b/ui/styling/font.android.ts
@@ -5,6 +5,34 @@ import * as typesModule from "utils/types";
 import * as traceModule from "trace";
 import * as fileSystemModule from "file-system";
 
+var application: typeof applicationModule;
+function ensureApplication() {
+    if (!application) {
+        application = require("application");
+    }
+}
+
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
+var trace: typeof traceModule;
+function ensureTrace() {
+    if (!trace) {
+        trace = require("trace");
+    }
+}
+
+var fs: typeof fileSystemModule;
+function ensureFS() {
+    if (!fs) {
+        fs = require("file-system");
+    }
+}
+
 var typefaceCache = new Map<string, android.graphics.Typeface>();
 var appAssets: android.content.res.AssetManager;
 var FONTS_BASE_PATH = "/fonts/";
@@ -88,21 +116,22 @@ export class Font extends common.Font {
     }
 
     private loadFontFromFile(fontFamily: string): android.graphics.Typeface {
-        var application: typeof applicationModule = require("application");
+        ensureApplication();
 
         appAssets = appAssets || application.android.context.getAssets();
         if (!appAssets) {
             return null;
         }
 
-        var types: typeof typesModule = require("utils/types");
+        ensureTypes();
 
         var result = typefaceCache.get(fontFamily);
         // Check for undefined explicitly as null mean we tried to load the font, but failed.
         if (types.isUndefined(result)) {
             result = null;
-            var trace: typeof traceModule = require("trace");
-            var fs: typeof fileSystemModule  = require("file-system");
+
+            ensureTrace();
+            ensureFS();
 
             var fontAssetPath: string;
             var basePath = fs.path.join(fs.knownFolders.currentApp().path, "fonts", fontFamily);

--- a/ui/styling/style-scope.ts
+++ b/ui/styling/style-scope.ts
@@ -8,6 +8,34 @@ import * as utilsModule from "utils/utils";
 import * as fileSystemModule from "file-system";
 import * as visualStateModule from "./visual-state";
 
+var types: typeof typesModule;
+function ensureTypes() {
+    if (!types) {
+        types = require("utils/types");
+    }
+}
+
+var utils: typeof utilsModule;
+function ensureUtils() {
+    if (!utils) {
+        utils = require("utils/utils");
+    }
+}
+
+var fs: typeof fileSystemModule;
+function ensureFS() {
+    if (!fs) {
+        fs = require("file-system");
+    }
+}
+
+var vs: typeof visualStateModule;
+function ensureVisualState() {
+    if (!vs) {
+        vs = require("./visual-state");
+    }
+}
+
 var pattern: RegExp = /('|")(.*?)\1/;
 
 export class StyleScope {
@@ -69,7 +97,7 @@ export class StyleScope {
 
     public static createSelectorsFromImports(tree: cssParser.SyntaxTree): cssSelector.CssSelector[] {
         var selectors = new Array<cssSelector.CssSelector>();
-        var types : typeof typesModule = require("utils/types");
+        ensureTypes();
 
         if (!types.isNullOrUndefined(tree)) {
             var imports = tree["stylesheet"]["rules"].filter(r=> r.type === "import");
@@ -81,10 +109,10 @@ export class StyleScope {
                 var url = match && match[2];
 
                 if (!types.isNullOrUndefined(url)) {
-                    var utils: typeof utilsModule = require("utils/utils");
+                    ensureUtils();
 
                     if (utils.isFileOrResourcePath(url)) {
-                        var fs: typeof fileSystemModule = require("file-system");
+                        ensureFS();
 
                         var fileName = types.isString(url) ? url.trim() : "";
                         if (fileName.indexOf("~/") === 0) {
@@ -183,7 +211,7 @@ export class StyleScope {
             stateSelector: cssSelector.CssVisualStateSelector;
 
         this._statesByKey[key] = allStates;
-        var vs: typeof visualStateModule = require("./visual-state");
+        ensureVisualState();
 
         for (i = 0; i < matchedStateSelectors.length; i++) {
             stateSelector = matchedStateSelectors[i];

--- a/ui/styling/style.ts
+++ b/ui/styling/style.ts
@@ -15,6 +15,13 @@ import platform = require("platform");
 import definition = require("ui/styling/style");
 import * as imageSourceModule from "image-source";
 
+var imageSource: typeof imageSourceModule;
+function ensureImageSource() {
+    if (!imageSource) {
+        imageSource = require("image-source");
+    }
+}
+
 // key is the property id and value is Dictionary<string, StylePropertyChangedHandler>;
 var _registeredHandlers = Array<Object>();
 
@@ -279,7 +286,7 @@ function onBackgroundImagePropertyChanged(data: PropertyChangeData) {
             url = match[2];
         }
 
-        var imageSource: typeof imageSourceModule = require("image-source");
+        ensureImageSource();
 
         if (utils.isDataURI(url)) {
             var base64Data = url.split(",")[1];

--- a/ui/styling/visual-state.ts
+++ b/ui/styling/visual-state.ts
@@ -1,7 +1,7 @@
 ﻿import viewModule = require("ui/core/view");
 import observable = require("ui/core/dependency-observable");
 import styleProperty = require("ui/styling/style-property");
-import * as visualStateConstantsModule from "ui/styling/visual-state-constants";
+import * as visualStateConstants from "ui/styling/visual-state-constants";
 
 export class VisualState {
     private _setters: {};
@@ -39,9 +39,7 @@ export function goToState(view: viewModule.View, state: string): string {
     // Step 1
     if (!(state in allStates)) {
         // TODO: Directly go to normal?
-        var constants: typeof visualStateConstantsModule = require("ui/styling/visual-state-constants");
-
-        state = constants.Normal;
+        state = visualStateConstants.Normal;
     }
 
     // Step 2

--- a/ui/switch/switch.ios.ts
+++ b/ui/switch/switch.ios.ts
@@ -1,7 +1,7 @@
 ﻿import common = require("./switch-common");
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
-import * as utilsModule from "utils/utils";
+import * as utils from "utils/utils";
 import styling = require("ui/styling");
 import style = require("ui/styling/style");
 import view = require("ui/core/view");
@@ -59,8 +59,7 @@ export class Switch extends common.Switch {
         let nativeSize = this._nativeView.sizeThatFits(CGSizeMake(0, 0));
         this.width = nativeSize.width;
         this.height = nativeSize.height;
-        var utils: typeof utilsModule = require("utils/utils");
-
+        
         let widthAndState = utils.layout.makeMeasureSpec(nativeSize.width, utils.layout.EXACTLY);
         let heightAndState = utils.layout.makeMeasureSpec(nativeSize.height, utils.layout.EXACTLY);
         this.setMeasuredDimension(widthAndState, heightAndState);

--- a/ui/tab-view/tab-view.android.ts
+++ b/ui/tab-view/tab-view.android.ts
@@ -7,10 +7,17 @@ import types = require("utils/types");
 import utils = require("utils/utils");
 import proxy = require("ui/core/proxy");
 import color = require("color");
-import * as imageSourceModule from "image-source";
 import style = require("ui/styling/style");
 import font = require("ui/styling/font");
 import styling = require("ui/styling");
+import * as imageSourceModule from "image-source";
+
+var imageSource: typeof imageSourceModule;
+function ensureImageSource() {
+    if (!imageSource) {
+        imageSource = require("image-source");
+    }
+}
 
 var VIEWS_STATES = "_viewStates";
 var ACCENT_COLOR = "colorAccent";
@@ -316,7 +323,7 @@ export class TabView extends common.TabView {
                 result.iconId = utils.ad.resources.getDrawableId(item.iconSource.substr(utils.RESOURCE_PREFIX.length));
             }
             else {
-                var imageSource: typeof imageSourceModule = require("image-source");
+                ensureImageSource();
 
                 var is = imageSource.fromFileOrResource(item.iconSource);
                 if (is) {

--- a/ui/tab-view/tab-view.ios.ts
+++ b/ui/tab-view/tab-view.ios.ts
@@ -14,6 +14,13 @@ import styling = require("ui/styling");
 
 global.moduleMerge(common, exports);
 
+var imageSource: typeof imageSourceModule;
+function ensureImageSource() {
+    if (!imageSource) {
+        imageSource = require("image-source");
+    }
+}
+
 class UITabBarControllerImpl extends UITabBarController {
 
     private _owner: WeakRef<TabView>;
@@ -240,7 +247,7 @@ export class TabView extends common.TabView {
         var image: UIImage;
         image = this._iconsCache[iconSource];
         if (!image) {
-            var imageSource: typeof imageSourceModule = require("image-source");
+            ensureImageSource();
 
             var is = imageSource.fromFileOrResource(iconSource);
             if (is && is.ios) {

--- a/ui/text-base/text-base.ts
+++ b/ui/text-base/text-base.ts
@@ -7,6 +7,13 @@ import formattedString = require("text/formatted-string");
 import * as weakEventListenerModule from "ui/core/weak-event-listener";
 import tbs = require("ui/text-base/text-base-styler");
 
+var weakEvents: typeof weakEventListenerModule;
+function ensureWeakEvents() {
+    if (!weakEvents) {
+        weakEvents = require("ui/core/weak-event-listener");
+    }
+}
+
 var textProperty = new dependencyObservable.Property(
     "text",
     "TextBase",
@@ -76,7 +83,7 @@ export class TextBase extends view.View implements definition.TextBase, formatte
 
     set formattedText(value: formattedString.FormattedString) {
         if (this.formattedText !== value) {
-            var weakEvents: typeof weakEventListenerModule = require("ui/core/weak-event-listener");
+            ensureWeakEvents();
 
             if (this.formattedText) {
                 weakEvents.removeWeakEventListener(this.formattedText, observable.Observable.propertyChangeEvent, this.onFormattedTextChanged, this);

--- a/ui/utils.ios.ts
+++ b/ui/utils.ios.ts
@@ -1,5 +1,5 @@
 ﻿import {View} from "ui/core/view";
-import * as utilsModule from "utils/utils";
+import * as utils from "utils/utils";
 
 export module ios {
     export function getActualHeight(view: UIView): number {
@@ -34,8 +34,6 @@ export module ios {
         if (superview) {
             superViewRotationRadians = atan2f(superview.transform.b, superview.transform.a);
         }
-
-        var utils: typeof utilsModule = require("utils/utils");
 
         if (utils.ios.MajorVersion < 8 && utils.ios.isLandscape() && !superViewRotationRadians) {
             // in iOS 7 when in landscape we switch width with height because on device they don't change even when rotated.

--- a/ui/web-view/web-view-common.ts
+++ b/ui/web-view/web-view-common.ts
@@ -2,9 +2,16 @@
 import view = require("ui/core/view");
 import dependencyObservable = require("ui/core/dependency-observable");
 import proxy = require("ui/core/proxy");
-import * as utilsModule from "utils/utils";
-import * as traceModule from "trace";
+import * as utils from "utils/utils";
+import * as trace from "trace";
 import * as fileSystemModule from "file-system";
+
+var fs: typeof fileSystemModule;
+function ensureFS() {
+    if (!fs) {
+        fs = require("file-system");
+    }
+}
 
 var urlProperty = new dependencyObservable.Property(
     "url",
@@ -38,15 +45,13 @@ function onSrcPropertyChanged(data: dependencyObservable.PropertyChangeData) {
         return;
     }
 
-    webView.stopLoading();
-    var trace: typeof traceModule = require("trace");
+    webView.stopLoading();    
 
     var src = <string>data.newValue;
     trace.write("WebView._loadSrc(" + src + ")", trace.categories.Debug);
-    var utils: typeof utilsModule = require("utils/utils");
 
     if (utils.isFileOrResourcePath(src)) {
-        var fs: typeof fileSystemModule = require("file-system");
+        ensureFS();
 
         if (src.indexOf("~/") === 0) {
             src = fs.path.join(fs.knownFolders.currentApp().path, src.replace("~/", ""));

--- a/ui/web-view/web-view.android.ts
+++ b/ui/web-view/web-view.android.ts
@@ -4,6 +4,13 @@ import * as fileSystemModule from "file-system";
 
 global.moduleMerge(common, exports);
 
+var fs: typeof fileSystemModule;
+function ensureFS() {
+    if (!fs) {
+        fs = require("file-system");
+    }
+}
+
 var WebViewClientClass;
 function ensureWebViewClientClass() {
     if (WebViewClientClass) {
@@ -130,7 +137,7 @@ export class WebView extends common.WebView {
             return;
         }
 
-        var fs: typeof fileSystemModule = require("file-system");
+        ensureFS();
 
         var baseUrl = `file:///${fs.knownFolders.currentApp().path}/`;
         this._android.loadDataWithBaseURL(baseUrl, src, "text/html", "utf-8", null);

--- a/utils/utils.android.ts
+++ b/utils/utils.android.ts
@@ -4,6 +4,13 @@ import enums = require("ui/enums");
 
 global.moduleMerge(common, exports);
 
+var trace: typeof traceModule;
+function ensureTrace() {
+    if (!trace) {
+        trace = require("trace");
+    }
+}
+
 export module layout {
     var density = -1;
     var metrics: android.util.DisplayMetrics;
@@ -234,7 +241,7 @@ export module ad {
                 }
             }
             catch (ex) {
-                var trace: typeof traceModule = require("trace");
+                ensureTrace();
 
                 trace.write("Cannot get pallete color: " + name, trace.categories.Error, trace.messageType.error);
             }


### PR DESCRIPTION
Lazy require calls degrade the runtime performance in some cases, especially when called frequently in a function that is performance-critical - for example [ListView._getItemTemplateContent](https://github.com/NativeScript/NativeScript/blob/master/ui/list-view/list-view-common.ts#L135). This degrade is particularly visible for Android where the `require` routine calls to Java to compute the absolute path of the module.

What this pull does is to revisit all the lazy calls, to remove some that are part of the loading routine anyways and to cache the rest on the JavaScript side.