### PR TITLE
Ignore iOS platform definitions in typedoc builds.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -175,6 +175,7 @@ module.exports = function(grunt) {
     ]);
     localCfg.srcTsdFiles = [
         "tns-core-modules/**/*.d.ts",
+        "!tns-core-modules/ios/**",
         "!**/org.nativescript.widgets.d.ts",
         "!**/android17.d.ts",
         "!**/*.android.d.ts",


### PR DESCRIPTION
Fixes an OOM crash in docs build.