### PR TITLE
Export all fetch types to the global object when running in snapshot context

### DIFF
--- a/tns-core-modules/globals/globals.ts
+++ b/tns-core-modules/globals/globals.ts
@@ -99,6 +99,9 @@ if (global.__snapshot) {
 
     var fetch = require("fetch");
     global.fetch = fetch.fetch;
+    global.Headers = fetch.Headers;
+    global.Request = fetch.Request;
+    global.Response = fetch.Response;
 } else {
     registerOnGlobalContext("setTimeout", "timer");
     registerOnGlobalContext("clearTimeout", "timer");


### PR DESCRIPTION
This comes from this test: https://github.com/NativeScript/NativeScript/blob/15df94ca829192f1d52796e19b6f41f599c53405/tests/app/fetch-tests.ts#L15

Ping @atanasovg, @enchev.

PR is for release branch.