### PR TITLE
changed getX and getY to getRawX and getRawY for CustomPanGestureDetector 

### DIFF
--- a/ui/gestures/gestures.android.ts
+++ b/ui/gestures/gestures.android.ts
@@ -110,7 +110,7 @@ export class GesturesObserver extends common.GesturesObserver {
                 this._eventData = new TouchGestureEventData();
             }
 
-            this._eventData.prepare(this.target, motionEvent);          
+            this._eventData.prepare(this.target, motionEvent);
             _executeCallback(this, this._eventData);
         }
 
@@ -489,9 +489,9 @@ class CustomPanGestureDetector {
     private getMotionEventCenter(event: android.view.MotionEvent): { x: number, y: number } {
         let count = event.getPointerCount();
         let res = { x: 0, y: 0 };
-        for (var i = 0; i < count; i++) {
-            res.x += event.getX(i);
-            res.y += event.getY(i);
+        for (let i = 0; i < count; i++) {
+            res.x += event.getRawX();
+            res.y += event.getRawY();
         }
 
         res.x /= (count * this.density);


### PR DESCRIPTION
Relates to issue https://github.com/NativeScript/NativeScript/issues/2113

getRawX & Y always return the X & Y coordinates relative to the view
getX and getY sometimes return coordinates that are relative to the
previous motion. this update will allow smoother coordinates on panning
instead of occasional  jumping back and fourth of the delta X and Y
coordinates