### PR TITLE
[Second Try] Add API that resolves the native android.app.Fragment instance created for a Page

### DIFF
--- a/tests/app/ui/page/page-tests.android.ts
+++ b/tests/app/ui/page/page-tests.android.ts
@@ -143,18 +143,22 @@ export var test_ChangePageCaching_BeforeNavigated_DoesNotThrow = function () {
 
 export var test_Resolve_Fragment_ForPage = function () {
     var testPage: PageModule.Page;
+    var navigatedTo = false;
+    
     var pageFactory = function () {
-        var testPage = new PageModule.Page();
+        testPage = new PageModule.Page();
         testPage.content = new LabelModule.Label();
+        // use navigatedTo to ensure the fragment is already created
+        testPage.on("navigatedTo", function(args) {
+            navigatedTo = true;
+        });
         return testPage;
     };
 
-    var topFrame = frame.topmost();
-    
     helper.navigate(pageFactory);
 
-    TKUnit.waitUntilReady(() => topFrame.currentPage !== null && topFrame.currentPage === testPage);
+    TKUnit.waitUntilReady(() => navigatedTo === true);
 
-    var fragment = topFrame.android.fragmentForPage(testPage);
+    var fragment = frame.topmost().android.fragmentForPage(testPage);
     TKUnit.assertFalse(types.isNullOrUndefined(fragment), "Failed to resolve native fragment for page");
 }

--- a/tests/app/ui/page/page-tests.android.ts
+++ b/tests/app/ui/page/page-tests.android.ts
@@ -4,6 +4,7 @@ import LabelModule = require("ui/label");
 import PageTestCommon = require("./page-tests-common");
 import helper = require("../helper");
 import frame = require("ui/frame");
+import types = require("utils/types");
 
 global.moduleMerge(PageTestCommon, exports);
 
@@ -138,4 +139,22 @@ export var test_ChangePageCaching_BeforeNavigated_DoesNotThrow = function () {
     finally {
         androidFrame.cachePagesOnNavigate = cachingBefore;
     }
+}
+
+export var test_Resolve_Fragment_ForPage = function () {
+    var testPage: PageModule.Page;
+    var pageFactory = function () {
+        var testPage = new PageModule.Page();
+        testPage.content = new LabelModule.Label();
+        return testPage;
+    };
+
+    var topFrame = frame.topmost();
+    
+    helper.navigate(pageFactory);
+
+    TKUnit.waitUntilReady(() => topFrame.currentPage !== null && topFrame.currentPage === testPage);
+
+    var fragment = topFrame.android.fragmentForPage(testPage);
+    TKUnit.assertFalse(types.isNullOrUndefined(fragment), "Failed to resolve native fragment for page");
 }

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -16,6 +16,7 @@ let FRAMEID = "_frameId";
 let navDepth = -1;
 let fragmentId = -1;
 let activityInitialized = false;
+const PAGE_FRAGMENT_TAG = "_fragmentTag";
 
 function onFragmentShown(fragment: FragmentClass) {
     if (trace.enabled) {
@@ -33,8 +34,9 @@ function onFragmentShown(fragment: FragmentClass) {
     // TODO: consider putting entry and page in queue so we can safely extract them here. Pass the index of current navigation and extract it from here.
     // After extracting navigation info - remove this index from navigation stack.
     var frame = fragment.frame;
-    var entry: definition.BackstackEntry = fragment.entry;
-    var page: pages.Page = entry.resolvedPage;
+    var entry = fragment.entry;
+    var page = entry.resolvedPage;
+    page[PAGE_FRAGMENT_TAG] = entry.fragmentTag;
 
     let currentNavigationContext;
     let navigationQueue = (<any>frame)._navigationQueue;
@@ -70,6 +72,7 @@ function onFragmentHidden(fragment: FragmentClass, destroyed: boolean) {
 
     var isBack = fragment.entry.isBack;
     fragment.entry.isBack = undefined;
+    fragment.entry.resolvedPage[PAGE_FRAGMENT_TAG] = undefined;
 
     // Handle page transitions.
     transitionModule._onFragmentHidden(fragment, isBack, destroyed);
@@ -511,6 +514,20 @@ class AndroidFrame extends Observable implements definition.AndroidFrame {
 
         // can go back only if it is not the main one.
         return this.activity.getIntent().getAction() !== android.content.Intent.ACTION_MAIN;
+    }
+    
+    public fragmentForPage(page: pages.Page): any {
+        if(!page) {
+            return undefined;
+        }
+
+        let tag = page[PAGE_FRAGMENT_TAG];
+        if(tag) {
+            let manager = this.activity.getFragmentManager();
+            return manager.findFragmentByTag(tag);
+        }
+        
+        return undefined;
     }
 }
 

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -294,6 +294,12 @@ declare module "ui/frame" {
          * Gets or sets whether the page UI will be cached when navigating away from the page.
          */
         cachePagesOnNavigate: boolean;
+        
+        /**
+         * Finds the native android.app.Fragment instance created for the specified Page.
+         * @param page The Page instance to search for.
+         */
+        fragmentForPage(page: pages.Page): any;
     }
 
     /* tslint:disable */


### PR DESCRIPTION
The specific use case is to enable the YouTube player plugin in a {N} app. The Google API works either through extending [YouTubeBaseActivity](https://developers.google.com/youtube/android/player/reference/com/google/android/youtube/player/YouTubeBaseActivity) or by creating an instance of the [YouTubePlayerFragment](https://developers.google.com/youtube/android/player/reference/com/google/android/youtube/player/YouTubePlayerFragment) class. Since navigation in the core Modules is fragment-based, it is more naturally to use the second approach of the player API.

This pull adds a method on the `AndroidFrame` interface that returns the native `android.app.Fragment` created for a Page instance. This native Fragment instance is needed so that we can take advantage of the [nested fragments](https://developer.android.com/about/versions/android-4.2.html#NestedFragments) functionality and integrate a YouTube fragment instance.