### PR TITLE
Call row/column removed callbacks on removeRows/removeColumns.

### DIFF
--- a/apps/tests/ui/layouts/grid-layout-tests.ts
+++ b/apps/tests/ui/layouts/grid-layout-tests.ts
@@ -12,10 +12,27 @@ import commonTests = require("./common-layout-tests");
 
 var DELTA = 1;
 
-export class GridLayoutTest extends testModule.UITest<GridLayout> {
+class RemovalTrackingGridLayout extends GridLayout {
+    public removedRows = 0;
+    public removedCols = 0;
 
-    public create(): GridLayout {
-        return new GridLayout();
+    public _onRowRemoved(itemSpec: ItemSpec, index: number) {
+        console.log("_onRowRemoved");
+        this.removedRows++;
+        super._onRowRemoved(itemSpec, index);
+    }
+
+    public _onColumnRemoved(itemSpec: ItemSpec, index: number) {
+        console.log("_onColumnRemoved");
+        this.removedCols++;
+        super._onColumnRemoved(itemSpec, index);
+    }
+}
+
+export class GridLayoutTest extends testModule.UITest<RemovalTrackingGridLayout> {
+
+    public create(): RemovalTrackingGridLayout {
+        return new RemovalTrackingGridLayout();
     }
 
     private row(view: view.View): number {
@@ -194,16 +211,20 @@ export class GridLayoutTest extends testModule.UITest<GridLayout> {
 
     public test_removeColumns() {
         this.prepareGridLayout(false);
-        TKUnit.assertTrue(this.testView.getColumns().length > 0, "There should be columns.");
+        const colsBefore = this.testView.getColumns().length;
+        TKUnit.assertTrue(colsBefore > 0, "There should be columns.");
         this.testView.removeColumns();
         TKUnit.assertTrue(this.testView.getColumns().length === 0, "Columns should be empty.");
+        TKUnit.assertTrue(this.testView.removedCols === colsBefore, "_onColumnRemoved called for each column.");
     }
 
     public test_removeRows() {
         this.prepareGridLayout(false);
-        TKUnit.assertTrue(this.testView.getRows().length > 0, "There should be rows.");
+        const rowsBefore = this.testView.getRows().length;
+        TKUnit.assertTrue(rowsBefore > 0, "There should be rows.");
         this.testView.removeRows();
         TKUnit.assertTrue(this.testView.getRows().length === 0, "Rows should be empty.");
+        TKUnit.assertTrue(this.testView.removedRows === rowsBefore, "_onRowRemoved called for each row.");
     }
 
     public test_removeChildren() {

--- a/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/ui/layouts/grid-layout/grid-layout-common.ts
@@ -169,7 +169,7 @@ export class GridLayout extends LayoutBase implements definition.GridLayout, App
         GridLayout.validateItemSpec(itemSpec);
         itemSpec.owner = this;
         this._rows.push(itemSpec);
-        this.onRowAdded(itemSpec);
+        this._onRowAdded(itemSpec);
         this.invalidate();
     }
 
@@ -177,7 +177,7 @@ export class GridLayout extends LayoutBase implements definition.GridLayout, App
         GridLayout.validateItemSpec(itemSpec);
         itemSpec.owner = this;
         this._cols.push(itemSpec);
-        this.onColumnAdded(itemSpec);
+        this._onColumnAdded(itemSpec);
         this.invalidate();
     }
 
@@ -193,7 +193,7 @@ export class GridLayout extends LayoutBase implements definition.GridLayout, App
 
         itemSpec.index = -1;
         this._rows.splice(index, 1);
-        this.onRowRemoved(itemSpec, index);
+        this._onRowRemoved(itemSpec, index);
         this.invalidate();
     }
 
@@ -209,21 +209,25 @@ export class GridLayout extends LayoutBase implements definition.GridLayout, App
 
         itemSpec.index = -1;
         this._cols.splice(index, 1);
-        this.onColumnRemoved(itemSpec, index);
+        this._onColumnRemoved(itemSpec, index);
         this.invalidate();
     }
 
     public removeColumns() {
-        for (var i = 0; i < this._cols.length; i++) {
-            this._cols[i].index = -1;
+        for (var i = this._cols.length - 1; i >= 0; i--) {
+            const colSpec = this._cols[i];
+            this._onColumnRemoved(colSpec, i);
+            colSpec.index = -1;
         }
         this._cols.length = 0;
         this.invalidate();
     }
 
     public removeRows() {
-        for (var i = 0; i < this._rows.length; i++) {
-            this._rows[i].index = -1;
+        for (var i = this._rows.length - 1; i >= 0; i--) {
+            const rowSpec = this._rows[i];
+            this._onRowRemoved(rowSpec, i);
+            rowSpec.index = -1;
         }
         this._rows.length = 0;
         this.invalidate();
@@ -245,19 +249,19 @@ export class GridLayout extends LayoutBase implements definition.GridLayout, App
         this.invalidate();
     }
 
-    protected onRowAdded(itemSpec: ItemSpec) {
+    public _onRowAdded(itemSpec: ItemSpec) {
         //
     }
 
-    protected onColumnAdded(itemSpec: ItemSpec) {
+    public _onColumnAdded(itemSpec: ItemSpec) {
         //
     }
 
-    protected onRowRemoved(itemSpec: ItemSpec, index: number) {
+    public _onRowRemoved(itemSpec: ItemSpec, index: number): void {
         //
     }
 
-    protected onColumnRemoved(itemSpec: ItemSpec, index: number) {
+    public _onColumnRemoved(itemSpec: ItemSpec, index: number): void {
         //
     }
 

--- a/ui/layouts/grid-layout/grid-layout.android.ts
+++ b/ui/layouts/grid-layout/grid-layout.android.ts
@@ -85,11 +85,11 @@ export class GridLayout extends common.GridLayout {
         this._layout = new org.nativescript.widgets.GridLayout(this._context);
         
         // Update native GridLayout
-        this.getRows().forEach((itemSpec: ItemSpec, index, rows) => { this.onRowAdded(itemSpec); }, this);
-        this.getColumns().forEach((itemSpec: ItemSpec, index, rows) => { this.onColumnAdded(itemSpec); }, this);
+        this.getRows().forEach((itemSpec: ItemSpec, index, rows) => { this._onRowAdded(itemSpec); }, this);
+        this.getColumns().forEach((itemSpec: ItemSpec, index, rows) => { this._onColumnAdded(itemSpec); }, this);
     }
 
-    protected onRowAdded(itemSpec: ItemSpec) {
+    public _onRowAdded(itemSpec: ItemSpec) {
         if (this._layout) {
             var nativeSpec = createNativeSpec(itemSpec);
             itemSpec.nativeSpec = nativeSpec;
@@ -97,7 +97,7 @@ export class GridLayout extends common.GridLayout {
         }
     }
 
-    protected onColumnAdded(itemSpec: ItemSpec) {
+    public _onColumnAdded(itemSpec: ItemSpec) {
         if (this._layout) {
             var nativeSpec = createNativeSpec(itemSpec);
             itemSpec.nativeSpec = nativeSpec;
@@ -105,14 +105,14 @@ export class GridLayout extends common.GridLayout {
         }
     }
 
-    protected onRowRemoved(itemSpec: ItemSpec, index: number) {
+    public _onRowRemoved(itemSpec: ItemSpec, index: number) {
         itemSpec.nativeSpec = null;
         if (this._layout) {
             this._layout.removeRowAt(index);
         }
     }
 
-    protected onColumnRemoved(itemSpec: ItemSpec, index: number) {
+    public _onColumnRemoved(itemSpec: ItemSpec, index: number) {
         itemSpec.nativeSpec = null;
         if (this._layout) {
             this._layout.removeColumnAt(index);

--- a/ui/layouts/grid-layout/grid-layout.d.ts
+++ b/ui/layouts/grid-layout/grid-layout.d.ts
@@ -175,5 +175,12 @@
          * Gets array of row specifications defined on this instance of GridLayout.
          */
         public getRows(): Array<ItemSpec>;
+
+        //@private
+        public _onRowAdded(itemSpec: ItemSpec): void;
+        public _onColumnAdded(itemSpec: ItemSpec): void;
+        public _onRowRemoved(itemSpec: ItemSpec, index: number): void;
+        public _onColumnRemoved(itemSpec: ItemSpec, index: number): void;
+        //@endprivate
     }
 }

--- a/ui/layouts/grid-layout/grid-layout.ios.ts
+++ b/ui/layouts/grid-layout/grid-layout.ios.ts
@@ -16,20 +16,20 @@ export class GridLayout extends common.GridLayout {
         this.helper = new MeasureHelper(this);
     }
 
-    protected onRowAdded(itemSpec: common.ItemSpec) {
+    public _onRowAdded(itemSpec: common.ItemSpec) {
         this.helper.rows.push(new ItemGroup(itemSpec));
     }
 
-    protected onColumnAdded(itemSpec: common.ItemSpec) {
+    public _onColumnAdded(itemSpec: common.ItemSpec) {
         this.helper.columns.push(new ItemGroup(itemSpec));
     }
 
-    protected onRowRemoved(itemSpec: common.ItemSpec, index: number) {
+    public _onRowRemoved(itemSpec: common.ItemSpec, index: number) {
         this.helper.rows[index].children.length = 0;
         this.helper.rows.splice(index, 1);
     }
 
-    protected onColumnRemoved(itemSpec: common.ItemSpec, index: number) {
+    public _onColumnRemoved(itemSpec: common.ItemSpec, index: number) {
         this.helper.columns[index].children.length = 0;
         this.helper.columns.splice(index, 1);
     }


### PR DESCRIPTION
Changed callback names to _onRowRemoved, etc and changed visibility to
public to work around a TypeScript "protected" limitation.

Originally reported in NativeScript/nativescript-angular#211.