### PR TITLE
Adds Android 6.0+ Permissions to NativeScript

### DIFF
--- a/application/application.android.ts
+++ b/application/application.android.ts
@@ -162,6 +162,7 @@ export class AndroidApplication extends observable.Observable implements definit
     public static saveActivityStateEvent = "saveActivityState";
     public static activityResultEvent = "activityResult";
     public static activityBackPressedEvent = "activityBackPressed";
+    public static activityRequestPermissionsEvent = "activityRequestPermissions";
 
     public paused: boolean;
     public nativeApp: android.app.Application;

--- a/application/application.d.ts
+++ b/application/application.d.ts
@@ -279,6 +279,26 @@ declare module "application" {
     }
 
     /**
+     * Data for the Android activity onRequestPermissions callback
+     */
+    export interface AndroidActivityRequestPermissionsEventData extends AndroidActivityEventData {
+        /**
+         * The request code.
+         */
+        requestCode: number,
+
+        /**
+         * The Permissions
+         */
+        permissions: Array<String>,
+
+        /**
+         * The Granted.
+         */
+        grantResults: Array<Number>
+    }
+
+    /**
      * Data for the Android activity result event.
      */
     export interface AndroidActivityResultEventData extends AndroidActivityEventData {
@@ -439,6 +459,11 @@ declare module "application" {
          * This event is raised on the back button is pressed in an android application.
          */
         on(event: "activityBackPressed", callback: (args: AndroidActivityBackPressedEventData) => void, thisArg?: any);
+
+        /**
+         * This event is raised on the back button is pressed in an android application.
+         */
+        on(event: "activityRequestPermissions", callback: (args: AndroidActivityBackPressedEventData) => void, thisArg?: any);
 
         /**
          * String value used when hooking to activityCreated event.

--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -803,6 +803,19 @@ class NativeScriptActivity extends android.app.Activity {
         }
     }
 
+    public onRequestPermissionsResult (requestCode: number, permissions: Array<String>, grantResults: Array<number>): void {
+        trace.write("NativeScriptActivity.onRequestPermissionsResult;", trace.categories.NativeLifecycle);
+
+        application.android.notify(<application.AndroidActivityRequestPermissionsEventData>{
+            eventName: "activityRequestPermissions",
+            object: application.android,
+            activity: this,
+            requestCode: requestCode,
+            permissions: permissions,
+            grantResults: grantResults
+        });
+    }
+
     protected onActivityResult(requestCode: number, resultCode: number, data: android.content.Intent): void {
         super.onActivityResult(requestCode, resultCode, data);
         trace.write(`NativeScriptActivity.onActivityResult(${requestCode}, ${resultCode}, ${data})`, trace.categories.NativeLifecycle);


### PR DESCRIPTION
### Does your commit message include the wording below to reference a specific issue in this repo?
Fixes #1434 and #1451 

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
No

If not, why?
You have to manually select any permissions, you are unable to programmatically accept permissions.

If not, please tell us why tests are not included, and list all steps needed to test your pull request manually.
You have to add a "dangerous" permission to the manifest, run it on a Android 6+ device, make sure to build for API 23+, add the code to ask for a permission and then manually accept the permission.  
Unfortunately, not something that can be "automatically" tested.   

As an aside; you can install nativescript-permissions (shortly to be released) that will make this whole getting permissions very easy (assuming this patch is accepted).  The other possibility is to merge my NS-permissions plugin into the core; but I figured I had a much better chance at getting a very "tiny" change accepted that adds just the minimal code needed to the core.  Then anyone can handle permissions how they want.

This goes along with patch 1 (https://github.com/NativeScript/android-runtime/pull/389)