### PR TITLE
Fix:  The navigation bar duplicates when going to TabView's "More" tab

### DIFF
--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -346,6 +346,10 @@ declare module "ui/frame" {
          * Use NavBarVisibility enumeration - auto, never, always
          */
         navBarVisibility: string;
+        
+        //@private
+        _disableNavBarAnimation: boolean;
+        //@endprivate
     }
 
     //@private

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -661,6 +661,10 @@ class iOSFrame implements definition.iOSFrame {
     private _showNavigationBar: boolean;
     private _navBarVisibility: string;
     private _frame: Frame;
+    
+    // TabView uses this flag to disable animation while showing/hiding the navigation bar because of the "< More" bar.
+    // See the TabView._handleTwoNavigationBars method for more details.
+    public _disableNavBarAnimation: boolean;
 
     constructor(frame: Frame) {
         this._frame = frame;
@@ -681,7 +685,7 @@ class iOSFrame implements definition.iOSFrame {
         var change = this._showNavigationBar !== value;
         this._showNavigationBar = value;
 
-        let animated = !this._frame._isInitialNavigation;
+        let animated = !this._frame._isInitialNavigation && !this._disableNavBarAnimation;
         this._controller.setNavigationBarHiddenAnimated(!value, animated);
 
         let currentPage = this._controller.owner.currentPage;

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -208,30 +208,35 @@ export class TabView extends common.TabView {
         }
     }
     
-    private _actionBarHidden: boolean;
+    private _actionBarHiddenByTabView: boolean;
     public _handleTwoNavigationBars(backToMoreWillBeVisible: boolean){
         if (trace.enabled) {
-            trace.write(`TabView._handleTwoNavigationBars(${backToMoreWillBeVisible})`, trace.categories.Debug);
+            trace.write(`TabView._handleTwoNavigationBars(backToMoreWillBeVisible: ${backToMoreWillBeVisible})`, trace.categories.Debug);
         }
  
         // The "< Back" and "< More" navigation bars should not be visible simultaneously.
         let page = <Page>this.page;
         let actionBarVisible = page.frame._getNavBarVisible(page);
-        let moreNavigationBar = this._ios.moreNavigationController.navigationBar;
         
         if (backToMoreWillBeVisible && actionBarVisible){
             page.frame.ios._disableNavBarAnimation = true;
             page.actionBarHidden = true;
             page.frame.ios._disableNavBarAnimation = false;
-            this._actionBarHidden = true;
+            this._actionBarHiddenByTabView = true;
+            if (trace.enabled) {
+                trace.write(`TabView hid action bar`, trace.categories.Debug);
+            }
             return;
         }
         
-        if (!backToMoreWillBeVisible && this._actionBarHidden){
+        if (!backToMoreWillBeVisible && this._actionBarHiddenByTabView){
             page.frame.ios._disableNavBarAnimation = true;
             page.actionBarHidden = false;
             page.frame.ios._disableNavBarAnimation = false;
-            this._actionBarHidden = undefined;
+            this._actionBarHiddenByTabView = undefined;
+            if (trace.enabled) {
+                trace.write(`TabView restored action bar`, trace.categories.Debug);
+            }
             return;
         }
     }


### PR DESCRIPTION
Resolves #2121

The action bar will now be hidden when we have "< More" visible.