### PR TITLE
[Android] Fix an issue with id not applied to ActionBar in XML

### DIFF
--- a/apps/tests/ui/action-bar/action-bar-tests-common.ts
+++ b/apps/tests/ui/action-bar/action-bar-tests-common.ts
@@ -465,6 +465,25 @@ export function test_LoadedEventsOrder_WithoutPageContent() {
     }
 };
 
+export function test_setId() {
+    var pageFactory = function (): PageModule.Page {
+        var page = new PageModule.Page();
+        page.actionBar.id = "myId";
+
+        return page;
+    };
+
+    try {
+        helper.navigate(pageFactory);
+    }
+    catch (e) {
+        TKUnit.assert(false, "Failed to apply property 'id' to actionBar before its nativeView is ready.");
+    }
+    finally {
+        helper.goBack();
+    }
+};
+
 export function createPageAndNavigate() {
     var page: PageModule.Page;
     var pageFactory = function (): PageModule.Page {

--- a/ui/core/proxy.ts
+++ b/ui/core/proxy.ts
@@ -1,7 +1,6 @@
 ﻿import bindable = require("ui/core/bindable");
 import dependencyObservable = require("ui/core/dependency-observable");
 import definition = require("ui/core/proxy");
-import * as platform from "platform";
 import * as types from "utils/types";
 import * as observable from "data/observable";
 
@@ -71,13 +70,20 @@ export class ProxyObject extends bindable.Bindable implements definition.ProxyOb
         this._eachSetProperty(eachPropertyCallback);
     }
 
+    /**
+     * Checks whether the proxied native object has been created and properties may be applied to it.
+     */
+    protected _canApplyNativeProperty(): boolean {
+        return false;
+    }
+
     private _trySetNativeValue(property: dependencyObservable.Property, oldValue?:any, newValue?: any) {
         if (this._updatingJSPropertiesDict[property.name]) {
             // This is the case when a property has changed from the native side directly and we have received the "_onPropertyChanged" event while synchronizing our local cache
             return;
         }
 
-        if (platform.device.os === platform.platformNames.android && !this.android) {
+        if (!this._canApplyNativeProperty()) {
             // in android we have lazy loading and we do not have a native widget created yet, do not call the onSetNativeValue callback
             // properties will be synced when the widget is created
             return;

--- a/ui/core/view-common.ts
+++ b/ui/core/view-common.ts
@@ -1165,4 +1165,9 @@ export class View extends ProxyObject implements definition.View {
     public _onStylePropertyChanged(property: Property): void {
         //
     }
+
+    protected _canApplyNativeProperty(): boolean {
+        // Check for a valid _nativeView instance
+        return !!this._nativeView;
+    }
 }

--- a/utils/debug.ts
+++ b/utils/debug.ts
@@ -47,11 +47,12 @@ export class Source {
 	}
 }
 
-export class ScopeError implements Error {
+export class ScopeError extends Error {
 	private _child: Error;
 	private _message: string;
 	
-	constructor(child: Error, message?: string) {
+    constructor(child: Error, message?: string) {
+        super(message);
 		if (!child) {
 			throw new Error("Required child error!");
 		}


### PR DESCRIPTION
This pull fixes #1691. The problem was with an erroneous check within the `ProxyObject` class.



