### PR TITLE
Update label tests

### DIFF
--- a/tests/app/ui/label/label-tests.ts
+++ b/tests/app/ui/label/label-tests.ts
@@ -73,7 +73,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         }
         else {
             this.waitUntilTestElementIsLoaded();
-            actualNative = testLabel.android.getText();
+            actualNative = testLabel.android.getText().toString();
         }
 
         TKUnit.assertEqual(actualNative, expectedValue, "Native text not equal");
@@ -90,7 +90,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         }
         else {
             this.waitUntilTestElementIsLoaded();
-            actualNative = testLabel.android.getText();
+            actualNative = testLabel.android.getText().toString();
         }
 
         TKUnit.assertEqual(actualNative, expectedValue, "Native text not equal");
@@ -107,7 +107,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         }
         else {
             this.waitUntilTestElementIsLoaded();
-            actualNative = testLabel.android.getText();
+            actualNative = testLabel.android.getText().toString();
         }
 
         TKUnit.assertEqual(actualNative, expectedValue, "Native text not equal");


### PR DESCRIPTION
Follow up: https://github.com/NativeScript/NativeScript/pull/2800.

These label tests fail on Android device due to `actualNative = testLabel.android.getText();` sometimes returns `SpannableString`, but not `String`. This PR makes it explicitly return `String`.