### PR TITLE
Fix clearEvent after programmatically setting text

### DIFF
--- a/ui/search-bar/search-bar.ios.ts
+++ b/ui/search-bar/search-bar.ios.ts
@@ -70,7 +70,6 @@ class UISearchBarDelegateImpl extends NSObject implements UISearchBarDelegate {
     public static ObjCProtocols = [UISearchBarDelegate];
 
     private _owner: WeakRef<SearchBar>;
-    private _searchText: string;
 
     public static initWithOwner(owner: WeakRef<SearchBar>): UISearchBarDelegateImpl {
         let delegate = <UISearchBarDelegateImpl>UISearchBarDelegateImpl.new();
@@ -87,11 +86,9 @@ class UISearchBarDelegateImpl extends NSObject implements UISearchBarDelegate {
         owner._onPropertyChangedFromNative(common.SearchBar.textProperty, searchText);
 
         // This code is needed since sometimes searchBarCancelButtonClicked is not called!
-        if (searchText === "" && this._searchText !== searchText) {
+        if (searchText === "") {
             owner._emit(common.SearchBar.clearEvent);
         }
-
-        this._searchText = searchText;
     }
 
     public searchBarCancelButtonClicked(searchBar: UISearchBar) {


### PR DESCRIPTION
searchBarTextDidChange only fires when the user changes the text. 
In the following scenario, clearEvent was not being fired:
1. User clears the text (clearEvent is fired from searchBarTextDidChange)
2. Text is programmatically set to a non-empty string (searchBarTextDidChange is not called)
3. User clears the text again (searchBarTextDidChange is called, but clearEvent is not fired)

This PR allows the clearEvent to fire at step 3. 

I would also suggest that a separate event be used when the cancel button is clicked (cancelEvent), as the cancel button being clicked does not imply that the text is cleared.