### PR TITLE
Replace reflection calls for native Java arrays

### DIFF
--- a/CrossPlatformModules.csproj
+++ b/CrossPlatformModules.csproj
@@ -774,7 +774,6 @@
     <TypeScriptCompile Include="ui\transition\transition.android.ts" />
     <TypeScriptCompile Include="ui\transition\transition.d.ts" />
     <TypeScriptCompile Include="ui\transition\transition.ios.ts" />
-    <TypeScriptCompile Include="ui\ui.d.ts" />
     <TypeScriptCompile Include="ui\html-view\html-view-common.ts" />
     <TypeScriptCompile Include="ui\html-view\html-view.android.ts" />
     <TypeScriptCompile Include="ui\html-view\html-view.d.ts" />
@@ -1018,7 +1017,6 @@
       <DependentUpon>text-field.d.ts</DependentUpon>
     </TypeScriptCompile>
     <TypeScriptCompile Include="ui\text-view\text-view.d.ts" />
-    <TypeScriptCompile Include="ui\ui.ts" />
     <TypeScriptCompile Include="ui\utils.d.ts" />
     <TypeScriptCompile Include="ui\utils.ios.ts">
       <DependentUpon>utils.d.ts</DependentUpon>
@@ -2207,7 +2205,7 @@
           <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>
-      <UserProperties ui_2layouts_2wrap-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2grid-layout_2package_1json__JSONSchema="" ui_2layouts_2dock-layout_2package_1json__JSONSchema="" ui_2layouts_2absolute-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2web-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2content-view_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2gallery-app_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2absolute-layout-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2editable-text-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2scroll-view_2package_1json__JSONSchema="http://json.schemastore.org/package" />
+      <UserProperties ui_2scroll-view_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2editable-text-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2absolute-layout-demo_2package_1json__JSONSchema="http://json.schemastore.org/package" apps_2gallery-app_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2content-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2web-view_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2absolute-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" ui_2layouts_2dock-layout_2package_1json__JSONSchema="" ui_2layouts_2grid-layout_2package_1json__JSONSchema="" ui_2layouts_2wrap-layout_2package_1json__JSONSchema="http://json.schemastore.org/package" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/apps/perf-tests/custom-transition.android.ts
+++ b/apps/perf-tests/custom-transition.android.ts
@@ -1,10 +1,8 @@
 ﻿import transition = require("ui/transition");
 
