### PR TITLE
fix(es6): objectcontstructor assign

### DIFF
--- a/es6.d.ts
+++ b/es6.d.ts
@@ -1,1 +1,9 @@
 declare var Symbol: any;
+
+interface ObjectConstructor {
+    assign(target: any, ...sources: any[]): any;
+    is(value1: any, value2: any): boolean;
+    setPrototypeOf(o: any, proto: any): any;
+}
+
+declare var Object: ObjectConstructor;


### PR DESCRIPTION
Silences TypeScript compiler warning:
```
error TS2339: Property 'assign' does not exist on type 'ObjectConstructor'
```

This is especially problematic for `nativescript-angular` projects that utilize various es6 features and including the `es6-shim` definition file is not an option as it creates numerous duplicate warnings due to same definitions found throughout tns-core-modules (es6-promise.d.ts, es-collections.d.ts, etc.).

A better fix down the line would be to remove all the individual es6 definitions (es6-promise.d.ts, es-collections.d.ts, etc.) in this repo and replace with the single `es6-shim` found here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/es6-shim/es6-shim.d.ts