### PR TITLE
Use the nativescript theme by default for api-ref

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -405,7 +405,7 @@ module.exports = function(grunt) {
                     "module": 'commonjs',
                     "target": 'es5',
                     "out": '<%= grunt.option("out") || localCfg.outApiRefDir %>',
-                    "theme": '<%= grunt.option("theme") || "default" %>',
+                    "theme": '<%= grunt.option("theme") || "./node_modules/nativescript-typedoc-theme" %>',
                     "name": 'NativeScript',
                     "includeDeclarations": undefined,
                     "experimentalDecorators": undefined,


### PR DESCRIPTION
No related issue. Small change to ease the documentation build script.

No tests, for the change is in the build scripts.


