### PR TITLE
Decouple Fragment implementation logic from the Extend call.

### DIFF
--- a/tns-core-modules/ui/frame/fragment.android.ts
+++ b/tns-core-modules/ui/frame/fragment.android.ts
@@ -1,0 +1,49 @@
+import * as frame from "ui/frame";
+
+@JavaProxy("com.tns.FragmentClass")
+class FragmentClass extends android.app.Fragment {
+    // This field is updated in the frame module upon `new` (although hacky this eases the Fragment->callbacks association a lot)
+    private _callbacks;
+
+    constructor() {
+        super();
+        return global.__native(this);
+    }
+
+    public onHiddenChanged(hidden: boolean): void {
+        this._callbacks.onHiddenChanged(this, hidden, super.onHiddenChanged);
+    }
+
+    public onCreateAnimator(transit: number, enter: boolean, nextAnim: number): android.animation.Animator {
+        let result = this._callbacks.onCreateAnimator(this, transit, enter, nextAnim, super.onCreateAnimator);
+        return result;
+    }
+
+    public onCreate(savedInstanceState: android.os.Bundle) {
+        super.setHasOptionsMenu(true);
+        this._callbacks.onCreate(this, savedInstanceState, super.onCreate);
+    }
+
+    public onCreateView(inflater: android.view.LayoutInflater, container: android.view.ViewGroup, savedInstanceState: android.os.Bundle) {
+        let result = this._callbacks.onCreateView(this, inflater, container, savedInstanceState, super.onCreateView);
+        return result;
+    }
+
+    public onSaveInstanceState(outState: android.os.Bundle) {
+        this._callbacks.onSaveInstanceState(this, outState, super.onSaveInstanceState);
+    }
+
+    public onDestroyView() {
+        this._callbacks.onDestroyView(this, super.onDestroyView);
+    }
+
+    public onDestroy() {
+        this._callbacks.onDestroy(this, super.onDestroy);
+    }
+
+    public toString(): string {
+        return this._callbacks.toStringOverride(this, super.toString);
+    }
+}
+
+frame.setFragmentClass(FragmentClass);

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -124,6 +124,8 @@ declare module "ui/frame" {
 
     export var activityCallbacks: AndroidActivityCallbacks;
 
+    export function setFragmentClass(clazz: any): void;
+
     /**
      * Gets the topmost frame in the frames stack. An application will typically has one frame instance. Multiple frames handle nested (hierarchical) navigation scenarios.
      */
@@ -313,6 +315,17 @@ declare module "ui/frame" {
         onBackPressed(activity: any, superFunc: Function): void;
         onRequestPermissionsResult(activity: any, requestCode: number, permissions: Array<String>, grantResults: Array<number>, superFunc: Function): void;
         onActivityResult(activity: any, requestCode: number, resultCode: number, data: any, superFunc: Function);
+    }
+
+    export interface AndroidFragmentCallbacks {
+        onHiddenChanged(fragment: any, hidden: boolean, superFunc: Function): void;
+        onCreateAnimator(fragment: any, transit: number, enter: boolean, nextAnim: number, superFunc: Function): any;
+        onCreate(fragment: any, savedInstanceState: any, superFunc: Function): void;
+        onCreateView(fragment: any, inflater: any, container: any, savedInstanceState: any, superFunc: Function): any;
+        onSaveInstanceState(fragment: any, outState: any, superFunc: Function): void;
+        onDestroyView(fragment: any, superFunc: Function): void;
+        onDestroy(fragment: any, superFunc: Function): void;
+        toStringOverride(fragment: any, superFunc: Function): string;
     }
 
     /* tslint:disable */

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -122,8 +122,14 @@ declare module "ui/frame" {
         on(event: "optionSelected", callback: (args: observable.EventData) => void, thisArg?: any);
     }
 
+    /**
+     * Gets the default AndroidActivityCallbacks implementation, used to bridge Activity events to the Frame and navigation routine. This field is initialized only for the Android platform.
+     */    
     export var activityCallbacks: AndroidActivityCallbacks;
 
+    /**
+     * Sets the extended android.app.Fragment class to the Frame and navigation routine. An instance of this class will be created to represent the Page currently visible on the srceen. This method is available only for the Android platform.
+     */
     export function setFragmentClass(clazz: any): void;
 
     /**

--- a/tns-core-modules/ui/transition/transition.android.ts
+++ b/tns-core-modules/ui/transition/transition.android.ts
@@ -344,8 +344,8 @@ export function _onFragmentHidden(fragment: any, isBack: boolean, destroyed: boo
 function _completePageAddition(fragment: any, isBack: boolean) {
     let expandedFragment = <ExpandedFragment>fragment;
     expandedFragment.completePageAdditionWhenTransitionEnds = undefined;
-    let frame = fragment.frame;
-    let entry: BackstackEntry = fragment.entry;
+    let frame = fragment._callbacks.frame;
+    let entry: BackstackEntry = fragment._callbacks.entry;
     let page: Page = entry.resolvedPage;
     if (trace.enabled) {
         trace.write(`STARTING ADDITION of ${page}...`, trace.categories.Transition);
@@ -363,8 +363,8 @@ function _completePageAddition(fragment: any, isBack: boolean) {
 function _completePageRemoval(fragment: any, isBack: boolean) {
     let expandedFragment = <ExpandedFragment>fragment;
     expandedFragment.completePageRemovalWhenTransitionEnds = undefined;
-    let frame = fragment.frame;
-    let entry: BackstackEntry = fragment.entry;
+    let frame = fragment._callbacks.frame;
+    let entry: BackstackEntry = fragment._callbacks.entry;
     let page: Page = entry.resolvedPage;
     if (trace.enabled) {
         trace.write(`STARTING REMOVAL of ${page}...`, trace.categories.Transition);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -129,6 +129,7 @@
         "tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts",
         "tns-core-modules/ui/enums/enums.ts",
         "tns-core-modules/ui/frame/activity.android.ts",
+        "tns-core-modules/ui/frame/fragment.android.ts",
         "tns-core-modules/ui/frame/frame-common.ts",
         "tns-core-modules/ui/frame/frame.android.ts",
         "tns-core-modules/ui/frame/frame.ios.ts",


### PR DESCRIPTION
This pull decouples the android.app.Fragment extend in a separate file, which allows it to be safely skipped from the snapshot bundle. It also allows users to provide custom extend logic, given they utilize the `frame` module as needed (calling back through the provided `_callbacks` member).