### PR TITLE
Use an improved docs header

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-untar": "0.0.1",
     "markdown-snippet-injector": "0.1.1",
     "mocha": "2.2.5",
-    "nativescript-typedoc-theme": "0.0.1",
+    "nativescript-typedoc-theme": "0.0.4",
     "shelljs": "^0.7.0",
     "time-grunt": "1.3.0",
     "tslint": "3.4.0",


### PR DESCRIPTION
Increase the version of the docs template used to have the api-ref header aligned to the docs one.