### PR TITLE
The 'grunt inplace' build generate source maps

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -352,6 +352,9 @@ module.exports = function(grunt) {
                 tsconfig: {
                     tsconfig: 'tsconfig.json',
                     passThrough: true,
+                },
+                options: {
+                    additionalFlags: "--sourceMap"
                 }
             },
             buildNodeTests: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "version": "1.6.2",
     "compilerOptions": {
-        "sourceMap": false,
         "noEmitOnError": true,
         "noEmitHelpers": true,
         "target": "es5",


### PR DESCRIPTION
### Does your commit message include the wording below to reference a specific issue in this repo?
Allows an app to be debugged using the TS modules.
Allows breakpoints to be set in TS modules source code, locals to be inspected in modules TS etc.

### Does your pull request have [unit tests]
No, this affects builds, not the delivery.

