### PR TITLE
Change test-results file path for android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     grunt buildOnlyTestsApp --verbose --platform=Android --modulesPath=./bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz --runtimeVersion=$RUNTIMEVERSION --emuPId=.*emulator.* --avd=$AVD_NAME --showEmu=false > /dev/null &&
     grunt runOnlyTestsApp --verbose --platform=Android --modulesPath=./bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz --emuPId=.*emulator.* --avd=$AVD_NAME --showEmu=false
   - node ./build/travis-scripts/check-testrun-broken.js
-  - adb pull /data/data/org.nativescript.TestsApp/files/test-results.xml &&
+  - adb pull /data/local/tmp/test-results.xml &&
     mv test-results.xml ~/test-run-results$PACKAGE_VERSION.xml
 before_deploy:
   - mv bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz ../.deploymentpackage

--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -177,6 +177,9 @@ function printRunTestStats() {
     testFileContent.push("</testsuites>");
 
     let testFilePath = fs.path.join(fs.knownFolders.documents().path, "test-results.xml");
+    if (platform.isAndroid){
+        testFilePath = "/data/local/tmp/test-results.xml";
+    }
     let testFile = fs.File.fromPath(testFilePath);
     testFile.writeTextSync(testFileContent.join(""));
 


### PR DESCRIPTION
It seems that Android 7 is better secured and it is not possible to *pull* a file from `/data/data/0/org.nativescript.TestApp/files`. Therefore write the *test-results.xml* at `/data/local/tmp/`.