### PR TITLE
Aligned the rotate animation behaviour between Android and iOS

### DIFF
--- a/ui/animation/animation.android.ts
+++ b/ui/animation/animation.android.ts
@@ -9,6 +9,10 @@ import styleModule = require("ui/styling/style");
 
 global.moduleMerge(common, exports);
 
+interface AnimationDefinitionInternal extends definition.AnimationDefinition {
+    valueSource?: number;
+}
+
 let argbEvaluator: android.animation.ArgbEvaluator;
 function ensureArgbEvaluator() {
     if (!argbEvaluator) {
@@ -79,11 +83,11 @@ export class Animation extends common.Animation implements definition.Animation 
         this._animatorSet.cancel();
     }
 
-    constructor(animationDefinitions: Array<definition.AnimationDefinition>, playSequentially?: boolean) {
+    constructor(animationDefinitions: Array<AnimationDefinitionInternal>, playSequentially?: boolean) {
         super(animationDefinitions, playSequentially);
 
-        if (animationDefinitions.length > 0 && (<any>animationDefinitions[0]).valueSource !== undefined) {
-            this._valueSource = (<any>animationDefinitions[0]).valueSource;
+        if (animationDefinitions.length > 0 && animationDefinitions[0].valueSource !== undefined) {
+            this._valueSource = animationDefinitions[0].valueSource;
         }
 
         let that = this;

--- a/ui/animation/animation.ios.ts
+++ b/ui/animation/animation.ios.ts
@@ -30,7 +30,7 @@ interface PropertyAnimationInfo extends common.PropertyAnimation {
 }
 
 interface AnimationDefinitionInternal extends definition.AnimationDefinition {
-    valueSource: number;
+    valueSource?: number;
 }
 
 interface IOSView extends viewModule.View {
@@ -257,6 +257,9 @@ export class Animation extends common.Animation implements definition.Animation 
                 }
                 else {
                   originalValue = nativeView.layer.valueForKeyPath("transform.rotation");
+                }
+                if (originalValue === 0 && animation.target.rotate !== 0 && Math.floor(value / 360) - value / 360 === 0) {
+                    originalValue = animation.target.rotate * Math.PI / 180;
                 }
                 value = value * Math.PI / 180;
                 abs = fabs(originalValue - value);


### PR DESCRIPTION
Animation behavior was different in Android and iOS when applying a rotate animation on 360 degrees. 
In Android you should reset the rotate property to 0 in order to reapply the animation. In iOS this is not necessary. The correct behavior is the Android one.