### PR TITLE
npm scripts for typechecking public .d.ts-es and running tslint

### DIFF
--- a/apps/app/gallery-app/main-page.ts
+++ b/apps/app/gallery-app/main-page.ts
@@ -6,4 +6,3 @@ export function itemTap(args: observable.EventData) {
         moduleName: "gallery-app/" + args.object.get("tag"),
     });
 }
- 

--- a/build/tslint.json
+++ b/build/tslint.json
@@ -4,7 +4,7 @@
         "curly": true,
         "forin": false,
         "indent": true,
-        "jsdoc-format": true,
+        "jsdoc-format": false,
         "max-line-length": [false, 120],
         "no-arg": true,
         "no-consecutive-blank-lines": true,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nativescript-typedoc-theme": "0.0.7",
     "shelljs": "^0.7.0",
     "time-grunt": "1.3.0",
-    "tslint": "3.4.0",
+    "tslint": "^3.15.1",
     "typedoc": "0.4.5",
     "typescript": "^2.0.3"
   },
@@ -53,6 +53,8 @@
     "test-watch-ios": "npm run pretest && concurrently --kill-others \"npm run tsc-tiw\" \"tns livesync ios --path tests --watch\"",
     "prepublish": "echo \"Development reminder: npm run setup\n\"",
     "typedoc": "typedoc --tsconfig tsconfig.typedoc.json --out bin/dist/apiref --mode file --includeDeclarations --name NativeScript --theme ./node_modules/nativescript-typedoc-theme",
-    "dev-typedoc": "npm run typedoc && cd bin/dist/apiref && http-server"
+    "dev-typedoc": "npm run typedoc && cd bin/dist/apiref && http-server",
+    "test-tsc-es2016": "tsc -p tsconfig.public.es2016.json",
+    "tslint": "tslint --config build/tslint.json 'tns-core-modules/**/*.ts' 'tests/**/*.ts' 'apps/**/*.ts' -e '**/node_modules/**' -e '**/platforms/**'"
   }
 }

--- a/tests/app/location-tests.ts
+++ b/tests/app/location-tests.ts
@@ -84,8 +84,6 @@ export var testLocation = function (done) {
 
     //TKUnit.waitUntilReady(isReady, 10);
 
-    
-
     //TKUnit.assert(true === locationReceived, locationReceived);
 };
 

--- a/tests/app/pages/page17.ts
+++ b/tests/app/pages/page17.ts
@@ -36,4 +36,3 @@ export function buttonTap(args: observable.EventData) {
         }
     }
 }
-

--- a/tests/app/platform-tests.ts
+++ b/tests/app/platform-tests.ts
@@ -38,4 +38,3 @@ export function testIsIOSandIsAndroid() {
         TKUnit.assertTrue(!!android, "isAndroid is true but common 'android' package is not available.");
     }
 }
-

--- a/tests/app/ui/button/button-tests-native.d.ts
+++ b/tests/app/ui/button/button-tests-native.d.ts
@@ -9,4 +9,3 @@ export declare function getNativeColor(button: buttonModule.Button): colorModule
 export declare function getNativeBackgroundColor(button: buttonModule.Button): colorModule.Color;
 export declare function getNativeTextAlignment(button: buttonModule.Button): string;
 export declare function performNativeClick(button: buttonModule.Button): void;
-

--- a/tests/app/ui/list-picker/list-picker-tests-native.ios.ts
+++ b/tests/app/ui/list-picker/list-picker-tests-native.ios.ts
@@ -8,5 +8,3 @@ export function selectNativeItem(listPicker: listPickerModule.ListPicker, index:
     listPicker.ios.selectRowInComponentAnimated(index, 0, false);
     (<UIPickerViewDelegate>(<any>listPicker)._delegate).pickerViewDidSelectRowInComponent(listPicker.ios, index, 0);
 }
-
-    

--- a/tests/app/ui/list-view/list-view-tests.ts
+++ b/tests/app/ui/list-view/list-view-tests.ts
@@ -800,7 +800,6 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
         TKUnit.assertEqual(templateKey1, "green", "itemTemplateSelector result for second item");
     }
 
