### PR TITLE
Renamed and moved to module Observable creation functions.

### DIFF
--- a/tests/app/data/observable-tests.ts
+++ b/tests/app/data/observable-tests.ts
@@ -529,7 +529,7 @@ export function test_CorrectPropertyValueAfterUsingWrappedValue() {
 
 export function test_NestedObservablesWithObservableArrayShouldNotCrash() {
     let someObservableArray = new ObservableArray<any>();
-    let testObservable = observable.Observable.fromJSONRecursive({
+    let testObservable = observable.fromObjectRecursive({
         firstProp: "test string",
         secondProp: someObservableArray
     });

--- a/tests/app/ui/bindable-tests.ts
+++ b/tests/app/ui/bindable-tests.ts
@@ -1265,7 +1265,7 @@ export function test_only_Bindable_BindingContext_Null_DoesNotThrow() {
 
 export function test_Observable_from_nested_json_binds_correctly() {
     let expectedValue = "Test";
-    let model = observable.Observable.fromJSONRecursive({
+    let model = observable.fromObjectRecursive({
         "firstObject": {
             "secondObject": {
                 "dummyProperty": "text"
@@ -1286,7 +1286,7 @@ export function test_Observable_from_nested_json_binds_correctly() {
 
 export function test_Observable_from_nested_json_binds_correctly_when_upper_object_is_changed() {
     let expectedValue = "Test";
-    let model = observable.Observable.fromJSONRecursive({
+    let model = observable.fromObjectRecursive({
         "firstObject": {
             "secondObject": {
                 "dummyProperty": "text"
@@ -1320,7 +1320,7 @@ export function test_BindingToBindingContextProperty_ShouldUseNewContext() {
         targetProperty: 'text'
     });
 
-    let testBindingContext = observable.Observable.fromJSONRecursive({
+    let testBindingContext = observable.fromObjectRecursive({
         context: {
             text: 'Alabala'
         }

--- a/tns-core-modules/data/observable/observable.d.ts
+++ b/tns-core-modules/data/observable/observable.d.ts
@@ -71,17 +71,6 @@ declare module "data/observable" {
         public static propertyChangeEvent: string;
 
         /**
-         * Creates an Observable instance and sets its properties according to the supplied JSON object. 
-         */
-        public static fromJSON(json: any): Observable;
-
-        /**
-         * Creates an Observable instance and sets its properties according to the supplied JSON object.
-         * This function will create new Observable for each nested object (expect arrays and functions) from supplied JSON.
-         */
-        public static fromJSONRecursive(json: any): Observable;
-
-        /**
          * [Deprecated please use static functions fromJSON or fromJSONRecursive instead] Creates an Observable instance and sets its properties according to the supplied JSON object.
          */
         constructor(json?: any);
@@ -161,4 +150,17 @@ declare module "data/observable" {
         _emit(eventNames: string);
         //@endprivate
     }
+
+    /**
+     * Creates an Observable instance and sets its properties according to the supplied JavaScript object.
+     * param obj - A JavaScript object used to initialize nativescript Observable instance. 
+     */
+    export function fromObject(obj: any): Observable;
+
+    /**
+     * Creates an Observable instance and sets its properties according to the supplied JavaScript object.
+     * This function will create new Observable for each nested object (expect arrays and functions) from supplied JavaScript object.
+     * param obj - A JavaScript object used to initialize nativescript Observable instance.
+     */
+    export function fromObjectRecursive(obj: any): Observable;
 }

--- a/tns-core-modules/data/observable/observable.ts
+++ b/tns-core-modules/data/observable/observable.ts
@@ -47,45 +47,17 @@ var _wrappedValues = [
 
 export class Observable implements definition.Observable {
     public static propertyChangeEvent = "propertyChange";
-    private _map: Map<string, Object>;
+    _map: Map<string, Object>;
 
     private _observers = {};
 
-    public static fromJSON(json: any): Observable {
-        let observable = new Observable();
-        observable.addPropertiesFromJSON(observable, json, false);
-        return observable;
-    }
-
-    public static fromJSONRecursive(json: any): Observable {
-        let observable = new Observable();
-        observable.addPropertiesFromJSON(observable, json, true);
-        return observable;
-    }
-
-    private addPropertiesFromJSON(observable: Observable, json: any, recursive?: boolean) {
-        let isRecursive = recursive || false;
-        observable._map = new Map<string, Object>();
-        for (var prop in json) {
-            if (json.hasOwnProperty(prop)) {
-                if (isRecursive) {
-                    if (!Array.isArray(json[prop]) && typeof json[prop] === 'object' && types.getClass(json[prop]) !== 'ObservableArray') {
-                        json[prop] = Observable.fromJSONRecursive(json[prop]);
-                    }
-                }
-                observable._defineNewProperty(prop);
-                observable.set(prop, json[prop]);
-            }
-        }
-    }
-
     constructor(json?: any) {
         if (json) {
-            this.addPropertiesFromJSON(this, json);
+            addPropertiesFromJSON(this, json);
         }
     }
 
-    private _defineNewProperty(propertyName: string): void {
+    _defineNewProperty(propertyName: string): void {
         Object.defineProperty(this, propertyName, {
             get: function () {
                 return this._map.get(propertyName);
@@ -275,4 +247,32 @@ export class Observable implements definition.Observable {
     public toString(): string {
         return this.typeName;
     }
+}
+
+function addPropertiesFromJSON(observable: Observable, json: any, recursive?: boolean) {
+    let isRecursive = recursive || false;
+    observable._map = new Map<string, Object>();
+    for (var prop in json) {
+        if (json.hasOwnProperty(prop)) {
+            if (isRecursive) {
+                if (!Array.isArray(json[prop]) && typeof json[prop] === 'object' && types.getClass(json[prop]) !== 'ObservableArray') {
+                    json[prop] = fromObjectRecursive(json[prop]);
+                }
+            }
+            observable._defineNewProperty(prop);
+            observable.set(prop, json[prop]);
+        }
+    }
+}
+
+export function fromObject(json: any): Observable {
+    let observable = new Observable();
+    addPropertiesFromJSON(observable, json, false);
+    return observable;
+}
+
+export function fromObjectRecursive(json: any): Observable {
+    let observable = new Observable();
+    addPropertiesFromJSON(observable, json, true);
+    return observable;
 }


### PR DESCRIPTION
Static functions `fromJSON` and `fromJSONRecursive` renamed to `fromObject` and `fromObjectRecursive` respectively (as the new names are more correct). Also functions are moved to Observable module instead exported as static functions of Observable class.

