### PR TITLE
Add ability to add & < > inside XML quoted strings

### DIFF
--- a/js-libs/easysax/easysax.js
+++ b/js-libs/easysax/easysax.js
@@ -462,7 +462,7 @@ EasySAXParser.prototype.parse = function(xml) {
     , elem
     , tagend = false
     , tagstart = false
-    , j = 0, i = 0
+    , j = 0, i = 0, k = 0, len
     , x, y, q, w
     , xmlns
     , stopIndex = 0
@@ -472,6 +472,7 @@ EasySAXParser.prototype.parse = function(xml) {
     , pos = 0, ln = 0, lnStart = -2, lnEnd = -1
     ;
 
+    len = xml.length;
     function getStringNode() {
         return xml.substring(i, j+1)
     };
@@ -582,7 +583,24 @@ EasySAXParser.prototype.parse = function(xml) {
             };
         };
 
-        j = xml.indexOf('>', i+1);
+        var inside=false;
+        for (k=i,j=-1;k<len;k++) {
+            var c = xml.charCodeAt(k);
+            if (!inside) {
+
+                if (c === 34) { // '"'
+                    inside = c;
+                }
+                else if (c === 39) { // "'"
+                    inside = c;
+                }
+                else if (c === 62) { // <
+                    j = k; break;
+                }
+            } else {
+                if (c === inside) { inside = false; }
+            }
+        }
 
         if (j == -1) { // error
             this.onError('...>', position(i + 1));

--- a/node-tests/test-xml.ts
+++ b/node-tests/test-xml.ts
@@ -43,4 +43,9 @@ describe("xml parser", () => {
         assert.equal("Ω", last_data);
     });
 
+    it("resolves <> inside quotes", () => {
+            parser.parse("<element name='<&>' blah=\"b<a&>\"/>");
+            assert.equal("<&>", last_attrs.name);
+            assert.equal("b<a&>", last_attrs.blah);
+    });
 });


### PR DESCRIPTION
### Does your commit message include the wording below to reference a specific issue in this repo?
Fixes/Implements #1797 

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
Yes, updated the node-tests/test-xml.ts test suite to now test this feature.

---

Please note; One of the issues that was raised when I proposed this feature was that it might be slower.   

I have tested the speed of this using a 112 meg XML file, in a parsing loop of 20 times, and the speed went from 27.79 seconds to 26.67 seconds.   On average it saved slightly over 1 second each time I ran the tests.   This implementation is FASTER than the original and now supports any characters inside quoted strings.   

  If you would like a copy of the benchmark & xml file; feel free to ask and I can drop them somewhere as I didn't figure we would want to add a 112 meg xml file added to the repo...  :grinning: 

   To keep this patch simple; I didn't do any other optimizations beyond just the quote loop code.  There are a couple other places that we could probably enhance the easysax parser and speed it up even more....