### PR TITLE
Make FileSystem.currentAppPath platform specific

### DIFF
--- a/file-system/file-system-access.android.ts
+++ b/file-system/file-system-access.android.ts
@@ -192,6 +192,10 @@ export class FileSystemAccess {
         var dir = utils.ad.getApplicationContext().getCacheDir();
         return dir.getAbsolutePath();
     }
+    
+    public getCurrentAppPath(): string {
+        return this.getLogicalRootPath() + "/app";
+    }
 
     public read(path: string, onError?: (error: any) => any) {
         try {

--- a/file-system/file-system-access.d.ts
+++ b/file-system/file-system-access.d.ts
@@ -105,6 +105,12 @@
         getLogicalRootPath(): string;
 
         /**
+         * Gets the root folder for the current application. This Folder is private for the application and not accessible from Users/External apps.
+         * iOS - this folder is read-only and contains the app and all its resources.
+         */
+        getCurrentAppPath(): string;
+
+        /**
          * Reads a text from a file with a given path.
          * @param path The path to the source file.
          * @param onSuccess A callback function which is called when a text is red.

--- a/file-system/file-system-access.ios.ts
+++ b/file-system/file-system-access.ios.ts
@@ -232,6 +232,20 @@ export class FileSystemAccess {
     public getTempFolderPath(): string {
         return this.getKnownPath(this.cachesDir);
     }
+    
+    public getCurrentAppPath(): string {
+        const currentDir = __dirname;
+        const tnsModulesIndex = currentDir.indexOf("/tns_modules");
+
+        // Module not hosted in ~/tns_modules when bundled. Use current dir.
+        let appPath = currentDir;
+        if (tnsModulesIndex !== -1) {
+            // Strip part after tns_modules to obtain app root
+            appPath = currentDir.substring(0, tnsModulesIndex);
+        }
+        
+        return appPath;
+    }
 
     public readText(path: string, onError?: (error: any) => any, encoding?: any) {
         var actualEncoding = encoding;

--- a/file-system/file-system.ts
+++ b/file-system/file-system.ts
@@ -483,17 +483,9 @@ export module knownFolders {
 
     export var currentApp = function (): Folder {
         if (!_app) {
-            const currentDir = __dirname;
-            const tnsModulesIndex = currentDir.indexOf("/tns_modules");
-
-            // Module not hosted in ~/tns_modules when bundled. Use current dir.
-            let appPath = currentDir;
-            if (tnsModulesIndex !== -1) {
-                // Strip part after tns_modules to obtain app root
-                appPath = currentDir.substring(0, tnsModulesIndex);
-            }
+            var path = getFileAccess().getCurrentAppPath();
             _app = new Folder();
-            _app[pathProperty] = appPath;
+            _app[pathProperty] = path;
             _app[isKnownProperty] = true;
         }
 


### PR DESCRIPTION
When running in the case of snapshot `__dirname` is not defined. Circumvent this by using platform-specific logic for finding the correct path.

Related to: https://github.com/NativeScript/NativeScript/issues/1563

ping @atanasovg, @KristinaKoeva 