### PR TITLE
Fixes breaking app on back btn clearHistory: true on android

### DIFF
--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -238,6 +238,7 @@ export class Frame extends frameCommon.Frame {
         }
 
         let manager = activity.getFragmentManager();
+        let isFirstNavigation = types.isNullOrUndefined(this._currentEntry);
 
         // Clear history
         if (backstackEntry.entry.clearHistory) {
@@ -307,7 +308,6 @@ export class Frame extends frameCommon.Frame {
         // remember the fragment tag at page level so that we can retrieve the fragment associated with a Page instance
         backstackEntry.resolvedPage[TAG] = newFragmentTag;
 
-        let isFirstNavigation = types.isNullOrUndefined(this._currentEntry);
         if (isFirstNavigation) {
             fragmentTransaction.add(this.containerViewId, newFragment, newFragmentTag);
             trace.write(`fragmentTransaction.add(${newFragmentTag});`, trace.categories.NativeLifecycle);


### PR DESCRIPTION
This pull fixes #1569. The problem was that the `clearHistory` option resets the `_currentEntry` field and the

```
let isFirstNavigation = types.isNullOrUndefined(this._currentEntry);
```

expression returned true when it is actually false and this corrupts the native Android backstack.