### PR TITLE
Extract the Activity implementation logic in a separate class.

### DIFF
--- a/tests/app/ui/dependency-observable-tests.ts
+++ b/tests/app/ui/dependency-observable-tests.ts
@@ -232,7 +232,6 @@ export function test_PropertyMetadata_Options() {
 }
 
 export function test_PropertyEntry_effectiveValue() {
-    var p = new dependencyObservableModule.Property(generatePropertyName(), "testOwner", new dependencyObservableModule.PropertyMetadata(0));
     var entry = new dependencyObservableModule.PropertyEntry();
 
     // default value

--- a/tns-core-modules/ui/frame/activity.android.ts
+++ b/tns-core-modules/ui/frame/activity.android.ts
@@ -1,0 +1,36 @@
+import {activityCallbacks as callbacks} from "ui/frame";
+
+@JavaProxy("com.tns.NativeScriptActivity")
+class NativeScriptActivity extends android.app.Activity {
+    protected onCreate(savedInstanceState: android.os.Bundle): void {
+        callbacks.onCreate(this, savedInstanceState, super.onCreate);
+    }
+
+    protected onSaveInstanceState(outState: android.os.Bundle): void {
+        callbacks.onSaveInstanceState(this, outState, super.onSaveInstanceState);
+    }
+
+    protected onStart(): void {
+        callbacks.onStart(this, super.onStart);
+    }
+
+    protected onStop(): void {
+        callbacks.onStop(this, super.onStop);
+    }
+
+    protected onDestroy(): void {
+        callbacks.onDestroy(this, super.onDestroy);
+    }
+
+    public onBackPressed(): void {
+        callbacks.onBackPressed(this, super.onBackPressed);
+    }
+
+    public onRequestPermissionsResult (requestCode: number, permissions: Array<String>, grantResults: Array<number>): void {
+        callbacks.onRequestPermissionsResult(this, requestCode, permissions, grantResults, undefined /*TODO: Enable if needed*/);
+    }
+
+    protected onActivityResult(requestCode: number, resultCode: number, data: android.content.Intent): void {
+        callbacks.onActivityResult(this, requestCode, resultCode, data, super.onActivityResult);
+    }
+}

--- a/tns-core-modules/ui/frame/activity.android.ts
+++ b/tns-core-modules/ui/frame/activity.android.ts
@@ -2,6 +2,11 @@ import {activityCallbacks as callbacks} from "ui/frame";
 
 @JavaProxy("com.tns.NativeScriptActivity")
 class NativeScriptActivity extends android.app.Activity {
+    constructor() {
+         super();
+         return global.__native(this);
+     }
+
     protected onCreate(savedInstanceState: android.os.Bundle): void {
         callbacks.onCreate(this, savedInstanceState, super.onCreate);
     }

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -728,9 +728,6 @@ class FragmentClass extends android.app.Fragment {
 
 class ActivityCallbacksImplementation implements definition.AndroidActivityCallbacks {
     private _rootView: View;
-    
-    constructor() {
-    }
 
     public onCreate(activity: android.app.Activity, savedInstanceState: android.os.Bundle, superFunc: Function): void {
         if (trace.enabled) {

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -122,6 +122,8 @@ declare module "ui/frame" {
         on(event: "optionSelected", callback: (args: observable.EventData) => void, thisArg?: any);
     }
 
+    export var activityCallbacks: AndroidActivityCallbacks;
+
     /**
      * Gets the topmost frame in the frames stack. An application will typically has one frame instance. Multiple frames handle nested (hierarchical) navigation scenarios.
      */
@@ -300,6 +302,17 @@ declare module "ui/frame" {
          * @param page The Page instance to search for.
          */
         fragmentForPage(page: pages.Page): any;
+    }
+
+    export interface AndroidActivityCallbacks {
+        onCreate(activity: any, savedInstanceState: any, superFunc: Function): void;
+        onSaveInstanceState(activity: any, outState: any, superFunc: Function): void;
+        onStart(activity: any, superFunc: Function): void;
+        onStop(activity: any, superFunc: Function): void;
+        onDestroy(activity: any, superFunc: Function): void;
+        onBackPressed(activity: any, superFunc: Function): void;
+        onRequestPermissionsResult(activity: any, requestCode: number, permissions: Array<String>, grantResults: Array<number>, superFunc: Function): void;
+        onActivityResult(activity: any, requestCode: number, resultCode: number, data: any, superFunc: Function);
     }
 
     /* tslint:disable */

--- a/tns-core-modules/ui/package.json
+++ b/tns-core-modules/ui/package.json
@@ -1,4 +1,6 @@
 {
 	"name" : "ui",
-	"nativescript": {}
+	"nativescript": {
+		"recursive-static-bindings": true
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -128,6 +128,7 @@
         "tns-core-modules/ui/editable-text-base/editable-text-base.android.ts",
         "tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts",
         "tns-core-modules/ui/enums/enums.ts",
+        "tns-core-modules/ui/frame/activity.android.ts",
         "tns-core-modules/ui/frame/frame-common.ts",
         "tns-core-modules/ui/frame/frame.android.ts",
         "tns-core-modules/ui/frame/frame.ios.ts",


### PR DESCRIPTION
This pull removes the prerequisite for a specific Activity type for the core modules and enables scenarios where users will need custom Activity base type - e.g. `YouTubeBaseActivity`. The modules now depend on being notified externally for an `Activity` event - like `onCreate`.

Steps for providing extended Activity at user level:

1. Add a new file, having the `*.android.*` suffix.
2. Implement/override the needed methods.
3. User must notify the core modules for the needed callbacks through the `ui/frame/AndroidActivityCallbacks` interface.
4. The static-binding-generator will take care of generating the new Activity class. The default one provided by the modules will be either overridden or will not be used (in case of a new Activity name).
5 User must update the manifest file if the Activity name, defined through the `JavaProxy` decorator, is changed to a new one.

**Cons:** The biggest concern with this approach is that if the user misses to call to the modules upon some needed event then the behavior of the entire application will become indeterminate and the app will either crash or perform in an unexpected way.