### PR TITLE
Allow the build to produce js files near the ts files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # generated files
 *.map
+*.tgz
 .baseDir.ts
 .sublime-grunt.cache
 tscommand*.tmp.txt
@@ -7,6 +8,7 @@ tscommand*.tmp.txt
 
 node_modules/
 dist/
+package/
 
 *.js
 !gruntfile.js
@@ -31,3 +33,7 @@ tags
 
 TestRunResult.txt
 .testsapprun
+
+tns-core-modules.base.d.ts
+tns-core-modules.d.ts
+tns-core-modules.es6.d.ts

--- a/package.json
+++ b/package.json
@@ -8,11 +8,18 @@
     "url": "https://github.com/NativeScript/NativeScript"
   },
   "files": [
-    "**/*.*",
-    "**/*",
-    "!.baseDir.*",
+    "**/*.d.ts",
+    "**/*.js",
+    "!android17.d.ts",
+    "!ios.d.ts",
+    "!bin/",
+    "!apps/",
+    "!build/",
     "!node-tests/",
-    "!apps/"
+    "!declarations.android.d.ts",
+    "!declarations.ios.d.ts",
+    "!gruntfile.js",
+    "!org.nativescript.widgets.d.ts"
   ],
   "license": "Apache-2.0",
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
         "noImplicitAny": false,
         "removeComments": true,
         "noImplicitUseStrict": true,
-        "outDir": "bin/dist/modules",
         "experimentalDecorators": true
     },
     "filesGlob": [


### PR DESCRIPTION
There is a `grunt inplace` task now that outputs the js files near the ts instead of in the bin folder.
The `npm pack` after `grunt inplace` produces a package similar to the one produced in `build/modules` with the only difference that it includes all readme and licence files.