### PR TITLE
Improve error message of `fetch` when xhr.onerror occurs

### DIFF
--- a/tests/app/fetch-tests.ts
+++ b/tests/app/fetch-tests.ts
@@ -64,6 +64,13 @@ export var test_fetch_fail_invalid_url = function (done) {
     }).catch(failOnError(done));
 };
 
+export var test_fetch_invalid_url_fail_message = function (done) {
+    fetch("hgfttp://httpbin.org/get").catch(function (e: TypeError) {
+        TKUnit.assert(e.message.match(/Network request failed:.{2,}/), "Failure message should contain details on the failure. Actual message was: " + e.message);
+        done(null);
+    }).catch(failOnError(done));
+};
+
 export var test_fetch_response_status = function (done) {
 
     // >> fetch-status-response

--- a/tests/app/fetch-tests.ts
+++ b/tests/app/fetch-tests.ts
@@ -14,7 +14,7 @@ export var test_fetch = function (done: (err: Error, res?: string) => void) {
         TKUnit.assert(r instanceof Response, "Result from fetch() should be valid Response object! Actual result is: " + r);
         done(null);
         // << (hide)
-    }, function (e) {
+    }).catch( function (e) {
             // Argument (e) is Error!
             // >> (hide)
             done(e);
@@ -31,7 +31,7 @@ export var test_fetch_text = function (done: (err: Error, res?: string) => void)
         TKUnit.assert(types.isString(r), "Result from text() should be string! Actual result is: " + r);
         done(null);
         // << (hide)
-    }, function (e) {
+    }).catch( function (e) {
             // Argument (e) is Error!
             // >> (hide)
             done(e);
@@ -48,7 +48,7 @@ export var test_fetch_json = function (done: (err: Error, res?: string) => void)
         TKUnit.assert(types.isString(JSON.stringify(r)), "Result from json() should be JSON object! Actual result is: " + r);
         done(null);
         // << (hide)
-    }, function (e) {
+    }).catch( function (e) {
             // Argument (e) is Error!
             // >> (hide)
             done(e);
@@ -65,7 +65,7 @@ export var test_fetch_formData = function (done: (err: Error, res?: string) => v
         TKUnit.assert(r instanceof FormData, "Result from formData() should be FormData object! Actual result is: " + r);
         done(null);
         // << (hide)
-    }, function (e) {
+    }).catch( function (e) {
             // Argument (e) is Error!
             // >> (hide)
             done(e);
@@ -81,7 +81,7 @@ export var test_fetch_fail_invalid_url = function (done) {
     fetch("hgfttp://httpbin.org/get").catch(function (e) {
         completed = true;
         done(null)
-    });
+    }).catch( e => done(e) );
 };
 
 export var test_fetch_response_status = function (done) {
@@ -91,15 +91,10 @@ export var test_fetch_response_status = function (done) {
         // Argument (response) is Response!
         var statusCode = response.status;
         // >> (hide)
-        try {
-            TKUnit.assert(types.isDefined(statusCode), "response.status should be defined! Actual result is: " + statusCode);
-            done(null);
-        }
-        catch (err) {
-            done(err);
-        }
+        TKUnit.assert(types.isDefined(statusCode), "response.status should be defined! Actual result is: " + statusCode);
+        done(null);
         // << (hide)
-    }, function (e) {
+    }).catch( function (e) {
             // Argument (e) is Error!
             // >> (hide)
             done(e);
@@ -115,15 +110,10 @@ export var test_fetch_response_headers = function (done) {
         // Argument (response) is Response!
         // var all = response.headers.getAll();
         // >> (hide)
-        try {
-            TKUnit.assert(types.isDefined(response.headers), "response.headers should be defined! Actual result is: " + response.headers);
-            done(null);
-        }
-        catch (err) {
-            done(err);
-        }
+        TKUnit.assert(types.isDefined(response.headers), "response.headers should be defined! Actual result is: " + response.headers);
+        done(null);
         // << (hide)
-    }, function (e) {
+    }).catch( function (e) {
             // Argument (e) is Error!
             // >> (hide)
             done(e);
@@ -138,14 +128,9 @@ export var test_fetch_headers_sent = function (done) {
         headers: { "Content-Type": "application/json" }
     }).then(function (response) {
         var result = response.headers;
-        try {
-            TKUnit.assert(result.get("Content-Type") === "application/json", "Headers not sent/received properly! Actual result is: " + result);
-            done(null);
-        }
-        catch (err) {
-            done(err);
-        }
-    }, function (e) {
+        TKUnit.assert(result.get("Content-Type") === "application/json", "Headers not sent/received properly! Actual result is: " + result);
+        done(null);
+    }).catch( function (e) {
             done(e);
         });
 };
@@ -162,14 +147,9 @@ export var test_fetch_post_form_data = function (done) {
     }).then(r => {
         return r.formData();
     }).then(function (r) {
-        try {
-            TKUnit.assert(r instanceof FormData, "Content not sent/received properly! Actual result is: " + r);
-            done(null);
-        }
-        catch (err) {
-            done(err);
-        }
-    }, function (e) {
+        TKUnit.assert(r instanceof FormData, "Content not sent/received properly! Actual result is: " + r);
+        done(null);
+    }).catch( function (e) {
             done(e);
         });
 };
