### PR TITLE
Fix for using css attribute selector alone.

### DIFF
--- a/apps/tests/ui/style/style-tests.ts
+++ b/apps/tests/ui/style/style-tests.ts
@@ -1513,6 +1513,19 @@ export function test_star_attr_selector_incorrect_syntax() {
     }
     helper.buildUIAndRunTest(testButton, testFunc, testCss);
 }
+
+export function test_alone_attr_selector() {
+    let testButton = new buttonModule.Button();
+    testButton["testAttr"] = "flow";
+    
+    let testCss = "[testAttr*='flower'] { background-color: #FF0000; } button { background-color: #00FF00; }";
+    
+    let testFunc = function (views: Array<viewModule.View>) {
+        // style from correct type css should be applied
+        helper.assertViewBackgroundColor(testButton, "#00FF00");
+    }
+    helper.buildUIAndRunTest(testButton, testFunc, testCss);
+}
 // <snippet module="ui/styling" title="styling">
 // For information and example how to use style properties please refer to special [**Styling**](../../../styling.md) topic. 
 // </snippet>

--- a/ui/styling/css-selector.ts
+++ b/ui/styling/css-selector.ts
@@ -24,7 +24,7 @@ export class CssSelector {
     constructor(expression: string, declarations: cssParser.Declaration[]) {
         if (expression) {
             let leftSquareBracketIndex = expression.indexOf(LSBRACKET);
-            if (leftSquareBracketIndex > 0) {
+            if (leftSquareBracketIndex >= 0) {
                 // extracts what is inside square brackets ([target = 'test'] will extract "target = 'test'")
                 let paramsRegex = /\[\s*(.*)\s*\]/;
                 let attrParams = paramsRegex.exec(expression);


### PR DESCRIPTION
Bug does not allow to place an attribute css selector alone (Application crash):

```
[testAttr='top'] { background-color: blue; }
```


