### PR TITLE
Fix language tags in doc-snippets

### DIFF
--- a/apps/tests/Readme.md
+++ b/apps/tests/Readme.md
@@ -1,7 +1,7 @@
 ﻿To run tests please build using one of the *_Tests build configurations and call runAll() method of the Tests module. For example:
 
 ##iOS
-```js
+``` JavaScript
 var app = require("application");
 app.init(null);
 var tests = require("Tests");
@@ -9,7 +9,7 @@ tests.runAll();
 ```
 
 ##Android
-```js
+``` JavaScript
 app.init({
 	getActivity: function(intent) {
 		return com.tns.NativeScriptActivity.extend({});

--- a/apps/tests/fetch-tests.ts
+++ b/apps/tests/fetch-tests.ts
@@ -107,7 +107,7 @@ export var test_fetch_response_status = function (done) {
 
     // <snippet module="fetch" title="fetch">
     // ### Get Response status
-    // ``` fetch
+    // ``` JavaScript
     fetch("https://httpbin.org/get").then(function (response) {
         //// Argument (response) is Response!
         var statusCode = response.status;

--- a/apps/tests/layouts/absolute-layout-tests.ts
+++ b/apps/tests/layouts/absolute-layout-tests.ts
@@ -14,7 +14,7 @@ import absoluteLayoutModule = require("ui/layouts/absolute-layout");
 // </snippet> 
 
 // ### Declaring a AbsoluteLayout.
-//```XML
+//``` XML
 // <Page>
 //   <AbsoluteLayout>
 //     <Label text="This is Label 1" left="30" top="70" />

--- a/apps/tests/layouts/dock-layout-tests.ts
+++ b/apps/tests/layouts/dock-layout-tests.ts
@@ -14,7 +14,7 @@ import dockModule = require("ui/layouts/dock-layout");
 // ```
 
 // ### Declaring a DockLayout.
-//```XML
+//``` XML
 //<Page>
 //  <DockLayout stretchLastChild="true" >
 //    <Button dock="left" text="left" style="background-color: red; margin: 5;"/ >/ >

--- a/apps/tests/layouts/stack-layout-tests.ts
+++ b/apps/tests/layouts/stack-layout-tests.ts
@@ -171,7 +171,7 @@ export class StackLayoutTest extends testModule.UITest<StackLayout> {
         //  ```
 
         // ### Declaring a StackLayout.
-        //```XML
+        //``` XML
         // <Page>
         //   <StackLayout orientation="horizontal">
         //     <Label text="This is Label 1" />

--- a/apps/tests/layouts/wrap-layout-tests.ts
+++ b/apps/tests/layouts/wrap-layout-tests.ts
@@ -28,7 +28,7 @@ export class WrapLayoutTest extends testModule.UITest<wrapLayoutModule.WrapLayou
         // </snippet>
 
         // ### Declaring a WrapLayout.
-        //```XML
+        //``` XML
         // <Page>
         //   <WrapLayout>
         //     <Label text="This is Label 1" />

--- a/apps/tests/ui/action-bar/action-bar-tests-common.ts
+++ b/apps/tests/ui/action-bar/action-bar-tests-common.ts
@@ -16,7 +16,7 @@ import actionBarModule = require("ui/action-bar");
 // ```
 // 
 // ## Setting Title and Icon
-//```XML
+//``` XML
 // <Page>
 //   <Page.actionBar>
 //     {%raw%}<ActionBar title="{{ title }}" android.icon="res://is_custom_home_icon"/>{%endraw%}
@@ -28,7 +28,7 @@ import actionBarModule = require("ui/action-bar");
 //
 // 
 // ## Setting Custom Title View 
-//```XML
+//``` XML
 // <Page loaded="pageLoaded">
 //   <Page.actionBar>
 //     <ActionBar title="Title">
@@ -46,7 +46,7 @@ import actionBarModule = require("ui/action-bar");
 //```
 //
 // ## Setting Action Items
-//```XML
+//``` XML
 // <Page>
 //   <Page.actionBar>
 //     <ActionBar title="Title">
@@ -66,7 +66,7 @@ import actionBarModule = require("ui/action-bar");
 // * **iOS** - `left` and `right`. The default is `left`.
 //
 // ## Displaying Platform-Specific System Icons on Action Items
-//```XML
+//``` XML
 // <Page>
 //   <Page.actionBar>
 //     <ActionBar>
@@ -119,7 +119,7 @@ import actionBarModule = require("ui/action-bar");
 //For a full list of Android drawable names, please visit http://androiddrawables.com
 //
 // ## Displaying Custom View in Action Items
-//```XML
+//``` XML
 // <Page>
 //   <Page.actionBar>
 //     <ActionBar>
@@ -140,7 +140,7 @@ import actionBarModule = require("ui/action-bar");
 //```
 //
 // ## Setting Navigation Button
-//```XML
+//``` XML
 // <Page>
 //   <Page.actionBar>
 //     <ActionBar title="Title">

--- a/apps/tests/ui/activity-indicator/activity-indicator-tests.ts
+++ b/apps/tests/ui/activity-indicator/activity-indicator-tests.ts
@@ -12,7 +12,7 @@ import color = require("color");
 import activityIndicatorModule = require("ui/activity-indicator");
 // ```
 // ### Binding the activity indicator busy property to a view-model property.
-//```XML
+//``` XML
 // <Page>
 //   {%raw%}<ActivityIndicator busy="{{ isLoading }}" />{%endraw%}
 // </Page>

--- a/apps/tests/ui/border/border-tests.ts
+++ b/apps/tests/ui/border/border-tests.ts
@@ -6,7 +6,7 @@
 // ```
 
 // ### Declaring a Border.
-//```XML
+//``` XML
 //  <Page>
 //      <Border borderRadius="10" borderWidth="1" borderColor="#FF0000">
 //          <Button text="OK"/>

--- a/apps/tests/ui/button/button-tests.ts
+++ b/apps/tests/ui/button/button-tests.ts
@@ -21,7 +21,7 @@ import observable = require("data/observable");
 // ```
 
 // ### Attaching event handler for the button tap event.
-//```XML
+//``` XML
 // <Page>
 //   <Button tap="buttonTap" />
 // </Page>

--- a/apps/tests/ui/html-view/html-view-tests.ts
+++ b/apps/tests/ui/html-view/html-view-tests.ts
@@ -13,7 +13,7 @@ import htmlViewModule = require("ui/html-view");
 
 // <snippet module="ui/html-view" title="HtmlView">
 // ### Declaring a HtmlView.
-//```XML
+//``` XML
 //  <Page>
 //       {%raw%}<HtmlView html="{{ htmlString }}" />{%endraw%}
 //  </Page>

--- a/apps/tests/ui/image/image-tests.ts
+++ b/apps/tests/ui/image/image-tests.ts
@@ -7,7 +7,7 @@ import ImageModule = require("ui/image");
 // ```
 
 // Binding the image source property to a view-model property.
-//```XML
+//``` XML
 // <Page>
 //   <StackLayout>
 //      <!--Bind the image source property to view-model property -->

--- a/apps/tests/ui/label/label-tests.ts
+++ b/apps/tests/ui/label/label-tests.ts
@@ -10,7 +10,7 @@ import LabelModule = require("ui/label");
 // ```
 
 // ### Binding the Label text property to a view-model property.
-//```XML
+//``` XML
 // <Page>
 //   {%raw%}<Label text="{{ title }}" />{%endraw%}
 // </Page>

--- a/apps/tests/ui/list-view/list-view-tests.ts
+++ b/apps/tests/ui/list-view/list-view-tests.ts
@@ -32,7 +32,7 @@ import labelModule = require("ui/label");
 //   {%raw%}<ListView items="{{ myItems }}" itemTap="listViewItemTap" />{%endraw%}
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function listViewItemTap(args) {
 //   var itemIndex = args.index;
 // }

--- a/apps/tests/ui/list-view/list-view-tests.ts
+++ b/apps/tests/ui/list-view/list-view-tests.ts
@@ -20,14 +20,14 @@ import labelModule = require("ui/label");
 // ```
 
 // ### Binding the ListView items property to collection in the view-model.
-//```XML
+//``` XML
 // <Page>
 //   {%raw%}<ListView items="{{ myItems }}" />{%endraw%}
 // </Page>
 //```
 
 // ### Attaching event handler for the ListView itemTap event.
-//```XML
+//``` XML
 // <Page>
 //   {%raw%}<ListView items="{{ myItems }}" itemTap="listViewItemTap" />{%endraw%}
 // </Page>
@@ -40,12 +40,12 @@ import labelModule = require("ui/label");
 //```
 
 // ### Attaching event handler for the ListView loadMoreItems event.
-//```XML
+//``` XML
 // <Page>
 //  {%raw%}<ListView items="{{ myItems }}" loadMoreItems="listViewLoadMoreItems" />{%endraw%}
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function listViewLoadMoreItems(args) {
 //   // Expand your collection bound to the ListView with more items here!
 // }
@@ -53,7 +53,7 @@ import labelModule = require("ui/label");
 //```
 
 // ### Define the ListView itemTemplate property.
-//```XML
+//``` XML
 // <Page>
 //  {%raw%}<ListView items="{{ myItems }}">
 //     <ListView.itemTemplate>

--- a/apps/tests/ui/placeholder/placeholder-tests.ts
+++ b/apps/tests/ui/placeholder/placeholder-tests.ts
@@ -12,12 +12,12 @@ import placeholderModule = require("ui/placeholder");
 // ```
 
 // Creating native view for the Placeholder using creatingView event.
-//```XML
+//``` XML
 // <Page>
 //   {%raw%}<Placeholder creatingView="creatingView" />{%endraw%}
 // </Page>
 //```
-//```JS
+//``` JavaScript
 //var platform = require("platform");
 //var utils = require("utils/utils");
 //

--- a/apps/tests/ui/progress/progress-tests.ts
+++ b/apps/tests/ui/progress/progress-tests.ts
@@ -13,12 +13,12 @@ import progressModule = require("ui/progress");
 // ```
 
 // Binding the Progress value property to a view-model property.
-//```XML
+//``` XML
 // <Page loaded="pageLoaded">
 //   {%raw%}<Progress value="{{ someProperty }}" />{%endraw%}
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function pageLoaded(args) {
 //   var page = args.object;
 //   page.bindingContext = { someProperty : 42 };

--- a/apps/tests/ui/repeater/repeater-tests.ts
+++ b/apps/tests/ui/repeater/repeater-tests.ts
@@ -23,14 +23,14 @@ import labelModule = require("ui/label");
 // ```
 
 // ### Binding the Repeater items property to collection in the view-model.
-//```XML
+//``` XML
 // <Page>
 //   {%raw%}<Repeater items="{{ myItems }}" />{%endraw%}
 // </Page>
 //```
 
 // ### Define the Repeater itemTemplate property.
-//```XML
+//``` XML
 // <Page>
 //  {%raw%}<Repeater items="{{ myItems }}">
 //     <Repeater.itemTemplate>
@@ -41,7 +41,7 @@ import labelModule = require("ui/label");
 //```
 
 // ### Define the Repeater itemsLayout property. Default is StackLayout with orientation="vertical".
-//```XML
+//``` XML
 // <Page>
 //  {%raw%}<Repeater items="{{ myItems }}">
 //     <Repeater.itemsLayout>
@@ -52,7 +52,7 @@ import labelModule = require("ui/label");
 //```
 
 // ### Repeater with WrapLayout inside ScrollView.
-//```XML
+//``` XML
 // <Page>
 // {%raw%}<ScrollView>
 //   <Repeater items="{{ myItems }}">

--- a/apps/tests/ui/scroll-view/scroll-view-tests.ts
+++ b/apps/tests/ui/scroll-view/scroll-view-tests.ts
@@ -14,7 +14,7 @@ import scrollViewModule = require("ui/scroll-view");
 // ```
 
 // ### Declaring the ScrollView.
-//```XML
+//``` XML
 // <Page>
 //  <ScrollView>
 //    {%raw%}<Image src="{{ someBigImageUrl }}" />{%endraw%}

--- a/apps/tests/ui/search-bar/search-bar-tests.ts
+++ b/apps/tests/ui/search-bar/search-bar-tests.ts
@@ -13,7 +13,7 @@ import searchBarModule = require("ui/search-bar");
 // </snippet>
 
 // ### Declaring a SearchBar.
-//```XML
+//``` XML
 //  <Page>
 //      <SearchBar text="{{ search }}" />
 //  </Page>

--- a/apps/tests/ui/segmented-bar/segmented-bar-tests.ts
+++ b/apps/tests/ui/segmented-bar/segmented-bar-tests.ts
@@ -21,7 +21,7 @@ function _createSegmentedBar(): segmentedBarModule.SegmentedBar {
     // ``` JavaScript
     var segmentedBar = new segmentedBarModule.SegmentedBar();
     // ```
-    // ``` xml
+    // ``` XML
     // <SegmentedBar>
     //   <SegmentedBar.items>
     //     <SegmentedBarItem title="Item 1" />

--- a/apps/tests/ui/slider/slider-tests.ts
+++ b/apps/tests/ui/slider/slider-tests.ts
@@ -15,7 +15,7 @@ import sliderModule = require("ui/slider");
 // ```
 
 // ### Binding the Progress and Slider value properties to a observable view-model property.
-//```XML
+//``` XML
 // <Page loaded="pageLoaded">
 //  <StackLayout orientation="vertical">
 //    {%raw%}<Progress value="{{ someProperty }}" />
@@ -23,7 +23,7 @@ import sliderModule = require("ui/slider");
 //  </StackLayout>
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function pageLoaded(args) {
 //   var page = args.object;
 //   var obj = new observable.Observable();

--- a/apps/tests/ui/switch/switch-tests.ts
+++ b/apps/tests/ui/switch/switch-tests.ts
@@ -13,7 +13,7 @@ import switchModule = require("ui/switch");
 // ```
 
 // ### Binding the Switch checked property and Button isEanbled property to a observable view-model property.
-//```XML
+//``` XML
 // <Page loaded="pageLoaded">
 //  <StackLayout orientation="vertical">
 //    {%raw%}<Switch checked="{{ someProperty }}" />
@@ -21,7 +21,7 @@ import switchModule = require("ui/switch");
 //  </StackLayout>
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function pageLoaded(args) {
 //   var page = args.object;
 //   var obj = new observable.Observable();

--- a/apps/tests/ui/tab-view/tab-view-tests.ts
+++ b/apps/tests/ui/tab-view/tab-view-tests.ts
@@ -9,7 +9,7 @@ import tabViewTestsNative = require("./tab-view-tests-native");
 // # TabView
 
 // ### Declaring the TabView in xml.
-//```XML
+//``` XML
 // <Page>
 //  <TabView>
 //    <TabView.items>

--- a/apps/tests/ui/text-field/text-field-tests.ts
+++ b/apps/tests/ui/text-field/text-field-tests.ts
@@ -21,7 +21,7 @@ import observable = require("data/observable");
 // ```
 
 // ### Binding two TextFields text property to observable view-model property.
-//```XML
+//``` XML
 // <Page loaded="pageLoaded">
 //  <StackLayout orientation="vertical">
 //    {%raw%}<TextField text="{{ someProperty }}" />
@@ -29,7 +29,7 @@ import observable = require("data/observable");
 //  </StackLayout>
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function pageLoaded(args) {
 //   var page = args.object;
 //   var obj = new observable.Observable();

--- a/apps/tests/ui/text-view/text-view-tests.ts
+++ b/apps/tests/ui/text-view/text-view-tests.ts
@@ -21,7 +21,7 @@ import observable = require("data/observable");
 // ```
 
 // ### Binding two TextViews text property to observable view-model property.
-//```XML
+//``` XML
 // <Page loaded="pageLoaded">
 //  <StackLayout orientation="vertical">
 //    {%raw%}<TextView text="{{ someProperty }}" />
@@ -29,7 +29,7 @@ import observable = require("data/observable");
 //  </StackLayout>
 // </Page>
 //```
-//```JS
+//``` JavaScript
 // function pageLoaded(args) {
 //   var page = args.object;
 //   var obj = new observable.Observable();

--- a/apps/tests/ui/web-view/web-view-tests.ts
+++ b/apps/tests/ui/web-view/web-view-tests.ts
@@ -11,7 +11,7 @@ import webViewModule = require("ui/web-view");
 
 // <snippet module="ui/web-view" title="WebView">
 // ### Declaring a WebView.
-//```XML
+//``` XML
 //  <Page>
 //       {%raw%}<WebView src="{{ someUrl | pathToLocalFile | htmlString }}" />{%endraw%}
 //  </Page>


### PR DESCRIPTION
The doc-snippets were inconsistent
(no spaces before title, small-caps, JS
instead of JavaScript, etc.)

Not bound to an issue. Change related to generated How-to articles.

The change itself is in the unit test comments.
