### PR TITLE
Page.showModal API extended to accept page instance

### DIFF
--- a/ui/page/page-common.ts
+++ b/ui/page/page-common.ts
@@ -69,7 +69,7 @@ export class Page extends ContentView implements dts.Page {
         this.style._setValue(style.backgroundColorProperty, "white", ValueSource.Inherited);
 
         this._applyCss();
-        
+
         if (this.actionBarHidden !== undefined) {
             this._updateActionBar(this.actionBarHidden);
         }
@@ -84,7 +84,7 @@ export class Page extends ContentView implements dts.Page {
     set backgroundSpanUnderStatusBar(value: boolean) {
         this._setValue(Page.backgroundSpanUnderStatusBarProperty, value);
     }
-    
+
     get actionBarHidden(): boolean {
         return this._getValue(Page.actionBarHiddenProperty);
     }
@@ -212,12 +212,17 @@ export class Page extends ContentView implements dts.Page {
             this._showNativeModalView(<any>frame.topmost().currentPage, undefined, undefined, true);
             return this;
         } else {
-            var moduleName: string = arguments[0];
             var context: any = arguments[1];
             var closeCallback: Function = arguments[2];
             var fullscreen: boolean = arguments[3];
 
-            var page = <Page>frame.resolvePageFromEntry({ moduleName: moduleName });
+            var page: Page;
+            if (arguments[0] instanceof Page) {
+                page = <Page>arguments[0];
+            } else {
+                page = <Page>frame.resolvePageFromEntry({ moduleName: arguments[0] });
+            }
+
             page._showNativeModalView(this, context, closeCallback, fullscreen);
             return page;
         }

--- a/ui/page/page.d.ts
+++ b/ui/page/page.d.ts
@@ -183,6 +183,15 @@ declare module "ui/page" {
         showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean): Page;
 
         /**
+         * Shows the page contained in moduleName as a modal view.
+         * @param page - Page instance to be shown modally.
+         * @param context - Any context you want to pass to the modally shown page. This same context will be available in the arguments of the Page.shownModally event handler.
+         * @param closeCallback - A function that will be called when the page is closed. Any arguments provided when calling ShownModallyData.closeCallback will be available here.
+         * @param fullscreen - An optional parameter specifying whether to show the modal page in full-screen mode.
+         */
+        showModal(page: Page, context: any, closeCallback: Function, fullscreen?: boolean): Page;
+
+        /**
          * Shows the page as a modal view.
          */
         showModal(): Page;


### PR DESCRIPTION
Added a `showModal` method overload that accepts page instance as a first argument