-   
     public test_ItemTemplateSelector_IsCorrectlyUsedAsAFunction() {
         let listView = this.testView;
         listView.itemTemplateSelector = selectItemTemplate;

--- a/tests/app/ui/repeater/repeater-tests.ts
+++ b/tests/app/ui/repeater/repeater-tests.ts
@@ -453,4 +453,3 @@ function getChildAt(repeater: repeaterModule.Repeater, index: number): viewModul
 function getChildAtText(repeater: repeaterModule.Repeater, index: number): string {
     return (<labelModule.Label>getChildAt(repeater, index)).text + "";
 }
-

--- a/tests/app/ui/search-bar/search-bar-tests-native.ios.ts
+++ b/tests/app/ui/search-bar/search-bar-tests-native.ios.ts
@@ -8,4 +8,3 @@ export function getNativeHintColor(searchBar: SearchBar): Color {
 export function getNativeFontSize(searchBar: SearchBar): number {
     return (<any>searchBar)._textField ? (<any>searchBar)._textField.font.pointSize : undefined;
 }
-

--- a/tns-core-modules/bundle-entry-points.ts
+++ b/tns-core-modules/bundle-entry-points.ts
@@ -33,4 +33,3 @@ if (global.TNS_WEBPACK) {
     global.registerModule("ui/text-view", () => require("ui/text-view"))
     global.registerModule("ui/time-picker", () => require("ui/time-picker"))
 }
-

--- a/tns-core-modules/js-libs/easysax/easysax.d.ts
+++ b/tns-core-modules/js-libs/easysax/easysax.d.ts
@@ -8,4 +8,3 @@ declare module "js-libs/easysax" {
         public angularSyntax: boolean;
     }
 }
-

--- a/tns-core-modules/text/text.d.ts
+++ b/tns-core-modules/text/text.d.ts
@@ -37,4 +37,3 @@ declare module "text" {
         export var UTF_8: any;
     }
 }
-

--- a/tns-core-modules/timer/timer.ios.ts
+++ b/tns-core-modules/timer/timer.ios.ts
@@ -1,6 +1,4 @@
-﻿/**
- * iOS specific timer functions implementation.
- */
+﻿//iOS specific timer functions implementation.
 var timeoutCallbacks = new Map<number, KeyValuePair<NSTimer, TimerTargetImpl>>();
 var timerId = 0;
 

--- a/tns-core-modules/trace/trace.ts
+++ b/tns-core-modules/trace/trace.ts
@@ -64,7 +64,6 @@ export function write(message: any, category: string, type?: number) {
         return;
     }
 
-    
     for (i = 0; i < _writers.length; i++) {
         _writers[i].write(message, category, type);
     }

--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -535,7 +535,6 @@ namespace xml2ui {
                             sourceTracker: this.sourceTracker
                         });
                     }
-                    
 
                 } else {
 

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -527,4 +527,3 @@ export function goBack(): boolean {
 export function stack(): Array<definition.Frame> {
     return frameStack;
 }
-

--- a/tns-platform-declarations/test.ts
+++ b/tns-platform-declarations/test.ts
@@ -5,6 +5,7 @@ class IOSTest extends NSObject {
 }
 
 let pointer = new interop.Pointer();
+console.log(pointer);
 
 class AndroidTest extends java.lang.Object {
     public do() {

--- a/tns-platform-declarations/test.ts
+++ b/tns-platform-declarations/test.ts
@@ -5,7 +5,6 @@ class IOSTest extends NSObject {
 }
 
 let pointer = new interop.Pointer();
-console.log(pointer);
 
 class AndroidTest extends java.lang.Object {
     public do() {

--- a/tsconfig.public.es2016.json
+++ b/tsconfig.public.es2016.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "noEmitOnError": true,
+        "noEmitHelpers": true,
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": false,
+        "noImplicitAny": false,
+        "noImplicitUseStrict": true,
+        "experimentalDecorators": true,
+        "lib": [
+            "es2016"
+        ]
+    },
+    "files": [
+        "tns-core-modules/tns-core-modules.es2016.d.ts"
+    ]
+}

--- a/tsconfig.public.es6.json
+++ b/tsconfig.public.es6.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "noEmitOnError": true,
+        "noEmitHelpers": true,
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": false,
+        "noImplicitAny": false,
+        "noImplicitUseStrict": true,
+        "experimentalDecorators": true,
+        "lib": [
+            "es6"
+        ]
+    },
+    "files": [
+        "tns-core-modules/tns-core-modules.es6.d.ts"
+    ]
+}


### PR DESCRIPTION
Moving one step closer to remove the grunt file.
The `tsconfig.public.es2016.json` now adds tsconfig that can be used to type check the public .d.ts-es exported by the tis-core-modules-es2016.d.ts using `npm run test-tsc-es2016`.
The tslint has been added as npm script too: `npm run tslint`.