### PR TITLE
Label zero height issue fixed.

### DIFF
--- a/tests/app/ui/label/label-tests.ts
+++ b/tests/app/ui/label/label-tests.ts
@@ -524,12 +524,13 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         TKUnit.assertNotEqual(this.errorMessage, undefined);
     }
 
-    private requestLayoutFixture(expectRequestLayout: boolean, setup: (label: Label) => LayoutBase): void {
+    private requestLayoutFixture(expectRequestLayout: boolean, initialValue: string, setup: (label: Label) => LayoutBase): void {
         if (!isIOS) {
             return;
         }
 
         let label = new Label();
+        label.text = initialValue;
         let host = setup(label);
 
         host.addChild(label);
@@ -540,7 +541,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
 
         let called = false;
         label.requestLayout = () => called = true;
-        label.text = "Hello World";
+        // changing text actually could request layout
+        label.text = initialValue + " Again";
 
         if (expectRequestLayout) {
             TKUnit.assertTrue(called, "label.requestLayout should be called.");
@@ -549,8 +551,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         }
     }
 
-    public test_SettingTextWhenInFixedSizeGridShouldNotRequestLayout() {
-        this.requestLayoutFixture(false, () => {
+    public test_SettingTextWhenInFixedSizeGridShouldRequestLayout() {
+        this.requestLayoutFixture(true, "", () => {
             let host = new GridLayout();
             host.width = 100;
             host.height = 100;
@@ -558,8 +560,26 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         });
     }
 
-    public test_SettingTextWhenFixedWidthAndHeightDoesNotRequestLayout() {
-        this.requestLayoutFixture(false, label => {
+    public test_ChangingTextWhenInFixedSizeGridShouldNotRequestLayout() {
+        this.requestLayoutFixture(false, "Hello World", () => {
+            let host = new GridLayout();
+            host.width = 100;
+            host.height = 100;
+            return host;
+        });
+    }
+
+    public test_SettingTextWhenFixedWidthAndHeightDoesRequestLayout() {
+        this.requestLayoutFixture(true, "", label => {
+            let host = new StackLayout();
+            label.width = 100;
+            label.height = 100;
+            return host;
+        });
+    };
+
+    public test_ChangingTextWhenFixedWidthAndHeightDoesNotRequestLayout() {
+        this.requestLayoutFixture(false, "Hello World", label => {
             let host = new StackLayout();
             label.width = 100;
             label.height = 100;
@@ -568,15 +588,31 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
     };
 
     public test_SettingTextWhenSizedToContentShouldInvalidate() {
-        this.requestLayoutFixture(true, () => {
+        this.requestLayoutFixture(true, "", () => {
             let host = new StackLayout();
             host.orientation = "horizontal";
             return host;
         });
     };
 
-    public test_SettingTextOnSingleLineTextWhenWidthIsSizedToParentAndHeightIsSizedToContentShouldNotRequestLayout() {
-        this.requestLayoutFixture(false, () => {
+    public test_ChangingTextWhenSizedToContentShouldInvalidate() {
+        this.requestLayoutFixture(true, "Hello World", () => {
+            let host = new StackLayout();
+            host.orientation = "horizontal";
+            return host;
+        });
+    };
+
+    public test_SettingTextOnSingleLineTextWhenWidthIsSizedToParentAndHeightIsSizedToContentShouldRequestLayout() {
+        this.requestLayoutFixture(true, "", () => {
+            let host = new StackLayout();
+            host.width = 100;
+            return host;
+        });
+    }
+
+    public test_ChangingTextOnSingleLineTextWhenWidthIsSizedToParentAndHeightIsSizedToContentShouldNotRequestLayout() {
+        this.requestLayoutFixture(false, "Hello World", () => {
             let host = new StackLayout();
             host.width = 100;
             return host;
@@ -584,7 +620,16 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
     }
 
     public test_SettingTextOnMultilineLineTextWhenWidthIsSizedToParentAndHeightIsSizedToContentShouldRequestLayout() {
-        this.requestLayoutFixture(true, label => {
+        this.requestLayoutFixture(true, "", label => {
+            label.textWrap = true;
+            let host = new StackLayout();
+            host.width = 100;
+            return host;
+        });
+    }
+
+    public test_ChangingTextOnMultilineLineTextWhenWidthIsSizedToParentAndHeightIsSizedToContentShouldRequestLayout() {
+        this.requestLayoutFixture(true, "Hello World", label => {
             label.textWrap = true;
             let host = new StackLayout();
             host.width = 100;

--- a/tests/app/ui/label/label-tests.ts
+++ b/tests/app/ui/label/label-tests.ts
@@ -551,8 +551,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         }
     }
 
-    public test_SettingTextWhenInFixedSizeGridShouldRequestLayout() {
-        this.requestLayoutFixture(true, "", () => {
+    public test_SettingTextWhenInFixedSizeGridShouldNotRequestLayout() {
+        this.requestLayoutFixture(false, "", () => {
             let host = new GridLayout();
             host.width = 100;
             host.height = 100;
@@ -569,8 +569,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         });
     }
 
-    public test_SettingTextWhenFixedWidthAndHeightDoesRequestLayout() {
-        this.requestLayoutFixture(true, "", label => {
+    public test_SettingTextWhenFixedWidthAndHeightDoesNotRequestLayout() {
+        this.requestLayoutFixture(false, "", label => {
             let host = new StackLayout();
             label.width = 100;
             label.height = 100;

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -45,15 +45,13 @@ export class Label extends common.Label {
     }
 
     _requestLayoutOnTextChanged(): void {
-        console.log("requestLayout called --------------------------------------->");
         if (this._fixedSize === FixedSize.BOTH) {
             return;
         }
-        if (this._fixedSize === FixedSize.WIDTH && !this.textWrap) {
+        if (this._fixedSize === FixedSize.WIDTH && !this.textWrap && this.getMeasuredHeight() > 0) {
             // Single line label with fixed width will skip request layout on text change.
             return;
         }
-        console.log("actual requestLayout called --------------------------------------->");
         super._requestLayoutOnTextChanged();
     }
 
@@ -74,13 +72,13 @@ export class Label extends common.Label {
                 height = Number.POSITIVE_INFINITY;
             }
 
-            if (this.text !== "") {
+            //if (this.text !== "") {
                 this._fixedSize = (widthMode === utils.layout.EXACTLY ? FixedSize.WIDTH : FixedSize.NONE)
                     | (heightMode === utils.layout.EXACTLY ? FixedSize.HEIGHT : FixedSize.NONE);
-            }
-            else {
-                this._fixedSize = FixedSize.NONE;
-            }
+            //}
+            //else {
+            //    this._fixedSize = FixedSize.NONE;
+            //}
 
             var nativeSize = nativeView.sizeThatFits(CGSizeMake(width, height));
             var labelWidth = nativeSize.width;

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -45,6 +45,7 @@ export class Label extends common.Label {
     }
 
     _requestLayoutOnTextChanged(): void {
+        console.log("requestLayout called --------------------------------------->");
         if (this._fixedSize === FixedSize.BOTH) {
             return;
         }
@@ -52,6 +53,7 @@ export class Label extends common.Label {
             // Single line label with fixed width will skip request layout on text change.
             return;
         }
+        console.log("actual requestLayout called --------------------------------------->");
         super._requestLayoutOnTextChanged();
     }
 
@@ -72,8 +74,13 @@ export class Label extends common.Label {
                 height = Number.POSITIVE_INFINITY;
             }
 
-            this._fixedSize = (widthMode === utils.layout.EXACTLY ? FixedSize.WIDTH : FixedSize.NONE)
-                | (heightMode === utils.layout.EXACTLY ? FixedSize.HEIGHT : FixedSize.NONE);
+            if (this.text !== "") {
+                this._fixedSize = (widthMode === utils.layout.EXACTLY ? FixedSize.WIDTH : FixedSize.NONE)
+                    | (heightMode === utils.layout.EXACTLY ? FixedSize.HEIGHT : FixedSize.NONE);
+            }
+            else {
+                this._fixedSize = FixedSize.NONE;
+            }
 
             var nativeSize = nativeView.sizeThatFits(CGSizeMake(width, height));
             var labelWidth = nativeSize.width;

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -72,13 +72,8 @@ export class Label extends common.Label {
                 height = Number.POSITIVE_INFINITY;
             }
 
-            //if (this.text !== "") {
-                this._fixedSize = (widthMode === utils.layout.EXACTLY ? FixedSize.WIDTH : FixedSize.NONE)
-                    | (heightMode === utils.layout.EXACTLY ? FixedSize.HEIGHT : FixedSize.NONE);
-            //}
-            //else {
-            //    this._fixedSize = FixedSize.NONE;
-            //}
+            this._fixedSize = (widthMode === utils.layout.EXACTLY ? FixedSize.WIDTH : FixedSize.NONE)
+                | (heightMode === utils.layout.EXACTLY ? FixedSize.HEIGHT : FixedSize.NONE);
 
             var nativeSize = nativeView.sizeThatFits(CGSizeMake(width, height));
             var labelWidth = nativeSize.width;


### PR DESCRIPTION
Rendering issue with a Label rendered for the first time with an empty string as text. This results in a zero height of the label and due to bug after changing text later layout request is rejected and text is not visible.

