### PR TITLE
Enable build times profiling

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,6 +2,10 @@ var tsconfig = require('./tsconfig.json');
 var shelljs = require("shelljs");
 
 module.exports = function(grunt) {
+    if (grunt.option('profile')) {
+        grunt.log.writeln('Profiling all grunt tasks...');
+        require('time-grunt')(grunt);
+    }
 
     if (grunt.cli.tasks.indexOf("testsapp") >= 0 || grunt.cli.tasks.indexOf("buildTestsApp")>= 0) {
         var tsTester = require("./build/run-testsapp.grunt.js");

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mocha": "2.2.5",
     "shelljs": "0.5.3",
     "grunt-tslint": "3.0.0",
+    "time-grunt": "^1.3.0",
     "tslint": "3.1.1",
     "typescript": "1.7.3"
   },


### PR DESCRIPTION
Will output build times for the grunt tasks by using:
```
grunt --profile
```
Profile will not print very small tasks. To list all tasks use:
```
grunt --profile=true --verbose=true
```