### PR TITLE
Make the Travis-CI image valid for the master branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NativeScript [![Build Status](https://travis-ci.org/NativeScript/NativeScript.svg)](https://travis-ci.org/NativeScript/NativeScript)
+# NativeScript [![Build Status](https://travis-ci.org/NativeScript/NativeScript.svg?branch=master)](https://travis-ci.org/NativeScript/NativeScript)
 
 ![NativeScript logo](http://i.imgur.com/YmNIMqS.png)
 


### PR DESCRIPTION
No issue related; The fix is really small and applies to GitHub only.
No unit tests. The status gets displayed on GitHub.

