### PR TITLE
Zone-aware versions of certain APIs: setTimeout/setInterval mostly.

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -146,6 +146,10 @@ declare function setInterval(callback: Function, milliseconds?: number): number;
  */
 declare function clearInterval(id: number): void;
 
+//@private
+declare function zonedCallback(callback: Function): Function;
+//@endprivate
+
 declare class WeakRef<T> {
     constructor(obj: T);
     get(): T;

--- a/globals/globals.ts
+++ b/globals/globals.ts
@@ -29,6 +29,14 @@ global.loadModule = function(name: string): any {
     }
 }
 
+global.zonedCallback = function(callback: Function): Function {
+    if (global.zone) {
+        return global.zone.bind(callback);
+    } else {
+        return callback;
+    }
+}
+
 global.registerModule("timer", () => require("timer"));
 global.registerModule("ui/dialogs", () => require("ui/dialogs"));
 global.registerModule("xhr", () => require("xhr"));

--- a/timer/timer.android.ts
+++ b/timer/timer.android.ts
@@ -15,11 +15,12 @@ function createHandlerAndGetId(): number {
 }
 
 export function setTimeout(callback: Function, milliseconds = 0): number {
-    var id = createHandlerAndGetId();
+    const id = createHandlerAndGetId();
+    const zoneBound = zonedCallback(callback);
 
     var runnable = new java.lang.Runnable({
         run: () => {
-            callback();
+            zoneBound();
 
             if (timeoutCallbacks[id]) {
                 delete timeoutCallbacks[id];
@@ -44,12 +45,13 @@ export function clearTimeout(id: number): void {
 }
 
 export function setInterval(callback: Function, milliseconds = 0): number {
-    var id = createHandlerAndGetId();
-    var handler = timeoutHandler;
+    const id = createHandlerAndGetId();
+    const handler = timeoutHandler;
+    const zoneBound = zonedCallback(callback);
 
     var runnable = new java.lang.Runnable({
         run: () => {
-            callback();
+            zoneBound();
             if (timeoutCallbacks[id]) {
                 handler.postDelayed(runnable, long(milliseconds));
             }

--- a/timer/timer.ios.ts
+++ b/timer/timer.ios.ts
@@ -40,7 +40,7 @@ function createTimerAndGetId(callback: Function, milliseconds: number, shouldRep
 }
 
 export function setTimeout(callback: Function, milliseconds = 0): number {
-    return createTimerAndGetId(callback, milliseconds, false);
+    return createTimerAndGetId(zonedCallback(callback), milliseconds, false);
 }
 
 export function clearTimeout(id: number): void {
@@ -51,7 +51,7 @@ export function clearTimeout(id: number): void {
 }
 
 export function setInterval(callback: Function, milliseconds = 0): number {
-    return createTimerAndGetId(callback, milliseconds, true);
+    return createTimerAndGetId(zonedCallback(callback), milliseconds, true);
 }
 
 export var clearInterval = clearTimeout;


### PR DESCRIPTION
Instead of waiting for zone.js to patch our global declarations and break
the lazy module loading optimizations there, we'll let it patch stuff
before "globals" gets loaded, so that it doesn't touch (and break) the code
there.

Of course, that requires that functions that need legit patching need to be
made aware of the zone, or get patched later on. The global.zonedCallback
function makes that easy, and we use it for setTimeout/setInterval.

TODO: Think this over again and identify other functions that need zone awareness.
//cc @vakrilov, @nsndeck 