### PR TITLE
Optional async mode for loading images from local files

### DIFF
--- a/apps/tests/ui/image/image-tests.ts
+++ b/apps/tests/ui/image/image-tests.ts
@@ -42,12 +42,7 @@ export var test_settingImageSource = function () {
 }
 */
 
-export var test_SettingImageSrc = function (done) {
-    // >> img-create-src
-    var image = new ImageModule.Image();
-    image.src = "https://www.google.com/images/errors/logo_sm_2.png";
-    // << img-create-src
-
+function runImageTest(done, image: ImageModule.Image, src: string) {
     image.src = null;
 
     var testModel = new ObservableModule.Observable();
@@ -61,10 +56,16 @@ export var test_SettingImageSrc = function (done) {
             TKUnit.assertTrue(!image.isLoading, "Image.isLoading should be false.");
             TKUnit.assertTrue(!testModel.get("imageIsLoading"), "imageIsLoading on viewModel should be false.");
             TKUnit.assertTrue(imageIsLoaded, "imageIsLoading should be true.");
-            done(null);
+            if (done) {
+                done(null);
+            }
         }
         catch (e) {
-            done(e);
+            if (done) {
+                done(e);
+            } else {
+                throw e;
+            }
         }
     };
 
@@ -74,53 +75,55 @@ export var test_SettingImageSrc = function (done) {
         twoWay: true
     }, testModel);
 
-    image.src = "https://www.google.com/images/errors/logo_sm_2.png";
+    image.src = src;
     testModel.on(ObservableModule.Observable.propertyChangeEvent, handler);
-    TKUnit.assertTrue(image.isLoading, "Image.isLoading should be true.");
-    TKUnit.assertTrue(testModel.get("imageIsLoading"), "model.isLoading should be true.");
+    if (done) {
+        TKUnit.assertTrue(image.isLoading, "Image.isLoading should be true.");
+        TKUnit.assertTrue(testModel.get("imageIsLoading"), "model.isLoading should be true.");
+    } else {
+        // Since it is synchronous check immediately.
+        handler(null);
+    }
 }
 
