### PR TITLE
Fixed: Folder.clear fails to remove empty subfolders on Android

### DIFF
--- a/apps/tests/file-system-tests.ts
+++ b/apps/tests/file-system-tests.ts
@@ -462,8 +462,6 @@ export var testFolderClear = function () {
     folder.getFile("Test1.txt");
     folder.getFile("Test2.txt");
     var subfolder = folder.getFolder("subfolder");
-    subfolder.getFile("Test3.txt");
-    subfolder.getFile("Test4.txt");
     var emptied;
     // << (hide)
     folder.clear()
@@ -548,4 +546,18 @@ export function test_CreateParentOnNewFile(done) {
         return fs.knownFolders.documents().getFolder("folder1").remove();
     }).then(() => done())
     .catch(done);
+}
+
+export function test_FolderClear_RemovesEmptySubfolders(done) {
+    let documents = fs.knownFolders.documents();
+    let rootFolder = documents.getFolder("rootFolder");
+    let emptySubfolder = rootFolder.getFolder("emptySubfolder");
+    TKUnit.assertTrue(fs.Folder.exists(emptySubfolder.path), "emptySubfolder should exist before parent folder is cleared.");
+    rootFolder.clear().then(
+        () => {
+            TKUnit.assertFalse(fs.File.exists(emptySubfolder.path), "emptySubfolder should not exist after parent folder was cleared.");
+            rootFolder.remove();
+            done();
+        })
+        .catch(done);
 }

--- a/apps/tests/file-system-tests.ts
+++ b/apps/tests/file-system-tests.ts
@@ -461,6 +461,9 @@ export var testFolderClear = function () {
     // >> (hide)
     folder.getFile("Test1.txt");
     folder.getFile("Test2.txt");
+    var subfolder = folder.getFolder("subfolder");
+    subfolder.getFile("Test3.txt");
+    subfolder.getFile("Test4.txt");
     var emptied;
     // << (hide)
     folder.clear()
@@ -478,7 +481,7 @@ export var testFolderClear = function () {
     // >> (hide)
     folder.getEntities()
         .then(function (entities) {
-            TKUnit.assert(entities.length === 0, "Failed to clear a Folder");
+            TKUnit.assertEqual(entities.length, 0, `${entities.length} entities left after clearing a folder.`);
             folder.remove();
         });
     // << (hide)

--- a/file-system/file-system-access.android.ts
+++ b/file-system/file-system-access.android.ts
@@ -300,6 +300,9 @@ export class FileSystemAccess {
 
     private deleteFolderContent(file: java.io.File): boolean {
         var filesList = file.listFiles();
+        if (filesList.length === 0) {
+            return true;// Nothing to delete, so success!
+        }
 
         var i,
             childFile: java.io.File,


### PR DESCRIPTION
Resolves #1945

