### PR TITLE
Frame.navigate while in background

### DIFF
--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -127,7 +127,7 @@ function pageFromBuilder(moduleNamePath: string, moduleExports: any): Page {
     return page;
 }
 
-interface NavigationContext {
+export interface NavigationContext {
     entry: definition.BackstackEntry;
     isBackNavigation: boolean;
 }
@@ -264,7 +264,7 @@ export class Frame extends CustomLayoutView implements definition.Frame {
         //trace.write("calling _updateActionBar on Frame", trace.categories.Navigation);
     }
 
-    private _processNavigationContext(navigationContext: NavigationContext) {
+    protected _processNavigationContext(navigationContext: NavigationContext) {
         if (navigationContext.isBackNavigation) {
             this.performGoBack(navigationContext);
         }

--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -1,13 +1,13 @@
 ﻿import definition = require("ui/frame");
 import frameCommon = require("./frame-common");
 import pages = require("ui/page");
+import transitionModule = require("ui/transition");
+import trace = require("trace");
 import {View} from "ui/core/view";
 import {Observable} from "data/observable";
-import trace = require("trace");
-import application = require("application");
+import * as application from "application";
 import * as types from "utils/types";
 import * as utils from "utils/utils";
-import transitionModule = require("ui/transition");
 
 global.moduleMerge(frameCommon, exports);
 
@@ -452,6 +452,45 @@ export class Frame extends frameCommon.Frame {
 
         return true;
     }
+    
+    protected _processNavigationContext(navigationContext: frameCommon.NavigationContext) {
+        let activity = this._android.activity;
+        if (activity) {
+            let isForegroundActivity = activity === application.android.foregroundActivity;
+            let isPaused = application.android.paused;
+
+            if (activity && !isForegroundActivity || (isForegroundActivity && isPaused)) {
+                let weakActivity = new WeakRef(activity);
+                let resume = (args: application.AndroidActivityEventData) => {
+                    let weakActivityInstance = weakActivity.get();
+                    let isCurrent = args.activity === weakActivityInstance;
+                    if (!weakActivityInstance) {
+                        trace.write(`Frame _processNavigationContext: Drop For Activity GC-ed`, trace.categories.Navigation);
+                        unsubscribe();
+                        return
+                    }
+                    if (isCurrent) {
+                        trace.write(`Frame _processNavigationContext: Activity.Resumed, Continue`, trace.categories.Navigation);
+                        super._processNavigationContext(navigationContext);
+                        unsubscribe();
+                    }
+                }
+                let unsubscribe = () => {
+                    trace.write(`Frame _processNavigationContext: Unsubscribe from Activity.Resumed`, trace.categories.Navigation);
+                    application.android.off(application.AndroidApplication.activityResumedEvent, resume);
+                    application.android.off(application.AndroidApplication.activityStoppedEvent, unsubscribe);
+                    application.android.off(application.AndroidApplication.activityDestroyedEvent, unsubscribe);
+                }
+
+                trace.write(`Frame._processNavigationContext: Subscribe for Activity.Resumed`, trace.categories.Navigation);
+                application.android.on(application.AndroidApplication.activityResumedEvent, resume);
+                application.android.on(application.AndroidApplication.activityStoppedEvent, unsubscribe);
+                application.android.on(application.AndroidApplication.activityDestroyedEvent, unsubscribe);
+                return;
+            }
+        }
+        super._processNavigationContext(navigationContext);
+    }
 }
 
 var NativeActivity = {
@@ -709,7 +748,7 @@ class AndroidFrame extends Observable implements definition.AndroidFrame {
                 return activity;
             }
         }
-
+        
         return undefined;
     }
 


### PR DESCRIPTION
Frame.navigate used to crash when in background, now it delays the navigation until activity resume.
Fixes #1389
The Android app should be sent to background to reproduce the issue so it should have ui tests.