### PR TITLE
Fix the leave comments option of the build

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -180,7 +180,8 @@ module.exports = function(grunt) {
     tsOptions.compiler = "node_modules/typescript/bin/tsc";
     tsOptions.failOnTypeErrors = true;
     tsOptions.outDir = localCfg.outModulesDir;
-    tsOptions.additionalFlags = "--outDir " + localCfg.outModulesDir;
+    var removeCommentsArgument = tsOptions.removeComments ? " --removeComments" : "";
+    tsOptions.additionalFlags = "--outDir " + localCfg.outModulesDir + removeCommentsArgument;
 
     grunt.initConfig({
         localCfg : localCfg,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
         "module": "commonjs",
         "declaration": false,
         "noImplicitAny": false,
-        "removeComments": true,
         "noImplicitUseStrict": true,
         "experimentalDecorators": true
     },


### PR DESCRIPTION
The grunt file respected the --leavecomments option, used when
generating the How-To articles of the API Reference. This was broken with
the passthrough option to grunt-ts.