### PR TITLE
Activity intent extras are set on application run which breaks Frame …

### DIFF
--- a/apps/css-perf-test/package.json
+++ b/apps/css-perf-test/package.json
@@ -1,0 +1,2 @@
+{ "name" : "css-perf-test",
+  "main" : "app.js" }

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -773,10 +773,13 @@ class ActivityCallbacksImplementation implements definition.AndroidActivityCallb
 
         // We have extras when we call - new Frame().navigate();
         // savedInstanceState is used when activity is recreated.
+        // NOTE: On API 23+ we get extras on first run.
+        // Check changed - first try to get frameId from Extras if not from saveInstanceState.
         if (extras) {
             frameId = extras.getInt(INTENT_EXTRA, -1);
         }
-        else if (savedInstanceState) {
+
+        if (savedInstanceState && frameId < 0) {
             frameId = savedInstanceState.getInt(INTENT_EXTRA, -1)
         }
 


### PR DESCRIPTION
…class logic. They were never set on lower API levels.