### PR TITLE
Fix ts:buildDts check

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -419,7 +419,7 @@ module.exports = function(grunt) {
             },
             buildDts: {
                 src: [
-                    '**/*.d.ts',
+                    'tns-core-modules/**/*.d.ts',
                     '!org.nativescript.widgets.d.ts',
                     '!**/*.android.d.ts',
                     '!node_modules/**/*',
@@ -427,8 +427,9 @@ module.exports = function(grunt) {
                     '!tests/platforms/**/*.*',
                     '!bin/**/*',
                     '!apps/**/*',
-                    '!android17.d.ts',
-                    '!ios.d.ts',
+                    '!tns-core-modules/android17.d.ts',
+                    '!tns-core-modules/ios.d.ts',
+                    '!tns-core-modules/org.nativescript.widgets.d.ts',
                 ],
                 outDir: localCfg.outDir,
                 dest: localCfg.outDir,

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -351,7 +351,7 @@ declare module "ui/frame" {
     //@private
     function reloadPage(): void;
     function resolvePageFromEntry(entry: NavigationEntry): pages.Page;
-    function setFragmentCallbacks(fragment: android.app.Fragment): void;
-    function setActivityCallbacks(activity: android.app.Activity): void;
+    function setFragmentCallbacks(fragment: any /*android.app.Fragment*/): void;
+    function setActivityCallbacks(activity: any /*android.app.Activity*/): void;
     //@endprivate
 }


### PR DESCRIPTION
The `tns-core-modules` file reorg had broken the platform d.ts excludes and was not correctly checking that our public dts files do not expose platform types.

That was breaking the `grunt docs` typedoc build as well