### PR TITLE
Fix navigatedFrom event raised when Activity is destroyed without act…

### DIFF
--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -205,6 +205,7 @@ export class Frame extends CustomLayoutView implements definition.Frame {
         var backstackEntry: definition.BackstackEntry = {
             entry: entry,
             resolvedPage: page,
+            isNavigation: true
         };
 
         var navigationContext: NavigationContext = {

--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -137,6 +137,11 @@ export class Frame extends frameCommon.Frame {
         let manager = activity.getFragmentManager();
         let isFirstNavigation = types.isNullOrUndefined(this._currentEntry);
 
+        backstackEntry.isNavigation = true;
+        if (this._currentEntry) {
+            this._currentEntry.isNavigation = true;
+        }
+
         // Clear history
         if (backstackEntry.entry.clearHistory) {
             let backStackEntryCount = manager.getBackStackEntryCount();
@@ -260,9 +265,11 @@ export class Frame extends frameCommon.Frame {
     public _goBackCore(backstackEntry: definition.BackstackEntry) {
         navDepth = backstackEntry[NAV_DEPTH];
 
+        backstackEntry.isNavigation = true;
         if (this._currentEntry) {
             // We need this information inside onFragmentHidden
             this._currentEntry[IS_BACK] = true;
+            this._currentEntry.isNavigation = true;
         }
 
         trace.write(`${this}._goBackCore(pageId: ${backstackEntry.resolvedPage.id}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);

--- a/ui/frame/frame.d.ts
+++ b/ui/frame/frame.d.ts
@@ -209,7 +209,7 @@ declare module "ui/frame" {
          * - slideBottom
          */
         name?: string;
-        
+
         /**
          * An user-defined instance of the "ui/transition".Transition class.
          */
@@ -233,6 +233,10 @@ declare module "ui/frame" {
     export interface BackstackEntry {
         entry: NavigationEntry;
         resolvedPage: pages.Page;
+
+        //@private
+        isNavigation: boolean;
+        //@endprivate
     }
 
     /**

--- a/ui/transition/transition.android.ts
+++ b/ui/transition/transition.android.ts
@@ -289,6 +289,7 @@ function _completePageAddition(fragment: any, isBack: boolean) {
     frame._currentEntry = entry;
     page.onNavigatedTo(isBack);
     frame._processNavigationQueue(page);
+    entry.isNavigation = undefined;
     trace.write(`ADDITION of ${page} completed`, trace.categories.Transition);
 }
 
@@ -300,7 +301,10 @@ function _completePageRemoval(fragment: any, isBack: boolean) {
     var page: pageModule.Page = entry.resolvedPage;
     if (page.frame) {
         frame._removeView(page);
-        page.onNavigatedFrom(isBack);
+        // This could be undefined if activity is destroyed (e.g. without actual navigation).
+        if (entry.isNavigation) {
+            page.onNavigatedFrom(isBack);
+        }
         trace.write(`REMOVAL of ${page} completed`, trace.categories.Transition);
     }
     else {
@@ -317,6 +321,8 @@ function _completePageRemoval(fragment: any, isBack: boolean) {
             trace.write(`DETACHMENT of ${page} has already been done`, trace.categories.Transition);
         }
     }
+
+    entry.isNavigation = undefined;
 }
 
 function _addNativeTransitionListener(fragment: any, nativeTransition: any/*android.transition.Transition*/) {


### PR DESCRIPTION
navigatedFrom event was raised when Activity is destroyed without actual navigation.
This was breaking application suspend/resume when `Don't keep activities` is `on`.