### PR TITLE
Add compiler that won't typecheck .d.ts-es

### DIFF
--- a/build/tsc-dev.js
+++ b/build/tsc-dev.js
@@ -1,0 +1,35 @@
+"use strict";
+var ts = require("typescript");
+var fs = require("fs");
+function compile(fileNames, options) {
+    var program = ts.createProgram(fileNames, options);
+    var sourceFiles = program.getSourceFiles().filter(function (f) { return f.fileName.lastIndexOf(".d.ts") !== f.fileName.length - 5; });
+    // sourceFiles.forEach(sf => console.log(" - " + sf.fileName));
+    var emitResults = [];
+    var allDiagnostics = [];
+    sourceFiles.forEach(function (srcFile) { return emitResults.push(program.emit(srcFile)); });
+    sourceFiles.forEach(function (srcFile) { return allDiagnostics = allDiagnostics.concat(ts.getPreEmitDiagnostics(program, srcFile)); });
+    emitResults.forEach(function (er) { return allDiagnostics = allDiagnostics.concat(er.diagnostics); });
+    allDiagnostics.forEach(function (diagnostic) {
+        var d = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        var line = d.line;
+        var character = d.character;
+        var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+        var code = diagnostic.code;
+        console.log(diagnostic.file.fileName + "(" + (line + 1) + "," + (character + 1) + "): TS" + code + ": " + message);
+    });
+    var exitCode = emitResults.some(function (er) { return er.emitSkipped; }) ? 1 : 0;
+    console.log("Process exiting with code " + exitCode + ".");
+    process.exit(exitCode);
+}
+var files = JSON.parse(fs.readFileSync("./tsconfig.json")).files;
+compile(files, {
+    noEmitOnError: true,
+    noEmitHelpers: true,
+    target: ts.ScriptTarget.ES5,
+    module: ts.ModuleKind.CommonJS,
+    declaration: false,
+    noImplicitAny: false,
+    noImplicitUseStrict: true,
+    experimentalDecorators: true
+});

--- a/build/tsc-dev.ts
+++ b/build/tsc-dev.ts
@@ -1,0 +1,45 @@
+import * as ts from "typescript";
+declare var process, require;
+var fs = require("fs");
+
+function compile(fileNames: string[], options: ts.CompilerOptions) {
+    var program = ts.createProgram(fileNames, options);
+    
+    var sourceFiles = program.getSourceFiles().filter(f => f.fileName.lastIndexOf(".d.ts") !== f.fileName.length - 5);
+    // sourceFiles.forEach(sf => console.log(" - " + sf.fileName));
+    
+    var emitResults = [];
+    var allDiagnostics = [];
+    
+    sourceFiles.forEach(srcFile => emitResults.push(program.emit(srcFile)));
+    sourceFiles.forEach(srcFile => allDiagnostics = allDiagnostics.concat(ts.getPreEmitDiagnostics(program, srcFile)));
+    emitResults.forEach(er => allDiagnostics = allDiagnostics.concat(er.diagnostics));
+
+    allDiagnostics.forEach(diagnostic => {
+        var d = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        var line = d.line;
+        var character = d.character;
+        var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+        var code = diagnostic.code;
+        console.log(diagnostic.file.fileName + "(" + (line + 1) + "," + (character + 1) + "): TS" + code + ": " + message);
+    });
+
+    var exitCode = emitResults.some(er => er.emitSkipped) ? 1 : 0;
+
+    console.log("Process exiting with code " + exitCode + ".");
+    process.exit(exitCode);
+}
+
+var files = JSON.parse(fs.readFileSync("./tsconfig.json")).files;
+compile(files,
+{
+    noEmitOnError: true,
+    noEmitHelpers: true,
+    target: ts.ScriptTarget.ES5,
+    module: ts.ModuleKind.CommonJS,
+    declaration: false,
+    noImplicitAny: false,
+    noImplicitUseStrict: true,
+    experimentalDecorators: true
+});
+


### PR DESCRIPTION
The following script emits and typechecks the `.ts` files but skips type checking for `.d.ts`-es. These are the time differences with regular tsc:
```
mcsofcankov:NativeScript cankov$ time node build/tsc-dev.js
Process exiting with code 0.

real	0m14.991s
user	0m15.791s
sys	0m0.834s

mcsofcankov:NativeScript cankov$ time tsc

real	0m27.993s
user	0m29.276s
sys	0m1.204s
```