### PR TITLE
Export single CSS property resolution API.

### DIFF
--- a/.ctags_exclude
+++ b/.ctags_exclude
@@ -1,2 +1,5 @@
 node_modules
+android17.d.ts
+ios.d.ts
+*.js
 bin

--- a/ui/styling/style-property.d.ts
+++ b/ui/styling/style-property.d.ts
@@ -2,6 +2,9 @@
     import definition = require("ui/styling");
     import observable = require("ui/core/dependency-observable");
 
+    export type StyleProperty = Property;
+    export type ResolvedStylePropertyHandler = (property: Property | string, value: any) => void;
+    export function withStyleProperty(name: string, value: any, resolvedCallback: ResolvedStylePropertyHandler): void;
     export function getShorthandPairs(name: string, value: any): Array<KeyValuePair<Property, any>>;
 
     export function registerShorthandCallback(name: string, callback: (value: any) => Array<KeyValuePair<Property, any>>): void;

--- a/ui/styling/style-property.ts
+++ b/ui/styling/style-property.ts
@@ -20,6 +20,30 @@ function registerProperty(property: Property) {
     }
 }
 
+export type StyleProperty = definition.Property;
+export type ResolvedStylePropertyHandler = (property: definition.Property | string, value: any) => void;
+export function withStyleProperty(name: string, value: any, resolvedCallback: ResolvedStylePropertyHandler): void {
+    let property = getPropertyByCssName(name);
+
+    if (property) {
+        // The property.valueConverter is now used to convert the value later on in DependencyObservable._setValueInternal.
+        resolvedCallback(property, value);
+    }
+    else {
+        let pairs = getShorthandPairs(name, value);
+        if (pairs) {
+            for (let j = 0; j < pairs.length; j++) {
+                let pair = pairs[j];
+                resolvedCallback(pair.property, pair.value);
+            }
+        } else {
+            //Fall back to the string property name as a last resort and let
+            //the callback handle it further.
+            resolvedCallback(name, value);
+        }
+    }
+}
+
 export function getShorthandPairs(name: string, value: any): Array<definition.KeyValuePair<definition.Property, any>> {
     var callback = callbackByShorthandName.get(name);
     if (callback) {


### PR DESCRIPTION
Extract single style property resolution to an exported API.

Used by CSS selectors, and now the Angular `setElementStyle` renderer API.