### PR TITLE
Padding is not reset if an element has a border-related property set

### DIFF
--- a/tns-core-modules/ui/styling/background.android.ts
+++ b/tns-core-modules/ui/styling/background.android.ts
@@ -101,11 +101,16 @@ export module ad {
             }
         }
 
+        let leftPadding = v.style.paddingLeft ?  v.style.paddingLeft : nativeView.getPaddingLeft() / density; 
+        let topPadding = v.style.paddingTop ? v.style.paddingTop : nativeView.getPaddingTop() / density; 
+        let rightPadding = v.style.paddingRight ? v.style.paddingRight : nativeView.getPaddingRight() / density;         
+        let bottomPadding = v.style.paddingBottom ? v.style.paddingBottom : nativeView.getPaddingBottom() / density; 
+
         nativeView.setPadding(
-            Math.round((background.borderWidth + v.style.paddingLeft) * density),
-            Math.round((background.borderWidth + v.style.paddingTop) * density),
-            Math.round((background.borderWidth + v.style.paddingRight) * density),
-            Math.round((background.borderWidth + v.style.paddingBottom) * density)
+            Math.round((background.borderWidth + leftPadding) * density),
+            Math.round((background.borderWidth + topPadding) * density),
+            Math.round((background.borderWidth + rightPadding) * density),
+            Math.round((background.borderWidth + bottomPadding) * density)
         );
     }
 }


### PR DESCRIPTION
If an element has both padding and border-related (width, color, radius, etc,) properties set, the padding is not reset. 

_Element_:  

`<Button text="padding and borderWidth"  style="padding: 0; border-width: 5; border-color: red; border-radius: 8"/>`

_Reset_:

`view.eachDescendant(stackLayout, function (v: view.View) {      
        v.style._resetValue(style.paddingLeftProperty);
        ....
        v.style._resetValue(style.borderColorProperty);
        ....
        return true;
    });`
