### PR TITLE
Introducing time property for TimePicker.

### DIFF
--- a/apps/tests/ui/time-picker/time-picker-tests.ts
+++ b/apps/tests/ui/time-picker/time-picker-tests.ts
@@ -1,6 +1,5 @@
 ﻿import TKUnit = require("../../TKUnit");
-import helper = require("../helper");
-import viewModule = require("ui/core/view");
+import testModule = require("../../ui-test");
 import timePickerTestsNative = require("./time-picker-tests-native");
 import color = require("color");
 import platform = require("platform");
@@ -13,315 +12,268 @@ import timePickerModule = require("ui/time-picker");
 // ```
 // </snippet>
 
-function _createTimePicker(hour?: number, minute?: number): timePickerModule.TimePicker {
-    // <snippet module="ui/time-picker" title="TimePicker">
-    // ## Creating a TimePicker
-    // ``` JavaScript
-    var timePicker = new timePickerModule.TimePicker();
-    // ```
-    // </snippet>
-    timePicker.id = "timePicker";
-
-    if (hour) {
-        timePicker.hour = hour;
-    }
-
-    if (minute) {
-        timePicker.minute = minute;
-    }
-
-    return timePicker;
-}
-
-export function test_DummyForCodeSnippet() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        // <snippet module="ui/time-picker" title="TimePicker">
-        // ## Configuring a TimePicker
-        // ``` JavaScript
-        timePicker.hour = 9;
-        timePicker.minute = 25;
-        // ```
-        // </snippet>
-    });
-}
-
-// Supported in iOS only.
-if (platform.device.os === platform.platformNames.ios) {
-    exports.test_set_color = function () {
-        helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-            var timePicker = <timePickerModule.TimePicker>views[0];
-            timePicker.color = new color.Color("red");
-            TKUnit.assertEqual(timePicker.color.ios.CGColor, timePicker.ios.valueForKey("textColor").CGColor, "timePicker.color");
-        });
-
-    }
-}
-
-export function test_WhenCreated_MinuteIntervalIs1() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.minuteInterval;
-        var expectedValue = 1;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function test_WhenCreated_HourIsCurrentHour() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.hour;
-        var expectedValue = timePickerTestsNative.getNativeHour(timePicker);
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function test_WhenCreated_MinHourIs0() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.minHour;
-        var expectedValue = 0;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function test_WhenCreated_MaxHourIs23() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.maxHour;
-        var expectedValue = 23;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function test_WhenCreated_MinuteIsCurrentMinute() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.minute;
-        var expectedValue = timePickerTestsNative.getNativeMinute(timePicker);
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function test_WhenCreated_MinMinuteIs0() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.minMinute;
-        var expectedValue = 0;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function test_WhenCreated_MaxMinuteIs59() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var actualValue = timePicker.maxMinute;
-        var expectedValue = 59;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function testMinuteIntervalThrowExceptionWhenLessThan1() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        TKUnit.assertThrows(function () {
-            timePicker.minuteInterval = 0;
-        }, "Setting minuteInterval property to a value less than 1 should throw.");
-    });
-}
-
-export function testMinuteIntervalThrowExceptionWhenGreaterThan30() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        TKUnit.assertThrows(function () {
-            timePicker.minuteInterval = 31;
-        }, "Setting minuteInterval property to a value greater than 30 should throw.");
-    });
-}
-
-export function testMinuteIntervalThrowExceptionWhenNotFold60() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        TKUnit.assertThrows(function () {
-            timePicker.minuteInterval = 7;
-        }, "Setting minuteInterval property to a value not fold 60 should throw.");
-    });
-}
-
-export function testHourThrowExceptionWhenLessThanMinHour() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        timePicker.minHour = timePicker.hour - 1;
-        TKUnit.assertThrows(function () {
-            timePicker.hour = timePicker.minHour - 1;
-        }, "Setting hour property to a value less than minHour property value should throw.");
-    });
-}
-
-export function testMinHourThrowExceptionWhenHourLessThanMinHour() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        TKUnit.assertThrows(function () {
-            timePicker.minHour = timePicker.hour + 1;
-        }, "Setting minHour property to a greater than hour property value should throw.");
-    });
-}
-
-export function testHourThrowExceptionWhenGreaterThanMaxHour() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        timePicker.maxHour = timePicker.hour + 1;
-        TKUnit.assertThrows(function () {
-            timePicker.hour = timePicker.maxHour + 1;;
-        }, "Setting hour property to a value greater than maxHour property value should throw.");
-    });
-}
-
-export function testMaxHourThrowExceptionWhenHourGreaterThanMaxHour() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        TKUnit.assertThrows(function () {
-            timePicker.maxHour = timePicker.hour - 1;
-        }, "Setting maxHour property to a value less than hour property value should throw.");
-    });
-}
-
-export function testMinuteThrowExceptionWhenLessThanMinMinute() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        timePicker.minute = 13;
-
-        timePicker.minHour = timePicker.hour;
-        timePicker.minMinute = timePicker.minute;
-        TKUnit.assertThrows(function () {
-            timePicker.minute = timePicker.minMinute - 1;
-        }, "Setting minute property to a value less than minMinute property value should throw.");
-    });
-}
-
-export function testMinMinuteThrowExceptionWhenMinuteLessThanMinMinute() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        timePicker.minute = 13;
-
-        timePicker.minHour = timePicker.hour;
-        TKUnit.assertThrows(function () {
-            timePicker.minMinute = timePicker.minute + 1;
-        }, "Setting minMinute property to a value greater than minute property value should throw.");
-    });
-}
-
-export function testMinuteThrowExceptionWhenGreaterThanMaxMinute() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        timePicker.minute = 13;
-
-        timePicker.maxHour = timePicker.hour;
-        timePicker.maxMinute = timePicker.minute;
-        TKUnit.assertThrows(function () {
-            timePicker.minute = timePicker.maxMinute + 1;
-        }, "Setting minute property to a value greater than maxMinute property value should throw.");
-    });
-}
-
-export function testMaxMinuteThrowExceptionWhenMinuteGreaterThanMaxMinute() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = 14;
-        timePicker.minute = 13;
-
-        timePicker.maxHour = timePicker.hour;
-        TKUnit.assertThrows(function () {
-            timePicker.maxMinute = timePicker.minute - 1;
-        }, "Setting maxMinute property to a value less than minute property value should throw.");
-    });
-}
-
-export function testHourFromLocalToNative() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var expectedValue = 13;
-        timePicker.hour = expectedValue;
-        var actualValue = timePickerTestsNative.getNativeHour(timePicker);
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function testMinuteFromLocalToNative() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var expectedValue = 59;
-        timePicker.minute = expectedValue;
-        var actualValue = timePickerTestsNative.getNativeMinute(timePicker);
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function testHourFromNativeToLocal() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var expectedValue = 14;
-        timePickerTestsNative.setNativeHour(timePicker, expectedValue);
-        var actualValue = timePicker.hour;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function testMinuteFromNativeToLocal() {
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        var expectedValue = 33;
-        timePickerTestsNative.setNativeMinute(timePicker, expectedValue);
-        var actualValue = timePicker.minute;
-        TKUnit.assertEqual(actualValue, expectedValue);
-    });
-}
-
-export function testHourAndMinuteFromNativeToLocal() {
-    var expectedHour = 12;
-    var expectedMinute = 34;
-
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePickerTestsNative.setNativeTime(timePicker, expectedHour, expectedMinute);
-        assertTime(timePicker, expectedHour, expectedMinute);
-    });
-}
-
-export function testSetHourMinute_BeforeLoaded() {
-    var expectedHour = 12;
-    var expectedMinute = 34;
-
-    helper.buildUIAndRunTest(_createTimePicker(expectedHour, expectedMinute), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        assertTime(timePicker, expectedHour, expectedMinute);
-    });
-}
-
-export function testSetHourMinute_AfterLoaded() {
-    var expectedHour = 12;
-    var expectedMinute = 34;
-
-    helper.buildUIAndRunTest(_createTimePicker(), function (views: Array<viewModule.View>) {
-        var timePicker = <timePickerModule.TimePicker>views[0];
-        timePicker.hour = expectedHour;
-        timePicker.minute = expectedMinute;
-
-        assertTime(timePicker, expectedHour, expectedMinute);
-    });
-}
-
 function assertTime(timePicker: timePickerModule.TimePicker, expectedHour: number, expectedMinute) {
     TKUnit.assertEqual(timePicker.hour, expectedHour, "timePicker.hour");
     TKUnit.assertEqual(timePicker.minute, expectedMinute, "timePicker.minute");
 
     TKUnit.assertEqual(timePickerTestsNative.getNativeHour(timePicker), expectedHour, "Native timePicker.hour");
     TKUnit.assertEqual(timePickerTestsNative.getNativeMinute(timePicker), expectedMinute, "Native timePicker.minute");
+}
+
+export class TimePickerTest extends testModule.UITest<timePickerModule.TimePicker> {
+    public create() {
+        let timePicker = new timePickerModule.TimePicker();
+        timePicker.id = "TimePicker";
+        return timePicker;
+    }
+    
+    public test_DummyForCodeSnippet() {
+        // <snippet module="ui/time-picker" title="TimePicker">
+        // ## Configuring a TimePicker
+        // ``` JavaScript
+        var timePicker = new timePickerModule.TimePicker();
+        timePicker.hour = 9;
+        timePicker.minute = 25;
+        // ```
+        // </snippet>
+    }
+    
+    private setUpTimePicker(hour?: number, minute?: number) {
+        if (hour) {
+            this.testView.hour = hour;
+        }
+        
+        if (minute) {
+            this.testView.minute = minute;
+        }
+    }
+
+    // Supported in iOS only.
+    public test_set_color() {
+        if (platform.device.os === platform.platformNames.ios) {
+            this.testView.color = new color.Color("red");
+            TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey("textColor").CGColor, "timePicker.color");
+        }
+    }
+
+    public test_WhenCreated_MinuteIntervalIs1() {
+        let actualValue = this.testView.minuteInterval;
+        let expectedValue = 1;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public test_WhenCreated_HourIsCurrentHour() {
+        let actualValue = this.testView.hour;
+        let expectedValue = timePickerTestsNative.getNativeHour(this.testView);
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public test_WhenCreated_MinHourIs0() {
+        let actualValue = this.testView.minHour;
+        let expectedValue = 0;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public test_WhenCreated_MaxHourIs23() {
+        let actualValue = this.testView.maxHour;
+        let expectedValue = 23;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public test_WhenCreated_MinuteIsCurrentMinute() {
+        let actualValue = this.testView.minute;
+        let expectedValue = timePickerTestsNative.getNativeMinute(this.testView);
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public test_WhenCreated_MinMinuteIs0() {
+        let actualValue = this.testView.minMinute;
+        let expectedValue = 0;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public test_WhenCreated_MaxMinuteIs59() {
+        let actualValue = this.testView.maxMinute;
+        let expectedValue = 59;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public testMinuteIntervalThrowExceptionWhenLessThan1() {
+        TKUnit.assertThrows(function() {
+            this.testView.minuteInterval = 0;
+        }, "Setting minuteInterval property to a value less than 1 should throw.");
+    }
+
+    public testMinuteIntervalThrowExceptionWhenGreaterThan30() {
+        TKUnit.assertThrows(function() {
+            this.testView.minuteInterval = 31;
+        }, "Setting minuteInterval property to a value greater than 30 should throw.");
+    }
+
+    public testMinuteIntervalThrowExceptionWhenNotFold60() {
+        TKUnit.assertThrows(function() {
+            this.testView.minuteInterval = 7;
+        }, "Setting minuteInterval property to a value not fold 60 should throw.");
+    }
+
+    public testHourThrowExceptionWhenLessThanMinHour() {
+        this.testView.hour = 14;
+        this.testView.minHour = this.testView.hour - 1;
+        TKUnit.assertThrows(function() {
+            this.testView.hour = this.testView.minHour - 1;
+        }, "Setting hour property to a value less than minHour property value should throw.");
+    }
+
+    public testMinHourThrowExceptionWhenHourLessThanMinHour() {
+        this.testView.hour = 14;
+        TKUnit.assertThrows(function() {
+            this.testView.minHour = this.testView.hour + 1;
+        }, "Setting minHour property to a greater than hour property value should throw.");
+    }
+
+    public testHourThrowExceptionWhenGreaterThanMaxHour() {
+        this.testView.hour = 14;
+        this.testView.maxHour = this.testView.hour + 1;
+        TKUnit.assertThrows(function() {
+            this.testView.hour = this.testView.maxHour + 1;;
+        }, "Setting hour property to a value greater than maxHour property value should throw.");
+    }
+
+    public testMaxHourThrowExceptionWhenHourGreaterThanMaxHour() {
+        this.testView.hour = 14;
+        TKUnit.assertThrows(function() {
+            this.testView.maxHour = this.testView.hour - 1;
+        }, "Setting maxHour property to a value less than hour property value should throw.");
+    }
+
+    public testMinuteThrowExceptionWhenLessThanMinMinute() {
+        this.testView.hour = 14;
+        this.testView.minute = 13;
+
+        this.testView.minHour = this.testView.hour;
+        this.testView.minMinute = this.testView.minute;
+        TKUnit.assertThrows(function() {
+            this.testView.minute = this.testView.minMinute - 1;
+        }, "Setting minute property to a value less than minMinute property value should throw.");
+    }
+
+    public testMinMinuteThrowExceptionWhenMinuteLessThanMinMinute() {
+        this.testView.hour = 14;
+        this.testView.minute = 13;
+
+        this.testView.minHour = this.testView.hour;
+        TKUnit.assertThrows(function() {
+            this.testView.minMinute = this.testView.minute + 1;
+        }, "Setting minMinute property to a value greater than minute property value should throw.");
+    }
+
+    public testMinuteThrowExceptionWhenGreaterThanMaxMinute() {
+        this.testView.hour = 14;
+        this.testView.minute = 13;
+
+        this.testView.maxHour = this.testView.hour;
+        this.testView.maxMinute = this.testView.minute;
+        TKUnit.assertThrows(function() {
+            this.testView.minute = this.testView.maxMinute + 1;
+        }, "Setting minute property to a value greater than maxMinute property value should throw.");
+    }
+
+    public testMaxMinuteThrowExceptionWhenMinuteGreaterThanMaxMinute() {
+        this.testView.hour = 14;
+        this.testView.minute = 13;
+
+        this.testView.maxHour = this.testView.hour;
+        TKUnit.assertThrows(function() {
+            this.testView.maxMinute = this.testView.minute - 1;
+        }, "Setting maxMinute property to a value less than minute property value should throw.");
+    }
+
+    public testHourFromLocalToNative() {
+        let expectedValue = 13;
+        this.testView.hour = expectedValue;
+        let actualValue = timePickerTestsNative.getNativeHour(this.testView);
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public testMinuteFromLocalToNative() {
+        let expectedValue = 59;
+        this.testView.minute = expectedValue;
+        let actualValue = timePickerTestsNative.getNativeMinute(this.testView);
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public testHourFromNativeToLocal() {
+        let expectedValue = 14;
+        timePickerTestsNative.setNativeHour(this.testView, expectedValue);
+        let actualValue = this.testView.hour;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public testMinuteFromNativeToLocal() {
+        let expectedValue = 33;
+        timePickerTestsNative.setNativeMinute(this.testView, expectedValue);
+        let actualValue = this.testView.minute;
+        TKUnit.assertEqual(actualValue, expectedValue);
+    }
+
+    public testHourAndMinuteFromNativeToLocal() {
+        let expectedHour = 12;
+        let expectedMinute = 34;
+
+        timePickerTestsNative.setNativeTime(this.testView, expectedHour, expectedMinute);
+        assertTime(this.testView, expectedHour, expectedMinute);
+    }
+
+    public testSetHourMinute_BeforeLoaded() {
+        let expectedHour = 12;
+        let expectedMinute = 34;
+        
+        this.setUpTimePicker(expectedHour, expectedMinute);
+        
+        assertTime(this.testView, expectedHour, expectedMinute);
+    }
+
+    public testTimeSetHourMinute_BeforeLoaded() {
+        let expectedHour = 12;
+        let expectedMinute = 34;
+        
+        this.setUpTimePicker(expectedHour, expectedMinute);
+        
+        TKUnit.assertEqual(this.testView.time.getHours(), expectedHour);
+        TKUnit.assertEqual(this.testView.time.getMinutes(), expectedMinute);
+    }
+
+    public testSetHourMinute_AfterLoaded() {
+        let expectedHour = 12;
+        let expectedMinute = 34;
+
+        this.testView.hour = expectedHour;
+        this.testView.minute = expectedMinute;
+
+        TKUnit.assertEqual(this.testView.time.getHours(), expectedHour);
+        TKUnit.assertEqual(this.testView.time.getMinutes(), expectedMinute);
+    }
+
+    public testTimeSetHourMinute_AfterLoaded() {
+        let expectedHour = 12;
+        let expectedMinute = 34;
+
+        this.testView.hour = expectedHour;
+        this.testView.minute = expectedMinute;
+
+        TKUnit.assertEqual(this.testView.time.getHours(), expectedHour);
+        TKUnit.assertEqual(this.testView.time.getMinutes(), expectedMinute);
+    }
+
+    public testSetTimeChangesHourAndMinute() {
+        let expectedHour = 12;
+        let expectedMinute = 34;
+        
+        this.testView.time = new Date(0, 0, 0, expectedHour, expectedMinute);
+        assertTime(this.testView, expectedHour, expectedMinute);
+    }
+}
+
+export function createTestCase(): TimePickerTest {
+    return new TimePickerTest();
 }

--- a/ui/time-picker/time-picker-common.ts
+++ b/ui/time-picker/time-picker-common.ts
@@ -26,10 +26,16 @@ function getMinutes(hour: number): number {
 }
 
 export function isGreaterThanMinTime(picker: definition.TimePicker, hour?: number, minute?: number): boolean {
+    if (!types.isDefined(picker.minHour) || !types.isDefined(picker.minMinute)) {
+        return true;
+    }
     return getMinutes(types.isDefined(hour) ? hour : picker.hour) + (types.isDefined(minute) ? minute : picker.minute) >= getMinutes(picker.minHour) + picker.minMinute;
 }
 
 export function isLessThanMaxTime(picker: definition.TimePicker, hour?: number, minute?: number): boolean {
+    if (!types.isDefined(picker.maxHour) || !types.isDefined(picker.maxMinute)) {
+        return true;
+    }
     return getMinutes(types.isDefined(hour) ? hour : picker.hour) + (types.isDefined(minute) ? minute : picker.minute) <= getMinutes(picker.maxHour) + picker.maxMinute;
 }
 
@@ -78,6 +84,7 @@ function onHourPropertyChanged(data: dependencyObservable.PropertyChangeData) {
 
     if (isValidTime(picker)) {
         picker._setNativeTime();
+        picker.time = new Date(0, 0, 0, picker.hour, picker.minute);
     } else {
         throw new Error(getErrorMessage(picker, "Hour", data.newValue));
     }
@@ -88,8 +95,23 @@ function onMinutePropertyChanged(data: dependencyObservable.PropertyChangeData) 
 
     if (isValidTime(picker)) {
         picker._setNativeTime();
+        picker.time = new Date(0, 0, 0, picker.hour, picker.minute);
     } else {
         throw new Error(getErrorMessage(picker, "Minute", data.newValue));
+    }
+}
+
+function onTimePropertyChanged(data: dependencyObservable.PropertyChangeData) {
+    var picker = <definition.TimePicker>data.object;
+    
+    let newTime = <Date>data.newValue;
+    picker.hour = newTime.getHours();
+    picker.minute = newTime.getMinutes();
+
+    if (isValidTime(picker)) {
+        picker._setNativeTime();
+    } else {
+        throw new Error(getErrorMessage(picker, "Time", data.newValue));
     }
 }
 
@@ -160,6 +182,9 @@ export class TimePicker extends view.View implements definition.TimePicker {
 
     public static minuteIntervalProperty = new dependencyObservable.Property("minuteInterval", "TimePicker",
         new proxy.PropertyMetadata(1, dependencyObservable.PropertyMetadataSettings.None, onMinuteIntervalPropertyChanged, isMinuteIntervalValid));
+        
+    public static timeProperty = new dependencyObservable.Property("time", "TimePicker",
+        new proxy.PropertyMetadata(undefined, dependencyObservable.PropertyMetadataSettings.None, onTimePropertyChanged, isValidTime));
 
     constructor() {
         super();
@@ -177,6 +202,13 @@ export class TimePicker extends view.View implements definition.TimePicker {
     }
     set minute(value: number) {
         this._setValue(TimePicker.minuteProperty, value);
+    }
+    
+    get time(): Date {
+        return this._getValue(TimePicker.timeProperty);
+    }
+    set time(value: Date) {
+        this._setValue(TimePicker.timeProperty, value);
     }
 
     get minuteInterval(): number {

--- a/ui/time-picker/time-picker.android.ts
+++ b/ui/time-picker/time-picker.android.ts
@@ -54,7 +54,7 @@ export class TimePicker extends common.TimePicker {
 
             this.minute = minute;
             this.hour = hour;
-
+            
             this.android.setOnTimeChangedListener(this._listener);
         }
     }

--- a/ui/time-picker/time-picker.d.ts
+++ b/ui/time-picker/time-picker.d.ts
@@ -11,6 +11,7 @@ declare module "ui/time-picker" {
     export class TimePicker extends view.View {
         public static hourProperty: dependencyObservable.Property;
         public static minuteProperty: dependencyObservable.Property;
+        public static timeProperty: dependencyObservable.Property;
 
         constructor();
 
@@ -33,6 +34,11 @@ declare module "ui/time-picker" {
          * Gets or sets the time minute.
          */
         minute: number;
+        
+        /**
+         * Gets or sets the time.
+         */
+        time: Date;
 
         /**
          * Gets or sets the max time hour.

--- a/ui/time-picker/time-picker.ios.ts
+++ b/ui/time-picker/time-picker.ios.ts
@@ -79,13 +79,20 @@ class UITimePickerChangeHandlerImpl extends NSObject {
         }
 
         var comps = getComponents(sender.date);
-
+        
+        let timeChanged = false;
         if (comps.hour !== owner.hour) {
             owner._onPropertyChangedFromNative(common.TimePicker.hourProperty, comps.hour);
+            timeChanged = true;
         }
 
         if (comps.minute !== owner.minute) {
             owner._onPropertyChangedFromNative(common.TimePicker.minuteProperty, comps.minute);
+            timeChanged = true;
+        }
+        
+        if (timeChanged) {
+            owner._onPropertyChangedFromNative(common.TimePicker.timeProperty, new Date(0, 0, 0, comps.hour, comps.minute));
         }
     }
 


### PR DESCRIPTION
Added `time` property for TimePicker. This property is cumulative for both existing properties (hour and minute) and will be used as a single input option in `Angular2 ngModel support` (two-way data binding).



