### PR TITLE
add native script key in package.son files

### DIFF
--- a/application-settings/package.json
+++ b/application-settings/package.json
@@ -1,2 +1,5 @@
-{ "name" : "application-settings",
-  "main" : "application-settings.js" }
+{
+	"name" : "application-settings",
+  	"main" : "application-settings.js",
+	"nativescript": {}
+}

--- a/application/package.json
+++ b/application/package.json
@@ -1,2 +1,5 @@
-{ "name" : "application",
-  "main" : "application.js" }
+{
+	"name" : "application",
+	"main" : "application.js",
+	"nativescript": {}
+}

--- a/camera/package.json
+++ b/camera/package.json
@@ -1,2 +1,6 @@
-{ "name" : "camera",
-  "main" : "camera.js" }
+{ 
+	"name" : "camera",
+  	"main" : "camera.js",
+	"nativescript": {}
+}
+

--- a/color/package.json
+++ b/color/package.json
@@ -1,2 +1,6 @@
-{ "name" : "color",
-  "main" : "color.js" }
+{ 
+	"name" : "color",
+  	"main" : "color.js",
+	"nativescript": {}
+}
+

--- a/connectivity/package.json
+++ b/connectivity/package.json
@@ -1,2 +1,5 @@
-{ "name" : "connectivity",
-  "main" : "connectivity.js" }
+{
+	"name" : "connectivity",
+	"main" : "connectivity.js",
+	"nativescript": {}
+}

--- a/console/package.json
+++ b/console/package.json
@@ -1,2 +1,6 @@
-{ "name" : "console",
-  "main" : "console.js" }
+{
+	"name" : "console",
+  	"main" : "console.js",
+	"nativescript": {}
+}
+

--- a/css-value/package.json
+++ b/css-value/package.json
@@ -13,5 +13,6 @@
     "mocha": "~1.9.0",
     "should": "~1.2.2"
   },
-  "main": "index"
+  "main": "index",
+  "nativescript": {}
 }

--- a/css/package.json
+++ b/css/package.json
@@ -30,5 +30,6 @@
     "parser",
     "stringifier",
     "stylesheet"
-  ]
+  ],
+  "nativescript": {}
 }

--- a/data/package.json
+++ b/data/package.json
@@ -1,4 +1,3 @@
 {
-	"name" : "ui",
 	"nativescript": {}
 }

--- a/debugger/package.json
+++ b/debugger/package.json
@@ -1,2 +1,5 @@
-{ "name" : "debugger",
-  "main" : "debugger.js" }
+{
+	"name" : "debugger",
+  	"main" : "debugger.js",
+	"nativescript": {}
+}

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -1,2 +1,5 @@
-{ "name" : "fetch",
-  "main" : "fetch.js" }
+{ 
+	"name" : "fetch",
+  	"main" : "fetch.js",
+	"nativescript": {}
+}

--- a/file-system/package.json
+++ b/file-system/package.json
@@ -1,2 +1,5 @@
-{ "name" : "file-system",
-  "main" : "file-system.js" }
+{
+	"name" : "file-system",
+  	"main" : "file-system.js",
+	"nativescript": {}
+}

--- a/fps-meter/package.json
+++ b/fps-meter/package.json
@@ -1,2 +1,6 @@
-{ "name" : "fps-meter",
-  "main" : "fps-meter.js" }
+{
+	"name" : "fps-meter",
+  	"main" : "fps-meter.js",
+	"nativescript": {}
+}
+

--- a/globals/package.json
+++ b/globals/package.json
@@ -1,2 +1,6 @@
-{ "name" : "globals",
-  "main" : "globals.js" }
+{
+	"name" : "globals",
+  	"main" : "globals.js",
+	"nativescript": {}
+}
+

--- a/http/package.json
+++ b/http/package.json
@@ -1,2 +1,6 @@
-{ "name" : "http",
-  "main" : "http.js" }
+{
+	"name" : "http",
+  	"main" : "http.js",
+	"nativescript": {}
+}
+

--- a/image-source/package.json
+++ b/image-source/package.json
@@ -1,2 +1,6 @@
-{ "name" : "image-source",
-  "main" : "image-source.js" }
+{
+	"name" : "image-source",
+	"main" : "image-source.js",
+	"nativescript": {}
+}
+

--- a/location/package.json
+++ b/location/package.json
@@ -1,2 +1,6 @@
-{ "name" : "location",
-  "main" : "location.js" }
+{
+	"name" : "location",
+  	"main" : "location.js",
+	"nativescript": {}
+}
+

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,2 +1,5 @@
-{ "name" : "platform",
-  "main" : "platform.js" }
+{
+	"name" : "platform",
+  	"main" : "platform.js",
+	"nativescript": {}
+}

--- a/text/package.json
+++ b/text/package.json
@@ -1,2 +1,5 @@
-{ "name" : "text",
-  "main" : "text.js" }
+{
+	"name" : "text",
+  	"main" : "text.js",
+	"nativescript": {}
+}

--- a/timer/package.json
+++ b/timer/package.json
@@ -1,2 +1,5 @@
-{ "name" : "timer",
-  "main" : "timer.js" }
+{
+	"name" : "timer",
+  	"main" : "timer.js",
+	"nativescript": {}
+}

--- a/trace/package.json
+++ b/trace/package.json
@@ -1,2 +1,5 @@
-{ "name" : "trace",
-  "main" : "trace.js" }
+{ 
+	"name" : "trace",
+  	"main" : "trace.js",
+	"nativescript": {}
+}

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,4 +1,3 @@
 {
-	"name" : "ui",
 	"nativescript": {}
 }

--- a/xhr/package.json
+++ b/xhr/package.json
@@ -1,2 +1,5 @@
-{ "name" : "xhr",
-  "main" : "xhr.js" }
+{
+	"name" : "xhr",
+  	"main" : "xhr.js",
+	"nativescript": {}
+}

--- a/xml/package.json
+++ b/xml/package.json
@@ -1,2 +1,5 @@
-{ "name" : "xml",
-  "main" : "xml.js" }
+{
+	"name" : "xml",
+  	"main" : "xml.js",
+	"nativescript": {}
+}


### PR DESCRIPTION
https://github.com/NativeScript/android-runtime/issues/436 - more optimized build.

In order for a more optimized build, we need to make a difference between pure javascript modules and native script specific ones. We will make the difference when we read the `package.json` file of each plugin, including the native script modules. That's why we need to add a native script key inside each modules `package.json`.
Cli already has this logic for plugins and uses the "nativescript" key of the plugins `package.json`. This PR will simply follow the established practice.

ping: @enchev @vakrilov @hshristov @PanayotCankov 