### PR TITLE
Rename Thenable<T> to PromiseLike<T>

### DIFF
--- a/tns-core-modules/es6-promise.d.ts
+++ b/tns-core-modules/es6-promise.d.ts
@@ -3,16 +3,16 @@
 // Project: https://github.com/jakearchibald/ES6-Promise
 // Definitions by: François de Campredon <https://github.com/fdecampredon/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-interface Thenable<R> {
-    then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => void): Thenable<U>;
+interface PromiseLike<T> {
+    then<U>(onFulfilled?: (value: T) => PromiseLike<U>, onRejected?: (error: any) => PromiseLike<U>): PromiseLike<U>;
+    then<U>(onFulfilled?: (value: T) => PromiseLike<U>, onRejected?: (error: any) => U): PromiseLike<U>;
+    then<U>(onFulfilled?: (value: T) => PromiseLike<U>, onRejected?: (error: any) => void): PromiseLike<U>;
+    then<U>(onFulfilled?: (value: T) => U, onRejected?: (error: any) => PromiseLike<U>): PromiseLike<U>;
+    then<U>(onFulfilled?: (value: T) => U, onRejected?: (error: any) => U): PromiseLike<U>;
+    then<U>(onFulfilled?: (value: T) => U, onRejected?: (error: any) => void): PromiseLike<U>;
 }
 
-interface Promise<R> extends Thenable<R> {
+interface Promise<T> extends PromiseLike<T> {
     /**
      * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
      * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
@@ -22,7 +22,7 @@ interface Promise<R> extends Thenable<R> {
      * @param onFulfilled called when/if "promise" resolves
      * @param onRejected called when/if "promise" rejects
      */
-    then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => Thenable<U>): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => PromiseLike<U>, onRejected?: (error: any) => PromiseLike<U>): Promise<U>;
     /**
      * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
      * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
@@ -32,7 +32,7 @@ interface Promise<R> extends Thenable<R> {
      * @param onFulfilled called when/if "promise" resolves
      * @param onRejected called when/if "promise" rejects
      */
-    then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => PromiseLike<U>, onRejected?: (error: any) => U): Promise<U>;
     /**
      * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects.
      * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called.
@@ -42,7 +42,7 @@ interface Promise<R> extends Thenable<R> {
      * @param onFulfilled called when/if "promise" resolves
      * @param onRejected called when/if "promise" rejects
      */
-    then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => void): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => PromiseLike<U>, onRejected?: (error: any) => void): Promise<U>;
     /**
      * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
      * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
@@ -52,7 +52,7 @@ interface Promise<R> extends Thenable<R> {
      * @param onFulfilled called when/if "promise" resolves
      * @param onRejected called when/if "promise" rejects
      */
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => Thenable<U>): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => U, onRejected?: (error: any) => PromiseLike<U>): Promise<U>;
     /**
      * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
      * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
@@ -62,7 +62,7 @@ interface Promise<R> extends Thenable<R> {
      * @param onFulfilled called when/if "promise" resolves
      * @param onRejected called when/if "promise" rejects
      */
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => U, onRejected?: (error: any) => U): Promise<U>;
     /**
      * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects.
      * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called.
@@ -72,13 +72,13 @@ interface Promise<R> extends Thenable<R> {
      * @param onFulfilled called when/if "promise" resolves
      * @param onRejected called when/if "promise" rejects
      */
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => void): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => U, onRejected?: (error: any) => void): Promise<U>;
 
     /**
      * Sugar for promise.then(undefined, onRejected)
      * @param onRejected called when/if "promise" rejects
      */
-    catch<U>(onRejected?: (error: any) => Thenable<U>): Promise<U>;
+    catch<U>(onRejected?: (error: any) => PromiseLike<U>): Promise<U>;
     /**
      * Sugar for promise.then(undefined, onRejected)
      * @param onRejected called when/if "promise" rejects
@@ -103,27 +103,27 @@ interface PromiseConstructor {
      * a resolve callback used resolve the promise with a value or the result of another promise,
      * and a reject callback used to reject the promise with a provided reason or error.
      */
-    new <T>(executor: (resolve: (value?: T | Thenable<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+    new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
 
     /**
      * Returns promise (only if promise.constructor == Promise)
      */
-    cast<R>(promise: Promise<R>): Promise<R>;
+    cast<T>(promise: Promise<T>): Promise<T>;
     /**
      * Make a promise that fulfills to obj.
      */
-    cast<R>(object: R): Promise<R>;
+    cast<T>(object: T): Promise<T>;
 
     /**
-     * Make a new promise from the thenable. 
-     * A thenable is promise-like in as far as it has a "then" method. 
+     * Make a new promise from the PromiseLike. 
+     * A promise-like can be anything as far as it has a "then" method. 
      * This also creates a new promise if you pass it a genuine JavaScript promise, making it less efficient for casting than Promise.cast.
      */
-    resolve<R>(thenable?: Thenable<R>): Promise<R>;
+    resolve<T>(promise?: PromiseLike<T>): Promise<T>;
     /**
      * Make a promise that fulfills to obj. Same as Promise.cast(obj) in this situation.
      */
-    resolve<R>(object?: R): Promise<R>;
+    resolve<T>(object?: T): Promise<T>;
 
     /**
      * Make a promise that rejects to obj. For consistency and debugging (eg stack traces), obj should be an instanceof Error
@@ -135,12 +135,12 @@ interface PromiseConstructor {
      * the array passed to all can be a mixture of promise-like objects and other objects. 
      * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
      */
-    all<R>(promises: Promise<R>[]): Promise<R[]>;
+    all<T>(promises: Promise<T>[]): Promise<T[]>;
 
     /**
      * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
      */
-    race<R>(promises: Promise<R>[]): Promise<R>;
+    race<T>(promises: Promise<T>[]): Promise<T>;
 }
 
 declare var Promise: PromiseConstructor;

--- a/tns-core-modules/ui/animation/animation.d.ts
+++ b/tns-core-modules/ui/animation/animation.d.ts
@@ -87,9 +87,9 @@
      */
     export class AnimationPromise extends Promise<void> {
         cancel(): void;
-        then(onFulfilled?: (value?: any) => Thenable<void>, onRejected?: (error?: any) => Thenable<void>): AnimationPromise;
+        then(onFulfilled?: (value?: any) => PromiseLike<void>, onRejected?: (error?: any) => PromiseLike<void>): AnimationPromise;
         then(onFulfilled?: (value?: any) => void, onRejected?: (error?: any) => void): AnimationPromise;
-        catch(onRejected?: (error?: any) => Thenable<void>): AnimationPromise;
+        catch(onRejected?: (error?: any) => PromiseLike<void>): AnimationPromise;
         catch(onRejected?: (error?: any) => void): AnimationPromise;
     }
 


### PR DESCRIPTION
Also change the Promise generic param from R to T.

Make it similar to TypeScript's lib.es6.d.ts until we actually
remove those typings.

/cc @PanayotCankov 