### PR TITLE
Remove global Object var declaration to avoid clashing with TS 2.0

### DIFF
--- a/tns-core-modules/es6.d.ts
+++ b/tns-core-modules/es6.d.ts
@@ -10,12 +10,3 @@ interface SymbolConstructor {
 }
 
 declare var Symbol: SymbolConstructor;
-
-interface ObjectConstructor {
-    assign(target: any, ...sources: any[]): any;
-    is(value1: any, value2: any): boolean;
-    setPrototypeOf(o: any, proto: any): any;
-    getOwnPropertySymbols(o: any): symbol[];
-}
-
-declare var Object: ObjectConstructor;


### PR DESCRIPTION
TypeScript 2.0 now has its own Object typings which clash with our own.

Note that this does not switch tns-core-modules to using TypeScript 2.0 yet! It only allows app developers to use TypeScript 2.0 for their code.

//cc @PanayotCankov 