### PR TITLE
Generate segmented d.ts files and resolve Angular type clashes

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -99,8 +99,7 @@ interface Console {
 }
 
 declare var console: Console;
-declare var global;
-declare var require;
+declare var require: NativeScriptRequire;
 
 // Global functions
 declare function Deprecated(target: Object, key?: string | symbol, value?: any): void;
@@ -146,10 +145,6 @@ declare class WeakRef<T> {
     clear(): void;
 }
 
-declare module module {
-    var id: string;
-    var filename: string;
-    var exports: any;
-}
+declare var module: NativeScriptModule;
 // Same as module.exports
 declare var exports: any;

--- a/module.d.ts
+++ b/module.d.ts
@@ -1,0 +1,13 @@
+//Base module declarations
+//Not required in Angular apps since it clashes with its typings.
+declare var global: any;
+
+interface NativeScriptRequire {
+    (id: string): any;
+}
+
+declare interface NativeScriptModule {
+    id: string;
+    filename: string;
+    exports: any;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -455,6 +455,7 @@
         "location/location.android.ts",
         "location/location.d.ts",
         "location/location.ios.ts",
+        "module.d.ts",
         "node-tests/definitions/chai.d.ts",
         "node-tests/definitions/mocha.d.ts",
         "node-tests/test-angular-xml.ts",


### PR DESCRIPTION
- tns-core-modules-base.d.ts containing modules definitions with as little
platform stuff as possible. Angular apps will reference this one.
- tns-core-modules.es6.d.ts adding some platform stuff to base. Intended to
be used in environments supporting ES6 (obviously)
- tns-core-modules.d.ts adding to the previous one definitions for our ES6
polyfills: promises, collections, weakmaps, etc. The usual reference point
for most apps.

Fixes #1457 too.