### PR TITLE
Publish XML Test results and publish @next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
+env:
+    global:
+        - DATE=$(date +%Y-%m-%d)
+        - PACKAGE_VERSION=$DATE-$TRAVIS_BUILD_NUMBER
+        - PACKAGE_NAME=tns-core-modules
+        - NODE_VERSION=5.10.1
+        - EMULATOR_API_VER=21
+        - RUNTIMEVERSION=next
+        - AVD_NAME=Arm$EMULATOR_API_VER
+addons:
+    artifacts:
+        paths: $HOME/test-run-results$PACKAGE_VERSION.xml
 sudo: required
 dist: trusty
 language: android
@@ -10,26 +22,48 @@ android:
         - platform-tools
         - tools
         - build-tools-23.0.3
-        - android-21
+        - android-$EMULATOR_API_VER
         - android-23
         - extra-android-support
         - extra-android-m2repository
-        - sys-img-armeabi-v7a-android-21
+        - sys-img-armeabi-v7a-android-$EMULATOR_API_VER
 
 before_script:
-    - nvm install 5.10.1
+    - nvm install $NODE_VERSION
     - npm install -g grunt-cli
     - npm install
     - (cd build/platform-declarations && npm install)
-    - echo no | android create avd --force -n Arm21 -t android-21 -b armeabi-v7a -c 12M
-    - emulator -avd Arm21 -no-skin -no-audio -no-window &
+    - echo no | android create avd --force -n $AVD_NAME -t android-$EMULATOR_API_VER -b armeabi-v7a -c 12M
+    - emulator -avd $AVD_NAME -no-skin -no-audio -no-window &
     - android-wait-for-emulator
 script:
     - jdk_switcher use oraclejdk8
     - grunt default &&
+        FULL_PACKAGE_VERSION=`node -e 'console.log(require("./bin/dist/modules/package.json").version);'` &&
         (cd build/platform-declarations && grunt) &&
         echo no | npm install nativescript -g > /dev/null &&
-        grunt buildOnlyTestsApp --platform=Android --modulesPath=./bin/dist/tns-core-modules-2.0.0.tgz --runtimeVersion=next --emuPId=.*emulator.* --avd=Api21 --showEmu=false > /dev/null &&
-        grunt runOnlyTestsApp --platform=Android --modulesPath=./bin/dist/tns-core-modules-2.0.0.tgz --emuPId=.*emulator.* --avd=Api21 --showEmu=false
+        grunt buildOnlyTestsApp --platform=Android --modulesPath=./bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz --runtimeVersion=$RUNTIMEVERSION --emuPId=.*emulator.* --avd=$AVD_NAME --showEmu=false > /dev/null &&
+        grunt runOnlyTestsApp --platform=Android --modulesPath=./bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz --emuPId=.*emulator.* --avd=$AVD_NAME --showEmu=false
 
     - node ./build/travis-scripts/check-testrun-broken.js
+    - adb pull /data/data/org.nativescript.TestsApp/files/test-results.xml &&
+        mv test-results.xml ~/test-run-results$PACKAGE_VERSION.xml
+before_deploy:
+    - mv bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz ../.deploymentpackage
+    - mv .build ../
+    - cd ..
+    - rm -rf NativeScript
+    - tar -zxvf .deploymentpackage
+    - mv package $PACKAGE_NAME
+    - cd $PACKAGE_NAME
+    - rm ../.deploymentpackage
+    - mv ../build ./
+    - node ./build/travis-scripts/add-publishConfig.js next
+deploy:
+    provider: npm
+    email: nativescript@telerik.com
+    on:
+        branch: master
+        skip_cleanup: true
+        api_key:
+            secure: aFJZR8VIbFAlXfFx5G2AveSgpGjr40prghvw8m06X0yvmUQlucwHVyq+Ov0ZD94br8d7OUOPbUzh+p9N/+oXLAXOj3DbQmJaCc+fk/e+avHu1BRy3fg295P9BQau1Abu+2ZO7tUbg5zAqJqhbEgjXsr9B5gxl+vwh4lbDhCPCwo=

--- a/build/run-testsapp.grunt.js
+++ b/build/run-testsapp.grunt.js
@@ -115,8 +115,8 @@ module.exports = {
                 },
                 addAndroidPermissions: {
                     src: "AndroidManifest.xml",
-                    dest: localCfg.applicationDir + "/platforms/android/src/main/",
-                    cwd: localCfg.applicationDir + "/platforms/android/src/main",
+                    dest: localCfg.applicationDir + "/app/App_Resources/Android/",
+                    cwd: localCfg.applicationDir + "/app/App_Resources/Android",
                     expand: true,
                     options: {
                         process: function(content, srcPath) {

--- a/build/travis-scripts/add-publishConfig.js
+++ b/build/travis-scripts/add-publishConfig.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+var fsModule = require('fs');
+
+//Adds a publishConfig section to the package.json file
+// and sets a tag to it
+
+var path = './package.json';
+var fileOptions = {encoding: "utf-8"};
+var content = fsModule.readFileSync(path, fileOptions);
+
+var tag = process.argv[2];
+if (!tag) {
+    console.log('Please pass the tag name as an argument!');
+    process.exit(1);
+}
+
+var packageDef = JSON.parse(content);
+if (!packageDef.publishConfig) {
+    packageDef.publishConfig = {};
+}
+packageDef.publishConfig.tag = tag;
+
+var newContent = JSON.stringify(packageDef, null, '  ');
+fsModule.writeFileSync(path, newContent, fileOptions);

--- a/build/travis-scripts/check-testrun-broken.js
+++ b/build/travis-scripts/check-testrun-broken.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 var fsModule = require('fs');
 var resultsFile = 'TestRunResult.txt';
-var successMarker ='=== ALL TESTS COMPLETE ===';
-var passMarker = /=== ALL TESTS COMPLETE ===\s+[^\n]*OK,\s+0\s+failed/mg;
+var successMarker = /=== ALL TESTS COMPLETE for \d+ ms ===/;
+var passMarker = /=== ALL TESTS COMPLETE for \d+ ms ===\s+[^\n]*OK,\s+0\s+failed/mg;
 
 var messages = {
     crash: 'TEST RUN CRASHED!',
@@ -13,7 +13,7 @@ var messages = {
 
 var results = fsModule.readFileSync(resultsFile, 'utf-8');
 
-if (results.indexOf(successMarker) == -1) {
+if (!results.match(successMarker)) {
     console.log(messages.crash);
     process.exit(1);
 } else if (results.match(passMarker)) {


### PR DESCRIPTION
Related to #1943
No tests - the builds run on Travis-CI and are actually running the tests.

Modify the AndroidManifest file in the app dir to fix the HTTP tests
Pull the test results in XML format
Publish the test results as artifacts
Have the test-results checks as a single command
Parametrize AVD version; Use the package version, retrieved from package.json for builds and runs
Make the package name a variable