@@ -182,16 +162,11 @@ export var test_fetch_post_json = function (done) {
         body: JSON.stringify({ MyVariableOne: "ValueOne", MyVariableTwo: "ValueTwo" })
     }).then(r => { return r.json(); }).then(function (r) {
         // >> (hide)
-        try {
-            TKUnit.assert(r.json["MyVariableOne"] === "ValueOne" && r.json["MyVariableTwo"] === "ValueTwo", "Content not sent/received properly! Actual result is: " + r.json);
-            done(null);
-        }
-        catch (err) {
-            done(err);
-        }
+        TKUnit.assert(r.json["MyVariableOne"] === "ValueOne" && r.json["MyVariableTwo"] === "ValueTwo", "Content not sent/received properly! Actual result is: " + r.json);
+        done(null);
         // << (hide)
         // console.log(result);
-    }, function (e) {
+    }).catch( function (e) {
             // >> (hide)
             done(e);
             // << (hide)

--- a/tests/app/fetch-tests.ts
+++ b/tests/app/fetch-tests.ts
@@ -14,12 +14,7 @@ export var test_fetch = function (done: (err: Error, res?: string) => void) {
         TKUnit.assert(r instanceof Response, "Result from fetch() should be valid Response object! Actual result is: " + r);
         done(null);
         // << (hide)
-    }).catch( function (e) {
-            // Argument (e) is Error!
-            // >> (hide)
-            done(e);
-            // << (hide)
-        });
+    }).catch(failOnError(done));
     // << fetch-response
 };
 
@@ -31,12 +26,7 @@ export var test_fetch_text = function (done: (err: Error, res?: string) => void)
         TKUnit.assert(types.isString(r), "Result from text() should be string! Actual result is: " + r);
         done(null);
         // << (hide)
-    }).catch( function (e) {
-            // Argument (e) is Error!
-            // >> (hide)
-            done(e);
-            // << (hide)
-        });
+    }).catch(failOnError(done));
     // << fetch-string
 };
 
@@ -48,12 +38,7 @@ export var test_fetch_json = function (done: (err: Error, res?: string) => void)
         TKUnit.assert(types.isString(JSON.stringify(r)), "Result from json() should be JSON object! Actual result is: " + r);
         done(null);
         // << (hide)
-    }).catch( function (e) {
-            // Argument (e) is Error!
-            // >> (hide)
-            done(e);
-            // << (hide)
-        });
+    }).catch(failOnError(done));
     // << fetch-json
 };
 
@@ -65,12 +50,7 @@ export var test_fetch_formData = function (done: (err: Error, res?: string) => v
         TKUnit.assert(r instanceof FormData, "Result from formData() should be FormData object! Actual result is: " + r);
         done(null);
         // << (hide)
-    }).catch( function (e) {
-            // Argument (e) is Error!
-            // >> (hide)
-            done(e);
-            // << (hide)
-        });
+    }).catch(failOnError(done));
     // << fetch-formdata
 };
 
