### PR TITLE
Fix broken node tests compilation.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -374,6 +374,7 @@ module.exports = function(grunt) {
             buildNodeTests: {
                 src: [
                         'js-libs/easysax/**/*.ts',
+                        'module.d.ts',
                         'xml/**/*.ts',
                         'node-tests/**/*.ts',
                         'es-collections.d.ts',

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -668,6 +668,7 @@ module.exports = function(grunt) {
     //aliasing pack-modules for backwards compatibility
     grunt.registerTask("pack-modules", [
         "compile-modules",
+        "node-tests",
         "exec:packModules"
     ]);
     grunt.registerTask("pack-apps", [


### PR DESCRIPTION
Just added the `global` typings file to the build.

Now running `node-tests` target for all builds too.