### PR TITLE
Setting bindingContext to null fails in some cases

### DIFF
--- a/ui/core/bindable.ts
+++ b/ui/core/bindable.ts
@@ -473,7 +473,7 @@ export class Binding {
                 var newProps = sourceProps.slice(changedPropertyIndex + 1);
                 // add new weakevent listeners
                 var newObject = data.object[sourceProps[changedPropertyIndex]]
-                if (typeof newObject === 'object') {
+                if (!types.isNullOrUndefined(newObject) && typeof newObject === 'object') {
                     this.addPropertyChangeListeners(new WeakRef(data.object[sourceProps[changedPropertyIndex]]), newProps, parentProps);
                 }
             }


### PR DESCRIPTION
Our QSF list view example selection fails when navigating away from the example when the bindingContext is set to null, but I couldn't reproduce it in a clean unit test.

We can create automated test in the QSF

