### PR TITLE
added jpg as synonim for ImageFormat jpeg

### DIFF
--- a/tns-core-modules/image-source/image-source.android.ts
+++ b/tns-core-modules/image-source/image-source.android.ts
@@ -160,7 +160,7 @@ function getTargetFormat(format: string): android.graphics.Bitmap.CompressFormat
     ensureEnums();
 
     switch (format) {
-        case enums.ImageFormat.jpeg:
+        case enums.ImageFormat.jpeg || enums.ImageFormat.jpg:
             return android.graphics.Bitmap.CompressFormat.JPEG;
         default:
             return android.graphics.Bitmap.CompressFormat.PNG;

--- a/tns-core-modules/image-source/image-source.ios.ts
+++ b/tns-core-modules/image-source/image-source.ios.ts
@@ -165,10 +165,9 @@ function getImageData(instance: UIImage, format: string, quality = 1.0): NSData 
         case enums.ImageFormat.png: // PNG
             data = UIImagePNGRepresentation(instance);
             break;
-        case enums.ImageFormat.jpeg: // JPEG
+        case enums.ImageFormat.jpeg || enums.ImageFormat.jpg: // JPEG
             data = UIImageJPEGRepresentation(instance, quality);
             break;
-
     }
     return data;
 }

--- a/tns-core-modules/ui/enums/enums.d.ts
+++ b/tns-core-modules/ui/enums/enums.d.ts
@@ -354,6 +354,11 @@
          * The Joint Photographic Experts Group (JPEG) image format.
          */
         export var jpeg: string;
+
+        /**
+         * The Joint Photographic Experts Group (JPEG) image format.
+         */
+        export var jpg: string;
     }
 
     /**

--- a/tns-core-modules/ui/enums/enums.ts
+++ b/tns-core-modules/ui/enums/enums.ts
@@ -138,6 +138,7 @@ export module IOSActionItemPosition {
 export module ImageFormat {
     export var png: string = "png";
     export var jpeg: string = "jpeg";
+    export var jpg: string = "jpg";
 }
 
 export module FontStyle {


### PR DESCRIPTION
Added acronym **jpg** in enums.ImageFormat and in image-source module

Related to [https://github.com/NativeScript/NativeScript/issues/2766](https://github.com/NativeScript/NativeScript/issues/2766)




