### PR TITLE
Make package mains more webpack-friendly

### DIFF
--- a/tns-core-modules/application-settings/package.json
+++ b/tns-core-modules/application-settings/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "application-settings",
-  	"main" : "application-settings.js",
+  	"main" : "application-settings",
 	"nativescript": {}
 }

--- a/tns-core-modules/application/package.json
+++ b/tns-core-modules/application/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "application",
-	"main" : "application.js",
+	"main" : "application",
 	"nativescript": {}
 }

--- a/tns-core-modules/camera/package.json
+++ b/tns-core-modules/camera/package.json
@@ -1,6 +1,6 @@
 { 
 	"name" : "camera",
-  	"main" : "camera.js",
+  	"main" : "camera",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/color/package.json
+++ b/tns-core-modules/color/package.json
@@ -1,6 +1,6 @@
 { 
 	"name" : "color",
-  	"main" : "color.js",
+  	"main" : "color",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/connectivity/package.json
+++ b/tns-core-modules/connectivity/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "connectivity",
-	"main" : "connectivity.js",
+	"main" : "connectivity",
 	"nativescript": {}
 }

--- a/tns-core-modules/console/package.json
+++ b/tns-core-modules/console/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "console",
-  	"main" : "console.js",
+  	"main" : "console",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/data/observable-array/package.json
+++ b/tns-core-modules/data/observable-array/package.json
@@ -1,4 +1,4 @@
 {
 	"name" : "observable-array",
-	"main" : "observable-array.js"
+	"main" : "observable-array"
 }

--- a/tns-core-modules/data/observable/package.json
+++ b/tns-core-modules/data/observable/package.json
@@ -1,4 +1,4 @@
 { 
   "name" : "observable",
-  "main" : "observable.js"
+  "main" : "observable"
 }

--- a/tns-core-modules/data/virtual-array/package.json
+++ b/tns-core-modules/data/virtual-array/package.json
@@ -1,4 +1,4 @@
 {
 	"name" : "virtual-array",
-	"main" : "virtual-array.js"
+	"main" : "virtual-array"
 }

--- a/tns-core-modules/debugger/package.json
+++ b/tns-core-modules/debugger/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "debugger",
-  	"main" : "debugger.js",
+  	"main" : "debugger",
 	"nativescript": {}
 }

--- a/tns-core-modules/fetch/package.json
+++ b/tns-core-modules/fetch/package.json
@@ -1,5 +1,5 @@
 { 
 	"name" : "fetch",
-  	"main" : "fetch.js",
+  	"main" : "fetch",
 	"nativescript": {}
 }

--- a/tns-core-modules/file-system/package.json
+++ b/tns-core-modules/file-system/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "file-system",
-  	"main" : "file-system.js",
+  	"main" : "file-system",
 	"nativescript": {}
 }

--- a/tns-core-modules/fps-meter/package.json
+++ b/tns-core-modules/fps-meter/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "fps-meter",
-  	"main" : "fps-meter.js",
+  	"main" : "fps-meter",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/globals/package.json
+++ b/tns-core-modules/globals/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "globals",
-  	"main" : "globals.js",
+  	"main" : "globals",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/http/package.json
+++ b/tns-core-modules/http/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "http",
-  	"main" : "http.js",
+  	"main" : "http",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/image-source/package.json
+++ b/tns-core-modules/image-source/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "image-source",
-	"main" : "image-source.js",
+	"main" : "image-source",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/js-libs/easysax/package.json
+++ b/tns-core-modules/js-libs/easysax/package.json
@@ -8,7 +8,7 @@
     "pure"
   ],
   "version": "0.1.14",
-  "main": "easysax.js",
+  "main": "easysax",
   "bugs": {
     "url": "https://github.com/vflash/easysax/issues"
   },

--- a/tns-core-modules/js-libs/esprima/package.json
+++ b/tns-core-modules/js-libs/esprima/package.json
@@ -2,7 +2,7 @@
     "name": "esprima",
     "description": "ECMAScript parsing infrastructure for multipurpose analysis",
     "homepage": "http://esprima.org",