-export var test_SettingImageSrcToFileWithinApp = function (done) {
+export var test_SettingImageSrc = function (done) {
+    // >> img-create-src
+    var image = new ImageModule.Image();
+    image.src = "https://www.google.com/images/errors/logo_sm_2.png";
+    // << img-create-src
+    runImageTest(done, image, image.src)
+}
+
+export var test_SettingImageSrcToFileWithinApp = function () {
     // >> img-create-local
     var image = new ImageModule.Image();
     image.src = "~/logo.png";
     // << img-create-local
 
-    var testFunc = function (views: Array<ViewModule.View>) {
-        var testImage = <ImageModule.Image> views[0];
-        TKUnit.waitUntilReady(() => !testImage.isLoading, 3);
-        try {
-            TKUnit.assertTrue(!testImage.isLoading, "isLoading should be false.");
-            done(null);
-        }
-        catch (e) {
-            done(e);
-        }
-    }
-
-    helper.buildUIAndRunTest(image, testFunc);
+    runImageTest(null, image, image.src)
 }
 
-export var test_SettingImageSrcToDataURI = function (done) {
+export var test_SettingImageSrcToDataURI = function () {
     // >> img-create-datauri
     var image = new ImageModule.Image();
     image.src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAAACAAAAKAAAAAIAAAACAAAARiS4uJEAAAASSURBVBgZYvjPwABHSMz/DAAAAAD//0GWpK0AAAAOSURBVGNgYPiPhBgQAACEvQv1D5y/pAAAAABJRU5ErkJggg==";
     // << img-create-datauri
 
-    var testFunc = function (views: Array<ViewModule.View>) {
-        var testImage = <ImageModule.Image>views[0];
-        TKUnit.waitUntilReady(() => !testImage.isLoading, 3);
-        try {
-            TKUnit.assertTrue(!testImage.isLoading, "isLoading should be false.");
-            TKUnit.assertNotNull(testImage.imageSource);
-            done(null);
-        }
-        catch (e) {
-            done(e);
-        }
-    }
+    runImageTest(null, image, image.src)
+}
 
-    helper.buildUIAndRunTest(image, testFunc);
+export var test_SettingImageSrcToFileWithinAppAsync = function (done) {
+    var image = new ImageModule.Image();
+    image.loadMode = "async";
+    image.src = "~/logo.png";
+    runImageTest(done, image, image.src)
+}
+
+export var test_SettingImageSrcToDataURIAsync = function (done) {
+    var image = new ImageModule.Image();
+    image.loadMode = "async";
+    image.src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAAACAAAAKAAAAAIAAAACAAAARiS4uJEAAAASSURBVBgZYvjPwABHSMz/DAAAAAD//0GWpK0AAAAOSURBVGNgYPiPhBgQAACEvQv1D5y/pAAAAABJRU5ErkJggg==";
+    runImageTest(done, image, image.src)
 }
 
 export var test_SettingStretch_AspectFit = function () {

--- a/http/http-request.ios.ts
+++ b/http/http-request.ios.ts
@@ -98,27 +98,14 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
                                 },
                                 toImage: () => {
                                     ensureImageSource();
-                                    if (UIImage.imageWithData["async"]) {
-                                        return UIImage.imageWithData["async"](UIImage, [data])
-                                                      .then(image => {
-                                                          if (!image) {
-                                                              throw new Error("Response content may not be converted to an Image");
-                                                          }
-                                    
-                                                          var source = new imageSource.ImageSource();
-                                                          source.setNativeSource(image);
-                                                          return source;
-                                                      });
-                                    }
-   
-                                    return new Promise<any>((resolveImage, rejectImage) => {
-                                        var img = imageSource.fromData(data);
-                                        if (img instanceof imageSource.ImageSource) {
-                                            resolveImage(img);
-                                        } else {
-                                            rejectImage(new Error("Response content may not be converted to an Image"));
-                                        }
-
+                                    return new Promise((resolve, reject) => {
+                                        (<any>UIImage).tns_decodeImageWithDataCompletion(data, image => {
+                                            if (image) {
+                                                resolve(imageSource.fromNativeSource(image))
+                                            } else {
+                                                reject(new Error("Response content may not be converted to an Image"));
+                                            }
+                                        });
                                     });
                                 },
                                 toFile: (destinationFilePath?: string) => {

--- a/http/http.ts
+++ b/http/http.ts
@@ -33,12 +33,9 @@ export function getJSON<T>(arg: any): Promise<T> {
 }
 
 export function getImage(arg: any): Promise<image.ImageSource> {
-    return new Promise<image.ImageSource>((resolve, reject) => {
-        httpRequest.request(typeof arg === "string" ? { url: arg, method: "GET" } : arg)
-            .then(r => {
-            r.content.toImage().then(source => resolve(source), e => reject(e));
-        }, e => reject(e));
-    });
+    return httpRequest
+        .request(typeof arg === "string" ? { url: arg, method: "GET" } : arg)
+        .then(responce => responce.content.toImage());
 }
 
 export function getFile(arg: any, destinationFilePath?: string): Promise<any> {

--- a/image-source/image-source.android.ts
+++ b/image-source/image-source.android.ts
@@ -44,12 +44,18 @@ export class ImageSource implements definition.ImageSource {
                 // Load BitmapDrawable with getDrawable to make use of Android internal caching
                 var bitmapDrawable = <android.graphics.drawable.BitmapDrawable>res.getDrawable(identifier);
                 if (bitmapDrawable && bitmapDrawable.getBitmap) {
-                    this.android  = bitmapDrawable.getBitmap();
+                    this.android = bitmapDrawable.getBitmap();
                 }
             }
         }
 
         return this.android != null;
+    }
+
+    public fromResource(name: string): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+            resolve(this.loadFromResource(name));
+        });
     }
 
     public loadFromFile(path: string): boolean {
@@ -64,9 +70,21 @@ export class ImageSource implements definition.ImageSource {
         return this.android != null;
     }
 
+    public fromFile(path: string): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+            resolve(this.loadFromFile(path));
+        });
+    }
+
     public loadFromData(data: any): boolean {
         this.android = android.graphics.BitmapFactory.decodeStream(data);
         return this.android != null;
+    }
+
+    public fromData(data: any): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+            resolve(this.loadFromData(data));
+        });
     }
 
     public loadFromBase64(source: string): boolean {
@@ -75,6 +93,12 @@ export class ImageSource implements definition.ImageSource {
             this.android = android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.length)
         }
         return this.android != null;
