### PR TITLE
Fixed animation value sync issues

### DIFF
--- a/tns-core-modules/ui/animation/keyframe-animation.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.ts
@@ -36,6 +36,7 @@ export class KeyframeAnimation {
     private _isPlaying: boolean;
     private _isForwards: boolean;
     private _nativeAnimations: Array<animationModule.Animation>;
+    private _target: view.View;
 
     public static keyframeAnimationFromInfo(info: KeyframeAnimationInfo, valueSourceModifier: number) {
         let animations = new Array<Object>();
@@ -109,6 +110,10 @@ export class KeyframeAnimation {
                     animation.cancel();
                 }
             }
+            if (this._nativeAnimations.length > 0) {
+                let animation = this._nativeAnimations[0];
+                this._resetAnimationValues(this._target, animation);
+            }
             this._rejectAnimationFinishedPromise();
         }
     }
@@ -125,6 +130,7 @@ export class KeyframeAnimation {
 
         this._isPlaying = true;
         this._nativeAnimations = new Array<animationModule.Animation>();
+        this._target = view;
 
         if (this.delay !== 0) {
             let that = this;
@@ -174,24 +180,7 @@ export class KeyframeAnimation {
             else {
                 if (this._isForwards === false) {
                     let animation = this.animations[this.animations.length - 1];
-                    let modifier = animation["valueSource"];
-                    if ("backgroundColor" in animation) {
-                        view.style._resetValue(style.backgroundColorProperty, modifier);
-                    }
-                    if ("scale" in animation) {
-                        view.style._resetValue(style.scaleXProperty, modifier);
-                        view.style._resetValue(style.scaleYProperty, modifier);
-                    }
-                    if ("translate" in animation) {
-                        view.style._resetValue(style.translateXProperty, modifier);
-                        view.style._resetValue(style.translateYProperty, modifier);
-                    }
-                    if ("rotate" in animation) {
-                        view.style._resetValue(style.rotateProperty, modifier);
-                    }
-                    if ("opacity" in animation) {
-                        view.style._resetValue(style.opacityProperty, modifier);
-                    }
+                    this._resetAnimationValues(view, animation);
                 }
                 this._resolveAnimationFinishedPromise();
             }
@@ -210,12 +199,35 @@ export class KeyframeAnimation {
     public _resolveAnimationFinishedPromise() {
         this._nativeAnimations = new Array<animationModule.Animation>();
         this._isPlaying = false;
+        this._target = null;
         this._resolve();
     }
 
     public _rejectAnimationFinishedPromise() {
         this._nativeAnimations = new Array<animationModule.Animation>();
         this._isPlaying = false;
+        this._target = null;
         this._reject(new Error("Animation cancelled."));
+    }
+
+    private _resetAnimationValues(view: view.View, animation: Object) {
+        let modifier = animation["valueSource"];
+        if ("backgroundColor" in animation) {
+            view.style._resetValue(style.backgroundColorProperty, modifier);
+        }
+        if ("scale" in animation) {
+            view.style._resetValue(style.scaleXProperty, modifier);
+            view.style._resetValue(style.scaleYProperty, modifier);
+        }
+        if ("translate" in animation) {
+            view.style._resetValue(style.translateXProperty, modifier);
+            view.style._resetValue(style.translateYProperty, modifier);
+        }
+        if ("rotate" in animation) {
+            view.style._resetValue(style.rotateProperty, modifier);
+        }
+        if ("opacity" in animation) {
+            view.style._resetValue(style.opacityProperty, modifier);
+        }
     }
 }

--- a/tns-core-modules/ui/core/view-common.ts
+++ b/tns-core-modules/ui/core/view-common.ts
@@ -129,13 +129,8 @@ var cssClassProperty = new Property("cssClass", "View", new PropertyMetadata(und
 var classNameProperty = new Property("className", "View", new PropertyMetadata(undefined, PropertyMetadataSettings.AffectsStyle, onCssClassPropertyChanged));
 var idProperty = new Property("id", "View", new PropertyMetadata(undefined, PropertyMetadataSettings.AffectsStyle));
 var automationTextProperty = new Property("automationText", "View", new PropertyMetadata(undefined));
-var translateXProperty = new Property("translateX", "View", new PropertyMetadata(0));
-var translateYProperty = new Property("translateY", "View", new PropertyMetadata(0));
-var scaleXProperty = new Property("scaleX", "View", new PropertyMetadata(1));
-var scaleYProperty = new Property("scaleY", "View", new PropertyMetadata(1));
 var originXProperty = new Property("originX", "View", new PropertyMetadata(0.5));
 var originYProperty = new Property("originY", "View", new PropertyMetadata(0.5));
-var rotateProperty = new Property("rotate", "View", new PropertyMetadata(0));
 var isEnabledProperty = new Property("isEnabled", "View", new PropertyMetadata(true));
 var isUserInteractionEnabledProperty = new Property("isUserInteractionEnabled", "View", new PropertyMetadata(true));
 
@@ -147,13 +142,8 @@ export class View extends ProxyObject implements definition.View {
     public static idProperty = idProperty;
     public static cssClassProperty = cssClassProperty;
     public static classNameProperty = classNameProperty;
-    public static translateXProperty = translateXProperty;
-    public static translateYProperty = translateYProperty;
-    public static scaleXProperty = scaleXProperty;
-    public static scaleYProperty = scaleYProperty;
     public static originXProperty = originXProperty;
     public static originYProperty = originYProperty;
-    public static rotateProperty = rotateProperty;
     public static isEnabledProperty = isEnabledProperty;
     public static isUserInteractionEnabledProperty = isUserInteractionEnabledProperty;
 
@@ -423,31 +413,31 @@ export class View extends ProxyObject implements definition.View {
     //END Style property shortcuts
 
     get translateX(): number {
-        return this._getValue(View.translateXProperty);
+        return this.style.translateX;
     }
     set translateX(value: number) {
-        this._setValue(View.translateXProperty, value);
+        this.style.translateX = value;
     }
 
     get translateY(): number {
-        return this._getValue(View.translateYProperty);
+        return this.style.translateY;
     }
     set translateY(value: number) {
-        this._setValue(View.translateYProperty, value);
+        this.style.translateY = value;
     }
 
     get scaleX(): number {
-        return this._getValue(View.scaleXProperty);
+        return this.style.scaleX;
     }
     set scaleX(value: number) {
-        this._setValue(View.scaleXProperty, value);
+        this.style.scaleX = value;
     }
 
     get scaleY(): number {
-        return this._getValue(View.scaleYProperty);
+        return this.style.scaleY;
     }
     set scaleY(value: number) {
-        this._setValue(View.scaleYProperty, value);
+        this.style.scaleY = value;
     }
 
     get originX(): number {
@@ -465,10 +455,10 @@ export class View extends ProxyObject implements definition.View {
     }
 
     get rotate(): number {
-        return this._getValue(View.rotateProperty);
+        return this.style.rotate;
     }
     set rotate(value: number) {
-        this._setValue(View.rotateProperty, value);
+        this.style.rotate = value;
     }
 
     get isEnabled(): boolean {

--- a/tns-core-modules/ui/core/view.android.ts
+++ b/tns-core-modules/ui/core/view.android.ts
@@ -29,30 +29,6 @@ function onIdPropertyChanged(data: dependencyObservable.PropertyChangeData) {
 }
 (<proxy.PropertyMetadata>viewCommon.View.idProperty.metadata).onSetNativeValue = onIdPropertyChanged;
 
-function onTranslateXPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    view._nativeView.setTranslationX(data.newValue * utils.layout.getDisplayDensity());
-}
-(<proxy.PropertyMetadata>viewCommon.View.translateXProperty.metadata).onSetNativeValue = onTranslateXPropertyChanged;
-
-function onTranslateYPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    view._nativeView.setTranslationY(data.newValue * utils.layout.getDisplayDensity());
-}
-(<proxy.PropertyMetadata>viewCommon.View.translateYProperty.metadata).onSetNativeValue = onTranslateYPropertyChanged;
-
-function onScaleXPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    view._nativeView.setScaleX(data.newValue);
-}
-(<proxy.PropertyMetadata>viewCommon.View.scaleXProperty.metadata).onSetNativeValue = onScaleXPropertyChanged;
-
-function onScaleYPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    view._nativeView.setScaleY(data.newValue);
-}
-(<proxy.PropertyMetadata>viewCommon.View.scaleYProperty.metadata).onSetNativeValue = onScaleYPropertyChanged;
-
 function onOriginXPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     org.nativescript.widgets.OriginPoint.setX((<View>data.object)._nativeView, data.newValue);
 }
@@ -62,12 +38,6 @@ function onOriginYPropertyChanged(data: dependencyObservable.PropertyChangeData)
     org.nativescript.widgets.OriginPoint.setY((<View>data.object)._nativeView, data.newValue);
 }
 (<proxy.PropertyMetadata>viewCommon.View.originYProperty.metadata).onSetNativeValue = onOriginYPropertyChanged;
-
-function onRotatePropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    view._nativeView.setRotation(data.newValue);
-}
-(<proxy.PropertyMetadata>viewCommon.View.rotateProperty.metadata).onSetNativeValue = onRotatePropertyChanged;
 
 function onIsEnabledPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var view = <View>data.object;
@@ -479,7 +449,7 @@ export class CustomLayoutView extends View implements viewDefinition.CustomLayou
 }
 
 export class ViewStyler implements style.Styler {
-    //Background and borders methods
+    // Background and borders methods
     private static setBackgroundBorderProperty(view: View, newValue: any, defaultValue?: any) {
         background.ad.onBackgroundOrBorderPropertyChanged(view);
     }
@@ -488,7 +458,7 @@ export class ViewStyler implements style.Styler {
         background.ad.onBackgroundOrBorderPropertyChanged(view);
     }
 
-    //Visibility methods
+    // Visibility methods
     private static setVisibilityProperty(view: View, newValue: any) {
         var androidValue = (newValue === enums.Visibility.visible) ? android.view.View.VISIBLE : android.view.View.GONE;
         (<android.view.View>view._nativeView).setVisibility(androidValue);
@@ -498,7 +468,7 @@ export class ViewStyler implements style.Styler {
         (<android.view.View>view._nativeView).setVisibility(android.view.View.VISIBLE);
     }
 
-    //Opacity methods
+    // Opacity methods
     private static setOpacityProperty(view: View, newValue: any) {
         (<android.view.View>view._nativeView).setAlpha(float(newValue));
     }
@@ -507,7 +477,7 @@ export class ViewStyler implements style.Styler {
         (<android.view.View>view._nativeView).setAlpha(float(1.0));
     }
 
-    //minWidth methods
+    // minWidth methods
     private static setMinWidthProperty(view: View, newValue: any) {
         (<android.view.View>view._nativeView).setMinimumWidth(Math.round(newValue * utils.layout.getDisplayDensity()));
     }
@@ -516,7 +486,7 @@ export class ViewStyler implements style.Styler {
         (<android.view.View>view._nativeView).setMinimumWidth(0);
     }
 
-    //minHeight methods
+    // minHeight methods
     private static setMinHeightProperty(view: View, newValue: any) {
         (<android.view.View>view._nativeView).setMinimumHeight(Math.round(newValue * utils.layout.getDisplayDensity()));
     }
@@ -647,69 +617,49 @@ export class ViewStyler implements style.Styler {
 
     // Rotate
     private static setRotateProperty(view: View, newValue: any) {
-        view.rotate = newValue;
+        view._nativeView.setRotation(newValue);
     }
 
     private static resetRotateProperty(view: View, nativeValue: any) {
-        view.rotate = nativeValue;
+        view._nativeView.setRotation(float(0));
     }
 
-    private static getRotateProperty(view: View): any {
-        return view.rotate;
-    }
-
-    //ScaleX
+    // ScaleX
     private static setScaleXProperty(view: View, newValue: any) {
-        view.scaleX = newValue;
+        view._nativeView.setScaleX(newValue);
     }
 
     private static resetScaleXProperty(view: View, nativeValue: any) {
-        view.scaleX = nativeValue;
+        view._nativeView.setScaleX(float(1.0));
     }
 
-    private static getScaleXProperty(view: View): any {
-        return view.scaleX;
-    }
-
-    //ScaleY
+    // ScaleY
     private static setScaleYProperty(view: View, newValue: any) {
-        view.scaleY = newValue;
+        view._nativeView.setScaleY(newValue);
     }
 
     private static resetScaleYProperty(view: View, nativeValue: any) {
-        view.scaleY = nativeValue;
+        view._nativeView.setScaleY(float(1.0));
     }
 
-    private static getScaleYProperty(view: View): any {
-        return view.scaleY;
-    }
-
-    //TranslateX
+    // TranslateX
     private static setTranslateXProperty(view: View, newValue: any) {
-        view.translateX = newValue;
+        view._nativeView.setTranslationX(newValue * utils.layout.getDisplayDensity());
     }
 
     private static resetTranslateXProperty(view: View, nativeValue: any) {
-        view.translateX = nativeValue;
+        view._nativeView.setTranslationX(float(0));
     }
 
-    private static getTranslateXProperty(view: View): any {
-        return view.translateX;
-    }
-
-    //TranslateY
+    // TranslateY
     private static setTranslateYProperty(view: View, newValue: any) {
-        view.translateY = newValue;
+        view._nativeView.setTranslationY(newValue * utils.layout.getDisplayDensity());
     }
 
     private static resetTranslateYProperty(view: View, nativeValue: any) {
-        view.translateY = nativeValue;
+        view._nativeView.setTranslationY(float(0));
     }
 
-    private static getTranslateYProperty(view: View): any {
-        return view.translateY;
-    }
-    
     // z-index
     private static getZIndexProperty(view: View): any {
         return view.android.getZ ? view.android.getZ() : 0;
@@ -718,7 +668,7 @@ export class ViewStyler implements style.Styler {
     private static setZIndexProperty(view: View, newValue: any) {
         if (view.android.setZ) {
             view.android.setZ(newValue);
-            
+
             if(view.android instanceof android.widget.Button){
                 view.android.setStateListAnimator(null);
             }
@@ -729,7 +679,7 @@ export class ViewStyler implements style.Styler {
         if (view.android.setZ) {
             view.android.setZ(nativeValue);
         }
-    }    
+    }
 
     public static registerHandlers() {
         style.registerHandler(style.visibilityProperty, new style.StylePropertyChangedHandler(
@@ -775,32 +725,27 @@ export class ViewStyler implements style.Styler {
         style.registerHandler(style.nativePaddingsProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setPaddingProperty,
             ViewStyler.resetPaddingProperty), "LayoutBase");
-            
-             style.registerHandler(style.rotateProperty, new style.StylePropertyChangedHandler(
+
+        style.registerHandler(style.rotateProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setRotateProperty,
-            ViewStyler.resetRotateProperty,
-            ViewStyler.getRotateProperty));
+            ViewStyler.resetRotateProperty));
 
         style.registerHandler(style.scaleXProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setScaleXProperty,
-            ViewStyler.resetScaleXProperty,
-            ViewStyler.getScaleXProperty));
+            ViewStyler.resetScaleXProperty));
 
         style.registerHandler(style.scaleYProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setScaleYProperty,
-            ViewStyler.resetScaleYProperty,
-            ViewStyler.getScaleYProperty));
+            ViewStyler.resetScaleYProperty));
 
         style.registerHandler(style.translateXProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setTranslateXProperty,
-            ViewStyler.resetTranslateXProperty,
-            ViewStyler.getTranslateXProperty));
+            ViewStyler.resetTranslateXProperty));
 
         style.registerHandler(style.translateYProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setTranslateYProperty,
-            ViewStyler.resetTranslateYProperty,
-            ViewStyler.getTranslateYProperty));
-            
+            ViewStyler.resetTranslateYProperty));
+
         style.registerHandler(style.zIndexProperty, new style.StylePropertyChangedHandler(
             ViewStyler.setZIndexProperty,
             ViewStyler.resetZIndexProperty,

--- a/tns-core-modules/ui/core/view.ios.ts
+++ b/tns-core-modules/ui/core/view.ios.ts
@@ -24,16 +24,6 @@ function onAutomationTextPropertyChanged(data: dependencyObservable.PropertyChan
 }
 (<proxy.PropertyMetadata>viewCommon.View.automationTextProperty.metadata).onSetNativeValue = onAutomationTextPropertyChanged;
 
-function onTransfromPropertyChanged(data: dependencyObservable.PropertyChangeData) {
-    var view = <View>data.object;
-    view._updateNativeTransform();
-}
-(<proxy.PropertyMetadata>viewCommon.View.translateXProperty.metadata).onSetNativeValue = onTransfromPropertyChanged;
-(<proxy.PropertyMetadata>viewCommon.View.translateYProperty.metadata).onSetNativeValue = onTransfromPropertyChanged;
-(<proxy.PropertyMetadata>viewCommon.View.scaleXProperty.metadata).onSetNativeValue = onTransfromPropertyChanged;
-(<proxy.PropertyMetadata>viewCommon.View.scaleYProperty.metadata).onSetNativeValue = onTransfromPropertyChanged;
-(<proxy.PropertyMetadata>viewCommon.View.rotateProperty.metadata).onSetNativeValue = onTransfromPropertyChanged;
-
 function onOriginPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var view = <View>data.object;
     view._updateOriginPoint();
@@ -252,7 +242,7 @@ export class View extends viewCommon.View {
         return {
             x: utils.layout.toDeviceIndependentPixels(pointInWindow.x),
             y: utils.layout.toDeviceIndependentPixels(pointInWindow.y),
-        }
+        };
     }
 
     public getLocationOnScreen(): viewDefinition.Point {
@@ -265,7 +255,7 @@ export class View extends viewCommon.View {
         return {
             x: utils.layout.toDeviceIndependentPixels(pointOnScreen.x),
             y: utils.layout.toDeviceIndependentPixels(pointOnScreen.y),
-        }
+        };
     }
 
     public getLocationRelativeTo(otherView: viewDefinition.View): viewDefinition.Point {
@@ -280,7 +270,7 @@ export class View extends viewCommon.View {
         return {
             x: utils.layout.toDeviceIndependentPixels(myPointInWindow.x - otherPointInWindow.x),
             y: utils.layout.toDeviceIndependentPixels(myPointInWindow.y - otherPointInWindow.y),
-        }
+        };
     }
 
     private _onSizeChanged() {
@@ -288,10 +278,15 @@ export class View extends viewCommon.View {
     }
 
     public _updateNativeTransform() {
-        var newTransform = CGAffineTransformIdentity;
-        newTransform = CGAffineTransformTranslate(newTransform, this.translateX, this.translateY);
-        newTransform = CGAffineTransformRotate(newTransform, this.rotate * Math.PI / 180);
-        newTransform = CGAffineTransformScale(newTransform, this.scaleX, this.scaleY);
+        let translateX = this.translateX || 0;
+        let translateY = this.translateY || 0;
+        let scaleX = this.scaleX || 1;
+        let scaleY = this.scaleY || 1;
+        let rotate = this.rotate || 0;
+        let newTransform = CGAffineTransformIdentity;
+        newTransform = CGAffineTransformTranslate(newTransform, translateX, translateY);
+        newTransform = CGAffineTransformRotate(newTransform, rotate * Math.PI / 180);
+        newTransform = CGAffineTransformScale(newTransform, scaleX, scaleY);
         if (!CGAffineTransformEqualToTransform(this._nativeView.transform, newTransform)) {
             this._nativeView.transform = newTransform;
             this._hasTransfrom = this._nativeView && !CGAffineTransformEqualToTransform(this._nativeView.transform, CGAffineTransformIdentity);
@@ -377,7 +372,7 @@ export class CustomLayoutView extends View {
 }
 
 export class ViewStyler implements style.Styler {
-    //Background methods
+    // Background methods
     private static setBackgroundInternalProperty(view: View, newValue: any) {
         var nativeView: UIView = <UIView>view._nativeView;
         if (nativeView) {
@@ -408,7 +403,7 @@ export class ViewStyler implements style.Styler {
         return undefined;
     }
 
-    //Visibility methods
+    // Visibility methods
     private static setVisibilityProperty(view: View, newValue: any) {
         var nativeView: UIView = <UIView>view._nativeView;
         if (nativeView) {
@@ -423,7 +418,7 @@ export class ViewStyler implements style.Styler {
         }
     }
 
-    //Opacity methods
+    // Opacity methods
     private static setOpacityProperty(view: View, newValue: any) {
         var nativeView: UIView = <UIView>view._nativeView;
         if (nativeView) {
@@ -446,7 +441,7 @@ export class ViewStyler implements style.Styler {
         }
     }
 
-    //Border width methods
+    // Border width methods
     private static setBorderWidthProperty(view: View, newValue: any) {
         if (view._nativeView instanceof UIView) {
             (<UIView>view._nativeView).layer.borderWidth = newValue;
@@ -466,7 +461,7 @@ export class ViewStyler implements style.Styler {
         return 0;
     }
 
-    //Border color methods
+    // Border color methods
     private static setBorderColorProperty(view: View, newValue: any) {
         if (view._nativeView instanceof UIView && newValue instanceof UIColor) {
             (<UIView>view._nativeView).layer.borderColor = (<UIColor>newValue).CGColor;
@@ -486,7 +481,7 @@ export class ViewStyler implements style.Styler {
         return undefined;
     }
 
-    //Border radius methods
+    // Border radius methods
     private static setBorderRadiusProperty(view: View, newValue: any) {
         if (view._nativeView instanceof UIView) {
             (<UIView>view._nativeView).layer.cornerRadius = newValue;
@@ -509,70 +504,90 @@ export class ViewStyler implements style.Styler {
 
     // Rotate
     private static setRotateProperty(view: View, newValue: any) {
-        view.rotate = newValue;
+        view._updateNativeTransform();
     }
 
     private static resetRotateProperty(view: View, nativeValue: any) {
-        view.rotate = nativeValue;
+        view._updateNativeTransform();
     }
 
     private static getRotateProperty(view: View): any {
-        return view.rotate;
+        if (view._nativeView instanceof UIView) {
+            let t: CGAffineTransform = (<UIView>view._nativeView).transform;
+            return Math.atan2(t.b, t.a);
+        }
+        return 0;
     }
 
-    //ScaleX
+    // ScaleX
     private static setScaleXProperty(view: View, newValue: any) {
-        view.scaleX = newValue;
+        view._updateNativeTransform();
     }
 
     private static resetScaleXProperty(view: View, nativeValue: any) {
-        view.scaleX = nativeValue;
+        view._updateNativeTransform();
     }
 
     private static getScaleXProperty(view: View): any {
-        return view.scaleX;
+        if (view._nativeView instanceof UIView) {
+            let t: CGAffineTransform = (<UIView>view._nativeView).transform;
+            return Math.sqrt(t.a * t.a + t.c * t.c);
+        }
+        return 0;
     }
 
-    //ScaleY
+    // ScaleY
     private static setScaleYProperty(view: View, newValue: any) {
-        view.scaleY = newValue;
+        view._updateNativeTransform();
     }
 
     private static resetScaleYProperty(view: View, nativeValue: any) {
-        view.scaleY = nativeValue;
+        view._updateNativeTransform();
     }
 
     private static getScaleYProperty(view: View): any {
-        return view.scaleY;
+        if (view._nativeView instanceof UIView) {
+            let t: CGAffineTransform = (<UIView>view._nativeView).transform;
+            return Math.sqrt(t.b * t.b + t.d * t.d);
+        }
+        return 0;
     }
 
-    //TranslateX
+    // TranslateX
     private static setTranslateXProperty(view: View, newValue: any) {
-        view.translateX = newValue;
+        view._updateNativeTransform();
     }
 
     private static resetTranslateXProperty(view: View, nativeValue: any) {
-        view.translateX = nativeValue;
+        view._updateNativeTransform();
     }
 
     private static getTranslateXProperty(view: View): any {
-        return view.translateX;
+        if (view._nativeView instanceof UIView) {
+            let t: CGAffineTransform = (<UIView>view._nativeView).transform;
+            return t.tx;
+        }
+        return 0;
     }
 
-    //TranslateY
+    // TranslateY
     private static setTranslateYProperty(view: View, newValue: any) {
-        view.translateY = newValue;
+        view._updateNativeTransform();
     }
 
     private static resetTranslateYProperty(view: View, nativeValue: any) {
-        view.translateY = nativeValue;
+        view._updateNativeTransform();
     }
 
     private static getTranslateYProperty(view: View): any {
-        return view.translateY;
+        if (view._nativeView instanceof UIView) {
+            let t: CGAffineTransform = (<UIView>view._nativeView).transform;
+            return t.ty;
+        }
+        return 0;
     }
 
-    //z-index
+    // z-index
     private static setZIndexProperty(view: View, newValue: any) {
         view.ios.layer.zPosition = newValue;
     }
@@ -584,8 +599,8 @@ export class ViewStyler implements style.Styler {
     private static getZIndexProperty(view: View): any {
         return view.ios.layer.zPosition;
     }
-    
-    //Clip-path methods
+
+    // Clip-path methods
     private static setClipPathProperty(view: View, newValue: any) {
         var nativeView: UIView = <UIView>view._nativeView;
         if (nativeView) {

--- a/tns-core-modules/ui/styling/css-selector.ts
+++ b/tns-core-modules/ui/styling/css-selector.ts
@@ -66,6 +66,7 @@ export class CssSelector {
     }
 
     public apply(view: view.View, valueSourceModifier: number) {
+        view._unregisterAllAnimations();
         let modifier = valueSourceModifier || this.valueSourceModifier;
         this.eachSetter((property, value) => {
             if (types.isString(property)) {
@@ -92,7 +93,6 @@ export class CssSelector {
                 }
             }
         });
-        view._unregisterAllAnimations();
         if (this.animations && view.isLoaded && view._nativeView !== undefined) {
             for (let animationInfo of this.animations) {
                 let animation = keyframeAnimation.KeyframeAnimation.keyframeAnimationFromInfo(animationInfo, modifier);


### PR DESCRIPTION
Fixes the following scenario (existing in iOS):

1. Execute an animation (e.g. translate 0, 100)
2. Reset transformX, transformY values with code
3. Animate again (translate 0, 100) and the animation will look wrong because style property values will be out of sync compared to the View properties.