### PR TITLE
Add a mechanism the launch screen theme to be reset after launch

### DIFF
--- a/tns-core-modules/application/application.android.ts
+++ b/tns-core-modules/application/application.android.ts
@@ -14,6 +14,16 @@ function initLifecycleCallbacks() {
     let lifecycleCallbacks = new android.app.Application.ActivityLifecycleCallbacks({
         onActivityCreated: function (activity: any, bundle: any) {
             if (!androidApp.startActivity) {
+
+                // Set app theme after launch screen was used during startup
+                let activityInfo = activity.getPackageManager().getActivityInfo(activity.getComponentName(), android.content.pm.PackageManager.GET_META_DATA);
+                if (activityInfo.metaData) {
+                    let setThemeOnLaunch = activityInfo.metaData.getInt("SET_THEME_ON_LAUNCH", -1);
+                    if (setThemeOnLaunch !== -1) {
+                        activity.setTheme(setThemeOnLaunch);
+                    }
+                }
+
                 androidApp.startActivity = activity;
                 androidApp.notify(<definition.AndroidActivityBundleEventData>{ eventName: "activityCreated", object: androidApp, activity: activity, bundle: bundle });
 


### PR DESCRIPTION
Adding "SET_THEME_ON_LAUNCH" on the activity in the android manifest will allow a second theme to be applied on create after the activity is launched.

``` XML
<activity
	android:name="com.tns.NativeScriptActivity"
	android:label="@string/title_activity_kimera"
	android:configChanges="keyboardHidden|orientation|screenSize"
	android:theme="@style/LaunchScreenTheme">

	<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />
	<!-- ... -->
</activity>
```