### PR TITLE
Use global.require in loadModule

### DIFF
--- a/globals/globals.ts
+++ b/globals/globals.ts
@@ -25,7 +25,7 @@ global.loadModule = function(name: string): any {
     if (loader) {
         return loader();
     } else {
-        return require(name);
+        return global.require(name);
     }
 }
 


### PR DESCRIPTION
This is required when preparing only the tns-core-modules for snapshotting. Otherwise webpack replaces this with custom webpack contexts (https://webpack.github.io/docs/configuration.html#automatically-created-contexts-defaults-module-xxxcontextxxx) which is not what we want.

Related to #1563

@hdeshev Do you think this change is going to conflict in any way with the webpack plugin? 