### PR TITLE
how-to's fixed slashes in code comments

### DIFF
--- a/apps/tests/application-settings-tests.ts
+++ b/apps/tests/application-settings-tests.ts
@@ -44,7 +44,7 @@ export var testNumber = function () {
 export var testDefaults = function () {
     // >> application-settings-notset
     var defaultValue = appSettings.getString("noStringKey", "No string value");
-    //// will return "No string value" if there is no value for "noStringKey"
+    // will return "No string value" if there is no value for "noStringKey"
     // << application-settings-notset
     TKUnit.assert("No string value" === defaultValue, "Bad default string value");
     TKUnit.assert(true === appSettings.getBoolean(noBoolKey, true), "Bad default boolean value");
@@ -54,7 +54,7 @@ export var testDefaults = function () {
 export var testDefaultsWithNoDefaultValueProvided = function () {
     // >> application-settings-nodefault
     var defaultValue = appSettings.getString("noStringKey");
-    //// will return undefined if there is no value for "noStringKey"
+    // will return undefined if there is no value for "noStringKey"
     // << application-settings-nodefault
     TKUnit.assert("undefined" === typeof defaultValue, "Default string value is not undefined");
 
@@ -69,7 +69,7 @@ export var testDefaultsWithNoDefaultValueProvided = function () {
 export var testHasKey = function () {
     // >> application-settings-haskey
     var hasKey = appSettings.hasKey("noBoolKey");
-    //// will return false if there is no value for "noBoolKey"
+    // will return false if there is no value for "noBoolKey"
     // << application-settings-haskey
     TKUnit.assert(!hasKey, "There is a key: " + noBoolKey);
     TKUnit.assert(!appSettings.hasKey(noStringKey), "There is a key: " + noStringKey);

--- a/apps/tests/camera-tests.ts
+++ b/apps/tests/camera-tests.ts
@@ -1,13 +1,11 @@
-﻿import camera = require("camera");
-
-// >> camera-require
-// var camera = require("camera");
+﻿// >> camera-require
+import camera = require("camera");
 // << camera-require
 
 export var test_takePicture = function () {
     // >> camera-take-picture
     camera.takePicture().then(result => {
-        //// result is ImageSource
+        // result is ImageSource
     });
     // << camera-take-picture
 };

--- a/apps/tests/color-tests.ts
+++ b/apps/tests/color-tests.ts
@@ -6,7 +6,7 @@ import TKUnit = require("./TKUnit");
 
 export var test_Hex_Color = function () {
     // >> color-hex
-    //// Creates the red color
+    // Creates the red color
     var color = new Color("#FF0000");
     // << color-hex
     TKUnit.assertEqual(color.a, 255, "Color.a not properly parsed");
@@ -19,7 +19,7 @@ export var test_Hex_Color = function () {
 
 export var test_ShortHex_Color = function () {
     // >> color-hex-short
-    //// Creates the color #FF8800
+    // Creates the color #FF8800
     var color = new Color("#F80");
     // << color-hex-short
     TKUnit.assertEqual(color.a, 255, "Color.a not properly parsed");
@@ -32,7 +32,7 @@ export var test_ShortHex_Color = function () {
 
 export var test_Argb_Color = function () {
     // >> color-rgb
-    //// Creates the color with 100 alpha, 255 red, 100 green, 100 blue
+    // Creates the color with 100 alpha, 255 red, 100 green, 100 blue
     var color = new Color(100, 255, 100, 100);
     // << color-rgb
     TKUnit.assertEqual(color.a, 100, "Color.a not properly parsed");
@@ -45,7 +45,7 @@ export var test_Argb_Color = function () {
 
 export var test_ArgbInt_Color = function () {
     // >> color-rgb-single
-    //// Creates the color with 100 alpha, 100 red, 100 green, 100 blue
+    // Creates the color with 100 alpha, 100 red, 100 green, 100 blue
     var argb = (100 << 24) | (100 << 16) | (100 << 8) | 100;
     var color = new Color(argb);
     // << color-rgb-single
@@ -61,7 +61,7 @@ export var test_rgb_Color_CSS = function () {
     // <snippet module="color" title="color">
     // ### Creating a Color from four RGB values
     // ``` JavaScript
-    //// Creates the color with 255 red, 100 green, 100 blue
+    // Creates the color with 255 red, 100 green, 100 blue
     var color = new Color("rgb(255, 100, 100)");
     // ```
     // </snippet>
@@ -79,7 +79,7 @@ export var test_rgba_Color_CSS = function () {
     // <snippet module="color" title="color">
     // ### Creating a Color from four RGB values
     // ``` JavaScript
-    //// Creates the color with 255 red, 100 green, 100 blue and 0 alpha
+    // Creates the color with 255 red, 100 green, 100 blue and 0 alpha
     var color = new Color(`rgba(255, 100, 100, ${alpha})`);
     // ```
     // </snippet>

--- a/apps/tests/connectivity-tests.ts
+++ b/apps/tests/connectivity-tests.ts
@@ -7,13 +7,13 @@ export var test_DummyTestForSnippetOnly0 = function () {
     var connectionType = connectivity.getConnectionType();
     switch (connectionType) {
         case connectivity.connectionType.none:
-            ////console.log("No connection");
+            //console.log("No connection");
             break;
         case connectivity.connectionType.wifi:
-            ////console.log("WiFi connection");
+            //console.log("WiFi connection");
             break;
         case connectivity.connectionType.mobile:
-            ////console.log("Mobile connection");
+            //console.log("Mobile connection");
             break;
     }
     // << connectivity-type
@@ -24,17 +24,17 @@ export var test_DummyTestForSnippetOnly1 = function () {
     connectivity.startMonitoring(function onConnectionTypeChanged(newConnectionType: number) {
         switch (newConnectionType) {
             case connectivity.connectionType.none:
-                ////console.log("Connection type changed to none.");
+                //console.log("Connection type changed to none.");
                 break;
             case connectivity.connectionType.wifi:
-                ////console.log("Connection type changed to WiFi.");
+                //console.log("Connection type changed to WiFi.");
                 break;
             case connectivity.connectionType.mobile:
-                ////console.log("Connection type changed to mobile.");
+                //console.log("Connection type changed to mobile.");
                 break;
         }
     });
-    ////...
+    //...
     connectivity.stopMonitoring();
     // << connectivity-monitoring
 }

--- a/apps/tests/data/observable-array-tests.ts
+++ b/apps/tests/data/observable-array-tests.ts
@@ -134,12 +134,12 @@ export var test_ObservableArray_popShouldRemoveTheLastElementAndRaiseChangeEvent
     // << (hide)
 
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "delete".
-        //// args.index is equal to the array length - 1.
-        //// args.removed.length is 1.
-        //// args.addedCount is 0.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "delete".
+        // args.index is equal to the array length - 1.
+        // args.removed.length is 1.
+        // args.addedCount is 0.
 
         // >> (hide)
         result = args;
@@ -173,12 +173,12 @@ export var test_ObservableArray_pushShouldAppendNewElementAndRaiseChangeEventWit
     // >> observable-array-change-push
     var array = new observableArrayModule.ObservableArray([1, 2, 3]);
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "add".
-        //// args.index is equal to the array length.
-        //// args.removed.length is 0.
-        //// args.addedCount is 1.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "add".
+        // args.index is equal to the array length.
+        // args.removed.length is 0.
+        // args.addedCount is 1.
 
         // >> (hide)
         result = args;
@@ -212,12 +212,12 @@ export var test_ObservableArray_pushShouldAppendNewElementsAndRaiseChangeEventWi
     // >> observable-array-push-multiple-info
     var array = new observableArrayModule.ObservableArray([1, 2, 3]);
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "add".
-        //// args.index is equal to the array length.
-        //// args.removed.length is 0.
-        //// args.addedCount is equal to the number of added items.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "add".
+        // args.index is equal to the array length.
+        // args.removed.length is 0.
+        // args.addedCount is equal to the number of added items.
 
         // >> (hide)
         result = args;
@@ -251,12 +251,12 @@ export var test_ObservableArray_pushShouldAppendNewElementsFromSourceArrayAndRai
     // >> observable-array-push-source-info
     var array = new observableArrayModule.ObservableArray([1, 2, 3]);
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "add".
-        //// args.index is equal to the array length.
-        //// args.removed.length is 0.
-        //// args.addedCount is equal to the number of added items.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "add".
+        // args.index is equal to the array length.
+        // args.removed.length is 0.
+        // args.addedCount is equal to the number of added items.
 
         // >> (hide)
         result = args;
@@ -299,12 +299,12 @@ export var test_ObservableArray_shiftShouldRemoveTheFirstElementAndRaiseChangeEv
     var array = new observableArrayModule.ObservableArray([1, 2, 3]);
 
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "delete".
-        //// args.index is 0.
-        //// args.removed.length is 1.
-        //// args.addedCount is 0.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "delete".
+        // args.index is 0.
+        // args.removed.length is 1.
+        // args.addedCount is 0.
 
         // >> (hide)
         result = args;
@@ -372,12 +372,12 @@ export var test_ObservableArray_spliceShouldRemoveSpecifiedNumberOfElementsStart
     var array = new observableArrayModule.ObservableArray([1, 2, 3]);
 
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "splice".
-        //// args.index is the start index.
-        //// args.removed.length is equal to the number of deleted items.
-        //// args.addedCount is 0.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "splice".
+        // args.index is the start index.
+        // args.removed.length is equal to the number of deleted items.
+        // args.addedCount is 0.
 
         // >> (hide)
         result = args;
@@ -407,12 +407,12 @@ export var test_ObservableArray_spliceShouldRemoveAndInertSpecifiedNumberOfEleme
     var array = new observableArrayModule.ObservableArray(["one", "two", "three"]);
 
     array.on(observableArrayModule.ObservableArray.changeEvent, (args: observableArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "splice".
-        //// args.index is the start index.
-        //// args.removed.length is equal to the number of deleted items.
-        //// args.addedCount is equal to the delta between number of inserted items and number of deleted items but not less than 0.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "splice".
+        // args.index is the start index.
+        // args.removed.length is equal to the number of deleted items.
+        // args.addedCount is equal to the delta between number of inserted items and number of deleted items but not less than 0.
 
         // >> (hide)
         result = args;

--- a/apps/tests/data/observable-tests.ts
+++ b/apps/tests/data/observable-tests.ts
@@ -25,7 +25,7 @@ export var test_Observable_Constructor = function () {
     var name = person.get("Name");
     var age = person.get("Age");
     var married = person.get("Married");
-    //// console.log(name + " " + age + " " + married); // Prints out "John 34 true" if uncommented.
+    // console.log(name + " " + age + " " + married); // Prints out "John 34 true" if uncommented.
     // << observable-creating
     TKUnit.assert(name === "John", "Expected name is John");
     TKUnit.assert(age === 34, "Expected age is 34");
@@ -43,9 +43,9 @@ export var tests_DummyTestForCodeSnippet = function () {
     });
     person.set("Age", 35);
     person.set("Married", false);
-    //// If uncommented, the console.log above produces the following output:
-    //// propertyChange Age 35
-    //// propertyChange Married false
+    // If uncommented, the console.log above produces the following output:
+    // propertyChange Age 35
+    // propertyChange Married false
     // << observable-property-change
 }
 

--- a/apps/tests/data/virtual-array-tests.ts
+++ b/apps/tests/data/virtual-array-tests.ts
@@ -46,16 +46,16 @@ export var test_VirtualArray_setItemShouldRaiseChangeEventWhenYouSetDifferentIte
     // << (hide)
 
     array.on(virtualArrayModule.VirtualArray.itemsLoadingEvent, (args: virtualArrayModule.ItemsLoading) => {
-        //// Argument (args) is ItemsLoading.
-        //// args.index is start index of the page where the requested index is located.
-        //// args.count number of requested items.
-        ////
-        //// Note: Virtual array will divide total number of items to pages using "loadSize" property value. When you request an 
-        //// item at specific index the array will raise "itemsLoading" event with "ItemsLoading" argument index set to the first index of the requested page
-        //// and count set to number of items in this page. 
-        ////
-        //// Important: If you have already loaded items in the requested page the array will raise multiple times "itemsLoading" event to request 
-        //// all ranges of still not loaded items in this page. 
+        // Argument (args) is ItemsLoading.
+        // args.index is start index of the page where the requested index is located.
+        // args.count number of requested items.
+        //
+        // Note: Virtual array will divide total number of items to pages using "loadSize" property value. When you request an 
+        // item at specific index the array will raise "itemsLoading" event with "ItemsLoading" argument index set to the first index of the requested page
+        // and count set to number of items in this page. 
+        //
+        // Important: If you have already loaded items in the requested page the array will raise multiple times "itemsLoading" event to request 
+        // all ranges of still not loaded items in this page. 
 
         var itemsToLoad = new Array<number>();
         for (var i = 0; i < args.count; i++) {
@@ -78,10 +78,10 @@ export var test_VirtualArray_loadShouldRaiseChangeEventWithCorrectArgs = functio
     // << (hide)
 
     array.on(virtualArrayModule.VirtualArray.changeEvent, (args: virtualArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "update".
-        //// args.removed.length and result.addedCount are equal to number of loaded items with load() method.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "update".
+        // args.removed.length and result.addedCount are equal to number of loaded items with load() method.
 
         // >> (hide)
         result = args;
@@ -109,10 +109,10 @@ export var test_VirtualArray_lengthIncreaseShouldRaiseChangeEventWithCorrectArgs
     // << (hide)
 
     array.on(virtualArrayModule.VirtualArray.changeEvent, (args: virtualArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "add".
-        //// args.removed.length is 0, result.addedCount is equal to the delta between new and old "length" property values.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "add".
+        // args.removed.length is 0, result.addedCount is equal to the delta between new and old "length" property values.
 
         // >> (hide)
         result = args;
@@ -140,10 +140,10 @@ export var test_VirtualArray_lengthDecreaseShouldRaiseChangeEventWithCorrectArgs
     // </hide>
 
     array.on(virtualArrayModule.VirtualArray.changeEvent, (args: virtualArrayModule.ChangedData<number>) => {
-        //// Argument (args) is ChangedData<T>.
-        //// args.eventName is "change".
-        //// args.action is "remove".
-        //// result.addedCount is 0, args.removed.length is equal to the delta between new and old "length" property values.
+        // Argument (args) is ChangedData<T>.
+        // args.eventName is "change".
+        // args.action is "remove".
+        // result.addedCount is 0, args.removed.length is equal to the delta between new and old "length" property values.
 
         // <hide>
         result = args;

--- a/apps/tests/fetch-tests.ts
+++ b/apps/tests/fetch-tests.ts
@@ -10,13 +10,13 @@ export var test_fetch = function (done: (err: Error, res?: string) => void) {
     var result;
     // >> fetch-response
     fetch("https://httpbin.org/get").then(function (r) {
-        //// Argument (r) is Response!
+        // Argument (r) is Response!
         // >> (hide)
         TKUnit.assert(r instanceof Response, "Result from fetch() should be valid Response object! Actual result is: " + result);
         done(null);
         // << (hide)
     }, function (e) {
-            //// Argument (e) is Error!
+            // Argument (e) is Error!
             // >> (hide)
             done(e);
             // << (hide)
@@ -29,13 +29,13 @@ export var test_fetch_text = function (done: (err: Error, res?: string) => void)
 
     // >> fetch-string'
     fetch("https://httpbin.org/get").then(response => { return response.text(); }).then(function (r) {
-        //// Argument (r) is string!
+        // Argument (r) is string!
         // >> (hide)
         TKUnit.assert(types.isString(r), "Result from text() should be string! Actual result is: " + r);
         done(null);
         // << (hide)
     }, function (e) {
-            //// Argument (e) is Error!
+            // Argument (e) is Error!
             // >> (hide)
             done(e);
             // << (hide)
@@ -48,13 +48,13 @@ export var test_fetch_json = function (done: (err: Error, res?: string) => void)
 
     // >> fetch-json
     fetch("https://httpbin.org/get").then(response => { return response.json(); }).then(function (r) {
-        //// Argument (r) is JSON object!
+        // Argument (r) is JSON object!
         // >> (hide)
         TKUnit.assert(types.isString(JSON.stringify(r)), "Result from json() should be JSON object! Actual result is: " + r);
         done(null);
         // << (hide)
     }, function (e) {
-            //// Argument (e) is Error!
+            // Argument (e) is Error!
             // >> (hide)
             done(e);
             // << (hide)
@@ -67,13 +67,13 @@ export var test_fetch_formData = function (done: (err: Error, res?: string) => v
 
     // >> fetch-formdata
     fetch("https://httpbin.org/get").then(response => { return response.formData(); }).then(function (r) {
-        //// Argument (r) is FormData object!
+        // Argument (r) is FormData object!
         // >> (hide)
         TKUnit.assert(r instanceof FormData, "Result from formData() should be FormData object! Actual result is: " + r);
         done(null);
         // << (hide)
     }, function (e) {
-            //// Argument (e) is Error!
+            // Argument (e) is Error!
             // >> (hide)
             done(e);
             // << (hide)
@@ -95,7 +95,7 @@ export var test_fetch_response_status = function (done) {
 
     // >> fetch-status-response
     fetch("https://httpbin.org/get").then(function (response) {
-        //// Argument (response) is Response!
+        // Argument (response) is Response!
         var statusCode = response.status;
         // >> (hide)
         try {
@@ -107,7 +107,7 @@ export var test_fetch_response_status = function (done) {
         }
         // << (hide)
     }, function (e) {
-            //// Argument (e) is Error!
+            // Argument (e) is Error!
             // >> (hide)
             done(e);
             // << (hide)
@@ -119,7 +119,7 @@ export var test_fetch_response_headers = function (done) {
 
     // >> fetch-headers-response
     fetch("https://httpbin.org/get").then(function (response) {
-        //// Argument (response) is Response!
+        // Argument (response) is Response!
         // var all = response.headers.getAll();
         // >> (hide)
         try {
@@ -131,7 +131,7 @@ export var test_fetch_response_headers = function (done) {
         }
         // << (hide)
     }, function (e) {
-            //// Argument (e) is Error!
+            // Argument (e) is Error!
             // >> (hide)
             done(e);
             // << (hide)

--- a/apps/tests/file-system-tests.ts
+++ b/apps/tests/file-system-tests.ts
@@ -11,7 +11,7 @@ export var testPathNormalize = function () {
     // >> file-system-normalize
     var documents = fs.knownFolders.documents();
     var testPath = "///test.txt";
-    //// Get a normalized path such as <folder.path>/test.txt from <folder.path>///test.txt
+    // Get a normalized path such as <folder.path>/test.txt from <folder.path>///test.txt
     var normalizedPath = fs.path.normalize(documents.path + testPath);
     // >> (hide)
     var expected = documents.path + "/test.txt";
@@ -23,7 +23,7 @@ export var testPathNormalize = function () {
 export var testPathJoin = function () {
     // >> file-system-multiple-args
     var documents = fs.knownFolders.documents();
-    //// Generate a path like <documents.path>/myFiles/test.txt
+    // Generate a path like <documents.path>/myFiles/test.txt
     var path = fs.path.join(documents.path, "myFiles", "test.txt");
     // >> (hide)
     var expected = documents.path + "/myFiles/test.txt";
@@ -34,7 +34,7 @@ export var testPathJoin = function () {
 
 export var testPathSeparator = function () {
     // >> file-system-separator
-    //// An OS dependent path separator, "\" or "/".
+    // An OS dependent path separator, "\" or "/".
     var separator = fs.path.separator;
     // >> (hide)
     var expected = "/";
@@ -49,10 +49,10 @@ export var testFileFromPath = function () {
     var path = fs.path.join(documents.path, "FileFromPath.txt");
     var file = fs.File.fromPath(path);
 
-    //// Writing text to the file.
+    // Writing text to the file.
     file.writeText("Something")
         .then(function () {
-            //// Succeeded writing to the file.
+            // Succeeded writing to the file.
             // >> (hide)
             file.readText()
                 .then(function (content) {
@@ -64,7 +64,7 @@ export var testFileFromPath = function () {
                 });
             // << (hide)
         }, function (error) {
-            //// Failed to write to the file.
+            // Failed to write to the file.
             // >> (hide)
             TKUnit.assert(false, "Failed to read/write text");
             //console.dump(error);
@@ -90,10 +90,10 @@ export var testFileWrite = function () {
     var documents = fs.knownFolders.documents();
     var file = documents.getFile("Test_Write.txt");
 
-    //// Writing text to the file.
+    // Writing text to the file.
     file.writeText("Something")
         .then(function () {
-            //// Succeeded writing to the file.
+            // Succeeded writing to the file.
             // >> (hide)
             file.readText()
                 .then(function (content) {
@@ -105,7 +105,7 @@ export var testFileWrite = function () {
                 });
             // << (hide)
         }, function (error) {
-            //// Failed to write to the file.
+            // Failed to write to the file.
             // >> (hide)
             TKUnit.assert(false, "Failed to read/write text");
             //console.dump(error);
@@ -144,29 +144,29 @@ export var testFileRead = function () {
     var myFile = documents.getFile("Test_Write.txt");
 
     var written: boolean;
-    //// Writing text to the file.
+    // Writing text to the file.
     myFile.writeText("Something")
         .then(function () {
-            //// Succeeded writing to the file.
+            // Succeeded writing to the file.
 
-            //// Getting back the contents of the file.
+            // Getting back the contents of the file.
             myFile.readText()
                 .then(function (content) {
-                    //// Successfully read the file's content.
+                    // Successfully read the file's content.
                     // >> (hide)
                     written = content === "Something";
                     TKUnit.assert(written, "File read/write not working.");
                     myFile.remove();
                     // << (hide)
                 }, function (error) {
-                    //// Failed to read from the file.
+                    // Failed to read from the file.
                     // >> (hide)
                     TKUnit.assert(false, "Failed to read/write text");
                     //console.dump(error);
                     // << (hide)
                 });
         }, function (error) {
-            //// Failed to write to the file.
+            // Failed to write to the file.
             // >> (hide)
             TKUnit.assert(false, "Failed to read/write text");
             //console.dump(error);
@@ -203,13 +203,13 @@ export var testFileReadWriteBinary = function () {
 
 export var testGetKnownFolders = function () {
     // >> file-system-known-folders
-    //// Getting the application's 'documents' folder.
+    // Getting the application's 'documents' folder.
     var documents = fs.knownFolders.documents();
     // >> (hide)
     TKUnit.assert(<any>documents, "Could not retrieve the Documents known folder.");
     TKUnit.assert(documents.isKnown, "The Documents folder should have its isKnown property set to true.");
     // << (hide)
-    //// Getting the application's 'temp' folder.
+    // Getting the application's 'temp' folder.
     var temp = fs.knownFolders.temp();
     // >> (hide)
     TKUnit.assert(<any>temp, "Could not retrieve the Temporary known folder.");
@@ -243,7 +243,7 @@ export var testGetEntities = function () {
     // << (hide)
     documents.getEntities()
         .then(function (entities) {
-            //// entities is array with the document's files and folders.
+            // entities is array with the document's files and folders.
             entities.forEach(function (entity) {
                 console.log(entity.name);
             });
@@ -256,7 +256,7 @@ export var testGetEntities = function () {
             file1.remove();
             // << (hide)
         }, function (error) {
-            //// Failed to obtain folder's contents.
+            // Failed to obtain folder's contents.
             // globalConsole.error(error.message);
         });
     // << file-system-folders-content
@@ -286,7 +286,7 @@ export var testEnumEntities = function () {
     // << (hide)
     documents.eachEntity(function (entity) {
         console.log(entity.name);
-        //// Return true to continue, or return false to stop the iteration.
+        // Return true to continue, or return false to stop the iteration.
         return true;
     });
     // >> (hide)
@@ -308,7 +308,7 @@ export var testGetParent = function () {
     // >> (hide)
     TKUnit.assert(<any>file, "Failed to create file in the Documents folder.");
     // << (hide)
-    //// The parent folder of the file would be the documents folder.
+    // The parent folder of the file would be the documents folder.
     var parent = file.parent;
     // >> (hide)
     TKUnit.assert(documents === parent, "The parent folder should be the Documents folder.");
@@ -321,9 +321,9 @@ export var testFileNameExtension = function () {
     // >> file-system-extension
     var documents = fs.knownFolders.documents();
     var file = documents.getFile("Test.txt");
-    //// Getting the file name "Test.txt".
+    // Getting the file name "Test.txt".
     var fileName = file.name;
-    //// Getting the file extension ".txt".
+    // Getting the file extension ".txt".
     var fileExtension = file.extension;
     // >> (hide)
     TKUnit.assert(fileName === "Test.txt", "Wrong file name.");
@@ -379,14 +379,14 @@ export var testFileRename = function () {
 
     file.rename("Test_renamed.txt")
         .then(function (result) {
-            //// Successfully Renamed.
+            // Successfully Renamed.
             // >> (hide)
             TKUnit.assert(file.name === "Test_renamed.txt", "File.rename API not working.");
             file.remove();
             documents.getFile("Test.txt").remove();
             // << (hide)
         }, function (error) {
-            //// Failed to rename the file.
+            // Failed to rename the file.
             // >> (hide)
             TKUnit.assert(false, "Failed to rename file");
             // << (hide)
@@ -401,14 +401,14 @@ export var testFolderRename = function () {
 
     myFolder.rename("Something")
         .then(function (result) {
-            //// Successfully Renamed.
+            // Successfully Renamed.
             // >> (hide)
             TKUnit.assert(myFolder.name === "Something", "Folder.rename API not working.");
             myFolder.remove();
             folder.getFolder("Test__").remove();
             // << (hide)
         }, function (error) {
-            //// Failed to rename the folder.
+            // Failed to rename the folder.
             // >> (hide)
             TKUnit.assert(false, "Folder.rename API not working.");
             // << (hide)
@@ -422,12 +422,12 @@ export var testFileRemove = function () {
     var file = documents.getFile("AFileToRemove.txt");
     file.remove()
         .then(function (result) {
-            //// Success removing the file.
+            // Success removing the file.
             // >> (hide)
             TKUnit.assert(!fs.File.exists(file.path));
             // << (hide)
         }, function (error) {
-            //// Failed to remove the file.
+            // Failed to remove the file.
             // >> (hide)
             TKUnit.assert(false, "File.remove API not working.");
             // << (hide)
@@ -439,15 +439,15 @@ export var testFolderRemove = function () {
     // >> file-system-remove-folder
     var documents = fs.knownFolders.documents();
     var file = documents.getFolder("AFolderToRemove");
-    //// Remove a folder and recursively its content.
+    // Remove a folder and recursively its content.
     file.remove()
         .then(function (result) {
-            //// Success removing the folder.
+            // Success removing the folder.
             // >> (hide)
             TKUnit.assert(!fs.File.exists(file.path));
             // << (hide)
         }, function (error) {
-            //// Failed to remove the folder.
+            // Failed to remove the folder.
             // >> (hide)
             TKUnit.assert(false, "File.remove API not working.");
             // << (hide)
@@ -467,12 +467,12 @@ export var testFolderClear = function () {
     // << (hide)
     folder.clear()
         .then(function () {
-            //// Successfully cleared the folder.
+            // Successfully cleared the folder.
             // >> (hide)
             emptied = true;
             // << (hide)
         }, function (error) {
-            //// Failed to clear the folder.
+            // Failed to clear the folder.
             // >> (hide)
             TKUnit.assert(false, error.message);
             // << (hide)

--- a/apps/tests/ui/activity-indicator/activity-indicator-tests.ts
+++ b/apps/tests/ui/activity-indicator/activity-indicator-tests.ts
@@ -68,7 +68,7 @@ function binding_busy_to_image() {
     indicator.width = 100;
     indicator.height = 100;
 
-    //// Bind the busy property of the indicator to the isLoading property of the image
+    // Bind the busy property of the indicator to the isLoading property of the image
     indicator.bind({
         sourceProperty: "isLoading",
         targetProperty: "busy"

--- a/apps/tests/ui/animation/animation-tests.ts
+++ b/apps/tests/ui/animation/animation-tests.ts
@@ -38,7 +38,7 @@ export function test_AnimatingProperties(done) {
         curve: enums.AnimationCurve.easeIn
     })
         .then(() => {
-            ////console.log("Animation finished.");
+            //console.log("Animation finished.");
             // >> (hide)
             assertIOSNativeTransformIsCorrect(label);
             done();
@@ -61,13 +61,13 @@ export function test_CancellingAnimation(done) {
 
     animation1.play()
         .then(() => {
-            ////console.log("Animation finished");
+            //console.log("Animation finished");
             // >> (hide)
             throw new Error("Cancelling Animation - Should not be in the Promise Then()");
             // << (hide)
         })
         .catch((e) => {
-            ////console.log("Animation cancelled");
+            //console.log("Animation cancelled");
             // >> (hide)
             if (!e) {
                 done(new Error("Cancel path did not have proper error"));
@@ -88,13 +88,13 @@ export function test_CancellingAnimate(done) {
     // >> animation-cancel2
     var animation1 = label.animate({ translate: { x: 100, y: 100 }, duration: 20 })
         .then(() => {
-            ////console.log("Animation finished");
+            //console.log("Animation finished");
             // >> (hide)
             throw new Error("Cancelling Animate - Should not be in Promise Then()");
             // << (hide)
         })
         .catch((e) => {
-            ////console.log("Animation cancelled");
+            //console.log("Animation cancelled");
             // >> (hide)
             if (!e) {
                 done(new Error("Cancel path did not have proper error"));
@@ -126,7 +126,7 @@ export function test_ChainingAnimations(done) {
         .then(() => label.animate({ rotate: 180, duration: duration }))
         .then(() => label.animate({ rotate: 0, duration: duration }))
         .then(() => {
-            ////console.log("Animation finished");
+            //console.log("Animation finished");
             // >> (hide)
             assertIOSNativeTransformIsCorrect(label);
             done();
@@ -155,7 +155,7 @@ export function test_ReusingAnimations(done) {
         .then(() => animation1.play())
         .then(() => animation2.play())
         .then(() => {
-            ////console.log("Animation finished");
+            //console.log("Animation finished");
             // >> (hide)
             assertIOSNativeTransformIsCorrect(label);
             done();
@@ -194,7 +194,7 @@ export function test_AnimatingMultipleViews(done) {
     var a = new animation.Animation(animations);
     a.play()
         .then(() => {
-            ////console.log("Animations finished");
+            //console.log("Animations finished");
             // >> (hide)
             assertIOSNativeTransformIsCorrect(label1);
             assertIOSNativeTransformIsCorrect(label2);

--- a/apps/tests/ui/button/button-tests.ts
+++ b/apps/tests/ui/button/button-tests.ts
@@ -101,7 +101,7 @@ var _testOnClick = function (views: Array<viewModule.View>) {
     var actualValue = false;
     // >> button-tap
     button.on(buttonModule.Button.tapEvent, function (args: observable.EventData) {
-        //// Do something
+        // Do something
         // >> (hide)
         actualValue = true;
         // << (hide)
@@ -123,12 +123,12 @@ var _testBindTextDirectlyToModel = function (views: Array<viewModule.View>) {
         targetProperty: "text"
     }
     button.bind(options, model);
-    //// button.text is now "OK"
+    // button.text is now "OK"
     // >> (hide)
     TKUnit.assert(button.text === "OK", "Actual: " + button.text + "; Expected: " + "OK");
     // << (hide)
     model.set("buttonTitle", "Cancel");
-    //// button.text is now "Cancel"
+    // button.text is now "Cancel"
     // >> (hide)
     TKUnit.assert(button.text === "Cancel", "Actual: " + button.text + "; Expected: " + "Cancel");
     // << (hide)

--- a/apps/tests/ui/dialogs/dialog-tests.ts
+++ b/apps/tests/ui/dialogs/dialog-tests.ts
@@ -26,7 +26,7 @@ export function test_DummyTestForSnippetOnly1() {
         neutralButtonText: "Cancel"
     };
     dialogs.confirm(options).then((result: boolean) => {
-        //// result can be true/false/undefined
+        // result can be true/false/undefined
         console.log(result);
     });
     // << dialog-confirm
@@ -54,7 +54,7 @@ export function test_DummyTestForSnippetOnly3() {
         password: ""
     };
     dialogs.login(options).then((loginResult: dialogs.LoginResult) => {
-        //// true or false.
+        // true or false.
         console.log(loginResult.result);
     });
     // << dialog-login

--- a/apps/tests/ui/image-cache/image-cache-tests.ts
+++ b/apps/tests/ui/image-cache/image-cache-tests.ts
@@ -10,19 +10,19 @@ export function test_DummyTestForSnippetOnly() {
     cache.placeholder = imageSource.fromFile(fs.path.join(__dirname, "res/no-image.png"));
     cache.maxRequests = 5;
     
-    //// Enable download while not scrolling
+    // Enable download while not scrolling
     cache.enableDownload();
     
     var imgSouce: imageSource.ImageSource;
     var url = "https://github.com/NativeScript.png";
-    //// Try to read the image from the cache
+    // Try to read the image from the cache
     var image = cache.get(url);
     if (image) {
-        //// If present -- use it.
+        // If present -- use it.
         imgSouce = imageSource.fromNativeSource(image);
     }
     else {
-        //// If not present -- request its download.
+        // If not present -- request its download.
         cache.push({
             key: url,
             url: url,
@@ -34,7 +34,7 @@ export function test_DummyTestForSnippetOnly() {
         });
     }
 
-    //// Disable download while scrolling
+    // Disable download while scrolling
     cache.disableDownload();
     // << image-cache-request-images
 }

--- a/apps/tests/ui/image/image-tests.ts
+++ b/apps/tests/ui/image/image-tests.ts
@@ -127,9 +127,9 @@ export var test_SettingStretch_AspectFit = function () {
     // >> img-set-stretch
     var image = new ImageModule.Image();
     image.imageSource = ImageSourceModule.fromFile(imagePath);
-    //// There are 4 modes of stretching none, fill, aspectFill, aspectFit
-    //// The default value is aspectFit.
-    //// Image stretch can be set by using ImageModule.stretch enum.
+    // There are 4 modes of stretching none, fill, aspectFill, aspectFit
+    // The default value is aspectFit.
+    // Image stretch can be set by using ImageModule.stretch enum.
     image.stretch = enumsModule.Stretch.aspectFit;
     // << img-set-stretch
 

--- a/apps/tests/ui/label/label-tests.ts
+++ b/apps/tests/ui/label/label-tests.ts
@@ -235,8 +235,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         // >> label-cssclass
         label.text = "The quick brown fox jumps over the lazy dog.";
         label.className = "title";
-        //// after that all we have to do is to set a similar css entry within parent page css property
-        //// label.parentPage.css = ".title {background-color: #C6C6C6; color: #10C2B0; font-size: 14;}";
+        // after that all we have to do is to set a similar css entry within parent page css property
+        // label.parentPage.css = ".title {background-color: #C6C6C6; color: #10C2B0; font-size: 14;}";
         // << label-cssclass
 
         var actualTextSize;
@@ -298,9 +298,9 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
 
         // >> label-cssclass-type
         label.text = "The quick brown fox jumps over the lazy dog.";
-        //// in order to style label with a "type style scope" just put a similar css entry
-        //// testLabel.parentPage.css = "label {background-color: #C6C6C6; color: #10C2B0; font-size: 14;}";
-        //// all labels within the parent page will be styled according to css values
+        // in order to style label with a "type style scope" just put a similar css entry
+        // testLabel.parentPage.css = "label {background-color: #C6C6C6; color: #10C2B0; font-size: 14;}";
+        // all labels within the parent page will be styled according to css values
         // << label-cssclass-type
         var expectedBackgroundColor = new colorModule.Color(backgroundColor);
         var actualBackgroundColor = label.style.backgroundColor;
@@ -329,8 +329,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         // >> label-css-identifier
         label.text = "The quick brown fox jumps over the lazy dog.";
         label.id = "testLabel";
-        //// after that all we have to do is to set a similar css entry within parent page css property
-        //// label.parentPage.css = "#testLabel {background-color: #C6C6C6; color: #10C2B0; font-size: 14;}";
+        // after that all we have to do is to set a similar css entry within parent page css property
+        // label.parentPage.css = "#testLabel {background-color: #C6C6C6; color: #10C2B0; font-size: 14;}";
         // << label-css-identifier
 
         var expectedBackgroundColor = new colorModule.Color(backgroundColor);
@@ -356,7 +356,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         };
         label.bind(bindingOptions, sourceModel);
         sourceModel.set("sourceProperty", expValue);
-        //// console.log(label.text); --> prints: "Expected Value"
+        // console.log(label.text); --> prints: "Expected Value"
         // << label-observable
 
         TKUnit.assertEqual(label.text, expValue);

--- a/apps/tests/ui/layouts/absolute-layout-tests.ts
+++ b/apps/tests/ui/layouts/absolute-layout-tests.ts
@@ -23,7 +23,7 @@ export class AbsoluteLayoutTest extends testModule.UITest<absoluteLayoutModule.A
         absoluteLayout.height = 230;
         absoluteLayout.style.backgroundColor = new colorModule.Color("LightGray");
         var label = new labelModule.Label();
-        //// In absolute layout place of an UI element is determined by 4 parameters : left, top, width and height.
+        // In absolute layout place of an UI element is determined by 4 parameters : left, top, width and height.
         absoluteLayoutModule.AbsoluteLayout.setLeft(label, 10);
         absoluteLayoutModule.AbsoluteLayout.setTop(label, 10);
         label.width = 100;

--- a/apps/tests/ui/layouts/grid-layout-tests.ts
+++ b/apps/tests/ui/layouts/grid-layout-tests.ts
@@ -592,15 +592,15 @@ export class GridLayoutTest extends testModule.UITest<GridLayout> {
         // << grid-layout-columnspan
 
         // >> grid-layout-itemspec
-        //// ItemSpec modes of the column refers to its width.
-        //// Absolute size of the column
+        // ItemSpec modes of the column refers to its width.
+        // Absolute size of the column
         var firstColumn = new ItemSpec(80, GridUnitType.pixel);
-        //// Star width means that this column will expand to fill the gap left from other columns
+        // Star width means that this column will expand to fill the gap left from other columns
         var secondColumn = new ItemSpec(1, GridUnitType.star);
-        //// Auto size means that column will expand or shrink in order to give enough place for all child UI elements.
+        // Auto size means that column will expand or shrink in order to give enough place for all child UI elements.
         var thirdColumn = new ItemSpec(1, GridUnitType.auto);
 
-        //// Star and Auto modes for rows behave like corresponding setting for columns but refer to row height.
+        // Star and Auto modes for rows behave like corresponding setting for columns but refer to row height.
         var firstRow = new ItemSpec(1, GridUnitType.auto);
         var secondRow = new ItemSpec(1, GridUnitType.star);
         // << grid-layout-itemspec

--- a/apps/tests/ui/list-view/list-view-tests.ts
+++ b/apps/tests/ui/list-view/list-view-tests.ts
@@ -68,7 +68,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
         listView.items = colors;
         listView.on(listViewModule.ListView.itemLoadingEvent, function (args: listViewModule.ItemEventData) {
             if (!args.view) {
-                //// Create label if it is not already created.
+                // Create label if it is not already created.
                 args.view = new labelModule.Label();
             }
             (<labelModule.Label>args.view).text = colors[args.index];
@@ -164,7 +164,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
 
         // >> article-change-refresh-listview
         colors.push("yellow");
-        //// Manually trigger the update so that the new color is shown.
+        // Manually trigger the update so that the new color is shown.
         listView.refresh();
         // << article-change-refresh-listview
         TKUnit.waitUntilReady(() => { return this.getNativeViewCount(listView) === listView.items.length; }, ASYNC);
@@ -253,7 +253,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
         listView.items = colors;
         listView.on(listViewModule.ListView.itemLoadingEvent, function (args: listViewModule.ItemEventData) {
             if (!args.view) {
-                //// Create label if it is not already created.
+                // Create label if it is not already created.
                 args.view = new labelModule.Label();
             }
             (<labelModule.Label>args.view).text = colors.getItem(args.index);
@@ -280,7 +280,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
 
         // >> article-push-in-observablearray
         colors.push("yellow");
-        //// The ListView will be updated automatically.
+        // The ListView will be updated automatically.
         // << article-push-in-observablearray
         TKUnit.waitUntilReady(() => { return this.getNativeViewCount(listView) === listView.items.length; }, ASYNC);
         TKUnit.assertEqual(this.getNativeViewCount(listView), 4, "getNativeViewCount");
@@ -329,7 +329,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
         listView.on(listViewModule.ListView.itemTapEvent, function (args: listViewModule.ItemEventData) {
             var tappedItemIndex = args.index;
             var tappedItemView = args.view;
-            //// Do someting
+            // Do someting
             // >> (hide)
             nativeTapRaised = true;
             itemIndex = args.index;
@@ -352,7 +352,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
         listView.on(listViewModule.ListView.itemLoadingEvent, this.loadViewWithItemNumber);
         // >> article-loadmoreitems-event
         listView.on(listViewModule.ListView.loadMoreItemsEvent, function (data: observable.EventData) {
-            //// Do something.
+            // Do something.
             // >> (hide)
             loadMoreItemsCount++;
             // << (hide)
@@ -597,8 +597,8 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
         //TKUnit.waitUntilReady(() => { return this.getNativeViewCount(this.testView) === this.testView.items.length; }, ASYNC);
 
         //if (platform.device.os === platform.platformNames.ios) {
-            //// Could cause GC on the next call.
-            //// NOTE: Don't replace this with forceGC();
+            // Could cause GC on the next call.
+            // NOTE: Don't replace this with forceGC();
             //new ArrayBuffer(4 * 1024 * 1024);
         //}
         //utils.GC();

--- a/apps/tests/ui/page/page-tests-common.ts
+++ b/apps/tests/ui/page/page-tests-common.ts
@@ -1,6 +1,6 @@
 ﻿// >> article-require-page-module
 import pageModule = require("ui/page");
-//// FrameModule is needed in order to have an option to navigate to the new page.
+// FrameModule is needed in order to have an option to navigate to the new page.
 import frameModule = require("ui/frame");
 // << article-require-page-module
 
@@ -210,7 +210,7 @@ export function test_NavigateTo_WithContext() {
     var pageFactory = function (): pageModule.Page {
         testPage = new pageModule.Page();
         testPage.on(pageModule.Page.navigatedToEvent, function () {
-            ////console.log(JSON.stringify(context));
+            //console.log(JSON.stringify(context));
         });
         return testPage;
     };

--- a/apps/tests/ui/repeater/repeater-tests.ts
+++ b/apps/tests/ui/repeater/repeater-tests.ts
@@ -70,7 +70,7 @@ export function test_refresh_after_adding_items_to_array_loads_new_items() {
         TKUnit.assertEqual(getChildrenCount(repeater), colors.length, "views count.");
         // >> artcle-array-push-element
         colors.push("yellow");
-        //// Manually trigger the update so that the new color is shown.
+        // Manually trigger the update so that the new color is shown.
         repeater.refresh();
         // << artcle-array-push-element
         TKUnit.wait(ASYNC);
@@ -206,7 +206,7 @@ export function test_add_to_observable_array_refreshes_the_Repeater() {
 
         // >> article-push-to-observablearray
         colors.push("yellow");
-        //// The Repeater will be updated automatically.
+        // The Repeater will be updated automatically.
         // << article-push-to-observablearray
         TKUnit.wait(ASYNC);
         TKUnit.waitUntilReady(() => repeater.isLayoutValid);

--- a/apps/tests/ui/slider/slider-tests.ts
+++ b/apps/tests/ui/slider/slider-tests.ts
@@ -325,12 +325,12 @@ export function test_binding_value_to_model() {
             targetProperty: "value"
         };
         slider.bind(options, model);
-        //// slider.value is now 21
+        // slider.value is now 21
         // >> (hide)
         TKUnit.assertEqual(slider.value, 21, "slider.value");
         // << (hide)
         model.set("age", 22);
-        //// slider.value is now 22
+        // slider.value is now 22
         // >> (hide)
         TKUnit.assertEqual(slider.value, 22, "slider.value");
         // << (hide)

--- a/apps/tests/ui/switch/switch-tests.ts
+++ b/apps/tests/ui/switch/switch-tests.ts
@@ -121,12 +121,12 @@ export function test_binding_value_to_model() {
             targetProperty: "checked"
         };
         mySwitch.bind(options, model);
-        //// mySwitch.checked is now true
+        // mySwitch.checked is now true
         // >> (hide)
         TKUnit.assertEqual(mySwitch.checked, true, "mySwitch.checked");
         // << (hide)
         model.set("enabled", false);
-        //// mySwitch.checked is now false
+        // mySwitch.checked is now false
         // >> (hide)
         TKUnit.assertEqual(mySwitch.checked, false, "mySwitch.checked");
         // << (hide)

--- a/apps/tests/ui/text-field/text-field-tests.ts
+++ b/apps/tests/ui/text-field/text-field-tests.ts
@@ -171,13 +171,13 @@ export var testBindTextDirectlyToModel = function () {
             targetProperty: "text"
         }
         textField.bind(options, model);
-        //// textField.text is now "john"
+        // textField.text is now "john"
         // >> (hide)
         TKUnit.assert(textField.text === "john", "Actual: " + textField.text + "; Expected: " + "john");
         TKUnit.assert(textFieldTestsNative.getNativeText(textField) === "john", "Actual: " + textFieldTestsNative.getNativeText(textField) + "; Expected: " + "john");
         // << (hide)
         model.set("username", "mary");
-        //// textField.text is now "mary"
+        // textField.text is now "mary"
         // >> (hide)
         TKUnit.assert(textField.text === "mary", "Actual: " + textField.text + "; Expected: " + "mary");
         TKUnit.assert(textFieldTestsNative.getNativeText(textField) === "mary", "Actual: " + textFieldTestsNative.getNativeText(textField) + "; Expected: " + "mary");
@@ -260,13 +260,13 @@ export var testBindHintDirectlyToModel = function () {
             targetProperty: "hint"
         }
         textField.bind(options, model);
-        //// textField.hint is now "type your username here"
+        // textField.hint is now "type your username here"
         // >> (hide)
         TKUnit.assert(textField.hint === "type your username here", "Actual: " + textField.text + "; Expected: " + "type your username here");
         TKUnit.assert(textFieldTestsNative.getNativeHint(textField) === "type your username here", "Actual: " + textFieldTestsNative.getNativeHint(textField) + "; Expected: " + "type your username here");
         // << (hide)
         model.set("hint", "type your password here");
-        //// textField.hint is now "type your password here"
+        // textField.hint is now "type your password here"
         // >> (hide)
         TKUnit.assert(textField.hint === "type your password here", "Actual: " + textField.text + "; Expected: " + "type your password here");
         TKUnit.assert(textFieldTestsNative.getNativeHint(textField) === "type your password here", "Actual: " + textFieldTestsNative.getNativeHint(textField) + "; Expected: " + "type your password here");
@@ -325,13 +325,13 @@ export var testBindSecureDirectlyToModel = function () {
             targetProperty: "secure"
         }
         textField.bind(options, model);
-        //// textField.secure is now true
+        // textField.secure is now true
         // >> (hide)
         TKUnit.assert(textField.secure === true, "Actual: " + textField.secure + "; Expected: " + true);
         TKUnit.assert(textFieldTestsNative.getNativeSecure(textField) === true, "Actual: " + textFieldTestsNative.getNativeSecure(textField) + "; Expected: " + true);
         // << (hide)
         model.set("secure", false);
-        //// textField.secure is now false
+        // textField.secure is now false
         // >> (hide)
         TKUnit.assert(textField.secure === false, "Actual: " + textField.secure + "; Expected: " + false);
         TKUnit.assert(textFieldTestsNative.getNativeSecure(textField) === false, "Actual: " + textFieldTestsNative.getNativeSecure(textField) + "; Expected: " + false);

--- a/apps/tests/ui/text-view/text-view-tests.ts
+++ b/apps/tests/ui/text-view/text-view-tests.ts
@@ -104,13 +104,13 @@ export var testBindTextDirectlyToModel = function () {
             targetProperty: "text"
         }
         textView.bind(options, model);
-        //// textView.text is now "john"
+        // textView.text is now "john"
         // >> (hide)
         TKUnit.assert(textView.text === "john", "Actual: " + textView.text + "; Expected: " + "john");
         TKUnit.assert(textViewTestsNative.getNativeText(textView) === "john", "Actual: " + textViewTestsNative.getNativeText(textView) + "; Expected: " + "john");
         // << (hide)
         model.set("username", "mary");
-        //// textView.text is now "mary"
+        // textView.text is now "mary"
         // >> (hide)
         TKUnit.assert(textView.text === "mary", "Actual: " + textView.text + "; Expected: " + "mary");
         TKUnit.assert(textViewTestsNative.getNativeText(textView) === "mary", "Actual: " + textViewTestsNative.getNativeText(textView) + "; Expected: " + "mary");
@@ -184,13 +184,13 @@ export var testBindHintDirectlyToModel = function () {
             targetProperty: "hint"
         }
         textView.bind(options, model);
-        //// TextView.hint is now "type your username here"
+        // TextView.hint is now "type your username here"
         // >> (hide)
         TKUnit.assert(textView.hint === "type your username here", "Actual: " + textView.hint + "; Expected: " + "type your username here");
         TKUnit.assert(textViewTestsNative.getNativeHint(textView) === "type your username here", "Actual: " + textViewTestsNative.getNativeHint(textView) + "; Expected: " + "type your username here");
         // << (hide)
         model.set("hint", "type your password here");
-        //// TextView.hint is now "type your password here"
+        // TextView.hint is now "type your password here"
         // >> (hide)
         TKUnit.assert(textView.hint === "type your password here", "Actual: " + textView.hint + "; Expected: " + "type your password here");
         TKUnit.assert(textViewTestsNative.getNativeHint(textView) === "type your password here", "Actual: " + textViewTestsNative.getNativeHint(textView) + "; Expected: " + "type your password here");
@@ -305,13 +305,13 @@ export var testBindEditableDirectlyToModel = function () {
             targetProperty: "editable"
         }
         textView.bind(options, model);
-        //// textView.editable is now false
+        // textView.editable is now false
         // >> (hide)
         TKUnit.assert(textView.editable === false, "Actual: " + textView.text + "; Expected: " + false);
         TKUnit.assert(textViewTestsNative.getNativeEditable(textView) === false, "Actual: " + textViewTestsNative.getNativeEditable(textView) + "; Expected: " + false);
         // << (hide)
         model.set("editable", true);
-        //// textView.editable is now true
+        // textView.editable is now true
         // >> (hide)
         TKUnit.assert(textView.editable === true, "Actual: " + textView.text + "; Expected: " + true);
         TKUnit.assert(textViewTestsNative.getNativeEditable(textView) === true, "Actual: " + textViewTestsNative.getNativeEditable(textView) + "; Expected: " + true);


### PR DESCRIPTION
Fixing the double comments in all how-to's in the new COOKBOOK section