@@ -81,7 +61,7 @@ export var test_fetch_fail_invalid_url = function (done) {
     fetch("hgfttp://httpbin.org/get").catch(function (e) {
         completed = true;
         done(null)
-    }).catch( e => done(e) );
+    }).catch(failOnError(done));
 };
 
 export var test_fetch_response_status = function (done) {
@@ -94,12 +74,7 @@ export var test_fetch_response_status = function (done) {
         TKUnit.assert(types.isDefined(statusCode), "response.status should be defined! Actual result is: " + statusCode);
         done(null);
         // << (hide)
-    }).catch( function (e) {
-            // Argument (e) is Error!
-            // >> (hide)
-            done(e);
-            // << (hide)
-        });
+    }).catch(failOnError(done));
     // << fetch-status-response
 };
 
@@ -113,12 +88,7 @@ export var test_fetch_response_headers = function (done) {
         TKUnit.assert(types.isDefined(response.headers), "response.headers should be defined! Actual result is: " + response.headers);
         done(null);
         // << (hide)
-    }).catch( function (e) {
-            // Argument (e) is Error!
-            // >> (hide)
-            done(e);
-            // << (hide)
-        });
+    }).catch(failOnError(done));
     // << fetch-headers-response
 };
 
@@ -130,9 +100,7 @@ export var test_fetch_headers_sent = function (done) {
         var result = response.headers;
         TKUnit.assert(result.get("Content-Type") === "application/json", "Headers not sent/received properly! Actual result is: " + result);
         done(null);
-    }).catch( function (e) {
-            done(e);
-        });
+    }).catch(failOnError(done));
 };
 
 export var test_fetch_post_form_data = function (done) {
@@ -149,9 +117,7 @@ export var test_fetch_post_form_data = function (done) {
     }).then(function (r) {
         TKUnit.assert(r instanceof FormData, "Content not sent/received properly! Actual result is: " + r);
         done(null);
-    }).catch( function (e) {
-            done(e);
-        });
+    }).catch(failOnError(done));
 };
 
 export var test_fetch_post_json = function (done) {
@@ -166,11 +132,10 @@ export var test_fetch_post_json = function (done) {
         done(null);
         // << (hide)
         // console.log(result);
-    }).catch( function (e) {
-            // >> (hide)
-            done(e);
-            // << (hide)
-            // console.log("Error occurred " + e);
-        });
+    }).catch(failOnError(done));
     // << fetch-post-json
 };
+
+const failOnError = function (done: (err: Error, res?: string) => void) {
+    return e => done(e);
+}

--- a/tests/app/fetch-tests.ts
+++ b/tests/app/fetch-tests.ts
@@ -35,7 +35,7 @@ export var test_fetch_json = function (done: (err: Error, res?: string) => void)
     fetch("https://httpbin.org/get").then(response => { return response.json(); }).then(function (r) {
         // Argument (r) is JSON object!
         // >> (hide)
-        TKUnit.assert(types.isString(JSON.stringify(r)), "Result from json() should be JSON object! Actual result is: " + r);
+        TKUnit.assertNotNull(r, "Result from json() should be JSON object!");
         done(null);
         // << (hide)
     }).catch(failOnError(done));

--- a/tns-core-modules/fetch/fetch.js
+++ b/tns-core-modules/fetch/fetch.js
@@ -310,8 +310,8 @@
                 resolve(new Response(xhr.responseText, options))
             }
 
-            xhr.onerror = function () {
-                reject(new TypeError('Network request failed'))
+            xhr.onerror = function (error) {
+                reject(new TypeError(['Network request failed:', error.message].join(' ')))
             }
 
             xhr.open(request.method, request.url, true)


### PR DESCRIPTION
### The commit message references a specific issue in this repo
Fixes/Implements #2952.

### You have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)
Added one test to cover this case.  Since I do not know what the error message will be on iOS, a pattern was used rather than checking for an exact message.

Additionally some cleanup of the existing tests was done to improve correctness of the tests.  Some would timeout, rather than fail, swallowing the failure message.