### PR TITLE
Ignore the case when getting a response header

### DIFF
--- a/tests/app/xhr-tests.ts
+++ b/tests/app/xhr-tests.ts
@@ -345,3 +345,21 @@ export function test_responseType(done) {
         );
     done(null);
 }
+
+export function test_getResponseHeader() {
+    const xhr = <any>new XMLHttpRequest();
+    const response = {
+        statusCode: 200,
+        content: {
+            toString: function() { return this.raw },
+            raw: '{"data": 42}'
+        },
+        headers: {
+            "content-type": "application/json"
+        }
+
+    }
+    xhr._loadResponse(response);
+
+    TKUnit.assertEqual(xhr.getResponseHeader("Content-Type"), "application/json");
+};

--- a/tns-core-modules/xhr/xhr.ts
+++ b/tns-core-modules/xhr/xhr.ts
@@ -119,7 +119,7 @@ export class XMLHttpRequest {
         this._responseTextReader = () => r.content.toString();
         this._response = JSON.parse(this.responseText);
 
-        // Add toString() method to ease debugging and 
+        // Add toString() method to ease debugging and
         // make Angular2 response.text() method work properly.
         Object.defineProperty(this._response, "toString", {
             configurable: true,
@@ -194,10 +194,14 @@ export class XMLHttpRequest {
     public getResponseHeader(header: string): string {
         if (types.isString(header) && this._readyState > 1
             && this._headers
-            && this._headers[header]
             && !this._errorFlag
         ) {
-            return this._headers[header];
+            header = header.toLowerCase();
+            for (var i in this._headers) {
+                if (i.toLowerCase() === header) {
+                    return this._headers[i];
+                }
+            }
         }
 
         return null;


### PR DESCRIPTION
According to the RFC: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
"Field names are case-insensitive".
For instance, Google Cloud Endpoints use "content-type" in the response.