+    }
+
+    public fromBase64(data: any): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+            resolve(this.loadFromBase64(data));
+        });
     }
 
     public setNativeSource(source: any): boolean {

--- a/image-source/image-source.d.ts
+++ b/image-source/image-source.d.ts
@@ -34,22 +34,46 @@ declare module "image-source" {
         loadFromResource(name: string): boolean;
 
        /**
+        * Loads this instance from the specified resource name asynchronously.
+        * @param name The name of the resource (without its extension).
+        */
+        fromResource(name: string): Promise<boolean>;
+        
+       /**
         * Loads this instance from the specified file.
         * @param path The location of the file on the file system.
         */
         loadFromFile(path: string): boolean;
 
        /**
+        * Loads this instance from the specified file asynchronously.
+        * @param path The location of the file on the file system.
+        */
+        fromFile(path: string): Promise<boolean>;
+
+       /**
         * Loads this instance from the specified native image data.
         * @param data The native data (byte array) to load the image from. This will be either Stream for Android or NSData for iOS.
         */
         loadFromData(data: any): boolean;
+        
+       /**
+        * Loads this instance from the specified native image data asynchronously.
+        * @param data The native data (byte array) to load the image from. This will be either Stream for Android or NSData for iOS.
+        */
+        fromData(data: any): Promise<boolean>;        
 
         /**
          * Loads this instance from the specified native image data.
          * @param source The Base64 string to load the image from.
          */
         loadFromBase64(source: string): boolean;
+        
+        /**
+         * Loads this instance from the specified native image data asynchronously.
+         * @param source The Base64 string to load the image from.
+         */
+        fromBase64(source: string): Promise<boolean>;        
 
        /**
         * Sets the provided native source object (typically a Bitmap).

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
-    "tns-core-modules-widgets": "2.0.0"
+    "tns-core-modules-widgets": "next"
   },
   "nativescript": {
     "platforms": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "declaration": false,
         "noImplicitAny": false,
         "noImplicitUseStrict": true,
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "diagnostics": false
     },
     "filesGlob": [
         "**/*.ts",
@@ -695,8 +696,8 @@
         "ui/transition/transition.android.ts",
         "ui/transition/transition.d.ts",
         "ui/transition/transition.ios.ts",
-    "ui/transition/fade-transition.d.ts",
-    "ui/transition/slide-transition.d.ts",
+        "ui/transition/fade-transition.d.ts",
+        "ui/transition/slide-transition.d.ts",
         "ui/utils.d.ts",
         "ui/utils.ios.ts",
         "ui/web-view/web-view-common.ts",

--- a/ui/image/image.d.ts
+++ b/ui/image/image.d.ts
@@ -44,5 +44,12 @@ declare module "ui/image" {
          * Gets or sets the image stretch mode.
          */
         stretch: string;
+        
+        /**
+         * Gets or sets the loading strategy for images on the local file system:
+         * - **sync** *(default)* - blocks the UI if necessary to display immediately, good for small icons.
+         * - **async** - will try to load in the background, may appear with short delay, good for large images.
+         */
+        loadMode: "sync" | "async";
     }
 }


### PR DESCRIPTION
Implements a `loadMode="async"` setting for `Image` that will use async loading for images on the local file system.

Requires the following PR in widgets: https://github.com/NativeScript/android-widgets/pull/22/files