### PR TITLE
Update grunt-typedoc to make it get new TS features

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-simple-mocha": "0.4.0",
     "grunt-ts": "5.3.2",
     "grunt-tslint": "3.0.3",
-    "grunt-typedoc": "0.2.3",
+    "grunt-typedoc": "0.2.4",
     "grunt-untar": "0.0.1",
     "markdown-snippet-injector": "0.1.1",
     "mocha": "2.2.5",


### PR DESCRIPTION
No tests. The change is in the build of the documentation, which was broken due to using new TypeScript features. The TypeDoc referred was old, hence the problem.