### PR TITLE
Add TabView.androidOffscreenTabLimit property

### DIFF
--- a/tests/app/ui/tab-view/tab-view-tests.ts
+++ b/tests/app/ui/tab-view/tab-view-tests.ts
@@ -275,6 +275,60 @@ export class TabViewTest extends testModule.UITest<tabViewModule.TabView> {
         TKUnit.assertEqual(actualOldIndex, expectedOldIndex, "expectedOldIndex");
         TKUnit.assertEqual(actualNewIndex, expectedNewIndex, "expectedNewIndex");
     }
+
+    public testAndroidOffscreenTabLimit_Default = function () {
+        let tabView = this.testView;
+        if (!tabView.android){
+            return;
+        }
+        
+        // The default setting is 1.
+        // tabView.androidOffscreenTabLimit = 1;
+        tabView.items = this._createItems(20);
+        this.waitUntilTestElementIsLoaded();
+        for (let index = 0, length = tabView.items.length; index < length; index++){
+            tabViewTestsNative.selectNativeTab(tabView, index);
+            TKUnit.waitUntilReady(function () {
+                return tabView.selectedIndex === index;
+            }, helper.ASYNC);
+        }
+
+        let viewsWithParent = 0;
+        let viewsWithoutParent = 0;
+        for (let i = 0, length = tabView.items.length; i < length; i++){
+            if (tabView.items[i].view.parent) {
+                viewsWithParent++;
+            }
+            else {
+                viewsWithoutParent++;
+            }
+        }
+
+        TKUnit.assertTrue(viewsWithoutParent > viewsWithParent, "Most of the views should be recycled!");
+    }
+
+    public testAndroidOffscreenTabLimit_KeepAllAlive = function () {
+        let tabView = this.testView;
+        if (!tabView.android){
+            return;
+        }
+        
+        tabView.androidOffscreenTabLimit = 20;
+        
+        tabView.items = this._createItems(20);
+        this.waitUntilTestElementIsLoaded();
+        for (let index = 0, length = tabView.items.length; index < length; index++){
+            tabViewTestsNative.selectNativeTab(tabView, index);
+            TKUnit.waitUntilReady(function () {
+                return tabView.selectedIndex === index;
+            }, helper.ASYNC);
+        }
+
+        for (let i = 0, length = tabView.items.length; i < length; i++){
+            TKUnit.assertNotNull(tabView.items[i].view.parent, `tabView.items[${i}].view should have a parent!`);
+        }
+    }
+
     /*
     public testBindingIsRefreshedWhenTabViewItemIsUnselectedAndThenSelectedAgain() {
 

--- a/tns-core-modules/ui/tab-view/tab-view-common.ts
+++ b/tns-core-modules/ui/tab-view/tab-view-common.ts
@@ -244,6 +244,13 @@ export class TabView extends View implements definition.TabView, AddArrayFromBui
         //
     }
 
+    get androidOffscreenTabLimit(): number {
+        return undefined;
+    }
+    set androidOffscreenTabLimit(value: number) {
+        //
+    }
+
     public _onSelectedIndexPropertyChangedSetNativeValue(data: PropertyChangeData) {
         var index = this.selectedIndex;
         if (types.isUndefined(index)) {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -214,6 +214,9 @@ export class TabView extends common.TabView {
         }
         
         this._viewPager = new android.support.v4.view.ViewPager(this._context);
+        if (this._androidOffscreenTabLimit !== 1) {
+            this._viewPager.setOffscreenPageLimit(this._androidOffscreenTabLimit);
+        }
         this._viewPager.setId(this._androidViewId);
         var lp = new org.nativescript.widgets.CommonLayoutParams();
         lp.row = 1;
@@ -332,6 +335,20 @@ export class TabView extends common.TabView {
     public _getAndroidTabView(): org.nativescript.widgets.TabLayout {
         return this._tabLayout;
     }
+
+    private _androidOffscreenTabLimit: number = 1;
+    get androidOffscreenTabLimit(): number {
+        return this._androidOffscreenTabLimit;
+    }
+    set androidOffscreenTabLimit(value: number) {
+        if (value !== this._androidOffscreenTabLimit) {
+            this._androidOffscreenTabLimit = value;
+            if (this._viewPager) {
+                this._viewPager.setOffscreenPageLimit(value);
+            }
+        }
+    }
+
 }
 
 export class TabViewStyler implements style.Styler {

--- a/tns-core-modules/ui/tab-view/tab-view.d.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.d.ts
@@ -115,6 +115,12 @@ declare module "ui/tab-view" {
         iosIconRenderingMode: string;
 
         /**
+         * Gets or sets the number of tabs that should be retained to either side of the current tab in the view hierarchy in an idle state. 
+         * Tabs beyond this limit will be recreated from the TabView when needed.  
+         */
+        androidOffscreenTabLimit: number;
+
+        /**
          * String value used when hooking to the selectedIndexChanged event.
          */
         public static selectedIndexChangedEvent: string;


### PR DESCRIPTION
Resolves #2815

* Gets or sets the number of tabs that should be retained to either side of the current tab in the view hierarchy in an idle state.
* Tabs beyond this limit will be recreated from the TabView when needed.