### PR TITLE
IOS Known folders are not created if do not exist

### DIFF
--- a/tests/app/file-system-tests.ts
+++ b/tests/app/file-system-tests.ts
@@ -222,8 +222,8 @@ function _testIOSSpecificKnownFolder(knownFolderName: string){
     let knownFolder: fs.Folder;
     let createdFile: fs.File;
     let testFunc = function testFunc(){
+        knownFolder = fs.knownFolders.ios[knownFolderName]();
         if (knownFolder) {
-            knownFolder = fs.knownFolders.ios[knownFolderName]();
             createdFile = knownFolder.getFile("createdFile");
             createdFile.writeTextSync("some text");
         }

--- a/tests/app/file-system-tests.ts
+++ b/tests/app/file-system-tests.ts
@@ -222,17 +222,20 @@ function _testIOSSpecificKnownFolder(knownFolderName: string){
     let knownFolder: fs.Folder;
     let createdFile: fs.File;
     let testFunc = function testFunc(){
-        knownFolder = fs.knownFolders.ios[knownFolderName]();
-        createdFile = knownFolder.getFile("createdFile");
-        createdFile.writeTextSync("some text");
+        if (knownFolder) {
+            knownFolder = fs.knownFolders.ios[knownFolderName]();
+            createdFile = knownFolder.getFile("createdFile");
+            createdFile.writeTextSync("some text");
+        }
     };
     if (platform.isIOS){
         testFunc();
-        TKUnit.assertNotNull(knownFolder, `Could not retrieve the ${knownFolderName} known folder.`);
-        TKUnit.assertTrue(knownFolder.isKnown, `The ${knownFolderName} folder should have its "isKnown" property set to true.`);
-        TKUnit.assertNotNull(createdFile, `Could not create a new file in the ${knownFolderName} known folder.`);
-        TKUnit.assertTrue(fs.File.exists(createdFile.path), `Could not create a new file in the ${knownFolderName} known folder.`);
-        TKUnit.assertEqual(createdFile.readTextSync(), "some text", `The contents of the new file created in the ${knownFolderName} known folder are not as expected.`);
+        if (knownFolder) {
+            TKUnit.assertTrue(knownFolder.isKnown, `The ${knownFolderName} folder should have its "isKnown" property set to true.`);
+            TKUnit.assertNotNull(createdFile, `Could not create a new file in the ${knownFolderName} known folder.`);
+            TKUnit.assertTrue(fs.File.exists(createdFile.path), `Could not create a new file in the ${knownFolderName} known folder.`);
+            TKUnit.assertEqual(createdFile.readTextSync(), "some text", `The contents of the new file created in the ${knownFolderName} known folder are not as expected.`);
+        }
     }
     else {
         TKUnit.assertThrows(testFunc, 

--- a/tns-core-modules/file-system/file-system-access.ios.ts
+++ b/tns-core-modules/file-system/file-system-access.ios.ts
@@ -109,7 +109,7 @@ export class FileSystemAccess {
 
      public getExistingFolder(path: string, onError?: (error: any) => any): { path: string; name: string } {
         try {
-            var fileManager = NSFileManager.defaultManager();
+            var fileManager = utils.ios.getter(NSFileManager, NSFileManager.defaultManager);
             var exists = this.folderExists(path);
 
             if (exists) {

--- a/tns-core-modules/file-system/file-system-access.ios.ts
+++ b/tns-core-modules/file-system/file-system-access.ios.ts
@@ -107,6 +107,30 @@ export class FileSystemAccess {
         }
     }
 
+     public getExistingFolder(path: string, onError?: (error: any) => any): { path: string; name: string } {
+        try {
+            var fileManager = NSFileManager.defaultManager();
+            var exists = this.folderExists(path);
+
+            if (exists) {
+                var dirName = fileManager.displayNameAtPath(path);
+
+                return {
+                    path: path,
+                    name: dirName
+                };
+            }
+            return undefined;
+        }
+        catch (ex) {
+            if (onError) {
+                onError(new Error("Failed to get folder at path '" + path + "'"));
+            }
+
+            return undefined;
+        }
+     }
+
     public eachEntity(path: string, onEntity: (file: { path: string; name: string; extension: string }) => any, onError?: (error: any) => any) {
         if (!onEntity) {
             return;

--- a/tns-core-modules/file-system/file-system.ts
+++ b/tns-core-modules/file-system/file-system.ts
@@ -512,10 +512,13 @@ export module knownFolders {
         export var library = function(): Folder {
             _checkPlatform("library");
             if (!_library) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.LibraryDirectory);
-                _library = Folder.fromPath(path);
-                _library[pathProperty] = path;
-                _library[isKnownProperty] = true;
+                let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.LibraryDirectory);
+
+                if (existingFolderInfo) {
+                    _library = existingFolderInfo.folder;
+                    _library[pathProperty] = existingFolderInfo.path;
+                    _library[isKnownProperty] = true;
+                }
             }
 
             return _library;
@@ -525,10 +528,13 @@ export module knownFolders {
         export var developer = function(): Folder {
             _checkPlatform("developer");
             if (!_developer) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.DeveloperDirectory);
-                _developer = Folder.fromPath(path);
-                _developer[pathProperty] = path;
-                _developer[isKnownProperty] = true;
+                let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.DeveloperDirectory);
+
+                if (existingFolderInfo) {
+                    _developer = existingFolderInfo.folder;
+                    _developer[pathProperty] = existingFolderInfo.path;
+                    _developer[isKnownProperty] = true;
+                }
             }
 
             return _developer;
@@ -538,10 +544,13 @@ export module knownFolders {
         export var desktop = function(): Folder {
             _checkPlatform("desktop");
             if (!_desktop) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.DesktopDirectory);
-                _desktop = Folder.fromPath(path);
-                _desktop[pathProperty] = path;
-                _desktop[isKnownProperty] = true;
+                 let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.DesktopDirectory);
+
+                if (existingFolderInfo) {
+                    _desktop = existingFolderInfo.folder;
+                    _desktop[pathProperty] = existingFolderInfo.path;
+                    _desktop[isKnownProperty] = true;
+                }
             }
 
             return _desktop;
@@ -551,10 +560,13 @@ export module knownFolders {
         export var downloads = function(): Folder {
             _checkPlatform("downloads");
             if (!_downloads) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.DownloadsDirectory);
-                _downloads = Folder.fromPath(path);
-                _downloads[pathProperty] = path;
-                _downloads[isKnownProperty] = true;
+                let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.DownloadsDirectory);
+
+                if (existingFolderInfo) {
+                    _downloads = existingFolderInfo.folder;
+                    _downloads[pathProperty] = existingFolderInfo.path;
+                    _downloads[isKnownProperty] = true;
+                }
             }
 
             return _downloads;
@@ -564,10 +576,13 @@ export module knownFolders {
         export var movies = function(): Folder {
             _checkPlatform("movies");
             if (!_movies) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.MoviesDirectory);
-                _movies = Folder.fromPath(path);
-                _movies[pathProperty] = path;
-                _movies[isKnownProperty] = true;
+                 let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.MoviesDirectory);
+
+                if (existingFolderInfo) {
+                    _movies = existingFolderInfo.folder;
+                    _movies[pathProperty] = existingFolderInfo.path;
+                    _movies[isKnownProperty] = true;
+                }
             }
 
             return _movies;
@@ -577,10 +592,13 @@ export module knownFolders {
         export var music = function(): Folder {
             _checkPlatform("music");
             if (!_music) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.MusicDirectory);
-                _music = Folder.fromPath(path);
-                _music[pathProperty] = path;
-                _music[isKnownProperty] = true;
+                let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.MusicDirectory);
+
+                if (existingFolderInfo) {
+                    _music = existingFolderInfo.folder;
+                    _music[pathProperty] = existingFolderInfo.path;
+                    _music[isKnownProperty] = true;
+                }
             }
 
             return _music;
@@ -590,10 +608,13 @@ export module knownFolders {
         export var pictures = function(): Folder {
             _checkPlatform("pictures");
             if (!_pictures) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.PicturesDirectory);
-                _pictures = Folder.fromPath(path);
-                _pictures[pathProperty] = path;
-                _pictures[isKnownProperty] = true;
+                  let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.PicturesDirectory);
+
+                if (existingFolderInfo) {
+                    _pictures = existingFolderInfo.folder;
+                    _pictures[pathProperty] = existingFolderInfo.path;
+                    _pictures[isKnownProperty] = true;
+                }
             }
 
             return _pictures;
@@ -603,14 +624,31 @@ export module knownFolders {
         export var sharedPublic = function(): Folder {
             _checkPlatform("sharedPublic");
             if (!_sharedPublic) {
-                var path = (<any>getFileAccess()).getKnownPath(NSSearchPathDirectory.SharedPublicDirectory);
-                _sharedPublic = Folder.fromPath(path);
-                _sharedPublic[pathProperty] = path;
-                _sharedPublic[isKnownProperty] = true;
+                let existingFolderInfo = getExistingFolderInfo(NSSearchPathDirectory.SharedPublicDirectory);
+
+                if (existingFolderInfo) {
+                    _sharedPublic = existingFolderInfo.folder;
+                    _sharedPublic[pathProperty] = existingFolderInfo.path;
+                    _sharedPublic[isKnownProperty] = true;
+                }
             }
 
             return _sharedPublic;
         };
+
+        function getExistingFolderInfo(pathDirectory: NSSearchPathDirectory): { folder: Folder; path: string } {
+            var fileAccess = (<any>getFileAccess());
+            var folderPath = fileAccess.getKnownPath(pathDirectory);
+            var folderInfo = fileAccess.getExistingFolder(folderPath);
+
+            if (folderInfo) {
+                return {
+                    folder: createFolder(folderInfo),
+                    path: folderPath
+                };
+            }
+            return undefined;
+        }
     }
 }
 


### PR DESCRIPTION
GetFolder method in file-system-access creates a new folder if the requested one does not exist. This action cannot be performed on IOS device for folders outside the scope of the app, consequently - the failing test on ios device (_testIOSSpecificKnownFolder).
