### PR TITLE
Work around a webpack bundling fail in transitions by using full imports

### DIFF
--- a/apps/tests/ui/date-picker/date-picker-tests.ts
+++ b/apps/tests/ui/date-picker/date-picker-tests.ts
@@ -154,13 +154,13 @@ export class DatePickerTest extends testModule.UITest<datePickerModule.DatePicke
     }
     
     public test_DateIsSetCorrectlyWhenYearIsSet() {
-        let today = new Date();
-        this.testView.month = today.getMonth();
-        this.testView.day = today.getDate();
+        let current = new Date(2016, 3, 15);
+        this.testView.month = current.getMonth();
+        this.testView.day = current.getDate();
         
         let expectedValue = 1980;
         this.testView.year = expectedValue;
-        let expectedDate = new Date(1980, today.getMonth() - 1, today.getDate());
+        let expectedDate = new Date(1980, current.getMonth() - 1, current.getDate());
         
         TKUnit.assertEqual(this.testView.date.getDate(), expectedDate.getDate(), "Getting Day from date property failed.");
         TKUnit.assertEqual(this.testView.date.getMonth(), expectedDate.getMonth(), "Getting Month from date property failed.");

--- a/ui/transition/transition.android.ts
+++ b/ui/transition/transition.android.ts
@@ -156,16 +156,19 @@ export function _setAndroidFragmentTransitions(navigationTransition: frameModule
     var transition: definition.Transition;
     if (name) {
         if (name.indexOf("slide") === 0) {
-            var slideTransitionModule = require("./slide-transition");
+            //HACK: Use an absolute import to work around a webpack issue that doesn't resolve relatively-imported "xxx.android/ios" modules
+            var slideTransitionModule = require("ui/transition/slide-transition");
             var direction = name.substr("slide".length) || "left"; //Extract the direction from the string
             transition = new slideTransitionModule.SlideTransition(direction, navigationTransition.duration, navigationTransition.curve);
         }
         else if (name === "fade") {
-            var fadeTransitionModule = require("./fade-transition");
+            //HACK: Use an absolute import to work around a webpack issue that doesn't resolve relatively-imported "xxx.android/ios" modules
+            var fadeTransitionModule = require("ui/transition/fade-transition");
             transition = new fadeTransitionModule.FadeTransition(navigationTransition.duration, navigationTransition.curve);
         }
         else if (name.indexOf("flip") === 0) {
-            var flipTransitionModule = require("./flip-transition");
+            //HACK: Use an absolute import to work around a webpack issue that doesn't resolve relatively-imported "xxx.android/ios" modules
+            var flipTransitionModule = require("ui/transition/flip-transition");
             var direction = name.substr("flip".length) || "right"; //Extract the direction from the string
             transition = new flipTransitionModule.FlipTransition(direction, navigationTransition.duration, navigationTransition.curve);
         }

--- a/ui/transition/transition.ios.ts
+++ b/ui/transition/transition.ios.ts
@@ -106,14 +106,16 @@ export function _createIOSAnimatedTransitioning(navigationTransition: frame.Navi
         if (name.indexOf("slide") === 0) {
             let direction = name.substr("slide".length) || "left"; //Extract the direction from the string
             if (!slideTransitionModule) {
-                slideTransitionModule = require("./slide-transition");
+                //HACK: Use an absolute import to work around a webpack issue that doesn't resolve relatively-imported "xxx.android/ios" modules
+                slideTransitionModule = require("ui/transition/slide-transition");
             }
 
             transition = new slideTransitionModule.SlideTransition(direction, navigationTransition.duration, nativeCurve);
         }
         else if (name === "fade") {
             if (!fadeTransitionModule) {
-                fadeTransitionModule = require("./fade-transition");
+                //HACK: Use an absolute import to work around a webpack issue that doesn't resolve relatively-imported "xxx.android/ios" modules
+                fadeTransitionModule = require("ui/transition/fade-transition");
             }
 
             transition = new fadeTransitionModule.FadeTransition(navigationTransition.duration, nativeCurve);


### PR DESCRIPTION
It seems Webpack can't discover aliased modules that relative-import other
aliased modules e.g. "ui/transition", aliased to
"ui/transition/transition.android", not discovering "./slide-transition"
which is aliased to "ui/transition/slide-transition.android.js"