### PR TITLE
Fixes #2621: Add accessibility labels to views

### DIFF
--- a/tests/app/ui/view/view-tests.ios.ts
+++ b/tests/app/ui/view/view-tests.ios.ts
@@ -79,4 +79,5 @@ export function test_automation_text_set_to_native() {
     var newButton = new button.Button();
     newButton.automationText = "Button1";
     TKUnit.assertEqual((<UIView>newButton.ios).accessibilityIdentifier, "Button1", "accessibilityIdentifier not set to native view.");
+    TKUnit.assertEqual((<UIView>newButton.ios).accessibilityLabel, "Button1", "accessibilityIdentifier not set to native view.");
 }

--- a/tns-core-modules/ui/core/view.ios.ts
+++ b/tns-core-modules/ui/core/view.ios.ts
@@ -21,6 +21,7 @@ global.moduleMerge(viewCommon, exports);
 function onAutomationTextPropertyChanged(data: dependencyObservable.PropertyChangeData) {
     var view = <View>data.object;
     view._nativeView.accessibilityIdentifier = data.newValue;
+    view._nativeView.accessibilityLabel = data.newValue;
 }
 (<proxy.PropertyMetadata>viewCommon.View.automationTextProperty.metadata).onSetNativeValue = onAutomationTextPropertyChanged;
 


### PR DESCRIPTION
### Fixes/Implements #2621

As suggested by @tsonevn I'm updating the `automationText` property on `ui/view` on iOS to set both `accessibilityIdentifier` and `accessibilityLabel`.

This fixes basic `VoiceOver` behavior on iOS.