-    "main": "esprima.js",
+    "main": "esprima",
     "bin": {
         "esparse": "./bin/esparse.js",
         "esvalidate": "./bin/esvalidate.js"

--- a/tns-core-modules/js-libs/polymer-expressions/package.json
+++ b/tns-core-modules/js-libs/polymer-expressions/package.json
@@ -1,2 +1,2 @@
 { "name" : "polymer-expressions",
-  "main" : "polymer-expressions.js" }
+  "main" : "polymer-expressions" }

--- a/tns-core-modules/location/package.json
+++ b/tns-core-modules/location/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "location",
-  	"main" : "location.js",
+  	"main" : "location",
 	"nativescript": {}
 }
 

--- a/tns-core-modules/platform/package.json
+++ b/tns-core-modules/platform/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "platform",
-  	"main" : "platform.js",
+  	"main" : "platform",
 	"nativescript": {}
 }

--- a/tns-core-modules/text/package.json
+++ b/tns-core-modules/text/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "text",
-  	"main" : "text.js",
+  	"main" : "text",
 	"nativescript": {}
 }

--- a/tns-core-modules/timer/package.json
+++ b/tns-core-modules/timer/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "timer",
-  	"main" : "timer.js",
+  	"main" : "timer",
 	"nativescript": {}
 }

--- a/tns-core-modules/trace/package.json
+++ b/tns-core-modules/trace/package.json
@@ -1,5 +1,5 @@
 { 
 	"name" : "trace",
-  	"main" : "trace.js",
+  	"main" : "trace",
 	"nativescript": {}
 }

--- a/tns-core-modules/ui/action-bar/package.json
+++ b/tns-core-modules/ui/action-bar/package.json
@@ -1,2 +1,2 @@
 { "name" : "action-bar",
-  "main" : "action-bar.js" }
+  "main" : "action-bar" }

--- a/tns-core-modules/ui/activity-indicator/package.json
+++ b/tns-core-modules/ui/activity-indicator/package.json
@@ -1,2 +1,2 @@
 { "name" : "activity-indicator",
-  "main" : "activity-indicator.js" }
+  "main" : "activity-indicator" }

--- a/tns-core-modules/ui/animation/package.json
+++ b/tns-core-modules/ui/animation/package.json
@@ -1,2 +1,2 @@
 { "name" : "animation",
-  "main" : "animation.js" }
+  "main" : "animation" }

--- a/tns-core-modules/ui/border/package.json
+++ b/tns-core-modules/ui/border/package.json
@@ -1,2 +1,2 @@
 { "name" : "border",
-  "main" : "border.js" }
+  "main" : "border" }

--- a/tns-core-modules/ui/builder/package.json
+++ b/tns-core-modules/ui/builder/package.json
@@ -1,2 +1,2 @@
 { "name" : "builder",
-  "main" : "builder.js" }
+  "main" : "builder" }

--- a/tns-core-modules/ui/button/package.json
+++ b/tns-core-modules/ui/button/package.json
@@ -1,2 +1,2 @@
 { "name" : "button",
-  "main" : "button.js" }
+  "main" : "button" }

--- a/tns-core-modules/ui/content-view/package.json
+++ b/tns-core-modules/ui/content-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "content-view",
-  "main" : "content-view.js" }
+  "main" : "content-view" }

--- a/tns-core-modules/ui/date-picker/package.json
+++ b/tns-core-modules/ui/date-picker/package.json
@@ -1,2 +1,2 @@
 { "name" : "date-picker",
-  "main" : "date-picker.js" }
+  "main" : "date-picker" }

--- a/tns-core-modules/ui/dialogs/package.json
+++ b/tns-core-modules/ui/dialogs/package.json
@@ -1,2 +1,2 @@
 { "name" : "dialogs",
-  "main" : "dialogs.js" }
+  "main" : "dialogs" }

--- a/tns-core-modules/ui/editable-text-base/package.json
+++ b/tns-core-modules/ui/editable-text-base/package.json
@@ -1,2 +1,2 @@
 { "name" : "editable-text-base",
-  "main" : "editable-text-base.js" }
+  "main" : "editable-text-base" }

--- a/tns-core-modules/ui/enums/package.json
+++ b/tns-core-modules/ui/enums/package.json
@@ -1,2 +1,2 @@
 { "name" : "enums",
-  "main" : "enums.js" }
+  "main" : "enums" }

--- a/tns-core-modules/ui/frame/package.json
+++ b/tns-core-modules/ui/frame/package.json
@@ -1,2 +1,2 @@
 { "name" : "frame",
-  "main" : "frame.js" }
+  "main" : "frame" }

