### PR TITLE
Change time only once due to Angular issues.

### DIFF
--- a/ui/time-picker/time-picker-common.ts
+++ b/ui/time-picker/time-picker-common.ts
@@ -84,7 +84,12 @@ function onHourPropertyChanged(data: dependencyObservable.PropertyChangeData) {
 
     if (isValidTime(picker)) {
         picker._setNativeTime();
-        picker.time = new Date(0, 0, 0, picker.hour, picker.minute);
+        if (picker.time) {
+            picker.time.setHours(picker.hour);
+        }
+        else {
+            picker.time = new Date(0, 0, 0, picker.hour, picker.minute);
+        }
     } else {
         throw new Error(getErrorMessage(picker, "Hour", data.newValue));
     }
@@ -95,7 +100,12 @@ function onMinutePropertyChanged(data: dependencyObservable.PropertyChangeData) 
 
     if (isValidTime(picker)) {
         picker._setNativeTime();
-        picker.time = new Date(0, 0, 0, picker.hour, picker.minute);
+        if (picker.time) {
+            picker.time.setMinutes(picker.minute);
+        }
+        else {
+            picker.time = new Date(0, 0, 0, picker.hour, picker.minute);
+        }
     } else {
         throw new Error(getErrorMessage(picker, "Minute", data.newValue));
     }

--- a/ui/time-picker/time-picker.android.ts
+++ b/ui/time-picker/time-picker.android.ts
@@ -26,6 +26,7 @@ export class TimePicker extends common.TimePicker {
                     if (this.owner) {
                         var validTime = common.getValidTime(this.owner, hour, minute);
                         this.owner._setNativeValueSilently(validTime.hour, validTime.minute);
+                        this.owner._onPropertyChangedFromNative(common.TimePicker.timeProperty, new Date(0, 0, 0, hour, minute));
                     }
                 }
             });


### PR DESCRIPTION
A little change to the way `time` property is changed, since within Angular2 scenario too close (in time) changes are not handled correctly. The problem comes from the fact that android native time picker widget when minutes change from (0 to 59 and vice versa) also changes hour - which in previous implementation results in two changes of the `time` property.


