### PR TITLE
Fixed 'NavigationEntry.transitionAndroid' not used bug #1693

### DIFF
--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -406,7 +406,7 @@ export class Frame extends CustomLayoutView implements definition.Frame {
             }
 
             if (platform.device.os === platform.platformNames.android && isDefined(entry.transitionAndroid)) {
-                return entry.transitioniOS;
+                return entry.transitionAndroid;
             }
 
             if (entry && isDefined(entry.transition)) {


### PR DESCRIPTION
As title. Please see https://github.com/NativeScript/NativeScript/issues/1693 for details.