-var floatType = java.lang.Float.class.getField("TYPE").get(null);
-
 export class CustomTransition extends transition.Transition {
     public createAndroidAnimator(transitionType: string): android.animation.Animator {
-        var scaleValues = java.lang.reflect.Array.newInstance(floatType, 2);
+        var scaleValues = Array.create("float", 2);
         switch (transitionType) {
             case transition.AndroidTransitionType.enter:
             case transition.AndroidTransitionType.popEnter:
@@ -17,7 +15,7 @@ export class CustomTransition extends transition.Transition {
                 scaleValues[1] = 0;
                 break;
         }
-        var objectAnimators = java.lang.reflect.Array.newInstance(android.animation.Animator.class, 2);
+        var objectAnimators = Array.create(android.animation.Animator, 2);
         objectAnimators[0] = android.animation.ObjectAnimator.ofFloat(null, "scaleX", scaleValues);
         objectAnimators[1] = android.animation.ObjectAnimator.ofFloat(null, "scaleY", scaleValues);
         var animatorSet = new android.animation.AnimatorSet();

--- a/apps/tests/navigation/custom-transition.android.ts
+++ b/apps/tests/navigation/custom-transition.android.ts
@@ -1,14 +1,12 @@
 ﻿import transition = require("ui/transition");
 
-var floatType = java.lang.Float.class.getField("TYPE").get(null);
-
 export class CustomTransition extends transition.Transition {
     constructor(duration: number, curve: any) {
         super(duration, curve);
     }
 
     public createAndroidAnimator(transitionType: string): android.animation.Animator {
-        var scaleValues = java.lang.reflect.Array.newInstance(floatType, 2);
+        var scaleValues = Array.create("float", 2);
         switch (transitionType) {
             case transition.AndroidTransitionType.enter:
             case transition.AndroidTransitionType.popEnter:
@@ -21,7 +19,7 @@ export class CustomTransition extends transition.Transition {
                 scaleValues[1] = 0;
                 break;
         }
-        var objectAnimators = java.lang.reflect.Array.newInstance(android.animation.Animator.class, 2);
+        var objectAnimators = Array.create(android.animation.Animator, 2);
         objectAnimators[0] = android.animation.ObjectAnimator.ofFloat(null, "scaleX", scaleValues);
         objectAnimators[1] = android.animation.ObjectAnimator.ofFloat(null, "scaleY", scaleValues);
         var animatorSet = new android.animation.AnimatorSet();

--- a/declarations.android.d.ts
+++ b/declarations.android.d.ts
@@ -4,6 +4,10 @@ declare var app;
 declare var telerik;
 declare var gc: () => void;
 
+interface ArrayConstructor {
+    create(type: any, count: number): any;
+}
+
 declare module android {
     module support {
         module v4 {

--- a/ui/transition/fade-transition.android.ts
+++ b/ui/transition/fade-transition.android.ts
@@ -1,10 +1,8 @@
 ﻿import {Transition, AndroidTransitionType} from "ui/transition";
 
-var floatType = java.lang.Float.class.getField("TYPE").get(null);
-
 export class FadeTransition extends Transition {
     public createAndroidAnimator(transitionType: string): android.animation.Animator {
-        var alphaValues = java.lang.reflect.Array.newInstance(floatType, 2);
+        var alphaValues = Array.create("float", 2);
         switch (transitionType) {
             case AndroidTransitionType.enter:
             case AndroidTransitionType.popEnter:

--- a/ui/transition/flip-transition.android.ts
+++ b/ui/transition/flip-transition.android.ts
@@ -1,7 +1,5 @@
 ﻿import {Transition, AndroidTransitionType} from "ui/transition";
 
-var floatType = java.lang.Float.class.getField("TYPE").get(null);
-
 //http://developer.android.com/training/animation/cardflip.html
 export class FlipTransition extends Transition {
     private _direction: string;
@@ -22,16 +20,16 @@ export class FlipTransition extends Transition {
 
         switch (transitionType) {
             case AndroidTransitionType.enter: // card_flip_right_in
-                objectAnimators = java.lang.reflect.Array.newInstance(android.animation.Animator.class, 3);
+                objectAnimators = Array.create(android.animation.Animator, 3);
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 1.0;
                 values[1] = 0.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "alpha", values);
                 animator.setDuration(0);
                 objectAnimators[0] = animator;
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = rotationY;
                 values[1] = 0.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "rotationY", values);
@@ -39,7 +37,7 @@ export class FlipTransition extends Transition {
                 animator.setDuration(fullDuration);
                 objectAnimators[1] = animator;
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 0.0;
                 values[1] = 1.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "alpha", values);
@@ -48,9 +46,9 @@ export class FlipTransition extends Transition {
                 objectAnimators[2] = animator;
                 break;
             case AndroidTransitionType.exit: // card_flip_right_out
-                objectAnimators = java.lang.reflect.Array.newInstance(android.animation.Animator.class, 2);
+                objectAnimators = Array.create(android.animation.Animator, 2);
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 0.0;
                 values[1] = -rotationY;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "rotationY", values);
@@ -58,7 +56,7 @@ export class FlipTransition extends Transition {
                 animator.setDuration(fullDuration);
                 objectAnimators[0] = animator;
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 1.0;
                 values[1] = 0.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "alpha", values);
@@ -67,16 +65,16 @@ export class FlipTransition extends Transition {
                 objectAnimators[1] = animator;
                 break;
             case AndroidTransitionType.popEnter: // card_flip_left_in
-                objectAnimators = java.lang.reflect.Array.newInstance(android.animation.Animator.class, 3);
+                objectAnimators = Array.create(android.animation.Animator, 3);
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 1.0;
                 values[1] = 0.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "alpha", values);
                 animator.setDuration(0);
                 objectAnimators[0] = animator;
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = -rotationY;
                 values[1] = 0.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "rotationY", values);
@@ -84,7 +82,7 @@ export class FlipTransition extends Transition {
                 animator.setDuration(fullDuration);
                 objectAnimators[1] = animator;
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 0.0;
                 values[1] = 1.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "alpha", values);
@@ -93,9 +91,9 @@ export class FlipTransition extends Transition {
                 objectAnimators[2] = animator;
                 break;
             case AndroidTransitionType.popExit: // card_flip_left_out
-                objectAnimators = java.lang.reflect.Array.newInstance(android.animation.Animator.class, 2);
+                objectAnimators = Array.create(android.animation.Animator, 2);
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 0.0;
                 values[1] = rotationY;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "rotationY", values);
@@ -103,7 +101,7 @@ export class FlipTransition extends Transition {
                 animator.setDuration(fullDuration);
                 objectAnimators[0] = animator;
 
-                values = java.lang.reflect.Array.newInstance(floatType, 2);
+                values = Array.create("float", 2);
                 values[0] = 1.0;
                 values[1] = 0.0;
                 animator = android.animation.ObjectAnimator.ofFloat(null, "alpha", values);

--- a/ui/transition/slide-transition.android.ts
+++ b/ui/transition/slide-transition.android.ts
@@ -1,7 +1,6 @@
 ﻿import transition = require("ui/transition");
 import platform = require("platform");
 
-var floatType = java.lang.Float.class.getField("TYPE").get(null);
 var screenWidth = platform.screen.mainScreen.widthPixels;
 var screenHeight = platform.screen.mainScreen.heightPixels;
 
@@ -14,7 +13,7 @@ export class SlideTransition extends transition.Transition {
     }
 
     public createAndroidAnimator(transitionType: string): android.animation.Animator {
-        var translationValues = java.lang.reflect.Array.newInstance(floatType, 2);
+        var translationValues = Array.create("float", 2);
         switch (this._direction) {
             case "left":
                 switch (transitionType) {


### PR DESCRIPTION
The [better syntax for Java arrays](https://github.com/NativeScript/android-runtime/issues/70) feature has landed in the Android Runtime and this pull takes advantage of it.