### PR TITLE
Rename com.tns.Async.xxx to org.nativescript.widgets.Async.xxx

### DIFF
--- a/tns-core-modules/declarations.android.d.ts
+++ b/tns-core-modules/declarations.android.d.ts
@@ -49,45 +49,49 @@ declare module android {
     }
 }
 
-declare module com {
-    export module tns {
-        export module Async {
-            export class CompleteCallback {
-                constructor(implementation: ICompleteCallback);
-                onComplete(result: Object, context: Object): void;
-            }
-
-            export interface ICompleteCallback {
-                onComplete(result: Object, context: Object): void;
-            }
-
-            export module Http {
-                export class KeyValuePair {
-                    public key: string;
-                    public value: string;
-                    constructor(key: string, value: string);
+declare module org {
+    export module nativescript {
+        export module widgets {
+            export module Async {
+                export class CompleteCallback {
+                    constructor(implementation: ICompleteCallback);
+                    onComplete(result: Object, context: Object): void;
                 }
 
-                export class RequestOptions {
-                    public url: string;
-                    public method: string;
-                    public headers: java.util.ArrayList<KeyValuePair>;
-                    public content: string;
-                    public timeout: number;
-                    public screenWidth: number;
-                    public screenHeight: number;
+                export interface ICompleteCallback {
+                    onComplete(result: Object, context: Object): void;
                 }
 
-                export class RequestResult {
-                    public raw: java.io.ByteArrayOutputStream;
-                    public headers: java.util.ArrayList<KeyValuePair>;
-                    public statusCode: number;
-                    public responseAsString: string;
-                    public responseAsImage: android.graphics.Bitmap;
-                    public error: java.lang.Exception;
-                }
+                export function DownloadImage(url: string, callback: CompleteCallback, context: any);
 
-                export function MakeRequest(options: RequestOptions, callback: CompleteCallback, context: any);
+                export module Http {
+                    export class KeyValuePair {
+                        public key: string;
+                        public value: string;
+                        constructor(key: string, value: string);
+                    }
+
+                    export class RequestOptions {
+                        public url: string;
+                        public method: string;
+                        public headers: java.util.ArrayList<KeyValuePair>;
+                        public content: string;
+                        public timeout: number;
+                        public screenWidth: number;
+                        public screenHeight: number;
+                    }
+
+                    export class RequestResult {
+                        public raw: java.io.ByteArrayOutputStream;
+                        public headers: java.util.ArrayList<KeyValuePair>;
+                        public statusCode: number;
+                        public responseAsString: string;
+                        public responseAsImage: android.graphics.Bitmap;
+                        public error: java.lang.Exception;
+                    }
+
+                    export function MakeRequest(options: RequestOptions, callback: CompleteCallback, context: any);
+                }
             }
         }
     }

--- a/tns-core-modules/http/http-request.android.ts
+++ b/tns-core-modules/http/http-request.android.ts
@@ -34,13 +34,13 @@ function ensurePlatform() {
     }
 }
 
-var completeCallback: com.tns.Async.CompleteCallback;
+var completeCallback: org.nativescript.widgets.Async.CompleteCallback;
 function ensureCompleteCallback() {
     if (completeCallback) {
         return;
     }
 
-    completeCallback = new com.tns.Async.CompleteCallback({
+    completeCallback = new org.nativescript.widgets.Async.CompleteCallback({
         onComplete: function (result: any, context: any) {
             // as a context we will receive the id of the request
             onRequestComplete(context, result);
@@ -48,7 +48,7 @@ function ensureCompleteCallback() {
     });
 }
 
-function onRequestComplete(requestId: number, result: com.tns.Async.Http.RequestResult) {
+function onRequestComplete(requestId: number, result: org.nativescript.widgets.Async.Http.RequestResult) {
     var callbacks = pendingRequests[requestId];
     delete pendingRequests[requestId];
 
@@ -63,7 +63,7 @@ function onRequestComplete(requestId: number, result: com.tns.Async.Http.Request
         var jHeaders = result.headers;
         var length = jHeaders.size();
         var i;
-        var pair: com.tns.Async.Http.KeyValuePair;
+        var pair: org.nativescript.widgets.Async.Http.KeyValuePair;
         for (i = 0; i < length; i++) {
             pair = jHeaders.get(i);
             
@@ -130,7 +130,7 @@ function buildJavaOptions(options: http.HttpRequestOptions) {
         throw new Error("Http request must provide a valid url.");
     }
 
-    var javaOptions = new com.tns.Async.Http.RequestOptions();
+    var javaOptions = new org.nativescript.widgets.Async.Http.RequestOptions();
 
     javaOptions.url = options.url;
 
@@ -145,8 +145,8 @@ function buildJavaOptions(options: http.HttpRequestOptions) {
     }
 
     if (options.headers) {
-        var arrayList = new java.util.ArrayList<com.tns.Async.Http.KeyValuePair>();
-        var pair = com.tns.Async.Http.KeyValuePair;
+        var arrayList = new java.util.ArrayList<org.nativescript.widgets.Async.Http.KeyValuePair>();
+        var pair = org.nativescript.widgets.Async.Http.KeyValuePair;
 
         for (var key in options.headers) {
             arrayList.add(new pair(key, options.headers[key] + ""));
@@ -186,7 +186,7 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
 
             ensureCompleteCallback();
             //make the actual async call
-            com.tns.Async.Http.MakeRequest(javaOptions, completeCallback, new java.lang.Integer(requestIdCounter));
+            org.nativescript.widgets.Async.Http.MakeRequest(javaOptions, completeCallback, new java.lang.Integer(requestIdCounter));
 
             // increment the id counter
             requestIdCounter++;

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -589,7 +589,8 @@ function findPageForFragment(fragment: android.app.Fragment, frame: Frame) {
 }
 
 function startActivity(activity: android.app.Activity, frameId: number) {
-    var intent = new android.content.Intent(activity, (<any>com).tns.NativeScriptActivity.class);
+    // TODO: Implicitly, we will open the same activity type as the current one
+    var intent = new android.content.Intent(activity, activity.getClass());
     intent.setAction(android.content.Intent.ACTION_DEFAULT);
     intent.putExtra(INTENT_EXTRA, frameId);
 

--- a/tns-core-modules/ui/image-cache/image-cache.android.ts
+++ b/tns-core-modules/ui/image-cache/image-cache.android.ts
@@ -41,7 +41,7 @@ export class Cache extends common.Cache {
         this._cache = new LruBitmapCacheClass(cacheSize);
 
         var that = new WeakRef(this);
-        this._callback = new (<any>com).tns.Async.CompleteCallback({
+        this._callback = new org.nativescript.widgets.Async.CompleteCallback({
             onComplete: function (result: any, context: any) {
                 var instance = that.get();
                 if (instance) {
@@ -52,7 +52,7 @@ export class Cache extends common.Cache {
     }
 
     public _downloadCore(request: common.DownloadRequest) {
-        (<any>com).tns.Async.DownloadImage(request.url, this._callback, request.key);
+        org.nativescript.widgets.Async.DownloadImage(request.url, this._callback, request.key);
     }
 
     public get(key: string): any {


### PR DESCRIPTION
The Async.java implementation is moved from the Android Runtime project template to the widgets repo. This pull renames the package - `com.tns.Async` is now `org.nativescript.widgets.Async`.

**Note:** Do not merge for now, these two pulls should be merged first:

* https://github.com/NativeScript/android-runtime/pull/478
* https://github.com/NativeScript/tns-core-modules-widgets/pull/26