### PR TITLE
Set package.json 'main' to application/application.js for webpack.

### DIFF
--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -3,6 +3,7 @@
   "description": "Telerik NativeScript Core Modules",
   "version": "2.5.0",
   "homepage":"https://www.nativescript.org",
+  "main":"application/application.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/NativeScript"


### PR DESCRIPTION
When dividing the bundle into chunks, it's necessary to import `tns-core-modules`.  This change allows webpack to go down the import graph and manually register modules via `bundle-entry-points.js`.