### PR TITLE
remove gc call

### DIFF
--- a/tns-core-modules/ui/transition/transition.android.ts
+++ b/tns-core-modules/ui/transition/transition.android.ts
@@ -7,27 +7,6 @@ import * as animationModule from "ui/animation";
 import lazy from "utils/lazy";
 import trace = require("trace");
 
-let idleGCHandler;
-let scheduledGC = false;
-function scheduleGCOnIdle() {
-    if (!idleGCHandler) {
-        idleGCHandler = new android.os.MessageQueue.IdleHandler({
-            queueIdle: function () {
-                gc();
-                scheduledGC = false;
-                return false;
-            }
-        });
-    }
-
-    if (!scheduledGC) {
-        android.os.Looper.myQueue().addIdleHandler(idleGCHandler);
-        scheduledGC = true;
-    }
-
-    return idleGCHandler;
-}
-
 let slideTransition: any;
 function ensureSlideTransition() {
     if (!slideTransition) {
@@ -443,8 +422,6 @@ function _completePageRemoval(fragment: any, isBack: boolean) {
     }
 
     entry.isNavigation = undefined;
-
-    scheduleGCOnIdle();
 }
 
 export function _removePageNativeViewFromAndroidParent(page: Page): void {


### PR DESCRIPTION
Most of the OOM Exceptions were caused by holding Bitmap references inside image-source. Image component was using imageSource internally. Now Image component is loading images in Java so OOM should be rare. 
Removing the GC call improve the UX but there still could be a case were manual gc call is needed.