### PR TITLE
Run tests in travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ package/
 !css-value/**/*.*
 !fetch/**/*.*
 !apps/TelerikNEXT/lib/**/*.*
-!build/*.*
+!build/**/*.*
 CrossPlatformModules.sln.ide/
 *.suo
 CrossPlatformModules.suo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,35 @@
-language: node_js
+sudo: required
+dist: trusty
+language: android
 node_js:
-    4.2.3
+    - 4.2.3
+jdk:
+    - oraclejdk8
+android:
+    components:
+        - platform-tools
+        - tools
+        - build-tools-23.0.3
+        - android-21
+        - android-23
+        - extra-android-support
+        - extra-android-m2repository
+        - sys-img-armeabi-v7a-android-21
+
 before_script:
+    - nvm install 5.10.1
     - npm install -g grunt-cli
     - npm install
     - (cd build/platform-declarations && npm install)
+    - echo no | android create avd --force -n Arm21 -t android-21 -b armeabi-v7a -c 12M
+    - emulator -avd Arm21 -no-skin -no-audio -no-window &
+    - android-wait-for-emulator
 script:
-    - grunt default
-    - (cd build/platform-declarations && grunt)
+    - jdk_switcher use oraclejdk8
+    - grunt default &&
+        (cd build/platform-declarations && grunt) &&
+        echo no | npm install nativescript -g > /dev/null &&
+        grunt buildOnlyTestsApp --platform=Android --modulesPath=./bin/dist/tns-core-modules-2.0.0.tgz --runtimeVersion=next --emuPId=.*emulator.* --avd=Api21 --showEmu=false > /dev/null &&
+        grunt runOnlyTestsApp --platform=Android --modulesPath=./bin/dist/tns-core-modules-2.0.0.tgz --emuPId=.*emulator.* --avd=Api21 --showEmu=false
+
+    - node ./build/travis-scripts/check-testrun-broken.js

--- a/build/run-testsapp.grunt.js
+++ b/build/run-testsapp.grunt.js
@@ -14,6 +14,7 @@ module.exports = {
             emuAvdName: grunt.option("avd"),
             outFile: grunt.option("logFilePath"),
             runtimePath: grunt.option("runtimePath"),
+            runtimeVersion: grunt.option("runtimeVersion"),
             showEmu: grunt.option("showEmu"),
             runAppOnly: grunt.option("runAppOnly"),
             pathToApp: grunt.option("pathToApp")
@@ -45,6 +46,7 @@ module.exports = {
             emuAvdName: args.emuAvdName,
             outFile: args.outFile || "./TestRunResult.txt",
             frameworkArgument: args.runtimePath ? " --frameworkPath=" + args.runtimePath : "",
+            runtimeVersionArgument: args.runtimeVersion ? "@" + args.runtimeVersion : "",
             showEmu: args.showEmu || false,
             runAppOnly: args.runAppOnly || false,
 
@@ -238,7 +240,7 @@ module.exports = {
                     }
                 },
                 addPlatform: {
-                    command: "tns platform add " + localCfg.platform.toLowerCase() + " " + localCfg.frameworkArgument,
+                    command: "tns platform add " + localCfg.platform.toLowerCase() + localCfg.runtimeVersionArgument + " " + localCfg.frameworkArgument,
                     options: {
                         execOptions: {
                             maxBuffer: Infinity,
@@ -286,7 +288,7 @@ module.exports = {
         ]);
 
         grunt.registerTask("cleanup", [
-            getPlatformSpecificTask("exec:kill{platform}Emulator"),
+//            getPlatformSpecificTask("exec:kill{platform}Emulator"),
             "clean:workingDir"
         ]);
 
@@ -310,9 +312,10 @@ module.exports = {
             "buildOnly"
 
         ]);
+        grunt.registerTask("buildOnlyTestsApp", ["buildTestsApp"]);
 
         grunt.registerTask("runOnly", [
-            getPlatformSpecificTask("doPreUninstallApp{platform}"),
+//            getPlatformSpecificTask("doPreUninstallApp{platform}"),
 
             getPlatformSpecificTask("exec:uninstallExisting{platform}App"),
             getPlatformSpecificTask("exec:installNew{platform}App"),
@@ -321,12 +324,14 @@ module.exports = {
         ]);
 
         grunt.registerTask("runApp", [
-            "cleanup",
-            getPlatformSpecificTask("startEmulator{platform}"),
+//            "cleanup",
+//            getPlatformSpecificTask("startEmulator{platform}"),
             "runOnly",
             "cleanup"
 
         ]);
+
+        grunt.registerTask("runOnlyTestsApp", ["runApp"]);
 
 
         var tasksToExecute = ["runApp"];

--- a/build/travis-scripts/check-testrun-broken.js
+++ b/build/travis-scripts/check-testrun-broken.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+var fsModule = require('fs');
+var resultsFile = 'TestRunResult.txt';
+var successMarker ='=== ALL TESTS COMPLETE ===';
+var passMarker = /=== ALL TESTS COMPLETE ===\s+[^\n]*OK,\s+0\s+failed/mg;
+
+var messages = {
+    crash: 'TEST RUN CRASHED!',
+    runGood: 'Test run exited successfully',
+    pass: 'NativeScript Cross-Platform Module Tests passed',
+    fail: 'TEST FAILURES FOUND!'
+};
+
+var results = fsModule.readFileSync(resultsFile, 'utf-8');
+
+if (results.indexOf(successMarker) == -1) {
+    console.log(messages.crash);
+    process.exit(1);
+} else if (results.match(passMarker)) {
+    console.log(messages.pass);
+    process.exit(0);
+} else {
+    console.log(messages.fail);
+    process.exit(1);
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
         require('time-grunt')(grunt);
     }
 
-    if (grunt.cli.tasks.indexOf("testsapp") >= 0 || grunt.cli.tasks.indexOf("buildTestsApp")>= 0) {
+    if (grunt.cli.tasks.indexOf("testsapp") >= 0 || grunt.cli.tasks.indexOf("buildOnlyTestsApp")>= 0 || grunt.cli.tasks.indexOf("runOnlyTestsApp")>= 0) {
         var tsTester = require("./build/run-testsapp.grunt.js");
         tsTester.run(grunt);
         return;


### PR DESCRIPTION
Add android definitions to check if they will get downloaded
Set the language to android
Disable the CLI install prompt
Add buildOnly- and runOnly- commands
Update the version of the packages used
Install android 23 to make the app build
Build the test app with the @next android runtime
Specify oracle java version 8
Use switcher to switch to oraclejdk8
Make the final build a single step so that it breaks on first failure
Reorder attempting to use higher nodejs
Use nodejs 5.10.1
Detect test failure
Decrease verbosity
Unignore the build folder recursively
Remove the redundant node-version messages
Run the tests with Api level 21