### PR TITLE
Fix bundle-entry-points by importing globals first.

### DIFF
--- a/tns-core-modules/bundle-entry-points.ts
+++ b/tns-core-modules/bundle-entry-points.ts
@@ -1,4 +1,6 @@
 if (global.TNS_WEBPACK) {
+    require("globals");
+
     // Register "dynamically" loaded module that need to be resolved by the
     // XML/component builders.
 


### PR DESCRIPTION
Avoiding a crash if the import happens too soon.