### PR TITLE
Color of buttons inside dialogs is not applied if there'are nested css styles

### DIFF
--- a/tns-core-modules/ui/dialogs/dialogs.android.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.android.ts
@@ -39,6 +39,20 @@ function showDialog(builder: android.app.AlertDialog.Builder) {
             }
         }
     }
+
+    var backgroundColor = dialogsCommon.getButtonColor();
+    if (backgroundColor) {
+        let buttons : android.widget.Button[] = [];
+        for (var i = 0; i < 3; i++) {
+            var id = dlg.getContext().getResources().getIdentifier("android:id/button" + i, null, null);
+            buttons[i] = <android.widget.Button>dlg.findViewById(id);
+        }
+        buttons.forEach(button => {
+            if (button) {
+                button.setTextColor(backgroundColor.android);
+            }
+        });
+    }
 }
 
 function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options: dialogs.ConfirmOptions,
@@ -75,7 +89,7 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
         }));
     }
     alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
-        onDismiss: function() {
+        onDismiss: function () {
             callback(false);
         }
     }));
@@ -95,7 +109,7 @@ export function alert(arg: any): Promise<void> {
                 }
             }));
             alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
-                onDismiss: function() {
+                onDismiss: function () {
                     resolve();
                 }
             }));
@@ -306,7 +320,7 @@ export function action(arg: any): Promise<string> {
             }
 
             alert.setOnDismissListener(new android.content.DialogInterface.OnDismissListener({
-                onDismiss: function() {
+                onDismiss: function () {
                     if (types.isString(options.cancelButtonText)) {
                         resolve(options.cancelButtonText);
                     } else {

--- a/tns-core-modules/ui/dialogs/dialogs.android.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.android.ts
@@ -40,11 +40,11 @@ function showDialog(builder: android.app.AlertDialog.Builder) {
         }
     }
 
-    var buttonColor = dialogsCommon.getButtonColor();
+    let buttonColor = dialogsCommon.getButtonColor();
     if (buttonColor) {
         let buttons : android.widget.Button[] = [];
-        for (var i = 0; i < 3; i++) {
-            var id = dlg.getContext().getResources().getIdentifier("android:id/button" + i, null, null);
+        for (let i = 0; i < 3; i++) {
+            let id = dlg.getContext().getResources().getIdentifier("android:id/button" + i, null, null);
             buttons[i] = <android.widget.Button>dlg.findViewById(id);
         }
         buttons.forEach(button => {

--- a/tns-core-modules/ui/dialogs/dialogs.android.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.android.ts
@@ -40,8 +40,8 @@ function showDialog(builder: android.app.AlertDialog.Builder) {
         }
     }
 
-    var backgroundColor = dialogsCommon.getButtonColor();
-    if (backgroundColor) {
+    var buttonColor = dialogsCommon.getButtonColor();
+    if (buttonColor) {
         let buttons : android.widget.Button[] = [];
         for (var i = 0; i < 3; i++) {
             var id = dlg.getContext().getResources().getIdentifier("android:id/button" + i, null, null);
@@ -49,7 +49,7 @@ function showDialog(builder: android.app.AlertDialog.Builder) {
         }
         buttons.forEach(button => {
             if (button) {
-                button.setTextColor(backgroundColor.android);
+                button.setTextColor(buttonColor.android);
             }
         });
     }


### PR DESCRIPTION
The color of buttons inside dialogs is not modified in case the following CSS is defined:

Page Button {
    background-color: #30BCFF;
    color: #FFFFFF;
}

 Button {
    font-size: 15;
    color: springgreen; 
}

In this case, the color of a button inside dialog will be still "#ffffff", while the desired one is "springgreen".