### PR TITLE
Ensure parent directory when creating a new file

### DIFF
--- a/apps/tests/file-system-tests.ts
+++ b/apps/tests/file-system-tests.ts
@@ -639,3 +639,13 @@ export function test_UnlockAfterWrite(done) {
     }).then(() => done())
     .catch(done);
 }
+
+export function test_CreateParentOnNewFile(done) {
+    var documentsFolderName = fs.knownFolders.documents().path;
+    var tempFileName = fs.path.join(documentsFolderName, "folder1", "folder2", "Test_File_Create_Parent.txt");
+    var file = fs.File.fromPath(tempFileName);
+    file.writeText("Hello World!").then(() =>  {
+        return fs.knownFolders.documents().getFolder("folder1").remove();
+    }).then(() => done())
+    .catch(done);
+}

--- a/file-system/file-system-access.android.ts
+++ b/file-system/file-system-access.android.ts
@@ -327,6 +327,7 @@ export class FileSystemAccess {
                 if (isFolder) {
                     created = javaFile.mkdirs();
                 } else {
+                    javaFile.getParentFile().mkdirs();
                     created = javaFile.createNewFile();
                 }
 

--- a/file-system/file-system-access.ios.ts
+++ b/file-system/file-system-access.ios.ts
@@ -52,11 +52,12 @@ export class FileSystemAccess {
             var exists = fileManager.fileExistsAtPath(path);
 
             if (!exists) {
-                if (!fileManager.createFileAtPathContentsAttributes(path, null, null)) {
+                var parentPath = this.getParent(path, onError).path;
+                if (!fileManager.createDirectoryAtPathWithIntermediateDirectoriesAttributesError(parentPath, true, null) ||
+                        !fileManager.createFileAtPathContentsAttributes(path, null, null)) {
                     if (onError) {
-                        onError(new Error("Failed to create folder at path '" + path + "'"));
+                        onError(new Error("Failed to create file at path '" + path + "'"));
                     }
-
                     return undefined;
                 }
             }


### PR DESCRIPTION
createNewFile throws an exception if the parent directory doesn't exist

Fixes #1887