### PR TITLE
http response add GBK charset support

### DIFF
--- a/tns-core-modules/http/http-request.android.ts
+++ b/tns-core-modules/http/http-request.android.ts
@@ -75,7 +75,12 @@ function onRequestComplete(requestId: number, result: org.nativescript.widgets.A
         content: {
             raw: result.raw,
             toString: (encode?:http.ResponseEncode) => {
-                let str = decodeResponse(result.raw,encode);
+                let str:string;
+                if(encode) {
+                    str = decodeResponse(result.raw,encode);
+                }else{
+                    str = result.responseAsString;
+                }
                 if (types.isString(str)) {
                     return str;
                 } else {
@@ -84,7 +89,12 @@ function onRequestComplete(requestId: number, result: org.nativescript.widgets.A
             },
             toJSON: (encode?:http.ResponseEncode) => {
                 ensureUtils();
-                let str = decodeResponse(result.raw,encode);
+                let str:string;
+                if(encode) {
+                    str = decodeResponse(result.raw,encode);
+                }else{
+                    str = result.responseAsString;
+                }
                 return utils.parseJSON(str);
             },
             toImage: () => {

--- a/tns-core-modules/http/http-request.android.ts
+++ b/tns-core-modules/http/http-request.android.ts
@@ -74,16 +74,18 @@ function onRequestComplete(requestId: number, result: org.nativescript.widgets.A
     callbacks.resolveCallback({
         content: {
             raw: result.raw,
-            toString: () => {
-                if (types.isString(result.responseAsString)) {
-                    return result.responseAsString;
+            toString: (encode?:http.ResponseEncode) => {
+                let str = decodeResponse(result.raw,encode);
+                if (types.isString(str)) {
+                    return str;
                 } else {
                     throw new Error("Response content may not be converted to string");
                 }
             },
-            toJSON: () => {
+            toJSON: (encode?:http.ResponseEncode) => {
                 ensureUtils();
-                return utils.parseJSON(result.responseAsString);
+                let str = decodeResponse(result.raw,encode);
+                return utils.parseJSON(str);
             },
             toImage: () => {
                 ensureImageSource();
@@ -194,4 +196,12 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
             reject(ex);
         }
     });
+}
+
+function decodeResponse(raw:any,encode?:http.ResponseEncode){
+    let charsetName = "UTF-8";
+    if(encode == http.ResponseEncode.GBK) {
+        charsetName = 'GBK';
+    }
+    return raw.toString(charsetName)
 }

--- a/tns-core-modules/http/http-request.android.ts
+++ b/tns-core-modules/http/http-request.android.ts
@@ -210,7 +210,7 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
 
 function decodeResponse(raw:any,encode?:http.ResponseEncode){
     let charsetName = "UTF-8";
-    if(encode == http.ResponseEncode.GBK) {
+    if(encode === http.ResponseEncode.GBK) {
         charsetName = 'GBK';
     }
     return raw.toString(charsetName)

--- a/tns-core-modules/http/http-request.ios.ts
+++ b/tns-core-modules/http/http-request.ios.ts
@@ -143,7 +143,7 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
 
 function NSDataToString(data: any,encode?:http.ResponseEncode): string {
     let code = 4; //UTF8
-    if(encode == http.ResponseEncode.GBK) {
+    if(encode === http.ResponseEncode.GBK) {
         code = 1586;
     }
     return NSString.alloc().initWithDataEncoding(data, code).toString();

--- a/tns-core-modules/http/http-request.ios.ts
+++ b/tns-core-modules/http/http-request.ios.ts
@@ -89,9 +89,9 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
                         resolve({
                             content: {
                                 raw: data,
-                                toString: () => { return NSDataToString(data); },
-                                toJSON: () => {
-                                    return utils.parseJSON(NSDataToString(data));
+                                toString: (encode?:http.ResponseEncode) => { return NSDataToString(data,encode); },
+                                toJSON: (encode?:http.ResponseEncode) => {
+                                    return utils.parseJSON(NSDataToString(data,encode));
                                 },
                                 toImage: () => {
                                     ensureImageSource();
@@ -141,6 +141,10 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
     });
 }
 
-function NSDataToString(data: any): string {
-    return NSString.alloc().initWithDataEncoding(data, 4).toString();
+function NSDataToString(data: any,encode?:http.ResponseEncode): string {
+    let code = 4; //UTF8
+    if(encode == http.ResponseEncode.GBK) {
+        code = 1586;
+    }
+    return NSString.alloc().initWithDataEncoding(data, code).toString();
 }

--- a/tns-core-modules/http/http.d.ts
+++ b/tns-core-modules/http/http.d.ts
@@ -113,6 +113,10 @@ declare module "http" {
     
     export type Headers = { [key: string]: string | string[] };
 
+    export const enum ResponseEncode{
+      UTF8,
+      GBK
+    }
    /**
     * Encapsulates the content of an HttpResponse.
     */
@@ -125,7 +129,7 @@ declare module "http" {
        /**
         * Gets the response body as string.
         */
-        toString: () => string;
+        toString: (encode?:ResponseEncode) => string;
 
        /**
         * Gets the response body as JSON object.


### PR DESCRIPTION
Add `http` module `HttpResponse.toString(encode?)`  GBK charset.

      http.request({
        url,
        method: 'GET'
      }).then(res => {
        let rule = getRuleByUrl(url);
        let encode = ResponseEncode.UTF8;
        if (rule && rule.encode == 'gbk') {
          encode = ResponseEncode.GBK

        }
        return res.content.toString(encode);
      })