### PR TITLE
Add source information on the view

### DIFF
--- a/apps/tests/xml-declaration/examples/test-page.xml
+++ b/apps/tests/xml-declaration/examples/test-page.xml
@@ -1,0 +1,5 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd">
+  <GridLayout id="grid">
+    <Label id="label" text="Text" />
+  </GridLayout>
+</Page>

--- a/apps/tests/xml-declaration/xml-declaration-tests.ts
+++ b/apps/tests/xml-declaration/xml-declaration-tests.ts
@@ -24,6 +24,7 @@ import viewModule = require("ui/core/view");
 import platform = require("platform");
 import gesturesModule = require("ui/gestures");
 import segmentedBar = require("ui/segmented-bar");
+import { Source } from "utils/debug";
 
 export function test_load_IsDefined() {
     TKUnit.assert(types.isFunction(builder.load), "ui/builder should have load method!");
@@ -973,4 +974,15 @@ export function test_TabViewHasCorrectParentChain() {
     var model = new Observable();
     model.set("testPassed", false);
     helper.navigateToModuleAndRunTest(("." + moduleName + "/mymodulewithxml/TabViewParentChain"), model, testFunc);
+}
+
+export function test_hasSourceCodeLocations() {
+    var basePath = "xml-declaration/";
+    var page = <Page>builder.load(__dirname + "/examples/test-page.xml");
+    var grid = page.getViewById("grid");
+    var gridSource = Source.get(grid);
+    TKUnit.assertEqual(gridSource.toString(), "file:///app/" + basePath + "examples/test-page.xml:2:3");
+    var label = page.getViewById("label");
+    var labelSource = Source.get(label);
+    TKUnit.assertEqual(labelSource.toString(), "file:///app/" + basePath + "examples/test-page.xml:3:5");
 }

--- a/ui/core/view-common.ts
+++ b/ui/core/view-common.ts
@@ -17,6 +17,7 @@ import * as visualStateConstants from "ui/styling/visual-state-constants";
 import * as bindableModule from "ui/core/bindable";
 import * as visualStateModule from "../styling/visual-state";
 import * as animModule from "ui/animation";
+import { Source } from "utils/debug";
 
 var bindable: typeof bindableModule;
 function ensureBindable() {
@@ -1151,11 +1152,18 @@ export class View extends ProxyObject implements definition.View {
     }
 
     public toString(): string {
+        var str = this.typeName;
         if (this.id) {
-            return this.typeName + `<${this.id}>`;
+            str += `<${this.id}>`;
+        } else {
+            str += `(${this._domId})`;
+        }
+        var source = Source.get(this);
+        if (source) {
+            str += `@${source};`;
         }
 
-        return this.typeName + `(${this._domId})`;
+        return str;
     }
 
     public _setNativeViewFrame(nativeView: any, frame: any) {

--- a/ui/core/view.ios.ts
+++ b/ui/core/view.ios.ts
@@ -137,7 +137,7 @@ export class View extends viewCommon.View {
             // flag not set, setMeasuredDimension() was not invoked, we raise
             // an exception to warn the developer
             if ((this._privateFlags & PFLAG_MEASURED_DIMENSION_SET) !== PFLAG_MEASURED_DIMENSION_SET) {
-                throw new Error("onMeasure() did not set the measured dimension by calling setMeasuredDimension()");
+                throw new Error("onMeasure() did not set the measured dimension by calling setMeasuredDimension() " + this);
             }
         }
     }


### PR DESCRIPTION
Closes #828
`ui/builder` will now attach source url, line and column to the created views.
view.toString() will now append `@file://file:line:column` to the view information.
The utils/debug.Source.get method can be used to extract SourceCode information from view instances.