### PR TITLE
Avoid excessive requestLayout calls

### DIFF
--- a/tns-core-modules/ui/core/view.android.ts
+++ b/tns-core-modules/ui/core/view.android.ts
@@ -280,6 +280,10 @@ export class View extends viewCommon.View {
         return this.android;
     }
 
+    get isLayoutRequired(): boolean {
+        return !this.isLayoutValid;
+    }
+
     get isLayoutValid(): boolean {
         if (this._nativeView) {
             return !this._nativeView.isLayoutRequested();

--- a/tns-core-modules/ui/core/view.d.ts
+++ b/tns-core-modules/ui/core/view.d.ts
@@ -484,8 +484,8 @@ declare module "ui/core/view" {
         isLoaded: boolean;
 
         _addView(view: View, atIndex?: number);
-        _propagateInheritableProperties(view: View)
-        _inheritProperties(parentView: View)
+        _propagateInheritableProperties(view: View);
+        _inheritProperties(parentView: View);
         _removeView(view: View);
         _context: any /* android.content.Context */;
 
@@ -499,8 +499,8 @@ declare module "ui/core/view" {
 
         public _applyXmlAttribute(attribute: string, value: any): boolean;
 
-        // TODO: Implement logic for stripping these lines out
         //@private
+        isLayoutRequired: boolean;
         _parentChanged(oldParent: View): void;
         _gestureObservers: any;
         _isInheritedChange(): boolean;
@@ -610,5 +610,4 @@ declare module "ui/core/view" {
          */
         _applyXmlAttribute(attributeName: string, attrValue: any): boolean;
     }
-
 }

--- a/tns-core-modules/ui/core/view.ios.ts
+++ b/tns-core-modules/ui/core/view.ios.ts
@@ -94,6 +94,10 @@ export class View extends viewCommon.View {
         return this.ios;
     }
 
+    get isLayoutRequired(): boolean {
+        return (this._privateFlags & PFLAG_LAYOUT_REQUIRED) === PFLAG_LAYOUT_REQUIRED;
+    }
+
     get isLayoutRequested(): boolean {
         return (this._privateFlags & PFLAG_FORCE_LAYOUT) === PFLAG_FORCE_LAYOUT;
     }
@@ -109,7 +113,6 @@ export class View extends viewCommon.View {
     }
 
     public measure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-
         var measureSpecsChanged = this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
         var forceLayout = (this._privateFlags & PFLAG_FORCE_LAYOUT) === PFLAG_FORCE_LAYOUT;
         if (forceLayout || measureSpecsChanged) {
@@ -136,9 +139,11 @@ export class View extends viewCommon.View {
             this.onLayout(left, top, right, bottom);
             this._privateFlags &= ~PFLAG_LAYOUT_REQUIRED;
         }
+
         if (sizeChanged) {
             this._onSizeChanged();
         }
+
         this._privateFlags &= ~PFLAG_FORCE_LAYOUT;
     }
 

--- a/tns-core-modules/ui/list-view/list-view-common.ts
+++ b/tns-core-modules/ui/list-view/list-view-common.ts
@@ -174,7 +174,8 @@ export class ListView extends view.View implements definition.ListView {
     }
 
     private _getDataItem(index: number): any {
-        return this.items.getItem ? this.items.getItem(index) : this.items[index];
+        let thisItems = this.items;
+        return thisItems.getItem ? thisItems.getItem(index) : thisItems[index];
     }
 
     public _getDefaultItemContent(index: number): view.View {


### PR DESCRIPTION
Added View.isLayoutRequired - to check if Layout call is needed after a measure call. Use in list-view.
Measure pass now get all its properties from nativeLayoutParams property instead of using instance dependency properties (e.g. perf improvement).
List-view now layouts cells only if there is need to.
List-view now measure rows with the specified rowHeight.