### PR TITLE
Element that isn't a View should not be added to its parent

### DIFF
--- a/tns-core-modules/ui/core/view-common.ts
+++ b/tns-core-modules/ui/core/view-common.ts
@@ -988,7 +988,10 @@ export class View extends ProxyObject implements definition.View {
         if (!view) {
             throw new Error("Expecting a valid View instance.");
         }
-
+        if(!(view instanceof View))
+        {
+            throw new Error(view + " is not a valid View instance.");
+        }
         if (view._parent) {
             throw new Error("View already has a parent. View: " + view + " Parent: " + view._parent);
         }


### PR DESCRIPTION
An element that is not an instance of a View should not be added directly to its parent and thus triggering the logic for setting any inherited or style properties. 
For example - ActionBar.actionItems in ng app.