### PR TITLE
Add a flag when logging to skip string template calculations in release

### DIFF
--- a/apps/perf-tests/ComplexObjectGraphMemoryTest/mainPage.ts
+++ b/apps/perf-tests/ComplexObjectGraphMemoryTest/mainPage.ts
@@ -8,7 +8,9 @@ import fps = require("fps-meter");
 
 export function createPage() {
     fps.addCallback(function (fps, minFps) {
-        trace.write("fps=" + fps + " minFps=" + minFps, trace.categories.Test, trace.messageType.info);
+        if (trace.enabled) {
+            trace.write("fps=" + fps + " minFps=" + minFps, trace.categories.Test, trace.messageType.info);
+        }
     });
     fps.start();
 
@@ -27,7 +29,9 @@ export function createPage() {
     var button;
     var childStackLayout;
     var childStackLayoutCount = count / buttonsPerRow;
-    trace.write("Creating " + count + " buttons.", trace.categories.Test, trace.messageType.info);
+    if (trace.enabled) {
+        trace.write("Creating " + count + " buttons.", trace.categories.Test, trace.messageType.info);
+    }
     console.time("creatingButtons");
     for (var i = 0; i < childStackLayoutCount; i++) {
         childStackLayout = new stackLayoutModule.StackLayout();
@@ -36,7 +40,9 @@ export function createPage() {
         for (var j = 0; j < buttonsPerRow; j++) {
             button = new buttonModule.Button();
             button.on(buttonModule.Button.tapEvent, function (data) {
-                trace.write("eventName=" + data.eventName + " object=" + data.object, trace.categories.Test, trace.messageType.info);
+                if (trace.enabled) {
+                    trace.write("eventName=" + data.eventName + " object=" + data.object, trace.categories.Test, trace.messageType.info);
+                }
             });
             button.text = "" + i + j;
             childStackLayout.addChild(button);
@@ -44,7 +50,9 @@ export function createPage() {
     }
     console.timeEnd("creatingButtons");
     var message = "Created " + count + " buttons";
-    trace.write(message, trace.categories.Test, trace.messageType.info);
+    if (trace.enabled) {
+        trace.write(message, trace.categories.Test, trace.messageType.info);
+    }
     label.text = message;
 
     var page = new pagesModule.Page();

--- a/apps/perf-tests/LargeObjectArrayMemoryTest/mainPage.ts
+++ b/apps/perf-tests/LargeObjectArrayMemoryTest/mainPage.ts
@@ -11,14 +11,21 @@ export function createPage() {
     var label = new labelModule.Label();
     page.content = label;
     
-    trace.write("Creating " + count + " objects.", trace.categories.Test, trace.messageType.info);
+    if (trace.enabled) {
+        trace.write("Creating " + count + " objects.", trace.categories.Test, trace.messageType.info);
+    }
+    
     console.time("creatingObjects");
     for (var i = 0; i < count; i++) {
         people[i] = new common.Person("John Doe", 33, 1234.56);
     }
     console.timeEnd("creatingObjects");
     var message = "Created " + people.length + " objects";
-    trace.write(message, trace.categories.Test, trace.messageType.info);
+    
+    if (trace.enabled) {
+        trace.write(message, trace.categories.Test, trace.messageType.info);
+    }
+    
     label.text = message;
     return page;
 }

--- a/apps/perf-tests/SpeedTests/tests.ts
+++ b/apps/perf-tests/SpeedTests/tests.ts
@@ -12,7 +12,10 @@ export function compareNativeDates(count: number): string {
     var elapsedTime = Math.round(new Date().getMilliseconds() - startTime);
     var averageTime = (elapsedTime / count);
     var message = "Total: " + elapsedTime + " ms. Avg: " + averageTime + " ms.";
-    trace.write(message, trace.categories.Test, trace.messageType.info);
+    
+    if (trace.enabled) {
+        trace.write(message, trace.categories.Test, trace.messageType.info);
+    }
     return message;
 }
 
@@ -25,7 +28,9 @@ export function compareJavaScriptDates(count: number): string {
     var elapsedTime = Math.round(new Date().getMilliseconds() - startTime);
     var averageTime = (elapsedTime / count);
     var message = "Total: " + elapsedTime + " ms. Avg: " + averageTime + " ms.";
-    trace.write(message, trace.categories.Test, trace.messageType.info);
+    if (trace.enabled) {
+        trace.write(message, trace.categories.Test, trace.messageType.info);
+    }
     return message;
 }
 
@@ -46,7 +51,9 @@ export function decodeAndEncodeBitmap(count: number, finishedCallback: (message)
         var elapsedTime = Math.round(new Date().getMilliseconds() - startTime);
         var averageTime = (elapsedTime / count);
         var message = "Total: " + elapsedTime + " ms. Avg: " + averageTime + " ms.";
-        trace.write(message, trace.categories.Test, trace.messageType.info);
+        if (trace.enabled) {
+            trace.write(message, trace.categories.Test, trace.messageType.info);
+        }
         return finishedCallback(message);
     }, function (error) {
             console.log(error.message);

--- a/apps/perf-tests/controls-page.ts
+++ b/apps/perf-tests/controls-page.ts
@@ -40,7 +40,9 @@ export class ControlsPage extends pagesModule.Page implements definition.Control
     }
 
     public onNavigatedTo() {
-        trace.write("Creating " + this._count + " controls...", trace.categories.Test, trace.messageType.info);
+        if (trace.enabled) {
+            trace.write("Creating " + this._count + " controls...", trace.categories.Test, trace.messageType.info);
+        }
         this._infoLabel.text = "Creating " + this._count + " controls...";
         var startTime = new Date().getMilliseconds();
         for (var i = 0; i < this._childStackLayoutCount; i++) {
@@ -55,7 +57,9 @@ export class ControlsPage extends pagesModule.Page implements definition.Control
         }
         var elapsedTime = Math.round(new Date().getMilliseconds() - startTime);
         var message = "Created " + this._count + " controls in " + elapsedTime + " ms.";
-        trace.write(message, trace.categories.Test, trace.messageType.info);
+        if (trace.enabled) {
+            trace.write(message, trace.categories.Test, trace.messageType.info);
+        }
         this._infoLabel.text = message;
     }
 }

--- a/apps/tests/TKUnit.ts
+++ b/apps/tests/TKUnit.ts
@@ -41,7 +41,9 @@ export function time(): number {
 
 export var write = function write(message: string, type?: number) {
     //console.log(message);
-    trace.write(message, trace.categories.Test, type);
+    if (trace.enabled) {
+        trace.write(message, trace.categories.Test, type);
+    }
 }
 
 var runTest = function (testInfo: TestInfoEntry) {

--- a/apps/tests/navigation/transition-tests.ts
+++ b/apps/tests/navigation/transition-tests.ts
@@ -9,7 +9,9 @@ import {AnimationCurve} from "ui/enums"
 
 function _testTransition(navigationTransition: NavigationTransition) {
     var testId = `Transition[${JSON.stringify(navigationTransition)}]`;
-    trace.write(`Testing ${testId}`, trace.categories.Test);
+    if (trace.enabled) {
+        trace.write(`Testing ${testId}`, trace.categories.Test);
+    }
     var navigationEntry: NavigationEntry = {
         create: function (): Page {
             let page = new Page();

--- a/apps/tests/trace-tests.ts
+++ b/apps/tests/trace-tests.ts
@@ -29,6 +29,8 @@ export var test_DummyTestForSnippetOnly2 = function () {
     // >> trace-message
     trace.setCategories(trace.categories.Debug);
     trace.enable();
-    trace.write("My Debug Message", trace.categories.Debug);
+    if (trace.enabled) {
+        trace.write("My Debug Message", trace.categories.Debug);
+    }
     // << trace-message
 }

--- a/file-system/file-name-resolver.ts
+++ b/file-system/file-name-resolver.ts
@@ -138,7 +138,9 @@ export class FileNameResolver implements definition.FileNameResolver {
         var candidates = this.getFileCandidatesFromFolder(path, ext);
         result = findFileMatch(path, ext, candidates, this._context);
 
-        trace.write("Resolved file name for \"" + path + ext + "\" result: " + (result ? result : "no match found"), trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write("Resolved file name for \"" + path + ext + "\" result: " + (result ? result : "no match found"), trace.categories.Navigation);
+        }
         return result;
     }
 
@@ -160,7 +162,9 @@ export class FileNameResolver implements definition.FileNameResolver {
             });
         }
         else {
-            trace.write("Could not find folder " + folderPath + " when loading " + path + ext, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write("Could not find folder " + folderPath + " when loading " + path + ext, trace.categories.Navigation);
+            }
         }
 
         return candidates;
@@ -171,7 +175,9 @@ export function findFileMatch(path: string, ext: string, candidates: Array<strin
     var bestValue = -1
     var result: string = null;
 
-    trace.write("Candidates for " + path + ext + ": " + candidates.join(", "), trace.categories.Navigation);
+    if (trace.enabled) {
+        trace.write("Candidates for " + path + ext + ": " + candidates.join(", "), trace.categories.Navigation);
+    }
     for (var i = 0; i < candidates.length; i++) {
         var filePath = candidates[i];
         var qualifiersStr: string = filePath.substr(path.length, filePath.length - path.length - ext.length);

--- a/trace/trace.d.ts
+++ b/trace/trace.d.ts
@@ -11,6 +11,13 @@ declare module "trace" {
      * Disables the trace module.
      */
     export function disable(): void;
+    
+    /**
+     * A field that indicates if the tracer is enabled and there is a point in writing messages.
+     * Check this to avoid writing complex string templates.
+     * Send error messages should even if tracing is disabled.
+     */
+    export var enabled: boolean;
 
     /**
      * Adds a TraceWriter instance to the trace module.

--- a/trace/trace.ts
+++ b/trace/trace.ts
@@ -1,17 +1,17 @@
 ﻿import definition = require("trace");
 import * as types from "utils/types";
 
-var _enabled = false;
+export var enabled = false;
 var _categories = {};
 var _writers: Array<definition.TraceWriter> = [];
 var _eventListeners: Array<definition.EventListener> = [];
 
 export function enable() {
-    _enabled = true;
+    enabled = true;
 }
 
 export function disable() {
-    _enabled = false;
+    enabled = false;
 }
 
 export function isCategorySet(category: string): boolean {
@@ -56,7 +56,7 @@ export function write(message: any, category: string, type?: number) {
         }
     }
     
-    if (!_enabled) {
+    if (!enabled) {
         return;
     }
 
@@ -71,7 +71,7 @@ export function write(message: any, category: string, type?: number) {
 }
 
 export function notifyEvent(object: Object, name: string, data?: any) {
-    if (!_enabled) {
+    if (!enabled) {
         return;
     }
 

--- a/ui/animation/animation-common.ts
+++ b/ui/animation/animation-common.ts
@@ -114,7 +114,9 @@ export class Animation implements definition.Animation {
 
         ensureTrace();
 
-        trace.write("Analyzing " + animationDefinitions.length + " animation definitions...", trace.categories.Animation);
+        if (trace.enabled) {
+            trace.write("Analyzing " + animationDefinitions.length + " animation definitions...", trace.categories.Animation);
+        }
         this._propertyAnimations = new Array<PropertyAnimation>();
         var i = 0;
         var length = animationDefinitions.length;
@@ -126,7 +128,9 @@ export class Animation implements definition.Animation {
         if (this._propertyAnimations.length === 0) {
             throw new Error("Nothing to animate.");
         }
-        trace.write("Created " + this._propertyAnimations.length + " individual property animations.", trace.categories.Animation);
+        if (trace.enabled) {
+            trace.write("Created " + this._propertyAnimations.length + " individual property animations.", trace.categories.Animation);
+        }
 
         this._playSequentially = playSequentially;
     }

--- a/ui/animation/animation.android.ts
+++ b/ui/animation/animation.android.ts
@@ -72,7 +72,9 @@ export class Animation extends common.Animation implements definition.Animation 
             }
         }
 
-        trace.write("Starting " + this._nativeAnimatorsArray.length + " animations " + (this._playSequentially ? "sequentially." : "together."), trace.categories.Animation);
+        if (trace.enabled) {
+            trace.write("Starting " + this._nativeAnimatorsArray.length + " animations " + (this._playSequentially ? "sequentially." : "together."), trace.categories.Animation);
+        }
         this._animatorSet.setupStartValues();
         this._animatorSet.start();
         return animationFinishedPromise;
@@ -80,7 +82,9 @@ export class Animation extends common.Animation implements definition.Animation 
 
     public cancel(): void {
         super.cancel();
-        trace.write("Cancelling AnimatorSet.", trace.categories.Animation);
+        if (trace.enabled) {
+            trace.write("Cancelling AnimatorSet.", trace.categories.Animation);
+        }
         this._animatorSet.cancel();
     }
 
@@ -94,17 +98,25 @@ export class Animation extends common.Animation implements definition.Animation 
         let that = this;
         this._animatorListener = new android.animation.Animator.AnimatorListener({
             onAnimationStart: function (animator: android.animation.Animator): void {
-                trace.write("MainAnimatorListener.onAndroidAnimationStart(" + animator +")", trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("MainAnimatorListener.onAndroidAnimationStart(" + animator +")", trace.categories.Animation);
+                }
             },
             onAnimationRepeat: function (animator: android.animation.Animator): void {
-                trace.write("MainAnimatorListener.onAnimationRepeat(" + animator + ")", trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("MainAnimatorListener.onAnimationRepeat(" + animator + ")", trace.categories.Animation);
+                }
             },
             onAnimationEnd: function (animator: android.animation.Animator): void {
-                trace.write("MainAnimatorListener.onAnimationEnd(" + animator + ")", trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("MainAnimatorListener.onAnimationEnd(" + animator + ")", trace.categories.Animation);
+                }
                 that._onAndroidAnimationEnd();
             },
             onAnimationCancel: function (animator: android.animation.Animator): void {
-                trace.write("MainAnimatorListener.onAnimationCancel(" + animator + ")", trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("MainAnimatorListener.onAnimationCancel(" + animator + ")", trace.categories.Animation);
+                }
                 that._onAndroidAnimationCancel();
             }
         });
@@ -139,7 +151,9 @@ export class Animation extends common.Animation implements definition.Animation 
             return;
         }
 
-        trace.write("Creating ObjectAnimator(s) for animation: " + common.Animation._getAnimationInfo(propertyAnimation) + "...", trace.categories.Animation);
+        if (trace.enabled) {
+            trace.write("Creating ObjectAnimator(s) for animation: " + common.Animation._getAnimationInfo(propertyAnimation) + "...", trace.categories.Animation);
+        }
 
         if (types.isNullOrUndefined(propertyAnimation.target)) {
             throw new Error("Animation target cannot be null or undefined!");
@@ -347,7 +361,10 @@ export class Animation extends common.Animation implements definition.Animation 
             if (propertyAnimation.curve !== undefined) {
                 animators[i].setInterpolator(propertyAnimation.curve);
             }
-            trace.write("Animator created: " + animators[i], trace.categories.Animation);
+            
+            if (trace.enabled) {
+                trace.write("Animator created: " + animators[i], trace.categories.Animation);
+            }
         }
 
         this._animators = this._animators.concat(animators);
@@ -368,24 +385,36 @@ let bounce = lazy(() => new android.view.animation.BounceInterpolator());
 export function _resolveAnimationCurve(curve: any): any {
     switch (curve) {
         case enums.AnimationCurve.easeIn:
-            trace.write("Animation curve resolved to android.view.animation.AccelerateInterpolator(1).", trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Animation curve resolved to android.view.animation.AccelerateInterpolator(1).", trace.categories.Animation);
+            }
             return easeIn();
         case enums.AnimationCurve.easeOut:
-            trace.write("Animation curve resolved to android.view.animation.DecelerateInterpolator(1).", trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Animation curve resolved to android.view.animation.DecelerateInterpolator(1).", trace.categories.Animation);
+            }
             return easeOut();
         case enums.AnimationCurve.easeInOut:
-            trace.write("Animation curve resolved to android.view.animation.AccelerateDecelerateInterpolator().", trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Animation curve resolved to android.view.animation.AccelerateDecelerateInterpolator().", trace.categories.Animation);
+            }
             return easeInOut();
         case enums.AnimationCurve.linear:
-            trace.write("Animation curve resolved to android.view.animation.LinearInterpolator().", trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Animation curve resolved to android.view.animation.LinearInterpolator().", trace.categories.Animation);
+            }
             return linear();
         case enums.AnimationCurve.spring:
-            trace.write("Animation curve resolved to android.view.animation.BounceInterpolator().", trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Animation curve resolved to android.view.animation.BounceInterpolator().", trace.categories.Animation);
+            }
             return bounce();
         case enums.AnimationCurve.ease:
             return (<any>android).support.v4.view.animation.PathInterpolatorCompat.create(0.25, 0.1, 0.25, 1.0);
         default:
-            trace.write("Animation curve resolved to original: " + curve, trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Animation curve resolved to original: " + curve, trace.categories.Animation);
+            }
             if (curve instanceof common.CubicBezierAnimationCurve) {
                 let animationCurve = <common.CubicBezierAnimationCurve>curve;
                 let interpolator = (<any>android).support.v4.view.animation.PathInterpolatorCompat.create(animationCurve.x1, animationCurve.y1, animationCurve.x2, animationCurve.y2);

--- a/ui/animation/animation.ios.ts
+++ b/ui/animation/animation.ios.ts
@@ -142,9 +142,13 @@ export class Animation extends common.Animation implements definition.Animation 
         }
 
         if (!playSequentially) {
-            trace.write("Non-merged Property Animations: " + this._propertyAnimations.length, trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Non-merged Property Animations: " + this._propertyAnimations.length, trace.categories.Animation);
+            }
             this._mergedPropertyAnimations = Animation._mergeAffineTransformAnimations(this._propertyAnimations);
-            trace.write("Merged Property Animations: " + this._mergedPropertyAnimations.length, trace.categories.Animation);
+            if (trace.enabled) {
+                trace.write("Merged Property Animations: " + this._mergedPropertyAnimations.length, trace.categories.Animation);
+            }
         }
         else {
             this._mergedPropertyAnimations = this._propertyAnimations;
@@ -171,11 +175,15 @@ export class Animation extends common.Animation implements definition.Animation 
                 }
 
                 if (that._cancelledAnimations > 0 && (that._cancelledAnimations + that._finishedAnimations) === that._mergedPropertyAnimations.length) {
-                    trace.write(that._cancelledAnimations + " animations cancelled.", trace.categories.Animation);
+                    if (trace.enabled) {
+                        trace.write(that._cancelledAnimations + " animations cancelled.", trace.categories.Animation);
+                    }
                     that._rejectAnimationFinishedPromise();
                 }
                 else if (that._finishedAnimations === that._mergedPropertyAnimations.length) {
-                    trace.write(that._finishedAnimations + " animations finished.", trace.categories.Animation);
+                    if (trace.enabled) {
+                        trace.write(that._finishedAnimations + " animations finished.", trace.categories.Animation);
+                    }
                     that._resolveAnimationFinishedPromise();
                 }
             }
@@ -188,7 +196,9 @@ export class Animation extends common.Animation implements definition.Animation 
         return (cancelled?: boolean) => {
 
             if (cancelled && finishedCallback) {
-                trace.write("Animation " + (index - 1).toString() + " was cancelled. Will skip the rest of animations and call finishedCallback(true).", trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("Animation " + (index - 1).toString() + " was cancelled. Will skip the rest of animations and call finishedCallback(true).", trace.categories.Animation);
+                }
                 finishedCallback(cancelled);
                 return;
             }
@@ -526,16 +536,22 @@ export class Animation extends common.Animation implements definition.Animation 
                     iterations: propertyAnimations[i].iterations,
                     curve: propertyAnimations[i].curve
                 };
-                trace.write("Curve: " + propertyAnimations[i].curve, trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("Curve: " + propertyAnimations[i].curve, trace.categories.Animation);
+                }
                 newTransformAnimation.value[propertyAnimations[i].property] = propertyAnimations[i].value;
-                trace.write("Created new transform animation: " + common.Animation._getAnimationInfo(newTransformAnimation), trace.categories.Animation);
+                if (trace.enabled) {
+                    trace.write("Created new transform animation: " + common.Animation._getAnimationInfo(newTransformAnimation), trace.categories.Animation);
+                }
 
                 // Merge all compatible affine transform animations to the right into this new animation.
                 j = i + 1;
                 if (j < length) {
                     for (; j < length; j++) {
                         if (Animation._canBeMerged(propertyAnimations[i], propertyAnimations[j])) {
-                            trace.write("Merging animations: " + common.Animation._getAnimationInfo(newTransformAnimation) + " + " + common.Animation._getAnimationInfo(propertyAnimations[j]) + ";", trace.categories.Animation);
+                            if (trace.enabled) {
+                                trace.write("Merging animations: " + common.Animation._getAnimationInfo(newTransformAnimation) + " + " + common.Animation._getAnimationInfo(propertyAnimations[j]) + ";", trace.categories.Animation);
+                            }
                             newTransformAnimation.value[propertyAnimations[j].property] = propertyAnimations[j].value;
                             // Mark that it has been merged so we can skip it on our outer loop.
                             propertyAnimations[j][_skip] = true;

--- a/ui/core/bindable.ts
+++ b/ui/core/bindable.ts
@@ -86,7 +86,9 @@ export class Bindable extends DependencyObservable implements definition.Bindabl
     }
 
     public _onPropertyChanged(property: Property, oldValue: any, newValue: any) {
-        trace.write(`${this}._onPropertyChanged(${property.name}, ${oldValue}, ${newValue})`, trace.categories.Binding);
+        if (trace.enabled) {
+            trace.write(`${this}._onPropertyChanged(${property.name}, ${oldValue}, ${newValue})`, trace.categories.Binding);
+        }
         super._onPropertyChanged(property, oldValue, newValue);
         if (this instanceof viewModule.View) {
             if (property.metadata.inheritable && (<viewModule.View>(<any>this))._isInheritedChange() === true) {
@@ -97,11 +99,15 @@ export class Bindable extends DependencyObservable implements definition.Bindabl
         let binding = this.bindings.get(property.name);
         if (binding && !binding.updating) {
             if (binding.options.twoWay) {
-                trace.write(`${this}._updateTwoWayBinding(${property.name}, ${newValue});` + property.name, trace.categories.Binding);
+                if (trace.enabled) {
+                    trace.write(`${this}._updateTwoWayBinding(${property.name}, ${newValue});` + property.name, trace.categories.Binding);
+                }
                 this._updateTwoWayBinding(property.name, newValue);
             }
             else {
-                trace.write(`${this}.unbind(${property.name});`, trace.categories.Binding);
+                if (trace.enabled) {
+                    trace.write(`${this}.unbind(${property.name});`, trace.categories.Binding);
+                }
                 this.unbind(property.name);
             }
         }
@@ -110,7 +116,9 @@ export class Bindable extends DependencyObservable implements definition.Bindabl
     public _onBindingContextChanged(oldValue: any, newValue: any) {
         this.bindings.forEach((binding, index, bindings) => {
             if (!binding.updating && binding.sourceIsBindingContext) {
-                trace.write(`Binding ${binding.target.get()}.${binding.options.targetProperty} to new context ${newValue}`, trace.categories.Binding);
+                if (trace.enabled) {
+                    trace.write(`Binding ${binding.target.get()}.${binding.options.targetProperty} to new context ${newValue}`, trace.categories.Binding);
+                }
                 binding.bind(newValue);
             }
         });

--- a/ui/core/view-common.ts
+++ b/ui/core/view-common.ts
@@ -646,7 +646,9 @@ export class View extends ProxyObject implements definition.View {
     public setMeasuredDimension(measuredWidth: number, measuredHeight: number): void {
         this._measuredWidth = measuredWidth;
         this._measuredHeight = measuredHeight;
-        trace.write(this + " :setMeasuredDimension: " + measuredWidth + ", " + measuredHeight, trace.categories.Layout);
+        if (trace.enabled) {
+            trace.write(this + " :setMeasuredDimension: " + measuredWidth + ", " + measuredHeight, trace.categories.Layout);
+        }
     }
 
     public requestLayout(): void {
@@ -768,7 +770,9 @@ export class View extends ProxyObject implements definition.View {
         childLeft = Math.round(childLeft);
         childTop = Math.round(childTop);
 
-        trace.write(child.parent + " :layoutChild: " + child + " " + childLeft + ", " + childTop + ", " + childRight + ", " + childBottom, trace.categories.Layout);
+        if (trace.enabled) {
+            trace.write(child.parent + " :layoutChild: " + child + " " + childLeft + ", " + childTop + ", " + childRight + ", " + childBottom, trace.categories.Layout);
+        }
         child.layout(childLeft, childTop, childRight, childBottom);
     }
 
@@ -787,7 +791,9 @@ export class View extends ProxyObject implements definition.View {
             var childWidthMeasureSpec = View.getMeasureSpec(child, width, widthMode, true);
             var childHeightMeasureSpec = View.getMeasureSpec(child, height, heightMode, false);
 
-            trace.write(child.parent + " :measureChild: " + child + " " + utils.layout.measureSpecToString(childWidthMeasureSpec) + ", " + utils.layout.measureSpecToString(childHeightMeasureSpec), trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write(child.parent + " :measureChild: " + child + " " + utils.layout.measureSpecToString(childWidthMeasureSpec) + ", " + utils.layout.measureSpecToString(childHeightMeasureSpec), trace.categories.Layout);
+            }
 
             child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
             measureWidth = child.getMeasuredWidth();
@@ -974,7 +980,9 @@ export class View extends ProxyObject implements definition.View {
         this._addViewCore(view, atIndex);
         view._parentChanged(null);
 
-        trace.write("called _addView on view " + this._domId + " for a child " + view._domId, trace.categories.ViewHierarchy);
+        if (trace.enabled) {
+            trace.write("called _addView on view " + this._domId + " for a child " + view._domId, trace.categories.ViewHierarchy);
+        }
     }
 
     /**
@@ -1028,7 +1036,9 @@ export class View extends ProxyObject implements definition.View {
         view._parent = undefined;
         view._parentChanged(this);
 
-        trace.write("called _removeView on view " + this._domId + " for a child " + view._domId, trace.categories.ViewHierarchy);
+        if (trace.enabled) {
+            trace.write("called _removeView on view " + this._domId + " for a child " + view._domId, trace.categories.ViewHierarchy);
+        }
     }
 
     /**
@@ -1089,7 +1099,9 @@ export class View extends ProxyObject implements definition.View {
     }
 
     public _goToVisualState(state: string) {
-        trace.write(this + " going to state: " + state, trace.categories.Style);
+        if (trace.enabled) {
+            trace.write(this + " going to state: " + state, trace.categories.Style);
+        }
         if (state === this._visualState || this._requestedVisualState === state) {
             return;
         }

--- a/ui/core/view.android.ts
+++ b/ui/core/view.android.ts
@@ -187,8 +187,10 @@ export class View extends viewCommon.View {
         if (!context) {
             throw new Error("Expected valid android.content.Context instance.");
         }
-
-        trace.write("calling _onAttached on view " + this._domId, trace.categories.VisualTreeEvents);
+        
+        if (trace.enabled) {
+            trace.write("calling _onAttached on view " + this._domId, trace.categories.VisualTreeEvents);
+        }
 
         if (this._context === context) {
             return;
@@ -234,7 +236,9 @@ export class View extends viewCommon.View {
             this._eachChildView(eachChild);
         }
 
-        trace.write("calling _onDetached on view " + this._domId, trace.categories.VisualTreeEvents);
+        if (trace.enabled) {
+            trace.write("calling _onDetached on view " + this._domId, trace.categories.VisualTreeEvents);
+        }
 
         this._clearAndroidReference();
 
@@ -260,7 +264,9 @@ export class View extends viewCommon.View {
     }
 
     public _onContextChanged() {
-        trace.write("calling _onContextChanged on view " + this._domId, trace.categories.VisualTreeEvents);
+        if (trace.enabled) {
+            trace.write("calling _onContextChanged on view " + this._domId, trace.categories.VisualTreeEvents);
+        }
 
         this._createUI();
         // Ensure layout params

--- a/ui/core/view.ios.ts
+++ b/ui/core/view.ios.ts
@@ -187,7 +187,9 @@ export class View extends viewCommon.View {
 
     public _setNativeViewFrame(nativeView: any, frame: any) {
         if (!CGRectEqualToRect(nativeView.frame, frame)) {
-            trace.write(this + ", Native setFrame: = " + NSStringFromCGRect(frame), trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write(this + ", Native setFrame: = " + NSStringFromCGRect(frame), trace.categories.Layout);
+            }
             this._cachedFrame = frame;
             if (this._hasTransfrom) {
                 // Always set identity transform before setting frame;
@@ -215,7 +217,9 @@ export class View extends viewCommon.View {
         // in iOS 8 we set frame to subview again otherwise we get clipped.
         var nativeView: UIView;
         if (!this.parent && this._nativeView.subviews.count > 0 && utils.ios.MajorVersion < 8) {
-            trace.write(this + " has no parent. Setting frame to first child instead.", trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write(this + " has no parent. Setting frame to first child instead.", trace.categories.Layout);
+            }
             nativeView = (<UIView>this._nativeView.subviews[0]);
         }
         else {

--- a/ui/frame/frame-common.ts
+++ b/ui/frame/frame-common.ts
@@ -71,12 +71,16 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): Page {
 
         var moduleExports;
         if (global.moduleExists(entry.moduleName)) {
-            trace.write("Loading pre-registered JS module: " + entry.moduleName, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write("Loading pre-registered JS module: " + entry.moduleName, trace.categories.Navigation);
+            }
             moduleExports = global.loadModule(entry.moduleName);
         } else {
             var moduleExportsResolvedPath = resolveFileName(moduleNamePath, "js");
             if (moduleExportsResolvedPath) {
-                trace.write("Loading JS file: " + moduleExportsResolvedPath, trace.categories.Navigation);
+                if (trace.enabled) {
+                    trace.write("Loading JS file: " + moduleExportsResolvedPath, trace.categories.Navigation);
+                }
 
                 // Exclude extension when doing require.
                 moduleExportsResolvedPath = moduleExportsResolvedPath.substr(0, moduleExportsResolvedPath.length - 3)
@@ -85,7 +89,9 @@ export function resolvePageFromEntry(entry: definition.NavigationEntry): Page {
         }
 
         if (moduleExports && moduleExports.createPage) {
-            trace.write("Calling createPage()", trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write("Calling createPage()", trace.categories.Navigation);
+            }
             page = moduleExports.createPage();
         }
         else {
@@ -113,7 +119,9 @@ function pageFromBuilder(moduleNamePath: string, moduleExports: any): Page {
     // Possible XML file path.
     var fileName = resolveFileName(moduleNamePath, "xml");
     if (fileName) {
-        trace.write("Loading XML file: " + fileName, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write("Loading XML file: " + fileName, trace.categories.Navigation);
+        }
 
         ensureBuilder();
 
@@ -163,7 +171,9 @@ export class Frame extends CustomLayoutView implements definition.Frame {
      * @param to The backstack entry to navigate back to.
      */
     public goBack(backstackEntry?: definition.BackstackEntry) {
-        trace.write(`GO BACK`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`GO BACK`, trace.categories.Navigation);
+        }
         if (!this.canGoBack()) {
             // TODO: Do we need to throw an error?
             return;
@@ -190,12 +200,16 @@ export class Frame extends CustomLayoutView implements definition.Frame {
             this._processNavigationContext(navigationContext);
         }
         else {
-            trace.write(`Going back scheduled`, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write(`Going back scheduled`, trace.categories.Navigation);
+            }
         }
     }
 
     public navigate(param: any) {
-        trace.write(`NAVIGATE`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`NAVIGATE`, trace.categories.Navigation);
+        }
 
         var entry = buildEntryFromArgs(param);
         var page = resolvePageFromEntry(entry);
@@ -219,7 +233,9 @@ export class Frame extends CustomLayoutView implements definition.Frame {
             this._processNavigationContext(navigationContext);
         }
         else {
-            trace.write(`Navigation scheduled`, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write(`Navigation scheduled`, trace.categories.Navigation);
+            }
         }
     }
 

--- a/ui/frame/frame.android.ts
+++ b/ui/frame/frame.android.ts
@@ -25,9 +25,13 @@ var navDepth = -1;
 var activityInitialized = false;
 
 function onFragmentShown(fragment: FragmentClass) {
-    trace.write(`SHOWN ${fragment.getTag()}`, trace.categories.NativeLifecycle);
+    if (trace.enabled) {
+        trace.write(`SHOWN ${fragment.getTag()}`, trace.categories.NativeLifecycle);
+    }
     if (fragment[CLEARING_HISTORY]) {
-        trace.write(`${fragment.getTag()} has been shown, but we are currently clearing history. Returning.`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${fragment.getTag()} has been shown, but we are currently clearing history. Returning.`, trace.categories.NativeLifecycle);
+        }
         return null;
     }
 
@@ -62,10 +66,14 @@ function onFragmentShown(fragment: FragmentClass) {
 }
 
 function onFragmentHidden(fragment: FragmentClass, destroyed: boolean) {
-    trace.write(`HIDDEN ${fragment.getTag()}`, trace.categories.NativeLifecycle);
+    if (trace.enabled) {
+        trace.write(`HIDDEN ${fragment.getTag()}`, trace.categories.NativeLifecycle);
+    }
 
     if (fragment[CLEARING_HISTORY]) {
-        trace.write(`${fragment.getTag()} has been hidden, but we are currently clearing history. Clearing any existing transitions.`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${fragment.getTag()} has been hidden, but we are currently clearing history. Clearing any existing transitions.`, trace.categories.NativeLifecycle);
+        }
         transitionModule._clearBackwardTransitions(fragment);
         transitionModule._clearForwardTransitions(fragment);
     }
@@ -118,7 +126,9 @@ export class Frame extends frameCommon.Frame {
     }
 
     public _navigateCore(backstackEntry: definition.BackstackEntry) {
-        trace.write(`${this}._navigateCore(page: ${backstackEntry.resolvedPage}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`${this}._navigateCore(page: ${backstackEntry.resolvedPage}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        }
 
         let activity = this._android.activity;
         if (!activity) {
@@ -149,7 +159,9 @@ export class Frame extends frameCommon.Frame {
             let fragment: android.app.Fragment;
             while (i >= 0) {
                 fragment = manager.findFragmentByTag(manager.getBackStackEntryAt(i--).getName());
-                trace.write(`${fragment.getTag()}[CLEARING_HISTORY] = true;`, trace.categories.NativeLifecycle);
+                if (trace.enabled) {
+                    trace.write(`${fragment.getTag()}[CLEARING_HISTORY] = true;`, trace.categories.NativeLifecycle);
+                }
                 fragment[CLEARING_HISTORY] = true;
             }
 
@@ -158,13 +170,17 @@ export class Frame extends frameCommon.Frame {
                 fragment = manager.findFragmentByTag(this.currentPage[TAG]);
                 if (fragment) {
                     fragment[CLEARING_HISTORY] = true;
-                    trace.write(`${fragment.getTag()}[CLEARING_HISTORY] = true;`, trace.categories.NativeLifecycle);
+                    if (trace.enabled) {
+                        trace.write(`${fragment.getTag()}[CLEARING_HISTORY] = true;`, trace.categories.NativeLifecycle);
+                    }
                 }
             }
 
             if (backStackEntryCount) {
                 let firstEntryName = manager.getBackStackEntryAt(0).getName();
-                trace.write(`manager.popBackStack(${firstEntryName}, android.app.FragmentManager.POP_BACK_STACK_INCLUSIVE);`, trace.categories.NativeLifecycle);
+                if (trace.enabled) {
+                    trace.write(`manager.popBackStack(${firstEntryName}, android.app.FragmentManager.POP_BACK_STACK_INCLUSIVE);`, trace.categories.NativeLifecycle);
+                }
                 manager.popBackStack(firstEntryName, android.app.FragmentManager.POP_BACK_STACK_INCLUSIVE);
             }
             this._currentEntry = null;
@@ -214,24 +230,34 @@ export class Frame extends frameCommon.Frame {
 
         if (isFirstNavigation) {
             fragmentTransaction.add(this.containerViewId, newFragment, newFragmentTag);
-            trace.write(`fragmentTransaction.add(${newFragmentTag});`, trace.categories.NativeLifecycle);
+            if (trace.enabled) {
+                trace.write(`fragmentTransaction.add(${newFragmentTag});`, trace.categories.NativeLifecycle);
+            }
         }
         else {
             if (this.android.cachePagesOnNavigate && !backstackEntry.entry.clearHistory) {
                 if (currentFragment) {
                     fragmentTransaction.hide(currentFragment);
-                    trace.write(`fragmentTransaction.hide(${currentFragmentTag});`, trace.categories.NativeLifecycle);
+                    if (trace.enabled) {
+                        trace.write(`fragmentTransaction.hide(${currentFragmentTag});`, trace.categories.NativeLifecycle);
+                    }
                 }
                 else {
-                    trace.write(`Could not find ${currentFragmentTag} to hide.`, trace.categories.NativeLifecycle);
+                    if (trace.enabled) {
+                        trace.write(`Could not find ${currentFragmentTag} to hide.`, trace.categories.NativeLifecycle);
+                    }
                 }
 
                 fragmentTransaction.add(this.containerViewId, newFragment, newFragmentTag);
-                trace.write(`fragmentTransaction.add(${newFragmentTag});`, trace.categories.NativeLifecycle);
+                if (trace.enabled) {
+                    trace.write(`fragmentTransaction.add(${newFragmentTag});`, trace.categories.NativeLifecycle);
+                }
             }
             else {
                 fragmentTransaction.replace(this.containerViewId, newFragment, newFragmentTag);
-                trace.write(`fragmentTransaction.replace(${newFragmentTag});`, trace.categories.NativeLifecycle);
+                if (trace.enabled) {
+                    trace.write(`fragmentTransaction.replace(${newFragmentTag});`, trace.categories.NativeLifecycle);
+                }
             }
 
             // Add to backStack if needed.
@@ -239,7 +265,9 @@ export class Frame extends frameCommon.Frame {
                 // We add each entry in the backstack to avoid the "Stack corrupted" mismatch
                 let backstackTag = this._currentEntry[BACKSTACK_TAG];
                 fragmentTransaction.addToBackStack(backstackTag);
-                trace.write(`fragmentTransaction.addToBackStack(${backstackTag});`, trace.categories.NativeLifecycle);
+                if (trace.enabled) {
+                    trace.write(`fragmentTransaction.addToBackStack(${backstackTag});`, trace.categories.NativeLifecycle);
+                }
             }
         }
 
@@ -259,7 +287,9 @@ export class Frame extends frameCommon.Frame {
         }
 
         fragmentTransaction.commit();
-        trace.write(`fragmentTransaction.commit();`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`fragmentTransaction.commit();`, trace.categories.NativeLifecycle);
+        }
     }
 
     public _goBackCore(backstackEntry: definition.BackstackEntry) {
@@ -272,7 +302,9 @@ export class Frame extends frameCommon.Frame {
             this._currentEntry.isNavigation = true;
         }
 
-        trace.write(`${this}._goBackCore(pageId: ${backstackEntry.resolvedPage.id}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`${this}._goBackCore(pageId: ${backstackEntry.resolvedPage.id}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        }
 
         var manager = this._android.activity.getFragmentManager();
         if (manager.getBackStackEntryCount() > 0) {
@@ -360,24 +392,32 @@ export class Frame extends frameCommon.Frame {
                     let weakActivityInstance = weakActivity.get();
                     let isCurrent = args.activity === weakActivityInstance;
                     if (!weakActivityInstance) {
-                        trace.write(`Frame _processNavigationContext: Drop For Activity GC-ed`, trace.categories.Navigation);
+                        if (trace.enabled) {
+                            trace.write(`Frame _processNavigationContext: Drop For Activity GC-ed`, trace.categories.Navigation);
+                        }
                         unsubscribe();
                         return
                     }
                     if (isCurrent) {
-                        trace.write(`Frame _processNavigationContext: Activity.Resumed, Continue`, trace.categories.Navigation);
+                        if (trace.enabled) {
+                            trace.write(`Frame _processNavigationContext: Activity.Resumed, Continue`, trace.categories.Navigation);
+                        }
                         super._processNavigationContext(navigationContext);
                         unsubscribe();
                     }
                 }
                 let unsubscribe = () => {
-                    trace.write(`Frame _processNavigationContext: Unsubscribe from Activity.Resumed`, trace.categories.Navigation);
+                    if (trace.enabled) {
+                        trace.write(`Frame _processNavigationContext: Unsubscribe from Activity.Resumed`, trace.categories.Navigation);
+                    }
                     application.android.off(application.AndroidApplication.activityResumedEvent, resume);
                     application.android.off(application.AndroidApplication.activityStoppedEvent, unsubscribe);
                     application.android.off(application.AndroidApplication.activityDestroyedEvent, unsubscribe);
                 }
 
-                trace.write(`Frame._processNavigationContext: Subscribe for Activity.Resumed`, trace.categories.Navigation);
+                if (trace.enabled) {
+                    trace.write(`Frame._processNavigationContext: Subscribe for Activity.Resumed`, trace.categories.Navigation);
+                }
                 application.android.on(application.AndroidApplication.activityResumedEvent, resume);
                 application.android.on(application.AndroidApplication.activityStoppedEvent, unsubscribe);
                 application.android.on(application.AndroidApplication.activityDestroyedEvent, unsubscribe);
@@ -508,16 +548,22 @@ function findPageForFragment(fragment: android.app.Fragment, frame: Frame) {
     var page: pages.Page;
     var entry: definition.BackstackEntry;
 
-    trace.write(`Finding page for ${fragmentTag}.`, trace.categories.NativeLifecycle);
+    if (trace.enabled) {
+        trace.write(`Finding page for ${fragmentTag}.`, trace.categories.NativeLifecycle);
+    }
     if (fragmentTag === (<any>pages).DIALOG_FRAGMENT_TAG) {
-        trace.write(`No need to find page for dialog fragment.`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`No need to find page for dialog fragment.`, trace.categories.NativeLifecycle);
+        }
         return;
     }
 
     if (frame.currentPage && frame.currentPage[TAG] === fragmentTag) {
         page = frame.currentPage;
         entry = frame._currentEntry;
-        trace.write(`Current page matches fragment ${fragmentTag}.`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`Current page matches fragment ${fragmentTag}.`, trace.categories.NativeLifecycle);
+        }
     }
     else {
         var backStack = frame.backStack;
@@ -529,7 +575,9 @@ function findPageForFragment(fragment: android.app.Fragment, frame: Frame) {
         }
         if (entry) {
             page = entry.resolvedPage;
-            trace.write(`Found ${page} for ${fragmentTag}`, trace.categories.NativeLifecycle);
+            if (trace.enabled) {
+                trace.write(`Found ${page} for ${fragmentTag}`, trace.categories.NativeLifecycle);
+            }
         }
     }
 
@@ -584,7 +632,9 @@ class FragmentClass extends android.app.Fragment {
     }
 
     public onHiddenChanged(hidden: boolean): void {
-        trace.write(`${this.getTag()}.onHiddenChanged(${hidden})`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onHiddenChanged(${hidden})`, trace.categories.NativeLifecycle);
+        }
         super.onHiddenChanged(hidden);
         if (hidden) {
             onFragmentHidden(this, false);
@@ -600,12 +650,16 @@ class FragmentClass extends android.app.Fragment {
             animator = super.onCreateAnimator(transit, enter, nextAnim);
         }
 
-        trace.write(`${this.getTag()}.onCreateAnimator(${transit}, ${enter}, ${nextAnim}): ${animator}`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onCreateAnimator(${transit}, ${enter}, ${nextAnim}): ${animator}`, trace.categories.NativeLifecycle);
+        }
         return animator;
     }
 
     public onCreate(savedInstanceState: android.os.Bundle): void {
-        trace.write(`${this.getTag()}.onCreate(${savedInstanceState})`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onCreate(${savedInstanceState})`, trace.categories.NativeLifecycle);
+        }
         super.onCreate(savedInstanceState);
         super.setHasOptionsMenu(true);
 
@@ -626,7 +680,9 @@ class FragmentClass extends android.app.Fragment {
     }
 
     public onCreateView(inflater: android.view.LayoutInflater, container: android.view.ViewGroup, savedInstanceState: android.os.Bundle): android.view.View {
-        trace.write(`${this.getTag()}.onCreateView(inflater, container, ${savedInstanceState})`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onCreateView(inflater, container, ${savedInstanceState})`, trace.categories.NativeLifecycle);
+        }
         var entry = this.entry;
         var page = entry.resolvedPage;
         if (savedInstanceState && savedInstanceState.getBoolean(HIDDEN, false)) {
@@ -641,7 +697,9 @@ class FragmentClass extends android.app.Fragment {
     }
 
     public onSaveInstanceState(outState: android.os.Bundle): void {
-        trace.write(`${this.getTag()}.onSaveInstanceState(${outState})`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onSaveInstanceState(${outState})`, trace.categories.NativeLifecycle);
+        }
         super.onSaveInstanceState(outState);
         if (this.isHidden()) {
             outState.putBoolean(HIDDEN, true);
@@ -649,14 +707,18 @@ class FragmentClass extends android.app.Fragment {
     }
 
     public onDestroyView(): void {
-        trace.write(`${this.getTag()}.onDestroyView()`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onDestroyView()`, trace.categories.NativeLifecycle);
+        }
         super.onDestroyView();
         // Detaching the page has been move in onFragmentHidden due to transitions.
         onFragmentHidden(this, true);
     }
 
     public onDestroy(): void {
-        trace.write(`${this.getTag()}.onDestroy()`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`${this.getTag()}.onDestroy()`, trace.categories.NativeLifecycle);
+        }
         super.onDestroy();
         this.entry[FRAGMENT] = undefined;
     }
@@ -672,7 +734,9 @@ class NativeScriptActivity extends android.app.Activity {
     }
 
     protected onCreate(savedInstanceState: android.os.Bundle): void {
-        trace.write(`NativeScriptActivity.onCreate(${savedInstanceState})`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`NativeScriptActivity.onCreate(${savedInstanceState})`, trace.categories.NativeLifecycle);
+        }
 
         let app = application.android;
         let intent = this.getIntent();
@@ -752,7 +816,9 @@ class NativeScriptActivity extends android.app.Activity {
 
     protected onStart(): void {
         super.onStart();
-        trace.write("NativeScriptActivity.onStart();", trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write("NativeScriptActivity.onStart();", trace.categories.NativeLifecycle);
+        }
         let rootView = this.rootView
         if (rootView && !rootView.isLoaded) {
             rootView.onLoaded();
@@ -761,7 +827,9 @@ class NativeScriptActivity extends android.app.Activity {
 
     protected onStop(): void {
         super.onStop();
-        trace.write("NativeScriptActivity.onStop();", trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write("NativeScriptActivity.onStop();", trace.categories.NativeLifecycle);
+        }
         let rootView = this.rootView
         if (rootView && rootView.isLoaded) {
             rootView.onUnloaded();
@@ -775,11 +843,15 @@ class NativeScriptActivity extends android.app.Activity {
         }
 
         super.onDestroy();
-        trace.write("NativeScriptActivity.onDestroy();", trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write("NativeScriptActivity.onDestroy();", trace.categories.NativeLifecycle);
+        }
     }
 
     public onBackPressed(): void {
-        trace.write("NativeScriptActivity.onBackPressed;", trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write("NativeScriptActivity.onBackPressed;", trace.categories.NativeLifecycle);
+        }
 
         var args = <application.AndroidActivityBackPressedEventData>{
             eventName: "activityBackPressed",
@@ -799,7 +871,9 @@ class NativeScriptActivity extends android.app.Activity {
     }
 
     public onRequestPermissionsResult (requestCode: number, permissions: Array<String>, grantResults: Array<number>): void {
-        trace.write("NativeScriptActivity.onRequestPermissionsResult;", trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write("NativeScriptActivity.onRequestPermissionsResult;", trace.categories.NativeLifecycle);
+        }
 
         application.android.notify(<application.AndroidActivityRequestPermissionsEventData>{
             eventName: "activityRequestPermissions",
@@ -813,7 +887,9 @@ class NativeScriptActivity extends android.app.Activity {
 
     protected onActivityResult(requestCode: number, resultCode: number, data: android.content.Intent): void {
         super.onActivityResult(requestCode, resultCode, data);
-        trace.write(`NativeScriptActivity.onActivityResult(${requestCode}, ${resultCode}, ${data})`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`NativeScriptActivity.onActivityResult(${requestCode}, ${resultCode}, ${data})`, trace.categories.NativeLifecycle);
+        }
 
         var result = application.android.onActivityResult;
         if (result) {

--- a/ui/frame/frame.ios.ts
+++ b/ui/frame/frame.ios.ts
@@ -70,7 +70,9 @@ export class Frame extends frameCommon.Frame {
     }
 
     public _navigateCore(backstackEntry: definition.BackstackEntry) {
-        trace.write(`${this}._navigateCore(page: ${backstackEntry.resolvedPage}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`${this}._navigateCore(page: ${backstackEntry.resolvedPage}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        }
         let viewController: UIViewController = backstackEntry.resolvedPage.ios;
         if (!viewController) {
             throw new Error("Required page does not have a viewController created.");
@@ -109,7 +111,9 @@ export class Frame extends frameCommon.Frame {
         // First navigation.
         if (!this._currentEntry) {
             this._ios.controller.pushViewControllerAnimated(viewController, animated);
-            trace.write(`${this}.pushViewControllerAnimated(${viewController}, ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write(`${this}.pushViewControllerAnimated(${viewController}, ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            }
             return;
         }
 
@@ -119,7 +123,9 @@ export class Frame extends frameCommon.Frame {
             var newControllers = NSMutableArray.alloc().initWithCapacity(1);
             newControllers.addObject(viewController);
             this._ios.controller.setViewControllersAnimated(newControllers, animated);
-            trace.write(`${this}.setViewControllersAnimated([${viewController}], ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write(`${this}.setViewControllersAnimated([${viewController}], ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            }
             return;
 
         }
@@ -141,25 +147,33 @@ export class Frame extends frameCommon.Frame {
 
             // replace the controllers instead of pushing directly
             this._ios.controller.setViewControllersAnimated(newControllers, animated);
-            trace.write(`${this}.setViewControllersAnimated([originalControllers - lastController + ${viewController}], ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write(`${this}.setViewControllersAnimated([originalControllers - lastController + ${viewController}], ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            }
             return;
         }
 
         // General case.
         this._ios.controller.pushViewControllerAnimated(viewController, animated);
-        trace.write(`${this}.pushViewControllerAnimated(${viewController}, ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`${this}.pushViewControllerAnimated(${viewController}, ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+        }
     }
 
     public _goBackCore(backstackEntry: definition.BackstackEntry) {
         navDepth = backstackEntry[NAV_DEPTH];
-        trace.write(`${this}._goBackCore(page: ${backstackEntry.resolvedPage}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(`${this}._goBackCore(page: ${backstackEntry.resolvedPage}, backstackVisible: ${this._isEntryBackstackVisible(backstackEntry)}, clearHistory: ${backstackEntry.entry.clearHistory}), navDepth: ${navDepth}`, trace.categories.Navigation);
+        }
 
         if (!this._shouldSkipNativePop) {
             var controller = backstackEntry.resolvedPage.ios;
             var animated = this._currentEntry ? this._getIsAnimatedNavigation(this._currentEntry.entry) : false;
 
             this._updateActionBar(backstackEntry.resolvedPage);
-            trace.write(`${this}.popToViewControllerAnimated(${controller}, ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            if (trace.enabled) {
+                trace.write(`${this}.popToViewControllerAnimated(${controller}, ${animated}); depth = ${navDepth}`, trace.categories.Navigation);
+            }
             this._ios.controller.popToViewControllerAnimated(controller, animated);
         }
     }
@@ -327,7 +341,10 @@ export class Frame extends frameCommon.Frame {
             return;
         }
 
-        trace.write(`Forcing navigationBar.frame.origin.y to ${statusBarHeight} due to a higher in-call status-bar`, trace.categories.Layout);
+        if (trace.enabled) {
+            trace.write(`Forcing navigationBar.frame.origin.y to ${statusBarHeight} due to a higher in-call status-bar`, trace.categories.Layout);
+        }
+        
         this._ios.controller.navigationBar.autoresizingMask = UIViewAutoresizing.UIViewAutoresizingNone;
         this._ios.controller.navigationBar.removeConstraints((<any>this)._ios.controller.navigationBar.constraints);
         this._ios.controller.navigationBar.frame = CGRectMake(
@@ -352,15 +369,21 @@ class TransitionDelegate extends NSObject {
     }
 
     public animationWillStart(animationID: string, context: any): void {
-        trace.write(`START ${this._id}`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`START ${this._id}`, trace.categories.Transition);
+        }
     }
 
     public animationDidStop(animationID: string, finished: boolean, context: any): void {
         if (finished) {
-            trace.write(`END ${this._id}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`END ${this._id}`, trace.categories.Transition);
+            }
         }
         else {
-            trace.write(`CANCEL ${this._id}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`CANCEL ${this._id}`, trace.categories.Transition);
+            }
         }
 
         var index = transitionDelegates.indexOf(this);
@@ -405,7 +428,10 @@ class UINavigationControllerAnimatedDelegate extends NSObject implements UINavig
             return null;
         }
 
-        trace.write(`UINavigationControllerImpl.navigationControllerAnimationControllerForOperationFromViewControllerToViewController(${operation}, ${fromVC}, ${toVC}), transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`UINavigationControllerImpl.navigationControllerAnimationControllerForOperationFromViewControllerToViewController(${operation}, ${fromVC}, ${toVC}), transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        }
+        
         if (!transitionModule) {
             transitionModule = require("ui/transition");
         }
@@ -440,7 +466,10 @@ class UINavigationControllerImpl extends UINavigationController {
     public viewDidLayoutSubviews(): void {
         let owner = this._owner.get();
         if (owner) {
-            trace.write(this._owner + " viewDidLayoutSubviews, isLoaded = " + owner.isLoaded, trace.categories.ViewHierarchy);
+            if (trace.enabled) {
+                trace.write(this._owner + " viewDidLayoutSubviews, isLoaded = " + owner.isLoaded, trace.categories.ViewHierarchy);
+            }
+            
             owner._updateLayout();
         }
     }
@@ -475,7 +504,9 @@ class UINavigationControllerImpl extends UINavigationController {
 
     public pushViewControllerAnimated(viewController: UIViewController, animated: boolean): void {
         let navigationTransition = <definition.NavigationTransition>viewController[TRANSITION];
-        trace.write(`UINavigationControllerImpl.pushViewControllerAnimated(${viewController}, ${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`UINavigationControllerImpl.pushViewControllerAnimated(${viewController}, ${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        }
 
         let nativeTransition = _getNativeTransition(navigationTransition, true);
         if (!animated || !navigationTransition || !nativeTransition) {
@@ -491,7 +522,9 @@ class UINavigationControllerImpl extends UINavigationController {
     public setViewControllersAnimated(viewControllers: NSArray, animated: boolean): void {
         var viewController = viewControllers.lastObject;
         var navigationTransition = <definition.NavigationTransition>viewController[TRANSITION];
-        trace.write(`UINavigationControllerImpl.setViewControllersAnimated(${viewControllers}, ${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`UINavigationControllerImpl.setViewControllersAnimated(${viewControllers}, ${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        }
 
         let nativeTransition = _getNativeTransition(navigationTransition, true);
         if (!animated || !navigationTransition || !nativeTransition) {
@@ -507,7 +540,9 @@ class UINavigationControllerImpl extends UINavigationController {
     public popViewControllerAnimated(animated: boolean): UIViewController {
         var lastViewController = this.viewControllers.lastObject;
         var navigationTransition = <definition.NavigationTransition>lastViewController[TRANSITION];
-        trace.write(`UINavigationControllerImpl.popViewControllerAnimated(${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`UINavigationControllerImpl.popViewControllerAnimated(${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        }
 
         if (navigationTransition && navigationTransition.name === "non-animated") {
             //https://github.com/NativeScript/NativeScript/issues/1787
@@ -529,7 +564,9 @@ class UINavigationControllerImpl extends UINavigationController {
     public popToViewControllerAnimated(viewController: UIViewController, animated: boolean): NSArray {
         let lastViewController = this.viewControllers.lastObject;
         let navigationTransition = <definition.NavigationTransition>lastViewController[TRANSITION];
-        trace.write(`UINavigationControllerImpl.popToViewControllerAnimated(${viewController}, ${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        if (trace.enabled) {
+            trace.write(`UINavigationControllerImpl.popToViewControllerAnimated(${viewController}, ${animated}); transition: ${JSON.stringify(navigationTransition)}`, trace.categories.NativeLifecycle);
+        }
 
         if (navigationTransition && navigationTransition.name === "non-animated") {
             //https://github.com/NativeScript/NativeScript/issues/1787
@@ -585,19 +622,29 @@ export function _getNativeCurve(transition: definition.NavigationTransition): UI
     if (transition.curve) {
         switch (transition.curve) {
             case AnimationCurve.easeIn:
-                trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveEaseIn.", trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveEaseIn.", trace.categories.Transition);
+                }
                 return UIViewAnimationCurve.UIViewAnimationCurveEaseIn;
             case AnimationCurve.easeOut:
-                trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveEaseOut.", trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveEaseOut.", trace.categories.Transition);
+                }
                 return UIViewAnimationCurve.UIViewAnimationCurveEaseOut;
             case AnimationCurve.easeInOut:
-                trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveEaseInOut.", trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveEaseInOut.", trace.categories.Transition);
+                }
                 return UIViewAnimationCurve.UIViewAnimationCurveEaseInOut;
             case AnimationCurve.linear:
-                trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveLinear.", trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write("Transition curve resolved to UIViewAnimationCurve.UIViewAnimationCurveLinear.", trace.categories.Transition);
+                }
                 return UIViewAnimationCurve.UIViewAnimationCurveLinear;
             default:
-                trace.write("Transition curve resolved to original: " + transition.curve, trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write("Transition curve resolved to original: " + transition.curve, trace.categories.Transition);
+                }
                 return transition.curve;
         }
     }

--- a/ui/gestures/gestures.android.ts
+++ b/ui/gestures/gestures.android.ts
@@ -29,11 +29,15 @@ export class GesturesObserver extends common.GesturesObserver {
         if (this.target) {
             this.type = type;
             this._onTargetLoaded = args => {
-                trace.write(this.target + ".target loaded. android:" + this.target._nativeView, "gestures");
+                if (trace.enabled) {
+                    trace.write(this.target + ".target loaded. android:" + this.target._nativeView, "gestures");
+                }
                 this._attach(this.target, type);
             };
             this._onTargetUnloaded = args => {
-                trace.write(this.target + ".target unloaded. android:" + this.target._nativeView, "gestures");
+                if (trace.enabled) {
+                    trace.write(this.target + ".target unloaded. android:" + this.target._nativeView, "gestures");
+                }
                 this._detach();
             };
 
@@ -61,7 +65,9 @@ export class GesturesObserver extends common.GesturesObserver {
     }
 
     private _detach() {
-        trace.write(this.target + "._detach() android:" + this.target._nativeView, "gestures");
+        if (trace.enabled) {
+            trace.write(this.target + "._detach() android:" + this.target._nativeView, "gestures");
+        }
 
         this._notifyTouch = false
         this._simpleGestureDetector = null;
@@ -73,7 +79,9 @@ export class GesturesObserver extends common.GesturesObserver {
     }
 
     private _attach(target: view.View, type: definition.GestureTypes) {
-        trace.write(this.target + "._attach() android:" + this.target._nativeView, "gestures");
+        if (trace.enabled) {
+            trace.write(this.target + "._attach() android:" + this.target._nativeView, "gestures");
+        }
         this._detach();
 
         if (type & definition.GestureTypes.tap || type & definition.GestureTypes.doubleTap || type & definition.GestureTypes.longPress) {

--- a/ui/gestures/gestures.ios.ts
+++ b/ui/gestures/gestures.ios.ts
@@ -78,11 +78,15 @@ export class GesturesObserver extends common.GesturesObserver {
         if (this.target) {
             this.type = type;
             this._onTargetLoaded = args => {
-                trace.write(this.target + ".target loaded. _nativeView:" + this.target._nativeView, "gestures");
+                if (trace.enabled) {
+                    trace.write(this.target + ".target loaded. _nativeView:" + this.target._nativeView, "gestures");
+                }
                 this._attach(this.target, type);
             };
             this._onTargetUnloaded = args => {
-                trace.write(this.target + ".target unloaded. _nativeView:" + this.target._nativeView, "gestures");
+                if (trace.enabled) {
+                    trace.write(this.target + ".target unloaded. _nativeView:" + this.target._nativeView, "gestures");
+                }
                 this._detach();
             };
 
@@ -96,7 +100,9 @@ export class GesturesObserver extends common.GesturesObserver {
     }
 
     private _attach(target: view.View, type: definition.GestureTypes) {
-        trace.write(target + "._attach() _nativeView:" + target._nativeView, "gestures");
+        if (trace.enabled) {
+            trace.write(target + "._attach() _nativeView:" + target._nativeView, "gestures");
+        }
         this._detach();
 
         if (target && target._nativeView && target._nativeView.addGestureRecognizer) {
@@ -160,7 +166,9 @@ export class GesturesObserver extends common.GesturesObserver {
     }
 
     private _detach() {
-        trace.write(this.target + "._detach() _nativeView:" + this.target._nativeView, "gestures");
+        if (trace.enabled) {
+            trace.write(this.target + "._detach() _nativeView:" + this.target._nativeView, "gestures");
+        }
         if (this.target && this.target._nativeView) {
             for (var name in this._recognizers) {
                 if (this._recognizers.hasOwnProperty(name)) {

--- a/ui/image-cache/image-cache.ios.ts
+++ b/ui/image-cache/image-cache.ios.ts
@@ -33,19 +33,25 @@ class MemmoryWarningHandler extends NSObject {
         this._cache = cache;
 
         NSNotificationCenter.defaultCenter().addObserverSelectorNameObject(this, "clearCache", "UIApplicationDidReceiveMemoryWarningNotification", null);
-        trace.write("[MemmoryWarningHandler] Added low memory observer.", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("[MemmoryWarningHandler] Added low memory observer.", trace.categories.Debug);
+        }
 
         return this;
     }
 
     public dealloc(): void {
         NSNotificationCenter.defaultCenter().removeObserverNameObject(this, "UIApplicationDidReceiveMemoryWarningNotification", null);
-        trace.write("[MemmoryWarningHandler] Removed low memory observer.", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("[MemmoryWarningHandler] Removed low memory observer.", trace.categories.Debug);
+        }
         super.dealloc();
     }
 
     public clearCache(): void {
-        trace.write("[MemmoryWarningHandler] Clearing Image Cache.", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("[MemmoryWarningHandler] Clearing Image Cache.", trace.categories.Debug);
+        }
         this._cache.removeAllObjects();
         utils.GC();
     }

--- a/ui/image/image.ios.ts
+++ b/ui/image/image.ios.ts
@@ -88,9 +88,11 @@ export class Image extends imageCommon.Image {
 
             var trace = require("trace");
 
-            trace.write("Image stretch: " + this.stretch +
-                ", nativeWidth: " + nativeWidth +
-                ", nativeHeight: " + nativeHeight, trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write("Image stretch: " + this.stretch +
+                    ", nativeWidth: " + nativeWidth +
+                    ", nativeHeight: " + nativeHeight, trace.categories.Layout);
+            }
         }
 
         var view = require("ui/core/view");

--- a/ui/layouts/layout.android.ts
+++ b/ui/layouts/layout.android.ts
@@ -58,7 +58,9 @@ export class Layout extends layoutBase.LayoutBase implements definition.Layout {
             var height = utils.layout.getMeasureSpecSize(heightMeasureSpec);
             var heightMode = utils.layout.getMeasureSpecMode(heightMeasureSpec);
 
-            trace.write(this + " :measure: " + utils.layout.getMode(widthMode) + " " + width + ", " + utils.layout.getMode(heightMode) + " " + height, trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write(this + " :measure: " + utils.layout.getMode(widthMode) + " " + width + ", " + utils.layout.getMode(heightMode) + " " + height, trace.categories.Layout);
+            }
             view.measure(widthMeasureSpec, heightMeasureSpec);
         }
     }
@@ -69,7 +71,9 @@ export class Layout extends layoutBase.LayoutBase implements definition.Layout {
         var view = this._nativeView;
         if (view) {
             this.layoutNativeView(left, top, right, bottom);
-            trace.write(this + " :layout: " + left + ", " + top + ", " + (right - left) + ", " + (bottom - top), trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write(this + " :layout: " + left + ", " + top + ", " + (right - left) + ", " + (bottom - top), trace.categories.Layout);
+            }
         }
     }
 

--- a/ui/list-picker/list-picker-common.ts
+++ b/ui/list-picker/list-picker-common.ts
@@ -40,7 +40,9 @@ export class ListPicker extends view.View implements definition.ListPicker {
     }
 
     public _onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-        trace.write("ListPicker._onSelectedIndexPropertyChanged("+data.oldValue+" => "+data.newValue+");", traceCategory);
+        if (trace.enabled) {
+            trace.write("ListPicker._onSelectedIndexPropertyChanged("+data.oldValue+" => "+data.newValue+");", traceCategory);
+        }
         var index = this.selectedIndex;
         if (types.isUndefined(index)) {
             return;
@@ -59,7 +61,9 @@ export class ListPicker extends view.View implements definition.ListPicker {
     }
 
     public _updateSelectedIndexOnItemsPropertyChanged(newItems) {
-        trace.write("ListPicker._updateSelectedIndexOnItemsPropertyChanged(" + newItems + ");", traceCategory);
+        if (trace.enabled) {
+            trace.write("ListPicker._updateSelectedIndexOnItemsPropertyChanged(" + newItems + ");", traceCategory);
+        }
         var newItemsCount = 0;
         if (newItems && newItems.length) {
             newItemsCount = newItems.length;

--- a/ui/page/page.android.ts
+++ b/ui/page/page.android.ts
@@ -135,7 +135,9 @@ export class Page extends pageCommon.Page {
         if (skipDetached) {
             ensureTrace();
             // Do not detach the context and android reference.
-            trace.write(`Caching ${this}`, trace.categories.NativeLifecycle);
+            if (trace.enabled) {
+                trace.write(`Caching ${this}`, trace.categories.NativeLifecycle);
+            }
         }
         else {
             super._onDetached();

--- a/ui/page/page.ios.ts
+++ b/ui/page/page.ios.ts
@@ -47,7 +47,10 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
 
-        trace.write(owner + " viewDidLayoutSubviews, isLoaded = " + owner.isLoaded, trace.categories.ViewHierarchy);
+        if (trace.enabled) {
+            trace.write(owner + " viewDidLayoutSubviews, isLoaded = " + owner.isLoaded, trace.categories.ViewHierarchy);
+        }
+        
         if (!owner.isLoaded) {
             return;
         }
@@ -99,7 +102,9 @@ class UIViewControllerImpl extends UIViewController {
                 }
             }
 
-            trace.write(owner + ", native frame = " + NSStringFromCGRect(this.view.frame), trace.categories.Layout);
+            if (trace.enabled) {
+                trace.write(owner + ", native frame = " + NSStringFromCGRect(this.view.frame), trace.categories.Layout);
+            }
         }
         else {
             owner._updateLayout();
@@ -108,7 +113,11 @@ class UIViewControllerImpl extends UIViewController {
 
     public viewWillAppear(animated: boolean): void {
         let page = this._owner.get();
-        trace.write(page + " viewWillAppear", trace.categories.Navigation);
+        if (trace.enabled) {
+            if (trace.enabled) {
+                trace.write(page + " viewWillAppear", trace.categories.Navigation);
+            }
+        }
         if (!page) {
             return;
         }
@@ -153,7 +162,9 @@ class UIViewControllerImpl extends UIViewController {
 
     public viewDidAppear(animated: boolean): void {
         let page = this._owner.get();
-        trace.write(page + " viewDidAppear", trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(page + " viewDidAppear", trace.categories.Navigation);
+        }
         if (!page) {
             return;
         }
@@ -190,7 +201,9 @@ class UIViewControllerImpl extends UIViewController {
 
     public viewWillDisappear(animated: boolean): void {
         let page = this._owner.get();
-        trace.write(page + " viewWillDisappear", trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(page + " viewWillDisappear", trace.categories.Navigation);
+        }
         if (!page) {
             return;
         }
@@ -208,7 +221,9 @@ class UIViewControllerImpl extends UIViewController {
 
     public viewDidDisappear(animated: boolean): void {
         let page = this._owner.get();
-        trace.write(page + " viewDidDisappear", trace.categories.Navigation);
+        if (trace.enabled) {
+            trace.write(page + " viewDidDisappear", trace.categories.Navigation);
+        }
         // Exit if no page or page is hiding because it shows another page modally.
         if (!page || page.modal) {
             return;
@@ -291,7 +306,9 @@ export class Page extends pageCommon.Page {
 
     private _addNativeView(view: View) {
         if (view) {
-            trace.write("Native: Adding " + view + " to " + this, trace.categories.ViewHierarchy);
+            if (trace.enabled) {
+                trace.write("Native: Adding " + view + " to " + this, trace.categories.ViewHierarchy);
+            }
             if (view.ios instanceof UIView) {
                 this._ios.view.addSubview(view.ios);
             } else if (view.ios instanceof UIViewController) {
@@ -303,7 +320,9 @@ export class Page extends pageCommon.Page {
 
     private _removeNativeView(view: View) {
         if (view) {
-            trace.write("Native: Removing " + view + " from " + this, trace.categories.ViewHierarchy);
+            if (trace.enabled) {
+                trace.write("Native: Removing " + view + " from " + this, trace.categories.ViewHierarchy);
+            }
             if (view.ios instanceof UIView) {
                 (<UIView>view.ios).removeFromSuperview();
             } else if (view.ios instanceof UIViewController) {

--- a/ui/proxy-view-container/proxy-view-container.ts
+++ b/ui/proxy-view-container/proxy-view-container.ts
@@ -57,7 +57,9 @@ export class ProxyViewContainer extends LayoutBase implements definition.ProxyVi
     }
 
     public _addViewToNativeVisualTree(child: View, atIndex?: number): boolean {
-        trace.write("ViewContainer._addViewToNativeVisualTree for a child " + child + " ViewContainer.parent: " + this.parent, trace.categories.ViewHierarchy);
+        if (trace.enabled) {
+            trace.write("ViewContainer._addViewToNativeVisualTree for a child " + child + " ViewContainer.parent: " + this.parent, trace.categories.ViewHierarchy);
+        }
         super._addViewToNativeVisualTree(child);
 
         var parent = this.parent;
@@ -75,8 +77,9 @@ export class ProxyViewContainer extends LayoutBase implements definition.ProxyVi
                 // Add last;
                 insideIndex = this._getNativeViewsCount();
             }
-
-            trace.write("ProxyViewContainer._addViewToNativeVisualTree at: " + atIndex + " base: " + baseIndex + " additional: " + insideIndex, trace.categories.ViewHierarchy);
+            if (trace.enabled) {
+                trace.write("ProxyViewContainer._addViewToNativeVisualTree at: " + atIndex + " base: " + baseIndex + " additional: " + insideIndex, trace.categories.ViewHierarchy);
+            }
             return parent._addViewToNativeVisualTree(child, baseIndex + insideIndex);
         }
 
@@ -84,7 +87,9 @@ export class ProxyViewContainer extends LayoutBase implements definition.ProxyVi
     }
 
     public _removeViewFromNativeVisualTree(child: View): void {
-        trace.write("ProxyViewContainer._removeViewFromNativeVisualTree for a child " + child + " ViewContainer.parent: " + this.parent, trace.categories.ViewHierarchy);
+        if (trace.enabled) {
+            trace.write("ProxyViewContainer._removeViewFromNativeVisualTree for a child " + child + " ViewContainer.parent: " + this.parent, trace.categories.ViewHierarchy);
+        }
         super._removeViewFromNativeVisualTree(child);
 
         var parent = this.parent;

--- a/ui/repeater/repeater.ts
+++ b/ui/repeater/repeater.ts
@@ -112,7 +112,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     public onLoaded() {
-        trace.write("Repeater.onLoaded()", "Repeater");
+        if (trace.enabled) {
+            trace.write("Repeater.onLoaded()", "Repeater");
+        }
         if (this._isDirty) {
             this.refresh();
         }
@@ -121,7 +123,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     private _requestRefresh() {
-        trace.write(`Repeater._requestRefresh()`, "Repeater");
+        if (trace.enabled) {
+            trace.write(`Repeater._requestRefresh()`, "Repeater");
+        }
         this._isDirty = true;
         if (this.isLoaded) {
             this.refresh();
@@ -129,7 +133,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     public refresh() {
-        trace.write("Repeater.refresh()", "Repeater");
+        if (trace.enabled) {
+            trace.write("Repeater.refresh()", "Repeater");
+        }
         if (this.itemsLayout) {
             this.itemsLayout.removeChildren();
         }
@@ -152,7 +158,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     public _onItemsPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-        trace.write(`Repeater._onItemsPropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
+        if (trace.enabled) {
+            trace.write(`Repeater._onItemsPropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
+        }
         if (data.oldValue instanceof observableArray.ObservableArray) {
             weakEvents.removeWeakEventListener(data.oldValue, observableArray.ObservableArray.changeEvent, this._onItemsChanged, this);
         }
@@ -165,12 +173,16 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     public _onItemTemplatePropertyChanged(data: dependencyObservable.PropertyChangeData) {
-        trace.write(`Repeater._onItemTemplatePropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
+        if (trace.enabled) {
+            trace.write(`Repeater._onItemTemplatePropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
+        }
         this._requestRefresh();
     }
 
     public _onItemsLayoutPropertyPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-        trace.write(`Repeater._onItemsLayoutPropertyPropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
+        if (trace.enabled) {
+            trace.write(`Repeater._onItemsLayoutPropertyPropertyChanged(${data.oldValue} => ${data.newValue})`, "Repeater");
+        }
         if (data.oldValue instanceof layoutBaseModule.LayoutBase) {
             this._removeView((<layoutBaseModule.LayoutBase>data.oldValue));
         }
@@ -183,7 +195,9 @@ export class Repeater extends viewModule.CustomLayoutView implements definition.
     }
 
     private _onItemsChanged(data: observable.EventData) {
-        trace.write(`Repeater._onItemsChanged(${data})`, "Repeater");
+        if (trace.enabled) {
+            trace.write(`Repeater._onItemsChanged(${data})`, "Repeater");
+        }
         this._requestRefresh();
     }
 

--- a/ui/styling/css-selector.ts
+++ b/ui/styling/css-selector.ts
@@ -86,7 +86,9 @@ export class CssSelector {
                 try {
                     view.style._setValue(resolvedProperty, value, modifier);
                 } catch (ex) {
-                    trace.write("Error setting property: " + resolvedProperty.name + " view: " + view + " value: " + value + " " + ex, trace.categories.Style, trace.messageType.error);
+                    if (trace.enabled) {
+                        trace.write("Error setting property: " + resolvedProperty.name + " view: " + view + " value: " + value + " " + ex, trace.categories.Style, trace.messageType.error);
+                    }
                 }
             }
         });

--- a/ui/styling/font.android.ts
+++ b/ui/styling/font.android.ts
@@ -106,7 +106,9 @@ function loadFontFromFile(fontFamily: string): android.graphics.Typeface {
             fontAssetPath = FONTS_BASE_PATH + fontFamily + ".otf";
         }
         else {
-            trace.write("Could not find font file for " + fontFamily, trace.categories.Error, trace.messageType.error);
+            if (trace.enabled) {
+                trace.write("Could not find font file for " + fontFamily, trace.categories.Error, trace.messageType.error);
+            }
         }
 
         if (fontAssetPath) {
@@ -114,7 +116,9 @@ function loadFontFromFile(fontFamily: string): android.graphics.Typeface {
                 fontAssetPath = fs.path.join(fs.knownFolders.currentApp().path, fontAssetPath);
                 result = android.graphics.Typeface.createFromFile(fontAssetPath)
             } catch (e) {
-                trace.write("Error loading font asset: " + fontAssetPath, trace.categories.Error, trace.messageType.error);
+                if (trace.enabled) {
+                    trace.write("Error loading font asset: " + fontAssetPath, trace.categories.Error, trace.messageType.error);
+                }
             }
         }
         typefaceCache.set(fontFamily, result);

--- a/ui/styling/font.ios.ts
+++ b/ui/styling/font.ios.ts
@@ -306,7 +306,9 @@ export module ios {
         if (!CTFontManagerRegisterGraphicsFont(font, error)) {
             var trace: typeof traceModule = require("trace");
 
-            trace.write("Error occur while registering font: " + CFErrorCopyDescription(<NSError>error.value), trace.categories.Error, trace.messageType.error);
+            if (trace.enabled) {
+                trace.write("Error occur while registering font: " + CFErrorCopyDescription(<NSError>error.value), trace.categories.Error, trace.messageType.error);
+            }
         }
 
         areSystemFontSetsValid = false;

--- a/ui/styling/style.ts
+++ b/ui/styling/style.ts
@@ -864,11 +864,13 @@ export class Style extends DependencyObservable implements styling.Style {
     }
 
     public _onPropertyChanged(property: Property, oldValue: any, newValue: any) {
-        trace.write(
-            "Style._onPropertyChanged view:" + this._view +
-            ", property: " + property.name +
-            ", oldValue: " + oldValue +
-            ", newValue: " + newValue, trace.categories.Style);
+        if (trace.enabled) {
+            trace.write(
+                "Style._onPropertyChanged view:" + this._view +
+                ", property: " + property.name +
+                ", oldValue: " + oldValue +
+                ", newValue: " + newValue, trace.categories.Style);
+        }
 
         super._onPropertyChanged(property, oldValue, newValue);
 
@@ -933,10 +935,14 @@ export class Style extends DependencyObservable implements styling.Style {
             var handler: definition.StylePropertyChangedHandler = getHandler(property, this._view);
 
             if (!handler) {
-                trace.write("No handler for property: " + property.name + " with id: " + property.id + ", view:" + this._view, trace.categories.Style);
+                if (trace.enabled) {
+                    trace.write("No handler for property: " + property.name + " with id: " + property.id + ", view:" + this._view, trace.categories.Style);
+                }
             }
             else {
-                trace.write("Found handler for property: " + property.name + ", view:" + this._view, trace.categories.Style);
+                if (trace.enabled) {
+                    trace.write("Found handler for property: " + property.name + ", view:" + this._view, trace.categories.Style);
+                }
 
                 var shouldReset = false;
                 if (property.metadata.equalityComparer) {
@@ -956,7 +962,9 @@ export class Style extends DependencyObservable implements styling.Style {
             }
         }
         catch (ex) {
-            trace.write("Error setting property: " + property.name + " on " + this._view + ": " + ex, trace.categories.Style, trace.messageType.error);
+            if (trace.enabled) {
+                trace.write("Error setting property: " + property.name + " on " + this._view + ": " + ex, trace.categories.Style, trace.messageType.error);
+            }
         }
     }
 

--- a/ui/tab-view/tab-view-common.ts
+++ b/ui/tab-view/tab-view-common.ts
@@ -122,7 +122,9 @@ export class TabView extends view.View implements definition.TabView, view.AddAr
     }
 
     public _onItemsPropertyChangedSetNativeValue(data: dependencyObservable.PropertyChangeData) {
-        trace.write("TabView.__onItemsPropertyChangedSetNativeValue(" + data.oldValue + " -> " + data.newValue + ");", traceCategory);
+        if (trace.enabled) {
+            trace.write("TabView.__onItemsPropertyChangedSetNativeValue(" + data.oldValue + " -> " + data.newValue + ");", traceCategory);
+        }
         if (data.oldValue) {
             this._removeTabs(data.oldValue);
         }
@@ -135,7 +137,9 @@ export class TabView extends view.View implements definition.TabView, view.AddAr
     }
 
     public _updateSelectedIndexOnItemsPropertyChanged(newItems) {
-        trace.write("TabView._updateSelectedIndexOnItemsPropertyChanged(" + newItems + ");", traceCategory);
+        if (trace.enabled) {
+            trace.write("TabView._updateSelectedIndexOnItemsPropertyChanged(" + newItems + ");", traceCategory);
+        }
         var newItemsCount = 0;
         if (newItems) {
             newItemsCount = newItems.length;

--- a/ui/tab-view/tab-view.android.ts
+++ b/ui/tab-view/tab-view.android.ts
@@ -67,7 +67,9 @@ function ensurePagerAdapterClass() {
         }
 
         instantiateItem(container: android.view.ViewGroup, index: number) {
-            trace.write("TabView.PagerAdapter.instantiateItem; container: " + container + "; index: " + index, common.traceCategory);
+            if (trace.enabled) {
+                trace.write("TabView.PagerAdapter.instantiateItem; container: " + container + "; index: " + index, common.traceCategory);
+            }
 
             var item = this.items[index];
             if (item.view.parent !== this.owner) {
@@ -75,7 +77,9 @@ function ensurePagerAdapterClass() {
             }
 
             if (this[VIEWS_STATES]) {
-                trace.write("TabView.PagerAdapter.instantiateItem; restoreHierarchyState: " + item.view, common.traceCategory);
+                if (trace.enabled) {
+                    trace.write("TabView.PagerAdapter.instantiateItem; restoreHierarchyState: " + item.view, common.traceCategory);
+                }
                 item.view._nativeView.restoreHierarchyState(this[VIEWS_STATES]);
             }
 
@@ -84,7 +88,9 @@ function ensurePagerAdapterClass() {
         }
 
         destroyItem(container: android.view.ViewGroup, index: number, _object: any) {
-            trace.write("TabView.PagerAdapter.destroyItem; container: " + container + "; index: " + index + "; _object: " + _object, common.traceCategory);
+            if (trace.enabled) {
+                trace.write("TabView.PagerAdapter.destroyItem; container: " + container + "; index: " + index + "; _object: " + _object, common.traceCategory);
+            }
             var item = this.items[index];
             var nativeView = item.view._nativeView;
 
@@ -111,7 +117,9 @@ function ensurePagerAdapterClass() {
         }
 
         saveState(): android.os.Parcelable {
-            trace.write("TabView.PagerAdapter.saveState", common.traceCategory);
+            if (trace.enabled) {
+                trace.write("TabView.PagerAdapter.saveState", common.traceCategory);
+            }
 
             var owner: TabView = this.owner;
             if (!owner || owner._childrenCount === 0) {
@@ -137,7 +145,9 @@ function ensurePagerAdapterClass() {
         }
 
         restoreState(state: android.os.Parcelable, loader: java.lang.ClassLoader) {
-            trace.write("TabView.PagerAdapter.restoreState", common.traceCategory);
+            if (trace.enabled) {
+                trace.write("TabView.PagerAdapter.restoreState", common.traceCategory);
+            }
             var bundle: android.os.Bundle = <android.os.Bundle>state;
             bundle.setClassLoader(loader);
             this[VIEWS_STATES] = bundle.getSparseParcelableArray(VIEWS_STATES);
@@ -199,7 +209,9 @@ export class TabView extends common.TabView {
     }
 
     public _createUI() {
-        trace.write("TabView._createUI(" + this + ");", common.traceCategory);
+        if (trace.enabled) {
+            trace.write("TabView._createUI(" + this + ");", common.traceCategory);
+        }
 
         this._grid = new org.nativescript.widgets.GridLayout(this._context);
         this._grid.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
@@ -246,7 +258,9 @@ export class TabView extends common.TabView {
     }
 
     public _onItemsPropertyChangedSetNativeValue(data: dependencyObservable.PropertyChangeData) {
-        trace.write("TabView._onItemsPropertyChangedSetNativeValue(" + data.oldValue + " ---> " + data.newValue + ");", common.traceCategory);
+        if (trace.enabled) {
+            trace.write("TabView._onItemsPropertyChangedSetNativeValue(" + data.oldValue + " ---> " + data.newValue + ");", common.traceCategory);
+        }
 
         if (data.oldValue) {
             var oldItems: Array<TabViewItem> = data.oldValue;
@@ -295,7 +309,9 @@ export class TabView extends common.TabView {
     }
 
     public _onSelectedIndexPropertyChangedSetNativeValue(data: dependencyObservable.PropertyChangeData) {
-        trace.write("TabView._onSelectedIndexPropertyChangedSetNativeValue(" + data.oldValue + " ---> " + data.newValue + ");", common.traceCategory);
+        if (trace.enabled) {
+            trace.write("TabView._onSelectedIndexPropertyChangedSetNativeValue(" + data.oldValue + " ---> " + data.newValue + ");", common.traceCategory);
+        }
         super._onSelectedIndexPropertyChangedSetNativeValue(data);
 
         var index = data.newValue;
@@ -303,7 +319,9 @@ export class TabView extends common.TabView {
             // Select the respective page in the ViewPager
             var viewPagerSelectedIndex = this._viewPager.getCurrentItem();
             if (viewPagerSelectedIndex !== index) {
-                trace.write("TabView this._viewPager.setCurrentItem(" + index + ", true);", common.traceCategory);
+                if (trace.enabled) {
+                    trace.write("TabView this._viewPager.setCurrentItem(" + index + ", true);", common.traceCategory);
+                }
                 this._viewPager.setCurrentItem(index, true);
             }
         }

--- a/ui/tab-view/tab-view.ios.ts
+++ b/ui/tab-view/tab-view.ios.ts
@@ -30,7 +30,9 @@ class UITabBarControllerImpl extends UITabBarController {
     }
 
     public viewDidLayoutSubviews(): void {
-        trace.write("TabView.UITabBarControllerClass.viewDidLayoutSubviews();", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView.UITabBarControllerClass.viewDidLayoutSubviews();", trace.categories.Debug);
+        }
         super.viewDidLayoutSubviews();
         let owner = this._owner.get();
         if (owner && owner.isLoaded) {
@@ -51,7 +53,9 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
     }
 
     public tabBarControllerDidSelectViewController(tabBarController: UITabBarController, viewController: UIViewController): void {
-        trace.write("TabView.UITabBarControllerDelegateClass.tabBarControllerDidSelectViewController(" + tabBarController + ", " + viewController + ");", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView.UITabBarControllerDelegateClass.tabBarControllerDidSelectViewController(" + tabBarController + ", " + viewController + ");", trace.categories.Debug);
+        }
         let owner = this._owner.get();
         if (owner) {
             owner._onViewControllerShown(viewController);
@@ -71,7 +75,9 @@ class UINavigationControllerDelegateImpl extends NSObject implements UINavigatio
     }
 
     navigationControllerDidShowViewControllerAnimated(navigationController: UINavigationController, viewController: UIViewController, animated: boolean): void {
-        trace.write("TabView.UINavigationControllerDelegateClass.navigationControllerDidShowViewControllerAnimated(" + navigationController + ", " + viewController + ", " + animated + ");", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView.UINavigationControllerDelegateClass.navigationControllerDidShowViewControllerAnimated(" + navigationController + ", " + viewController + ", " + animated + ");", trace.categories.Debug);
+        }
         // We don't need Edit button in More screen.
         navigationController.navigationBar.topItem.rightBarButtonItem = null;
         let owner = this._owner.get();
@@ -158,17 +164,23 @@ export class TabView extends common.TabView {
 
     public _onViewControllerShown(viewController: UIViewController) {
         // This method could be called with the moreNavigationController or its list controller, so we have to check.
-        trace.write("TabView._onViewControllerShown(" + viewController + ");", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView._onViewControllerShown(" + viewController + ");", trace.categories.Debug);
+        }
         if (this._ios.viewControllers.containsObject(viewController)) {
             this.selectedIndex = this._ios.viewControllers.indexOfObject(viewController);;
         }
         else {
-            trace.write("TabView._onViewControllerShown: viewController is not one of our viewControllers", trace.categories.Debug);
+            if (trace.enabled) {
+                trace.write("TabView._onViewControllerShown: viewController is not one of our viewControllers", trace.categories.Debug);
+            }
         }
     }
 
     public _removeTabs(oldItems: Array<definition.TabViewItem>) {
-        trace.write("TabView._removeTabs(" + oldItems + ");", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView._removeTabs(" + oldItems + ");", trace.categories.Debug);
+        }
         super._removeTabs(oldItems);
 
         var i: number;
@@ -184,7 +196,9 @@ export class TabView extends common.TabView {
     }
 
     public _addTabs(newItems: Array<definition.TabViewItem>) {
-        trace.write("TabView._addTabs(" + newItems + ");", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView._addTabs(" + newItems + ");", trace.categories.Debug);
+        }
         super._addTabs(newItems);
 
         var i: number;
@@ -262,7 +276,9 @@ export class TabView extends common.TabView {
         super._onSelectedIndexPropertyChangedSetNativeValue(data);
 
         var newIndex = data.newValue;
-        trace.write("TabView._onSelectedIndexPropertyChangedSetNativeValue(" + newIndex + ")", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("TabView._onSelectedIndexPropertyChangedSetNativeValue(" + newIndex + ")", trace.categories.Debug);
+        }
         if (types.isNullOrUndefined(newIndex)) {
             return;
         }

--- a/ui/transition/transition.android.ts
+++ b/ui/transition/transition.android.ts
@@ -37,19 +37,25 @@ export module AndroidTransitionType {
 export function _clearBackwardTransitions(fragment: any): void {
     var expandedFragment = <ExpandedFragment>fragment;
     if (expandedFragment.enterPopExitTransition) {
-        trace.write(`Cleared enterPopExitTransition ${expandedFragment.enterPopExitTransition} for ${fragment.getTag()}`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`Cleared enterPopExitTransition ${expandedFragment.enterPopExitTransition} for ${fragment.getTag()}`, trace.categories.Transition);
+        }
         expandedFragment.enterPopExitTransition = undefined;
     }
     
     if (_sdkVersion() >= 21) {
         var enterTransition = (<any>fragment).getEnterTransition();
         if (enterTransition) {
-            trace.write(`Cleared Enter ${enterTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`Cleared Enter ${enterTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            }
             (<any>fragment).setEnterTransition(null);
         }
         var returnTransition = (<any>fragment).getReturnTransition();
         if (returnTransition) {
-            trace.write(`Cleared Pop Exit ${returnTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`Cleared Pop Exit ${returnTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            }
             (<any>fragment).setReturnTransition(null);
         }
     }
@@ -58,19 +64,25 @@ export function _clearBackwardTransitions(fragment: any): void {
 export function _clearForwardTransitions(fragment: any): void {
     var expandedFragment = <ExpandedFragment>fragment;
     if (expandedFragment.exitPopEnterTransition) {
-        trace.write(`Cleared exitPopEnterTransition ${expandedFragment.exitPopEnterTransition} for ${fragment.getTag()}`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`Cleared exitPopEnterTransition ${expandedFragment.exitPopEnterTransition} for ${fragment.getTag()}`, trace.categories.Transition);
+        }
         expandedFragment.exitPopEnterTransition = undefined;
     }
 
     if (_sdkVersion() >= 21) {
         var exitTransition = (<any>fragment).getExitTransition();
         if (exitTransition) {
-            trace.write(`Cleared Exit ${exitTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`Cleared Exit ${exitTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            }
             (<any>fragment).setExitTransition(null);//exit
         }
         var reenterTransition = (<any>fragment).getReenterTransition();
         if (reenterTransition) {
-            trace.write(`Cleared Pop Enter ${reenterTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`Cleared Pop Enter ${reenterTransition.getClass().getSimpleName()} transition for ${fragment.getTag()}`, trace.categories.Transition);
+            }
             (<any>fragment).setReenterTransition(null);//popEnter
         }
     }
@@ -239,13 +251,17 @@ export function _onFragmentShown(fragment: any, isBack: boolean): void {
     var transitionType = isBack ? "Pop Enter" : "Enter";
     var relevantTransition = isBack ? expandedFragment.exitPopEnterTransition : expandedFragment.enterPopExitTransition;
     if (relevantTransition) {
-        trace.write(`${fragment.getTag() } has been shown when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${relevantTransition}. Will complete page addition when transition ends.`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`${fragment.getTag() } has been shown when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${relevantTransition}. Will complete page addition when transition ends.`, trace.categories.Transition);
+        }
         expandedFragment.completePageAdditionWhenTransitionEnds = { isBack: isBack };
     }
     else if (_sdkVersion() >= 21) {
         var nativeTransition = isBack ? (<any>fragment).getReenterTransition() : (<any>fragment).getEnterTransition();
         if (nativeTransition) {
-            trace.write(`${fragment.getTag() } has been shown when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${nativeTransition.getClass().getSimpleName()} transition. Will complete page addition when transition ends.`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`${fragment.getTag() } has been shown when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${nativeTransition.getClass().getSimpleName()} transition. Will complete page addition when transition ends.`, trace.categories.Transition);
+            }
             expandedFragment.completePageAdditionWhenTransitionEnds = { isBack: isBack };
         }
     }
@@ -260,13 +276,17 @@ export function _onFragmentHidden(fragment: any, isBack: boolean, destroyed: boo
     var transitionType = isBack ? "Pop Exit" : "Exit";
     var relevantTransition = isBack ? expandedFragment.enterPopExitTransition : expandedFragment.exitPopEnterTransition;
     if (relevantTransition) {
-        trace.write(`${fragment.getTag()} has been hidden when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${relevantTransition}. Will complete page removal when transition ends.`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`${fragment.getTag()} has been hidden when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${relevantTransition}. Will complete page removal when transition ends.`, trace.categories.Transition);
+        }
         expandedFragment.completePageRemovalWhenTransitionEnds = { isBack: isBack };
     }
     else if (_sdkVersion() >= 21) {
         var nativeTransition = isBack ? (<any>fragment).getReturnTransition() : (<any>fragment).getExitTransition();
         if (nativeTransition) {
-            trace.write(`${fragment.getTag()} has been hidden when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${nativeTransition.getClass().getSimpleName()} transition. Will complete page removal when transition ends.`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`${fragment.getTag()} has been hidden when going ${isBack ? "back" : "forward"}, but there is ${transitionType} ${nativeTransition.getClass().getSimpleName()} transition. Will complete page removal when transition ends.`, trace.categories.Transition);
+            }
             expandedFragment.completePageRemovalWhenTransitionEnds = { isBack: isBack };
         }
     }
@@ -290,7 +310,9 @@ function _completePageAddition(fragment: any, isBack: boolean) {
     page.onNavigatedTo(isBack);
     frame._processNavigationQueue(page);
     entry.isNavigation = undefined;
-    trace.write(`ADDITION of ${page} completed`, trace.categories.Transition);
+    if (trace.enabled) {
+        trace.write(`ADDITION of ${page} completed`, trace.categories.Transition);
+    }
 }
 
 function _completePageRemoval(fragment: any, isBack: boolean) {
@@ -305,20 +327,28 @@ function _completePageRemoval(fragment: any, isBack: boolean) {
         if (entry.isNavigation) {
             page.onNavigatedFrom(isBack);
         }
-        trace.write(`REMOVAL of ${page} completed`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`REMOVAL of ${page} completed`, trace.categories.Transition);
+        }
     }
     else {
-        trace.write(`REMOVAL of ${page} has already been done`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`REMOVAL of ${page} has already been done`, trace.categories.Transition);
+        }
     }
 
     if (expandedFragment.isDestroyed) {
         expandedFragment.isDestroyed = undefined;
         if (page._context) {
             page._onDetached(true);
-            trace.write(`DETACHMENT of ${page} completed`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`DETACHMENT of ${page} completed`, trace.categories.Transition);
+            }
         }
         else {
-            trace.write(`DETACHMENT of ${page} has already been done`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`DETACHMENT of ${page} has already been done`, trace.categories.Transition);
+            }
         }
     }
 
@@ -329,7 +359,9 @@ function _addNativeTransitionListener(fragment: any, nativeTransition: any/*andr
     var expandedFragment = <ExpandedFragment>fragment;
     var transitionListener = new (<any>android).transition.Transition.TransitionListener({
         onTransitionCancel: function (transition: any): void {
-            trace.write(`CANCEL ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`CANCEL ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            }
             if (expandedFragment.completePageRemovalWhenTransitionEnds) {
                 _completePageRemoval(fragment, expandedFragment.completePageRemovalWhenTransitionEnds.isBack);
             }
@@ -338,7 +370,9 @@ function _addNativeTransitionListener(fragment: any, nativeTransition: any/*andr
             }
         },
         onTransitionEnd: function (transition: any): void {
-            trace.write(`END ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`END ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            }
             if (expandedFragment.completePageRemovalWhenTransitionEnds) {
                 _completePageRemoval(fragment, expandedFragment.completePageRemovalWhenTransitionEnds.isBack);
             }
@@ -347,13 +381,19 @@ function _addNativeTransitionListener(fragment: any, nativeTransition: any/*andr
             }
         },
         onTransitionPause: function (transition: any): void {
-            trace.write(`PAUSE ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`PAUSE ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            }
         },
         onTransitionResume: function (transition: any): void {
-            trace.write(`RESUME ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`RESUME ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            }
         },
         onTransitionStart: function (transition: any): void {
-            trace.write(`START ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`START ${nativeTransition} transition for ${fragment}`, trace.categories.Transition);
+            }
         }
     });
     nativeTransition.addListener(transitionListener);
@@ -386,13 +426,19 @@ export function _onFragmentCreateAnimator(fragment: any, nextAnim: number): andr
         animator = <android.animation.Animator>transition.createAndroidAnimator(transitionType);
         var transitionListener = new android.animation.Animator.AnimatorListener({
             onAnimationStart: function (animator: android.animation.Animator): void {
-                trace.write(`START ${transitionType} ${transition} for ${fragment.getTag()}`, trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write(`START ${transitionType} ${transition} for ${fragment.getTag()}`, trace.categories.Transition);
+                }
             },
             onAnimationRepeat: function (animator: android.animation.Animator): void {
-                trace.write(`REPEAT ${transitionType} ${transition} for ${fragment.getTag()}`, trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write(`REPEAT ${transitionType} ${transition} for ${fragment.getTag()}`, trace.categories.Transition);
+                }
             },
             onAnimationEnd: function (animator: android.animation.Animator): void {
-                trace.write(`END ${transitionType} ${transition}`, trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write(`END ${transitionType} ${transition}`, trace.categories.Transition);
+                }
                 if (expandedFragment.completePageRemovalWhenTransitionEnds) {
                     _completePageRemoval(fragment, expandedFragment.completePageRemovalWhenTransitionEnds.isBack);
                 }
@@ -401,7 +447,9 @@ export function _onFragmentCreateAnimator(fragment: any, nextAnim: number): andr
                 }
             },
             onAnimationCancel: function (animator: android.animation.Animator): void {
-                trace.write(`CANCEL ${transitionType} ${transition} for ${fragment.getTag()}`, trace.categories.Transition);
+                if (trace.enabled) {
+                    trace.write(`CANCEL ${transitionType} ${transition} for ${fragment.getTag()}`, trace.categories.Transition);
+                }
                 if (expandedFragment.completePageRemovalWhenTransitionEnds) {
                     _completePageRemoval(fragment, expandedFragment.completePageRemovalWhenTransitionEnds.isBack);
                 }

--- a/ui/transition/transition.ios.ts
+++ b/ui/transition/transition.ios.ts
@@ -47,7 +47,9 @@ class AnimatedTransitioning extends NSObject implements UIViewControllerAnimated
             case UINavigationControllerOperation.UINavigationControllerOperationNone: this._transitionType = "none"; break;
         }
 
-        trace.write(`START ${this._transition} ${this._transitionType}`, trace.categories.Transition);
+        if (trace.enabled) {
+            trace.write(`START ${this._transition} ${this._transitionType}`, trace.categories.Transition);
+        }
         this._transition.animateIOSTransition(containerView, this._fromVC.view, this._toVC.view, this._operation, completion);
     }
 
@@ -57,10 +59,14 @@ class AnimatedTransitioning extends NSObject implements UIViewControllerAnimated
 
     public animationEnded(transitionCompleted: boolean): void {
         if (transitionCompleted) {
-            trace.write(`END ${this._transition} ${this._transitionType}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`END ${this._transition} ${this._transitionType}`, trace.categories.Transition);
+            }
         }
         else {
-            trace.write(`CANCEL ${this._transition} ${this._transitionType}`, trace.categories.Transition);
+            if (trace.enabled) {
+                trace.write(`CANCEL ${this._transition} ${this._transitionType}`, trace.categories.Transition);
+            }
         }
     }
 }

--- a/ui/web-view/web-view-common.ts
+++ b/ui/web-view/web-view-common.ts
@@ -48,7 +48,9 @@ function onSrcPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     webView.stopLoading();    
 
     var src = <string>data.newValue;
-    trace.write("WebView._loadSrc(" + src + ")", trace.categories.Debug);
+    if (trace.enabled) {
+        trace.write("WebView._loadSrc(" + src + ")", trace.categories.Debug);
+    }
 
     if (utils.isFileOrResourcePath(src)) {
         ensureFS();

--- a/ui/web-view/web-view.android.ts
+++ b/ui/web-view/web-view.android.ts
@@ -28,7 +28,9 @@ function ensureWebViewClientClass() {
         }
 
         public shouldOverrideUrlLoading(view: android.webkit.WebView, url: string) {
-            trace.write("WebViewClientClass.shouldOverrideUrlLoading(" + url + ")", trace.categories.Debug);
+            if (trace.enabled) {
+                trace.write("WebViewClientClass.shouldOverrideUrlLoading(" + url + ")", trace.categories.Debug);
+            }
             return false;
         }
 
@@ -36,7 +38,9 @@ function ensureWebViewClientClass() {
             super.onPageStarted(view, url, favicon);
 
             if (this._view) {
-                trace.write("WebViewClientClass.onPageStarted(" + url + ", " + favicon + ")", trace.categories.Debug);
+                if (trace.enabled) {
+                    trace.write("WebViewClientClass.onPageStarted(" + url + ", " + favicon + ")", trace.categories.Debug);
+                }
                 this._view._onLoadStarted(url, common.WebView.navigationTypes[common.WebView.navigationTypes.indexOf("linkClicked")]);
             }
         }
@@ -45,7 +49,9 @@ function ensureWebViewClientClass() {
             super.onPageFinished(view, url);
 
             if (this._view) {
-                trace.write("WebViewClientClass.onPageFinished(" + url + ")", trace.categories.Debug);
+                if (trace.enabled) {
+                    trace.write("WebViewClientClass.onPageFinished(" + url + ")", trace.categories.Debug);
+                }
                 this._view._onLoadFinished(url, undefined);
             }
         }
@@ -62,7 +68,9 @@ function ensureWebViewClientClass() {
                 super.onReceivedError(view, errorCode, description, failingUrl);
 
                 if (this._view) {
-                    trace.write("WebViewClientClass.onReceivedError(" + errorCode + ", " + description + ", " + failingUrl + ")", trace.categories.Debug);
+                    if (trace.enabled) {
+                        trace.write("WebViewClientClass.onReceivedError(" + errorCode + ", " + description + ", " + failingUrl + ")", trace.categories.Debug);
+                    }
                     this._view._onLoadFinished(failingUrl, description + "(" + errorCode + ")");
                 }
             } else {
@@ -73,7 +81,9 @@ function ensureWebViewClientClass() {
                 super.onReceivedError(view, request, error);
 
                 if (this._view) {
-                    trace.write("WebViewClientClass.onReceivedError(" + error.getErrorCode() + ", " + error.getDescription() + ", " + (error.getUrl && error.getUrl()) + ")", trace.categories.Debug);
+                    if (trace.enabled) {
+                        trace.write("WebViewClientClass.onReceivedError(" + error.getErrorCode() + ", " + error.getDescription() + ", " + (error.getUrl && error.getUrl()) + ")", trace.categories.Debug);
+                    }
                     this._view._onLoadFinished(error.getUrl && error.getUrl(), error.getDescription() + "(" + error.getErrorCode() + ")");
                 }
             }
@@ -117,7 +127,9 @@ export class WebView extends common.WebView {
             return;
         }
 
-        trace.write("WebView._loadUrl(" + url + ")", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("WebView._loadUrl(" + url + ")", trace.categories.Debug);
+        }
         this._android.stopLoading();
         this._android.loadUrl(url);
     }

--- a/ui/web-view/web-view.ios.ts
+++ b/ui/web-view/web-view.ios.ts
@@ -38,7 +38,9 @@ class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
                     break;
             }
 
-            trace.write("UIWebViewDelegateClass.webViewShouldStartLoadWithRequestNavigationType(" + request.URL.absoluteString + ", " + navigationType + ")", trace.categories.Debug);
+            if (trace.enabled) {
+                trace.write("UIWebViewDelegateClass.webViewShouldStartLoadWithRequestNavigationType(" + request.URL.absoluteString + ", " + navigationType + ")", trace.categories.Debug);
+            }
             owner._onLoadStarted(request.URL.absoluteString, common.WebView.navigationTypes[navTypeIndex]);
         }
 
@@ -46,11 +48,15 @@ class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
     }
 
     public webViewDidStartLoad(webView: UIWebView) {
-        trace.write("UIWebViewDelegateClass.webViewDidStartLoad(" + webView.request.URL + ")", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("UIWebViewDelegateClass.webViewDidStartLoad(" + webView.request.URL + ")", trace.categories.Debug);
+        }
     }
 
     public webViewDidFinishLoad(webView: UIWebView) {
-        trace.write("UIWebViewDelegateClass.webViewDidFinishLoad(" + webView.request.URL + ")", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("UIWebViewDelegateClass.webViewDidFinishLoad(" + webView.request.URL + ")", trace.categories.Debug);
+        }
         let owner = this._owner.get();
         if (owner) {
             owner._onLoadFinished(webView.request.URL.absoluteString);
@@ -65,7 +71,9 @@ class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
                 url = webView.request.URL.absoluteString;
             }
 
-            trace.write("UIWebViewDelegateClass.webViewDidFailLoadWithError(" + error.localizedDescription + ")", trace.categories.Debug);
+            if (trace.enabled) {
+                trace.write("UIWebViewDelegateClass.webViewDidFailLoadWithError(" + error.localizedDescription + ")", trace.categories.Debug);
+            }
             if (owner) {
                 owner._onLoadFinished(url, error.localizedDescription);
             }
@@ -103,7 +111,9 @@ export class WebView extends common.WebView {
     }
 
     public _loadUrl(url: string) {
-        trace.write("WebView._loadUrl(" + url + ")", trace.categories.Debug);
+        if (trace.enabled) {
+            trace.write("WebView._loadUrl(" + url + ")", trace.categories.Debug);
+        }
 
         if (this._ios.loading) {
             this._ios.stopLoading();


### PR DESCRIPTION
When logging non errors wrap guard them:
``` TypeScript
if (tracer.enabled) {
    tracer.write("some " + heavy + "calculations", nonErrorCategory);
}
```
Even if the tracer is disabled, the arguments will be calculated, sometimes calling heavy toString() implementations.

The guard is supposed to provide the most efficient way to skip any tracing overhead when running in release.