### PR TITLE
Fix Custom Fonts when bundled with Webpack

### DIFF
--- a/tns-core-modules/ui/styling/font.ios.ts
+++ b/tns-core-modules/ui/styling/font.ios.ts
@@ -317,6 +317,12 @@ export module ios {
 
 function registerCustomFonts() {
     var fontsFolderPath = fs.path.join(__dirname.substring(0, __dirname.indexOf("/tns_modules")), "fonts");
+    
+    // Try from root when bundled with webpack
+    if (!fs.Folder.exists(fontsFolderPath)) {
+        fontsFolderPath = fs.path.join(__dirname, "fonts");
+    }
+
     if (fs.Folder.exists(fontsFolderPath)) {
         var fontsFolder = fs.Folder.fromPath(fontsFolderPath);
         var onEachEntityFunc = function (fileEntity: fs.FileSystemEntity): boolean {


### PR DESCRIPTION
Fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/12

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
Uses the same test

In the function `registerCustomFonts()`, the `fontsFolderPath is trying to find the `/tns_modules path`. However, `/tns_modules` is not included in the `_dirname` path when we bundle.