### PR TITLE
setActivityCallbacks moved as public function

### DIFF
--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -357,10 +357,10 @@ declare module "ui/frame" {
         //@endprivate
     }
 
+    export function setActivityCallbacks(activity: any /*android.app.Activity*/): void;
     //@private
     function reloadPage(): void;
     function resolvePageFromEntry(entry: NavigationEntry): pages.Page;
     function setFragmentCallbacks(fragment: any /*android.app.Fragment*/): void;
-    function setActivityCallbacks(activity: any /*android.app.Activity*/): void;
     //@endprivate
 }


### PR DESCRIPTION
setActivityCallbacks moved as public function so that this article can be completed in TypeScript.
http://docs.nativescript.org/runtimes/android/advanced-topics/extend-application-activity

Fix: https://github.com/NativeScript/NativeScript/issues/2526

