### PR TITLE
Add typings for the ES6 Iterator interface for compatibility with rxjs.

### DIFF
--- a/es-collections.d.ts
+++ b/es-collections.d.ts
@@ -47,3 +47,15 @@ declare var Set: {
     new<T>(l: List<T>): Set<T>;
     prototype: Set<any>;
 }
+
+//Compatibility interfaces for rxjs
+interface IteratorResult<T> {
+    done: boolean;
+    value?: T;
+}
+
+interface Iterator<T> {
+    next(value?: any): IteratorResult<T>;
+    return?(value?: any): IteratorResult<T>;
+    throw?(e?: any): IteratorResult<T>;
+}


### PR DESCRIPTION
This will reduce the amount of boilerplate for Angular projects we drag around in a `compat.d.ts` reference file.