### PR TITLE
Add global __metadata function

### DIFF
--- a/globals/globals.ts
+++ b/globals/globals.ts
@@ -119,6 +119,14 @@ if (typeof global.__decorate !== "function") {
     }
 }
 
+if (typeof global.__metadata !== "function") {
+    global.__metadata = function (k, v) {
+        if (typeof global.Reflect === "object" && typeof global.Reflect.metadata === "function") {
+            return global.Reflect.metadata(k, v);
+        }
+    };
+}
+
 export function Deprecated(target: Object, key?: string | symbol, descriptor?: any) {
     if (descriptor) {
         var originalMethod = descriptor.value;


### PR DESCRIPTION
When `emitDecoratorMetadata` compiler option is set to true in `tsconfig.json`, TypeScript generates some calls to `__metadata` function.
By default in our NativeScript TypeScript projects the `noEmitHelpers` option is set to true, so TypeScript compiler does not generate the `__metadata` function.
So the application crashes at runtime. Add the missing method, so we can have both `noEmitHelpers` and `emitDecoratorMetadata` set to true in `tsconfig.json`.