### PR TITLE
webpack fixes

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -7,6 +7,7 @@ import * as fileSystemModule from "file-system";
 import * as styleScopeModule from "ui/styling/style-scope";
 import * as fileResolverModule  from "file-system/file-name-resolver";
 import * as builderModule from "ui/builder";
+import "../bundle-entry-points";
 
 var builder: typeof builderModule;
 function ensureBuilder() {

--- a/tns-core-modules/bundle-entry-points.ts
+++ b/tns-core-modules/bundle-entry-points.ts
@@ -1,0 +1,36 @@
+if (global.TNS_WEBPACK) {
+    // Register "dynamically" loaded module that need to be resolved by the
+    // XML/component builders.
+
+    global.registerModule("text/formatted-string", () => require("text/formatted-string"))
+    global.registerModule("text/span", () => require("text/span"))
+    global.registerModule("ui/action-bar", () => require("ui/action-bar"))
+    global.registerModule("ui/activity-indicator", () => require("ui/activity-indicator"))
+    global.registerModule("ui/border", () => require("ui/border"))
+    global.registerModule("ui/button", () => require("ui/button"))
+    global.registerModule("ui/content-view", () => require("ui/content-view"))
+    global.registerModule("ui/date-picker", () => require("ui/date-picker"))
+    global.registerModule("ui/html-view", () => require("ui/html-view"))
+    global.registerModule("ui/image", () => require("ui/image"))
+    global.registerModule("ui/label", () => require("ui/label"))
+    global.registerModule("ui/layouts/absolute-layout", () => require("ui/layouts/absolute-layout"))
+    global.registerModule("ui/layouts/dock-layout", () => require("ui/layouts/dock-layout"))
+    global.registerModule("ui/layouts/grid-layout", () => require("ui/layouts/grid-layout"))
+    global.registerModule("ui/layouts/stack-layout", () => require("ui/layouts/stack-layout"))
+    global.registerModule("ui/list-picker", () => require("ui/list-picker"))
+    global.registerModule("ui/page", () => require("ui/page"))
+    global.registerModule("ui/placeholder", () => require("ui/placeholder"))
+    global.registerModule("ui/progress", () => require("ui/progress"))
+    global.registerModule("ui/proxy-view-container", () => require("ui/proxy-view-container"))
+    global.registerModule("ui/repeater", () => require("ui/repeater"))
+    global.registerModule("ui/scroll-view", () => require("ui/scroll-view"))
+    global.registerModule("ui/search-bar", () => require("ui/search-bar"))
+    global.registerModule("ui/segmented-bar", () => require("ui/segmented-bar"))
+    global.registerModule("ui/slider", () => require("ui/slider"))
+    global.registerModule("ui/switch", () => require("ui/switch"))
+    global.registerModule("ui/tab-view", () => require("ui/tab-view"))
+    global.registerModule("ui/text-field", () => require("ui/text-field"))
+    global.registerModule("ui/text-view", () => require("ui/text-view"))
+    global.registerModule("ui/time-picker", () => require("ui/time-picker"))
+}
+


### PR DESCRIPTION
- Prefer registered modules in `builder` and `component-builder`.
- Implemented a bundle entrypoint registration mechanism using a package.json attribute.
- Register well-known modules used by the component builder as bundle entrypoints.
- Move text/(formatted-string|span) modules to subfolders, so we can register those as entry points (meh!)