### PR TITLE
Add the global __params helper.

### DIFF
--- a/globals/globals.ts
+++ b/globals/globals.ts
@@ -127,6 +127,12 @@ if (typeof global.__metadata !== "function") {
     };
 }
 
+if (typeof global.__param !== "function") {
+    global.__param = (global && global.__param) || function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+}
+
 export function Deprecated(target: Object, key?: string | symbol, descriptor?: any) {
     if (descriptor) {
         var originalMethod = descriptor.value;


### PR DESCRIPTION
Used by decorated constructor parameters, and you don't need to emit helpers for every file.