### PR TITLE
(Bugfix) Android Image memory leak, resolves #2571

### DIFF
--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -86,7 +86,16 @@ export class Image extends view.View implements definition.Image {
     /**
      * @internal
      */
+    
+    // Track the source of the image to fix a memory leak on Android
+    // FALSE for file, resource, or URL
+    // These will be recycled when the src changes or the component is unloaded
+    // TRUE for a passed in ImageSource or NativeImage. These will be left alone.
+    _wasNativeSource: boolean;
+    _isNativeSource: boolean;
+
     _createImageSourceFromSrc(): void {
+        this._wasNativeSource = this._isNativeSource || false;
         var value = this.src;
         if (types.isString(value)) {
             value = value.trim();
@@ -101,6 +110,7 @@ export class Image extends view.View implements definition.Image {
                 if (!types.isString(this.src) || value !== currentValue.trim()) {
                     return;
                 }
+                this._isNativeSource = false;
                 this.imageSource = source;
                 this._setValue(Image.isLoadingProperty, false);
             }
@@ -145,11 +155,13 @@ export class Image extends view.View implements definition.Image {
             }
         }
         else if (value instanceof imageSource.ImageSource) {
+            this._isNativeSource = true;
             // Support binding the imageSource trough the src property
             this.imageSource = value;
             this._setValue(Image.isLoadingProperty, false);
         }
         else {
+            this._isNativeSource = true;
             this.imageSource = imageSource.fromNativeSource(value);
             this._setValue(Image.isLoadingProperty, false);
         }

--- a/tns-core-modules/ui/image/image.android.ts
+++ b/tns-core-modules/ui/image/image.android.ts
@@ -61,12 +61,32 @@ export class Image extends imageCommon.Image {
         return this._android;
     }
 
+    public onUnloaded() {
+        super.onUnloaded();
+        if(!this._isNativeSource) {
+            this._recycle();
+        }
+    }
+
     public _createUI() {
         this._android = new org.nativescript.widgets.ImageView(this._context);
     }
 
     public _setNativeImage(nativeImage: any) {
+        if(!this._wasNativeSource) {
+            this._recycle();
+        }
         this.android.setImageBitmap(nativeImage);
+    }
+
+    private _recycle() {
+        let drawable: any = this.android.getDrawable();
+        if(drawable) {
+            let bitmap = drawable.getBitmap();
+            if(bitmap) {
+                drawable.getBitmap().recycle();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes a severe memory leak in the Image component on Android. Images loaded via `<Image src="..." />` are kept in memory forever even after the source is changed or the component is unloaded. This causes image intensive applications to quickly run out of memory and crash.

This problem is discussed at length in #2571 and is likely the culprit behind #123, #1808, and nativescript/android-runtime#77.

My solution is to track Image sources loaded via resource, file or URL and call `recycle()` on the Bitmap when either the source is swapped or the component is unloaded. When an existing ImageSource or native image is passed in as a source it is left alone, as these are likely to be reused later.

I've created tests for this issue at:
https://github.com/colinskow/tns-image-test

I need help to turn them into automated unit tests in this repo, as I am not sure how to do that. But they pass with my pull request and fail on both 2.2.1 and master. By failure I mean the app crashes with Out Of Memory.

This PR handles the image problem and stops apps from crashing. But it may also be a bandaid for a more serious bug in the NativeScript Android runtime that is causing hard references for all images loaded to be held onto forever.