### PR TITLE
Fixed adding converters to bindingContext.

### DIFF
--- a/apps/tests/ui/bindable-tests.ts
+++ b/apps/tests/ui/bindable-tests.ts
@@ -567,6 +567,7 @@ export function test_BindingToDictionaryAtAppLevel() {
         page.bindingContext = pageViewModel;
 
         TKUnit.assertEqual(testLabel.text, expectedValue);
+        TKUnit.assertTrue(testLabel.bindingContext["dict"] === undefined, "BindingContext should not contain properties from application resources.");
     }
 
     helper.buildUIAndRunTest(createLabel(), testFunc);

--- a/ui/core/bindable.ts
+++ b/ui/core/bindable.ts
@@ -386,17 +386,26 @@ export class Binding {
             if (exp) {
                 var context = this.source && this.source.get && this.source.get() || global;
                 var model = {};
+                var addedProps = [];
                 ensureApplication();
                 for (var prop in application.resources) {
                     if (application.resources.hasOwnProperty(prop) && !context.hasOwnProperty(prop)) {
                         context[prop] = application.resources[prop];
+                        addedProps.push(prop);
                     }
                 }
-
+                
                 this.prepareContextForExpression(context, expression);
-
                 model[contextKey] = context;
-                return exp.getValue(model, isBackConvert, changedModel ? changedModel : model);
+                let result = exp.getValue(model, isBackConvert, changedModel ? changedModel : model);
+                // clear added props
+                let addedPropsLength = addedProps.length;
+                for(let i = 0; i < addedPropsLength; i++) {
+                    delete context[addedProps[i]];
+                }
+                addedProps.length = 0;
+                
+                return result;
             }
             return new Error(expression + " is not a valid expression.");
         }


### PR DESCRIPTION
When converter is added to application.resources then this converters is copied to bindingContext. This pull request is fix this wrong behavior.


