### PR TITLE
Generate a package for the platform definitions

### DIFF
--- a/build/platform-declarations/.gitignore
+++ b/build/platform-declarations/.gitignore
@@ -1,0 +1,4 @@
+/diffs/
+/actuals/
+/extracted/
+*.tgz

--- a/build/platform-declarations/gruntfile.js
+++ b/build/platform-declarations/gruntfile.js
@@ -1,0 +1,141 @@
+module.exports = function(grunt) {
+
+    var fsModule = require("fs");
+
+    function cleanDeps(content, srcPath) {
+        var contentAsJson = JSON.parse(content);
+        delete contentAsJson.devDependencies;
+        return JSON.stringify(contentAsJson, null, "\t");
+    }
+
+    function isDiff(content, srcPath) {
+        var relativePath = srcPath.replace(/actuals\//, "");
+        var extractedRelativePath = "extracted/package/" + relativePath;
+        grunt.log.fail(extractedRelativePath);
+        try {
+            if (fsModule.statSync(extractedRelativePath)) {
+                return false;
+            }
+        } catch (ex) {
+            if (content.match(/\s*\/\/@private.*/)) {
+                return false;
+            }
+            return content;
+        }
+
+        return false;
+    }
+
+    grunt.initConfig({
+        copy: {
+            package: {
+                src: "../../bin/dist/tns-core-modules*.tgz",
+                dest: "./tns-core-modules.tgz"
+            },
+            packagejson: {
+                expand: true,
+                src: "./package.json",
+                dest: "./diffs/",
+                options: {
+                    process: cleanDeps
+                }
+            },
+            actualDeclaraions: {
+                expand: true,
+                src: [
+                    "**/*.d.ts",
+                    "!bin/**/*.*",
+                    "!.git/**/*.*",
+                    "!node_modules/**/*.*",
+                    "!apps/**/*.*",
+                    "!node-tests/**/*.*",
+                    "!**/*.android.d.ts",
+                    "!**/*.ios.d.ts",
+                    "!build/**/*.*"
+                ],
+                dest: "./actuals",
+                cwd: "../../"
+            },
+            differentNoPrivateFiles: {
+                expand: true,
+                src: "./**/*.*",
+                dest: "./diffs/",
+                cwd: "./actuals",
+                options: {
+                    process: isDiff
+                }
+            },
+            packeddeclarations: {
+                expand: true,
+                src: "./*.tgz",
+                dest: "./",
+                cwd: "./diffs"
+            }
+        },
+        shell: {
+            unpackPackage: {
+                command: "tar -zxvf tns-core-modules.tgz -C ./extracted"
+            },
+            createExtractedDir: {
+                command: "mkdir ./extracted"
+            },
+            createActualsDir: {
+                command: "mkdir ./actuals"
+            },
+            createDiffsDir: {
+                command: "mkdir ./diffs"
+            },
+            packdeclarations: {
+                command: "npm pack",
+                options: {
+                    execOptions: {
+                        cwd: "./diffs"
+                    }
+                }
+            }
+        },
+        clean: {
+            package: {
+                src: "./tns-core-modules.tgz"
+            },
+            extractedDir: {
+                src: "./extracted"
+            },
+            actualsDir: {
+                src: "./actuals"
+            },
+            diffsDir: {
+                src: ["./diffs/**/*.*", "./diffs"]
+            },
+            extractedNonDeclarations: {
+                src: ["./extracted/**/*.*", "!./extracted/**/*.d.ts"]
+            }
+        }
+    });
+
+    grunt.loadNpmTasks("grunt-shell");
+    grunt.loadNpmTasks("grunt-contrib-copy");
+    grunt.loadNpmTasks("grunt-contrib-clean");
+
+    grunt.registerTask("default", [
+        "clean:extractedDir",
+        "clean:actualsDir",
+        "clean:diffsDir",
+        "clean:package",
+        "copy:package",
+        "shell:createExtractedDir",
+        "shell:unpackPackage",
+        "clean:package",
+        "clean:extractedNonDeclarations",
+        "shell:createActualsDir",
+        "copy:actualDeclaraions",
+        "shell:createDiffsDir",
+        "copy:differentNoPrivateFiles",
+        "clean:extractedDir",
+        "clean:actualsDir",
+        "copy:packagejson",
+        "shell:packdeclarations",
+        "copy:packeddeclarations",
+        "clean:diffsDir",
+    ]);
+}

--- a/build/platform-declarations/package.json
+++ b/build/platform-declarations/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "tns-platform-declarations",
+  "version": "1.7.1",
+  "description": "Platform-specific TypeScript declarations for NativeScript for accessing native objects",
+  "main": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/NativeScript/NativeScript.git"
+  },
+  "keywords": [
+    "NativeScript",
+    "TypeScript",
+    "declarations",
+    "native",
+    "platform-specific",
+    "tns",
+    "ts",
+    "ns"
+  ],
+  "author": {
+    "name": "Telerik",
+    "email": "support@telerik.com",
+    "url": "http://www.telerik.com"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/NativeScript/NativeScript/issues"
+  },
+  "homepage": "https://github.com/NativeScript/NativeScript#readme",
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-copy": "git+https://github.com/ErjanGavalji/grunt-contrib-copy.git#1c976a133210be4ce8c96313f5daf14833f7f8f9",
+    "grunt-shell": "^1.1.2"
+  }
+}

--- a/build/platform-declarations/run.sh
+++ b/build/platform-declarations/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+grunt --verbose


### PR DESCRIPTION
Implements #1599

No unit tests, for the implementation of the test would duplicate the code for the generation of the package. To manually test it, the package must contain the files, that don't get packed to the tns-core-modules package.

Needs refactoring so that the command is part of the main build script.
Needs publishing to the [typings registry](https://github.com/typings/registry).