### PR TITLE
Update iOS TabView to use Automatic rendering mode

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -327,7 +327,7 @@ export class TabView extends common.TabView {
 
             var is = imageSource.fromFileOrResource(iconSource);
             if (is && is.ios) {
-                var originalRenderedImage = is.ios.imageWithRenderingMode(UIImageRenderingMode.UIImageRenderingModeAlwaysOriginal);
+                var originalRenderedImage = is.ios.imageWithRenderingMode(UIImageRenderingMode.UIImageRenderingModeAutomatic);
                 this._iconsCache[iconSource] = originalRenderedImage;
                 image = originalRenderedImage;
             }


### PR DESCRIPTION
Fixes/Implements #1278 

Very small change. Does not impact the TabView unit tests.

Changes the UIImageRenderingMode for tab icons from "AlwaysOriginal" to "Automatic." This allows icon images to inherit the `selectedColor` specified for the tabview (eliminating the need to provide two versions of every tab icon).

Unclear why this behavior was changed in NativeScript 1.5 (history of tab-view.ios.ts only goes back to May). This change restores behavior of tabview icons to pre-1.5 styling and is a huge time saver for iOS tabview styling.