### PR TITLE
Export several more missing iOS delegates to allow modification

### DIFF
--- a/tns-core-modules/ui/animation/animation.ios.ts
+++ b/tns-core-modules/ui/animation/animation.ios.ts
@@ -41,7 +41,7 @@ interface IOSView extends viewModule.View {
     _isPresentationLayerUpdateSuspeneded();
 }
 
-class AnimationDelegateImpl extends NSObject implements CAAnimationDelegate {
+export class AnimationDelegateImpl extends NSObject implements CAAnimationDelegate {
 
     public nextAnimation: Function;
 

--- a/tns-core-modules/ui/button/button.ios.ts
+++ b/tns-core-modules/ui/button/button.ios.ts
@@ -9,7 +9,7 @@ import dependencyObservable = require("ui/core/dependency-observable");
 import types = require("utils/types");
 import {PseudoClassHandler} from "ui/core/view";
 
-class TapHandlerImpl extends NSObject {
+export class TapHandlerImpl extends NSObject {
     private _owner: WeakRef<Button>;
 
     public static initWithOwner(owner: WeakRef<Button>): TapHandlerImpl {

--- a/tns-core-modules/ui/date-picker/date-picker.ios.ts
+++ b/tns-core-modules/ui/date-picker/date-picker.ios.ts
@@ -99,7 +99,7 @@ export class DatePicker extends common.DatePicker {
     }
 }
 
-class UIDatePickerChangeHandlerImpl extends NSObject {
+export class UIDatePickerChangeHandlerImpl extends NSObject {
 
     private _owner: WeakRef<DatePicker>;
 

--- a/tns-core-modules/ui/dialogs/dialogs.ios.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.ios.ts
@@ -10,7 +10,7 @@ import getter = utils.ios.getter;
 
 global.moduleMerge(dialogsCommon, exports);
 
-class UIAlertViewDelegateImpl extends NSObject implements UIAlertViewDelegate {
+export class UIAlertViewDelegateImpl extends NSObject implements UIAlertViewDelegate {
     public static ObjCProtocols = [UIAlertViewDelegate];
 
     static new(): UIAlertViewDelegateImpl {
@@ -29,7 +29,7 @@ class UIAlertViewDelegateImpl extends NSObject implements UIAlertViewDelegate {
     }
 }
 
-class UIActionSheetDelegateImpl extends NSObject implements UIActionSheetDelegate {
+export class UIActionSheetDelegateImpl extends NSObject implements UIActionSheetDelegate {
     public static ObjCProtocols = [UIActionSheetDelegate];
 
     static new(): UIActionSheetDelegateImpl {

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -411,7 +411,7 @@ class TransitionDelegate extends NSObject {
 
 const _defaultTransitionDuration = 0.35;
 
-class UINavigationControllerAnimatedDelegate extends NSObject implements UINavigationControllerDelegate {
+export class UINavigationControllerAnimatedDelegate extends NSObject implements UINavigationControllerDelegate {
     public static ObjCProtocols = [UINavigationControllerDelegate];
 
     navigationControllerAnimationControllerForOperationFromViewControllerToViewController(
@@ -453,7 +453,7 @@ class UINavigationControllerAnimatedDelegate extends NSObject implements UINavig
     }
 }
 
-class UINavigationControllerImpl extends UINavigationController {
+export class UINavigationControllerImpl extends UINavigationController {
     private _owner: WeakRef<Frame>;
 
     public static initWithOwner(owner: WeakRef<Frame>): UINavigationControllerImpl {
@@ -665,7 +665,7 @@ export function _getNativeCurve(transition: definition.NavigationTransition): UI
 }
 
 /* tslint:disable */
-class iOSFrame implements definition.iOSFrame {
+export class iOSFrame implements definition.iOSFrame {
     /* tslint:enable */
     private _controller: UINavigationControllerImpl;
     private _showNavigationBar: boolean;

--- a/tns-core-modules/ui/gestures/gestures.ios.ts
+++ b/tns-core-modules/ui/gestures/gestures.ios.ts
@@ -7,7 +7,7 @@ import types = require("utils/types");
 
 global.moduleMerge(common, exports);
 
-class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecognizerDelegate {
+export class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecognizerDelegate {
     public static ObjCProtocols = [UIGestureRecognizerDelegate];
     public gestureRecognizerShouldRecognizeSimultaneouslyWithGestureRecognizer(gestureRecognizer: UIGestureRecognizer, otherGestureRecognizer: UIGestureRecognizer): boolean {
         return true;
@@ -15,7 +15,7 @@ class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecog
 }
 var recognizerDelegateInstance: UIGestureRecognizerDelegateImpl = <UIGestureRecognizerDelegateImpl>UIGestureRecognizerDelegateImpl.new();
 
-class UIGestureRecognizerImpl extends NSObject {
+export class UIGestureRecognizerImpl extends NSObject {
 
     private _owner: WeakRef<GesturesObserver>;
     private _type: any;
@@ -348,7 +348,7 @@ function _getRotationData(args: definition.GestureEventData): definition.Rotatio
     };
 }
 
-class TouchGestureRecognizer extends UIGestureRecognizer {
+export class TouchGestureRecognizer extends UIGestureRecognizer {
     public observer: GesturesObserver;
     private _eventData: TouchGestureEventData;
 

--- a/tns-core-modules/ui/list-picker/list-picker.ios.ts
+++ b/tns-core-modules/ui/list-picker/list-picker.ios.ts
@@ -47,7 +47,7 @@ export class ListPicker extends common.ListPicker {
     }
 }
 
-class ListPickerDataSource extends NSObject implements UIPickerViewDataSource {
+export class ListPickerDataSource extends NSObject implements UIPickerViewDataSource {
     public static ObjCProtocols = [UIPickerViewDataSource];
     
     private _owner: WeakRef<ListPicker>;
@@ -68,7 +68,7 @@ class ListPickerDataSource extends NSObject implements UIPickerViewDataSource {
     }
 }
 
-class ListPickerDelegateImpl extends NSObject implements UIPickerViewDelegate {
+export class ListPickerDelegateImpl extends NSObject implements UIPickerViewDelegate {
     public static ObjCProtocols = [UIPickerViewDelegate];
 
     private _owner: WeakRef<ListPicker>;

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -26,7 +26,7 @@ global.moduleMerge(common, exports);
 
 var infinity = utils.layout.makeMeasureSpec(0, utils.layout.UNSPECIFIED);
 
-class ListViewCell extends UITableViewCell {
+export class ListViewCell extends UITableViewCell {
     public willMoveToSuperview(newSuperview: UIView): void {
         let parent = <ListView>(this.view ? this.view.parent : null);
 
@@ -50,7 +50,7 @@ function notifyForItemAtIndex(listView: definition.ListView, cell: any, view: vi
     return args;
 }
 
-class DataSource extends NSObject implements UITableViewDataSource {
+export class DataSource extends NSObject implements UITableViewDataSource {
     public static ObjCProtocols = [UITableViewDataSource];
 
     private _owner: WeakRef<ListView>;
@@ -87,7 +87,7 @@ class DataSource extends NSObject implements UITableViewDataSource {
     }
 }
 
-class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
+export class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
     public static ObjCProtocols = [UITableViewDelegate];
 
     private _owner: WeakRef<ListView>;
@@ -147,7 +147,7 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
     }
 }
 
-class UITableViewRowHeightDelegateImpl extends NSObject implements UITableViewDelegate {
+export class UITableViewRowHeightDelegateImpl extends NSObject implements UITableViewDelegate {
     public static ObjCProtocols = [UITableViewDelegate];
 
     private _owner: WeakRef<ListView>;

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -50,7 +50,7 @@ function isBackNavigationFrom(controller: UIViewControllerImpl, page: Page): boo
     return true;
 }
 
-class UIViewControllerImpl extends UIViewController {
+export class UIViewControllerImpl extends UIViewController {
 
     private _owner: WeakRef<Page>;
 

--- a/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
@@ -6,7 +6,7 @@ import utils = require("utils/utils");
 
 global.moduleMerge(common, exports);
 
-class UIScrollViewDelegateImpl extends NSObject implements UIScrollViewDelegate {
+export class UIScrollViewDelegateImpl extends NSObject implements UIScrollViewDelegate {
     private _owner: WeakRef<ScrollView>;
 
     public static initWithOwner(owner: WeakRef<ScrollView>): UIScrollViewDelegateImpl {

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
@@ -114,7 +114,7 @@ export class SegmentedBar extends common.SegmentedBar {
     }
 }
 
-class SelectionHandlerImpl extends NSObject {
+export class SelectionHandlerImpl extends NSObject {
 
     private _owner: WeakRef<SegmentedBar>;
 

--- a/tns-core-modules/ui/switch/switch.ios.ts
+++ b/tns-core-modules/ui/switch/switch.ios.ts
@@ -15,7 +15,7 @@ function onCheckedPropertyChanged(data: dependencyObservable.PropertyChangeData)
 
 global.moduleMerge(common, exports);
 
-class SwitchChangeHandlerImpl extends NSObject {
+export class SwitchChangeHandlerImpl extends NSObject {
 
     private _owner: WeakRef<Switch>;
 

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -22,7 +22,7 @@ function ensureImageSource() {
     }
 }
 
-class UITabBarControllerImpl extends UITabBarController {
+export class UITabBarControllerImpl extends UITabBarController {
 
     private _owner: WeakRef<TabView>;
 
@@ -44,7 +44,7 @@ class UITabBarControllerImpl extends UITabBarController {
     }
 }
 
-class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControllerDelegate {
+export class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControllerDelegate {
     public static ObjCProtocols = [UITabBarControllerDelegate];
 
     private _owner: WeakRef<TabView>;
@@ -82,7 +82,7 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
     }
 }
 
-class UINavigationControllerDelegateImpl extends NSObject implements UINavigationControllerDelegate {
+export class UINavigationControllerDelegateImpl extends NSObject implements UINavigationControllerDelegate {
     public static ObjCProtocols = [UINavigationControllerDelegate];
 
     private _owner: WeakRef<TabView>;

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -15,7 +15,7 @@ function onSecurePropertyChanged(data: PropertyChangeData) {
 
 global.moduleMerge(common, exports);
 
-class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
+export class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
     public static ObjCProtocols = [UITextFieldDelegate];
 
     private _owner: WeakRef<TextField>;
@@ -97,7 +97,7 @@ class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
     }
 }
 
-class UITextFieldImpl extends UITextField {
+export class UITextFieldImpl extends UITextField {
 
     private _owner: WeakRef<TextField>;
 

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -10,7 +10,7 @@ import * as utils from "utils/utils";
 
 global.moduleMerge(common, exports);
 
-class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
+export class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
     public static ObjCProtocols = [UITextViewDelegate];
 
     private _owner: WeakRef<TextView>;

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -3,7 +3,7 @@ import trace = require("trace");
 
 global.moduleMerge(common, exports);
 
-class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
+export class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
     public static ObjCProtocols = [UIWebViewDelegate];
 
     private _owner: WeakRef<WebView>;


### PR DESCRIPTION
This will allow us to modify the delegates before they are used to add any missing functionality.  I have personally ran into this several times, UINavigationController, Label and WebView have all been issues because the delegates are hard coded and so you can't extend them to add new or fix functionality.
### The commit message references a specific issue in this repo

Fixes/Implements #2640, #2471
### You have [unit tests]

No added unit tests needed; just added the "export" to the typescript code so that the delegates are exported.
