### PR TITLE
TextWatchListener is removed at onDetach 

### DIFF
--- a/tests/app/ui/text-view/text-view-tests.ts
+++ b/tests/app/ui/text-view/text-view-tests.ts
@@ -481,3 +481,16 @@ export var testMemoryLeak = function (done) {
         textViewTestsNative.typeTextNatively(textView, "Hello, world!");
     }, done);
 }
+
+export function test_watch_listerer_is_removed_at_onDetach() {
+    if (platform.isAndroid) {
+        helper.buildUIAndRunTest(_createTextViewFunc(), (views: Array<viewModule.View>) => {
+            let tv = <textViewModule.TextView>views[0];
+            let page = <pagesModule.Page>tv.page;
+            let editText = tv.android;
+            editText.setText("String");
+            page.content = null;
+            editText.setText("FAIL");
+        });
+    }
+}

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -107,8 +107,11 @@ export class EditableTextBase extends common.EditableTextBase {
     }
 
     public _onDetached(force?: boolean) {
-        this._android = undefined;
+        if (this._android && this._textWatcher) {
+            this._android.removeTextChangedListener(this._textWatcher);
+        }
 
+        this._android = undefined;
         super._onDetached(force);
     }
 


### PR DESCRIPTION
so that no exception is thrown if android raise textChanged but we destroyed our android object in onDestroy of edit-text.
Fixes #2391 