### PR TITLE
Fixes using setTimeout/setInterval in a Android Worker

### DIFF
--- a/tns-core-modules/timer/timer.android.ts
+++ b/tns-core-modules/timer/timer.android.ts
@@ -7,7 +7,7 @@ var timerId = 0;
 
 function createHandlerAndGetId(): number {
     if (!timeoutHandler) {
-        timeoutHandler = new android.os.Handler(android.os.Looper.getMainLooper());
+        timeoutHandler = new android.os.Handler(android.os.Looper.myLooper());
     }
 
     timerId++;


### PR DESCRIPTION
The current setTimeout code for android uses getMainLooper() which will cause the worker timer to fire on the main thread.   The code needs to actually run on the correct thread that started it; switching to "myLooper" will work on both the main thread and on worker threads.

To duplicate:
`app.js`
```
var x =new Worker('timer.js');
setTimeout(function() { console.log("Main thread worked"); }, 100);
```


`timer.js`
```
require('globals');
setTimeout(function() { console.log("Worker Worked"); }, 100);

```

Will produce on unfixed core modules: 
> An uncaught Exception occurred on "main" thread.
> com.tns.NativeScriptException: Cannot find object id for instance=com.tns.gen.java.lang.Runnable@52a37664
> 	at com.tns.Runtime.callJSMethodImpl(Runtime.java:889)
> 	at com.tns.Runtime.callJSMethod(Runtime.java:883)
> 	at com.tns.Runtime.callJSMethod(Runtime.java:867)
> 	at com.tns.Runtime.callJSMethod(Runtime.java:859)
> 	at com.tns.gen.java.lang.Runnable.run(java.lang.Runnable.java)
> 	at android.os.Handler.handleCallback(Handler.java:733)
> 	at android.os.Handler.dispatchMessage(Handler.java:95)
> 	at android.os.Looper.loop(Looper.java:136)
> 	at android.app.ActivityThread.main(ActivityThread.java:5001)
> 	at java.lang.reflect.Method.invokeNative(Native Method)
> 	at java.lang.reflect.Method.invoke(Method.java:515)
> 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:785)
> 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:601)
> 	at dalvik.system.NativeStart.main(Native Method)