### PR TITLE
Fixed issue #1655 cascading css selectors.

### DIFF
--- a/tests/app/ui/styling/style-tests.ts
+++ b/tests/app/ui/styling/style-tests.ts
@@ -1426,6 +1426,23 @@ export function test_UsingSameSelectorsWithSpecific_ShouldApplyLatest() {
     }
     helper.buildUIAndRunTest(testButton, testFunc, testCss);
 }
+
+export function test_CascadingClassNamesAppliesAfterPageLoad() {
+    const stack = new stackModule.StackLayout();
+    const label = new labelModule.Label();
+    label.text = "Some text";
+    label.cssClass = 'lab1';
+    stack.addChild(label);
+
+    application.addCss(".added { background-color: red; } .added .lab1 { background-color: blue; } .lab1 { color: red}");
+
+    helper.buildUIAndRunTest(stack, function (views: Array<viewModule.View>) {
+        helper.assertViewColor(label, "#FF0000");
+        stack.className = "added";
+        helper.assertViewBackgroundColor(label, "#0000FF");
+        helper.assertViewBackgroundColor(stack, "#FF0000");
+    });
+}
 // <snippet module="ui/styling" title="styling">
 // For information and example how to use style properties please refer to special [**Styling**](../../../styling.md) topic. 
 // </snippet>

--- a/tns-core-modules/ui/core/view-common.ts
+++ b/tns-core-modules/ui/core/view-common.ts
@@ -614,6 +614,10 @@ export class View extends ProxyObject implements definition.View {
         if (metadata.affectsStyle) {
             this.style._resetCssValues();
             this._applyStyleFromScope();
+            this._eachChildView((v) => {
+                v._checkMetadataOnPropertyChanged(metadata);
+                return true;
+            });
         }
     }
 


### PR DESCRIPTION
Adding a class name `cssClass` after page loaded does not reapplying all nested elements styles.


