### PR TITLE
Fixed issue when bind to bindingContext and other property.

### DIFF
--- a/tests/app/ui/bindable-tests.ts
+++ b/tests/app/ui/bindable-tests.ts
@@ -1304,3 +1304,31 @@ export function test_Observable_from_nested_json_binds_correctly_when_upper_obje
 
     TKUnit.assertEqual(obj.get("test"), expectedValue);
 }
+
+export function test_BindingToBindingContextProperty_ShouldUseNewContext() {
+    let stackLayout = new stackLayoutModule.StackLayout();
+    let label = new labelModule.Label();
+    stackLayout.addChild(label);
+
+    label.bind({
+        sourceProperty: 'context',
+        targetProperty: 'bindingContext'
+    });
+
+    label.bind({
+        sourceProperty: 'text',
+        targetProperty: 'text'
+    });
+
+    let testBindingContext = observable.Observable.fromJSONRecursive({
+        context: {
+            text: 'Alabala'
+        }
+    });
+
+    stackLayout.bindingContext = testBindingContext;
+
+    (<any>testBindingContext).context.text = "Tralala";
+
+    TKUnit.assertEqual(label.text, "Tralala");
+}

--- a/tns-core-modules/ui/core/bindable.ts
+++ b/tns-core-modules/ui/core/bindable.ts
@@ -114,13 +114,22 @@ export class Bindable extends DependencyObservable implements definition.Bindabl
     }
 
     public _onBindingContextChanged(oldValue: any, newValue: any) {
+        let bindingContextBinding = this.bindings.get("bindingContext"); 
+        if (bindingContextBinding) {
+            if (!bindingContextBinding.updating) {
+                bindingContextBinding.bind(newValue);
+            }
+        }
+
+        let bindingContextSource = this.bindingContext;
+
         this.bindings.forEach((binding, index, bindings) => {
-            if (!binding.updating && binding.sourceIsBindingContext) {
+            if (!binding.updating && binding.sourceIsBindingContext && binding.options.targetProperty !== "bindingContext") {
                 if (trace.enabled) {
-                    trace.write(`Binding ${binding.target.get()}.${binding.options.targetProperty} to new context ${newValue}`, trace.categories.Binding);
+                    trace.write(`Binding ${binding.target.get()}.${binding.options.targetProperty} to new context ${bindingContextSource}`, trace.categories.Binding);
                 }
-                if (!types.isNullOrUndefined(newValue)) {
-                    binding.bind(newValue);
+                if (!types.isNullOrUndefined(bindingContextSource)) {
+                    binding.bind(bindingContextSource);
                 } else {
                     binding.clearBinding();
                 }


### PR DESCRIPTION
Fixing an issue with binding an element to its bindingContext property. The issue can be reproduced if an element is bound to `bindingContext` and any other property. By design the other property should be relative to the local bindingContext (the new one which is result from the first binding to `bindingContext`). Unfortunately due to bug this local `bindingContext` is not taken into account - instead bindingContext object value when binding is created is used.

