### PR TITLE
Support for zone 0.6 callback wrapping

### DIFF
--- a/globals/globals.ts
+++ b/globals/globals.ts
@@ -29,9 +29,14 @@ global.loadModule = function(name: string): any {
     }
 }
 
-global.zonedCallback = function(callback: Function): Function {
+global.zonedCallback = function (callback: Function): Function {
     if (global.zone) {
+        // Zone v0.5.* style callback wrapping
         return global.zone.bind(callback);
+    }
+    if (global.Zone) {
+        // Zone v0.6.* style callback wrapping
+        return global.Zone.current.wrap(callback);
     } else {
         return callback;
     }


### PR DESCRIPTION
Handle some breaking changes in Zone 0.6.* 
- Global object changed: `zone` -> `Zone`
- `bind` method no longer exists - use `wrap`