### PR TITLE
Fixes incorrectly formed switch-case statements

### DIFF
--- a/ui/core/view-common.ts
+++ b/ui/core/view-common.ts
@@ -720,7 +720,8 @@ export class View extends ProxyObject implements definition.View {
                 childTop = top + marginTop * density;
                 break;
 
-            case enums.VerticalAlignment.center || enums.VerticalAlignment.middle:
+            case enums.VerticalAlignment.center:
+            case enums.VerticalAlignment.middle:
                 childTop = top + (bottom - top - childHeight + (marginTop - marginBottom) * density) / 2;
                 break;
 

--- a/ui/core/view.android.ts
+++ b/ui/core/view.android.ts
@@ -586,7 +586,8 @@ export class ViewStyler implements style.Styler {
                 gravity |= android.view.Gravity.TOP;
                 break;
 
-            case enums.VerticalAlignment.center || enums.VerticalAlignment.middle:
+            case enums.VerticalAlignment.center:
+            case enums.VerticalAlignment.middle:
                 gravity |= android.view.Gravity.CENTER_VERTICAL;
                 break;
 

--- a/ui/layouts/stack-layout/stack-layout.ios.ts
+++ b/ui/layouts/stack-layout/stack-layout.ios.ts
@@ -110,7 +110,8 @@ export class StackLayout extends common.StackLayout {
         var childRight = right - left - paddingRight;
 
         switch (this.verticalAlignment) {
-            case VerticalAlignment.center || VerticalAlignment.middle:
+            case VerticalAlignment.center:
+            case VerticalAlignment.middle:
                 childTop = (bottom - top - this._totalLength) / 2 + paddingTop - paddingBottom;
                 break;
 


### PR DESCRIPTION
Resolves issue #1822.

Replaces incorrectly formed switch-case statements with multiple options on the same case-line:

    case option1 || option2:
      ...
      break;

with correctly formed multiple case statements:

    case option1:
    case option2:
      ...
      break;

This bug prevented from using "middle" and "center" options for `verticalAlignment` style.

I can include tests, but it's a trivial change. Let me know if you need them.