### PR TITLE
fix issue #1614

### DIFF
--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -710,7 +710,8 @@ class NativeScriptActivity extends android.app.Activity {
         if (frameId >= 0) {
             rootView = getFrameById(frameId);
         }
-        else if (!rootView) {
+
+        if (!rootView) {
             navParam = application.mainEntry;
             if (!navParam) {
                 navParam = application.mainModule;


### PR DESCRIPTION
I took a look at the frame implementation and I think I found the issue. As I am not very familiar with the code, feel free to ignore this PR if it is inappropriate. 

Function `getFrameById` may [return](https://github.com/NativeScript/NativeScript/blob/v1.7.0/ui/frame/frame.android.ts#L565) `null` value. This may happen because the weak reference created in the [constructor](https://github.com/NativeScript/NativeScript/blob/v1.7.0/ui/frame/frame.android.ts#L407) may be GC'ed. Latter in `onCreate` we [call](https://github.com/NativeScript/NativeScript/blob/v1.7.0/ui/frame/frame.android.ts#L711) `getFrameById` which returns `null` and a few lines below we [call](https://github.com/NativeScript/NativeScript/blob/v1.7.0/ui/frame/frame.android.ts#L740) `_onAttached` on a `null` value and we get the following error

```
TypeError: Cannot read property '_onAttached' of null
```