### PR TITLE
Expose the zonedCallback function

### DIFF
--- a/tns-core-modules/declarations.d.ts
+++ b/tns-core-modules/declarations.d.ts
@@ -146,9 +146,7 @@ declare function setInterval(callback: Function, milliseconds?: number): number;
  */
 declare function clearInterval(id: number): void;
 
-//@private
 declare function zonedCallback(callback: Function): Function;
-//@endprivate
 
 declare class WeakRef<T> {
     constructor(obj: T);


### PR DESCRIPTION
Expose the `zonedCallback` function so that it can be used from plugin developers to wrap callbacks that come from native inside zone. This is needed in Angular project to trigger the change detection.