### PR TITLE
Typo in Pointer.getY method for iOS

### DIFF
--- a/ui/gestures/gestures.ios.ts
+++ b/ui/gestures/gestures.ios.ts
@@ -395,7 +395,7 @@ class Pointer implements definition.Pointer {
     }
 
     getY(): number {
-        return this.location.x;
+        return this.location.y;
     }
 }
 


### PR DESCRIPTION
Pointer.getY method for iOS returned this.location.x instead of this.location.y
