### PR TITLE
Implemented AddChildFromBuilder for SegmentedBar.

### DIFF
--- a/ui/segmented-bar/segmented-bar-common.ts
+++ b/ui/segmented-bar/segmented-bar-common.ts
@@ -5,6 +5,7 @@ import dependencyObservable = require("ui/core/dependency-observable");
 import color = require("color");
 import bindable = require("ui/core/bindable");
 import * as typesModule from "utils/types";
+import {WrappedValue} from "data/observable";
 
 var types: typeof typesModule;
 function ensureTypes() {
@@ -16,6 +17,8 @@ function ensureTypes() {
 export module knownCollections {
     export var items = "items";
 }
+
+var CHILD_SEGMENTED_BAR_ITEM = "SegmentedBarItem";
 
 export class SegmentedBarItem extends bindable.Bindable implements definition.SegmentedBarItem {
     private _title: string = "";
@@ -96,5 +99,38 @@ export class SegmentedBar extends view.View implements definition.SegmentedBar {
                 this.items[i].bindingContext = newValue;
             }
         }
+    }
+    
+    private itemsTimerId;
+    
+    public _addChildFromBuilder(name: string, value: any): void {
+        if(name === CHILD_SEGMENTED_BAR_ITEM) {
+            if (!this.items) {
+                this.items = new Array<SegmentedBarItem>();
+            }
+            this.items.push(<SegmentedBarItem>value);
+            this.insertTab(<SegmentedBarItem>value);
+            
+        }
+    }
+    
+    public insertTab(tabItem: SegmentedBarItem, index?: number): void {
+        //
+    }
+    
+    public getValidIndex(index?: number): number {
+        ensureTypes();
+        let idx: number;
+        let itemsLength = this.items ? this.items.length : 0; 
+        if (types.isNullOrUndefined(index)) {
+            idx = itemsLength;
+        } else {
+            if (index < 0 || index > itemsLength) {
+                idx = itemsLength;
+            } else {
+                idx = index;
+            }
+        }
+        return idx;
     }
 }

--- a/ui/segmented-bar/segmented-bar.android.ts
+++ b/ui/segmented-bar/segmented-bar.android.ts
@@ -27,7 +27,7 @@ function onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChang
             view.notify({ eventName: SegmentedBar.selectedIndexChangedEvent, object: view, oldIndex: data.oldValue, newIndex: data.newValue });
         } else {
             view.selectedIndex = undefined;
-            throw new Error("selectedIndex should be between [0, items.length - 1]");
+            throw new Error("selectedIndex should be between [0, " + (view.items.length - 1) + "]");
         }
     }
 }
@@ -53,19 +53,7 @@ function onItemsPropertyChanged(data: dependencyObservable.PropertyChangeData) {
 
     if (newItems && newItems.length) {
         for (var i = 0; i < newItems.length; i++) {
-            (<SegmentedBarItem>newItems[i])._parent = view;
-            var tab = view.android.newTabSpec(i + "");
-            tab.setIndicator(newItems[i].title || "");
-
-            tab.setContent(new android.widget.TabHost.TabContentFactory({
-                createTabContent: function(tag: string): android.view.View {
-                    var tv = new android.widget.TextView(view._context);
-                    tv.setVisibility(android.view.View.GONE);
-                    return tv;
-                }
-            }));
-
-            view.android.addTab(tab);
+            view.insertTab((<SegmentedBarItem>newItems[i]), i);
         }
 
         if (types.isNumber(view.selectedIndex) && view.android.getCurrentTab() !== view.selectedIndex) {
@@ -187,6 +175,24 @@ export class SegmentedBar extends common.SegmentedBar {
 
     get android(): android.widget.TabHost {
         return this._android;
+    }
+    
+    public insertTab(tabItem: SegmentedBarItem, index?: number): void {
+        super.insertTab(tabItem, index);
+        tabItem._parent = this;
+        
+        var tab = this.android.newTabSpec(this.getValidIndex(index) + "");
+        tab.setIndicator(tabItem.title || "");
+        let that = this;
+        tab.setContent(new android.widget.TabHost.TabContentFactory({
+            createTabContent: function (tag: string): android.view.View {
+                var tv = new android.widget.TextView(that._context);
+                tv.setVisibility(android.view.View.GONE);
+                return tv;
+            }
+        }));
+
+        this.android.addTab(tab);
     }
 }
 

--- a/ui/segmented-bar/segmented-bar.d.ts
+++ b/ui/segmented-bar/segmented-bar.d.ts
@@ -36,7 +36,7 @@ declare module "ui/segmented-bar" {
     /**
      * Represents a UI SegmentedBar component.
      */
-    export class SegmentedBar extends view.View {
+    export class SegmentedBar extends view.View implements view.AddChildFromBuilder {
         /**
          * Gets or sets the selected index of the SegmentedBar component.
          */
@@ -84,5 +84,16 @@ declare module "ui/segmented-bar" {
          * Raised when the selected index changes.
          */
         on(event: "selectedIndexChanged", callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any);
+        
+        /**
+         * Called for every child element declared in xml.
+         * @param name - Name of the element.
+         * @param value - Value of the element.
+         */
+        public _addChildFromBuilder(name: string, value: any): void;
+        
+        public insertTab(tabItem: SegmentedBarItem, index?: number): void;
+        
+        public getValidIndex(index?: number): number;
     }
 }

--- a/ui/segmented-bar/segmented-bar.ios.ts
+++ b/ui/segmented-bar/segmented-bar.ios.ts
@@ -56,8 +56,7 @@ function onItemsPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var newItems = <Array<definition.SegmentedBarItem>>data.newValue;
     if (newItems && newItems.length) {
         for (var i = 0; i < newItems.length; i++) {
-            view.ios.insertSegmentWithTitleAtIndexAnimated(newItems[i].title || "", i, false);
-            (<SegmentedBarItem>newItems[i])._parent = view;
+            view.insertTab(<SegmentedBarItem>(newItems[i]), i);
         }
 
         if (view.ios.selectedSegmentIndex !== view.selectedIndex) {
@@ -104,6 +103,12 @@ export class SegmentedBar extends common.SegmentedBar {
 
     get ios(): UISegmentedControl {
         return this._ios;
+    }
+    
+    public insertTab(tabItem: SegmentedBarItem, index?: number): void {
+        super.insertTab(tabItem, index);
+        tabItem._parent = this;
+        this.ios.insertSegmentWithTitleAtIndexAnimated(tabItem.title || "", this.getValidIndex(index), false);
     }
 }
 


### PR DESCRIPTION
Implemented AddChildFromBuilder for SegmentedBar. This is required by Angular, since in NativeScript-Angular nested properties are not supported:

```HTML
<SegmentedBar>
    <SegmentedBar.items>
         <SegmentedBarItem title="All" ></SegmentedBarItem>
    </SegmentedBar.items>
</SegmentedBar>
```
 now users will be able to use short syntax:

```HTML
<SegmentedBar>
     <SegmentedBarItem title="All" ></SegmentedBarItem>
</SegmentedBar>
```


