### PR TITLE
Fix for Dialogs crashing on iOS

### DIFF
--- a/tns-core-modules/ui/dialogs/dialogs-common.ts
+++ b/tns-core-modules/ui/dialogs/dialogs-common.ts
@@ -54,6 +54,7 @@ export function getButtonColor(): color.Color {
         var btn = new button.Button();
         applySelectors(btn);
         buttonColor = btn.color;
+        btn.onUnloaded();
     }
 
     return buttonColor;


### PR DESCRIPTION
The new cool Pseudo selector cool have a negative interaction with Dialogs; the code will now create a "NSInternalInconsistencyException" later in an iOS application.  (Depending on when GC occurs)

The issue is that the dialog-common creates a new button, applies the CSS selector and grabs its color.  The process of applying the CSS selector causes the pseudo selector code to be registered via the _updateHandler code inside the button.ios.ts file.    For every "observer" registered, you must de-register it before deallocation.   However, since the "onUnloaded" code is never called (because the button is not actually put into the DOM) the observer is never un-registered.   This patch manually calls the onUnloaded() function which de-registers the observer so everything is great again.

### The commit message references a specific issue in this repo
Fixes https://github.com/NativeScript/ios-runtime/issues/665



