### PR TITLE
Add timeout warning log for test runner. Increase timeout to 1200

### DIFF
--- a/expect.exp
+++ b/expect.exp
@@ -1,20 +1,13 @@
 #! /usr/bin/expect
 
-#exp_internal 1
-
-#set timeout 600
-
-#spawn grunt
-#expect "TypeScript compilation complete"
-#send \003
-
-
 set cmd [lindex $argv 0];
 set outfile [lindex $argv 1];
 
-set timeout 600
-#spawn (adb logcat | tee ./__TESTRESULT__.txt)
+set timeout 1200
 log_file -noappend $outfile
 eval spawn $cmd
-expect "Tests EOF!"
+expect {
+    "Tests EOF!" { puts "Tests completed in time, EOF found." }
+    timeout {  puts "Tests FAILED, timeout waiting tests EOF."; exit 1 }
+}
 send \003


### PR DESCRIPTION
Tinkering with the expect script...