--- a/tns-core-modules/ui/gestures/package.json
+++ b/tns-core-modules/ui/gestures/package.json
@@ -1,2 +1,2 @@
 { "name" : "gestures",
-  "main" : "gestures.js" }
+  "main" : "gestures" }

--- a/tns-core-modules/ui/html-view/package.json
+++ b/tns-core-modules/ui/html-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "html-view",
-  "main" : "html-view.js" }
+  "main" : "html-view" }

--- a/tns-core-modules/ui/image-cache/package.json
+++ b/tns-core-modules/ui/image-cache/package.json
@@ -1,2 +1,2 @@
 { "name" : "image-cache",
-  "main" : "image-cache.js" }
+  "main" : "image-cache" }

--- a/tns-core-modules/ui/image/package.json
+++ b/tns-core-modules/ui/image/package.json
@@ -1,2 +1,2 @@
 { "name" : "image",
-  "main" : "image.js" }
+  "main" : "image" }

--- a/tns-core-modules/ui/label/package.json
+++ b/tns-core-modules/ui/label/package.json
@@ -1,2 +1,2 @@
 { "name" : "label",
-  "main" : "label.js" }
+  "main" : "label" }

--- a/tns-core-modules/ui/layouts/absolute-layout/package.json
+++ b/tns-core-modules/ui/layouts/absolute-layout/package.json
@@ -1,2 +1,2 @@
 { "name" : "absolute-layout",
-  "main" : "absolute-layout.js" }
+  "main" : "absolute-layout" }

--- a/tns-core-modules/ui/layouts/dock-layout/package.json
+++ b/tns-core-modules/ui/layouts/dock-layout/package.json
@@ -1,2 +1,2 @@
 { "name" : "dock-layout",
-  "main" : "dock-layout.js" }
+  "main" : "dock-layout" }

--- a/tns-core-modules/ui/layouts/grid-layout/package.json
+++ b/tns-core-modules/ui/layouts/grid-layout/package.json
@@ -1,2 +1,2 @@
 { "name" : "grid-layout",
-  "main" : "grid-layout.js" }
+  "main" : "grid-layout" }

--- a/tns-core-modules/ui/layouts/stack-layout/package.json
+++ b/tns-core-modules/ui/layouts/stack-layout/package.json
@@ -1,2 +1,2 @@
 { "name" : "stack-layout",
-  "main" : "stack-layout.js" }
+  "main" : "stack-layout" }

--- a/tns-core-modules/ui/layouts/wrap-layout/package.json
+++ b/tns-core-modules/ui/layouts/wrap-layout/package.json
@@ -1,2 +1,2 @@
 { "name" : "wrap-layout",
-  "main" : "wrap-layout.js" }
+  "main" : "wrap-layout" }

--- a/tns-core-modules/ui/list-picker/package.json
+++ b/tns-core-modules/ui/list-picker/package.json
@@ -1,2 +1,2 @@
 { "name" : "list-picker",
-  "main" : "list-picker.js" }
+  "main" : "list-picker" }

--- a/tns-core-modules/ui/list-view/package.json
+++ b/tns-core-modules/ui/list-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "list-view",
-  "main" : "list-view.js" }
+  "main" : "list-view" }

--- a/tns-core-modules/ui/page/package.json
+++ b/tns-core-modules/ui/page/package.json
@@ -1,2 +1,2 @@
 { "name" : "page",
-  "main" : "page.js" }
+  "main" : "page" }

--- a/tns-core-modules/ui/placeholder/package.json
+++ b/tns-core-modules/ui/placeholder/package.json
@@ -1,2 +1,2 @@
 { "name" : "placeholder",
-  "main" : "placeholder.js" }
+  "main" : "placeholder" }

--- a/tns-core-modules/ui/progress/package.json
+++ b/tns-core-modules/ui/progress/package.json
@@ -1,2 +1,2 @@
 { "name" : "progress",
-  "main" : "progress.js" }
+  "main" : "progress" }

--- a/tns-core-modules/ui/proxy-view-container/package.json
+++ b/tns-core-modules/ui/proxy-view-container/package.json
@@ -1,2 +1,2 @@
 { "name" : "proxy-view-container",
-  "main" : "proxy-view-container.js" }
+  "main" : "proxy-view-container" }

