### PR TITLE
The ios.d.ts-es were split and updated

### DIFF
--- a/tns-core-modules/ios.d.ts
+++ b/tns-core-modules/ios.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="./ios/ios.d.ts" />


### PR DESCRIPTION
The ios.d.ts-es were split and generated using the latest iOS SDK and tns-ios tools, but that moved the ios.d.ts. Adding an ios.d.ts to keep backward compatibility.