### PR TITLE
Fix: Bold and italic do not work on Android when no font family

### DIFF
--- a/ui/styling/font.android.ts
+++ b/ui/styling/font.android.ts
@@ -64,7 +64,16 @@ export class Font extends common.Font {
 
     public getAndroidTypeface(): android.graphics.Typeface {
         if (!this._typeface) {
-            this._typeface = createTypeface(this);
+            var fontStyle = 0;
+            if (this.isBold) {
+                fontStyle |= android.graphics.Typeface.BOLD;
+            }
+            if (this.isItalic) {
+                fontStyle |= android.graphics.Typeface.ITALIC;
+            }
+
+            var typeFace  = createTypeface(this);
+            this._typeface = android.graphics.Typeface.create(typeFace, fontStyle);
         }
         return this._typeface;
     }
@@ -116,15 +125,6 @@ function loadFontFromFile(fontFamily: string): android.graphics.Typeface {
 
 function createTypeface(font: Font): android.graphics.Typeface {
     //http://stackoverflow.com/questions/19691530/valid-values-for-androidfontfamily-and-what-they-map-to
-
-    var fontStyle = 0;
-    if (font.isBold) {
-        fontStyle |= android.graphics.Typeface.BOLD;
-    }
-    if (font.isItalic) {
-        fontStyle |= android.graphics.Typeface.ITALIC;
-    }
-
     var fonts = common.parseFontFamily(font.fontFamily);
     var result = null;
     if (fonts.length === 0) {
@@ -134,16 +134,16 @@ function createTypeface(font: Font): android.graphics.Typeface {
     for (var i = 0; i < fonts.length; i++) {
         switch (fonts[i].toLowerCase()) {
             case common.genericFontFamilies.serif:
-                result = android.graphics.Typeface.create("serif" + getFontWeightSuffix(font.fontWeight), fontStyle);
+                result = android.graphics.Typeface.create("serif" + getFontWeightSuffix(font.fontWeight), 0);
                 break;
 
             case common.genericFontFamilies.sansSerif:
             case common.genericFontFamilies.system:
-                result = android.graphics.Typeface.create("sans-serif" + getFontWeightSuffix(font.fontWeight), fontStyle);
+                result = android.graphics.Typeface.create("sans-serif" + getFontWeightSuffix(font.fontWeight), 0);
                 break;
 
             case common.genericFontFamilies.monospace:
-                result = android.graphics.Typeface.create("monospace" + getFontWeightSuffix(font.fontWeight), fontStyle);
+                result = android.graphics.Typeface.create("monospace" + getFontWeightSuffix(font.fontWeight), 0);
                 break;
 
             default:


### PR DESCRIPTION
Resolves #2018