--- a/tns-core-modules/ui/repeater/package.json
+++ b/tns-core-modules/ui/repeater/package.json
@@ -1,2 +1,2 @@
 { "name" : "repeater",
-  "main" : "repeater.js" }
+  "main" : "repeater" }

--- a/tns-core-modules/ui/scroll-view/package.json
+++ b/tns-core-modules/ui/scroll-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "scroll-view",
-  "main" : "scroll-view.js" }
+  "main" : "scroll-view" }

--- a/tns-core-modules/ui/search-bar/package.json
+++ b/tns-core-modules/ui/search-bar/package.json
@@ -1,2 +1,2 @@
 { "name" : "search-bar",
-  "main" : "search-bar.js" }
+  "main" : "search-bar" }

--- a/tns-core-modules/ui/segmented-bar/package.json
+++ b/tns-core-modules/ui/segmented-bar/package.json
@@ -1,2 +1,2 @@
 { "name" : "segmented-bar",
-  "main" : "segmented-bar.js" }
+  "main" : "segmented-bar" }

--- a/tns-core-modules/ui/slider/package.json
+++ b/tns-core-modules/ui/slider/package.json
@@ -1,2 +1,2 @@
 { "name" : "slider",
-  "main" : "slider.js" }
+  "main" : "slider" }

--- a/tns-core-modules/ui/styling/package.json
+++ b/tns-core-modules/ui/styling/package.json
@@ -1,2 +1,2 @@
 { "name" : "styling",
-  "main" : "styling.js" }
+  "main" : "styling" }

--- a/tns-core-modules/ui/switch/package.json
+++ b/tns-core-modules/ui/switch/package.json
@@ -1,2 +1,2 @@
 { "name" : "switch",
-  "main" : "switch.js" }
+  "main" : "switch" }

--- a/tns-core-modules/ui/tab-view/package.json
+++ b/tns-core-modules/ui/tab-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "ui/tab-view",
-  "main" : "tab-view.js" }
+  "main" : "tab-view" }

--- a/tns-core-modules/ui/text-base/package.json
+++ b/tns-core-modules/ui/text-base/package.json
@@ -1,2 +1,2 @@
 { "name" : "text-base",
-  "main" : "text-base.js" }
+  "main" : "text-base" }

--- a/tns-core-modules/ui/text-field/package.json
+++ b/tns-core-modules/ui/text-field/package.json
@@ -1,2 +1,2 @@
 { "name" : "text-field",
-  "main" : "text-field.js" }
+  "main" : "text-field" }

--- a/tns-core-modules/ui/text-view/package.json
+++ b/tns-core-modules/ui/text-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "text-view",
-  "main" : "text-view.js" }
+  "main" : "text-view" }

--- a/tns-core-modules/ui/time-picker/package.json
+++ b/tns-core-modules/ui/time-picker/package.json
@@ -1,2 +1,2 @@
 { "name" : "time-picker",
-  "main" : "time-picker.js" }
+  "main" : "time-picker" }

--- a/tns-core-modules/ui/transition/package.json
+++ b/tns-core-modules/ui/transition/package.json
@@ -1,2 +1,2 @@
 { "name" : "transition",
-  "main" : "transition.js" }
+  "main" : "transition" }

--- a/tns-core-modules/ui/web-view/package.json
+++ b/tns-core-modules/ui/web-view/package.json
@@ -1,2 +1,2 @@
 { "name" : "web-view",
-  "main" : "web-view.js" }
+  "main" : "web-view" }

--- a/tns-core-modules/xhr/package.json
+++ b/tns-core-modules/xhr/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "xhr",
-  	"main" : "xhr.js",
+  	"main" : "xhr",
 	"nativescript": {}
 }

--- a/tns-core-modules/xml/package.json
+++ b/tns-core-modules/xml/package.json
@@ -1,5 +1,5 @@
 {
 	"name" : "xml",
-  	"main" : "xml.js",
+  	"main" : "xml",
 	"nativescript": {}
 }


### PR DESCRIPTION
Chop off the `.js` ending in the `main` setting for all package.json files, so that it gets easier for webpack to redirect stuff like page.js to page.android.js.

I added a validation step that will fail the build if it finds a `"main": "blah.js"` setting.