### PR TITLE
Border width cannot be reset to 0 on IOS

### DIFF
--- a/apps/app/ui-tests-app/issues/issue-3164.ts
+++ b/apps/app/ui-tests-app/issues/issue-3164.ts
@@ -1,0 +1,29 @@
+import { Color } from "color";
+import { EventData } from "data/observable";
+import { Page } from "ui/page";
+
+var page: Page;
+var borderColor : Color = new Color("#ff0000");
+export function navigatingTo(args: EventData) {
+    page = <Page>args.object;
+}
+
+export function onSetBorderWidthTo0() {
+    let buttonElement = page.getViewById("button1");
+    buttonElement.borderColor = borderColor;
+    buttonElement.borderWidth = 0;
+
+    let labelElement = page.getViewById("label1");
+    labelElement.borderColor = borderColor;
+    labelElement.borderWidth = 0;
+}
+
+export function onSetBorderWidthTo3() {
+    let buttonElement = page.getViewById("button1");
+    buttonElement.borderColor = borderColor;
+    buttonElement.borderWidth = 3;
+
+    let labelElement = page.getViewById("label1");
+    labelElement.borderColor = borderColor;
+    labelElement.borderWidth = 3;
+}

--- a/apps/app/ui-tests-app/issues/issue-3164.xml
+++ b/apps/app/ui-tests-app/issues/issue-3164.xml
@@ -1,0 +1,9 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo">
+    <StackLayout>
+            <Button id="button1" text="Shosho button" margin="10"/>
+            <Label id="label1" text="Shosho label" margin="10"/>
+
+            <Button text="1. Set border width to 3" tap="onSetBorderWidthTo3" />
+            <Button text="2. Set border width to 0" tap="onSetBorderWidthTo0" />
+    </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/issues/main-page.ts
+++ b/apps/app/ui-tests-app/issues/main-page.ts
@@ -17,6 +17,7 @@ export function pageLoaded(args: EventData) {
     examples.set("3007", "issues/issue-3007");
     examples.set("2661", "issues/issue-2661");
     examples.set("3113", "issues/issue-3113");
+    examples.set("3164", "issues/issue-3164");
 
     let viewModel = new SubMainPageViewModel(wrapLayout, examples);
     page.bindingContext = viewModel;

--- a/tns-core-modules/ui/styling/background.ios.ts
+++ b/tns-core-modules/ui/styling/background.ios.ts
@@ -22,16 +22,6 @@ export module ios {
         }
         ensureStyle();
 
-        let background = <common.Background>view.style._getValue(style.backgroundInternalProperty);
-        if (!background || background.isEmpty()) {
-            return undefined;
-        }
-
-        // Clip-path
-        if (background.clipPath) {
-            drawClipPath(nativeView, background);
-        }
-
         // Borders
 
         // Clear all borders
@@ -54,6 +44,16 @@ export module ios {
         
         if (nativeView["leftBorderLayer"]){
             (<CAShapeLayer>nativeView["leftBorderLayer"]).removeFromSuperlayer();
+        }
+
+        let background = <common.Background>view.style._getValue(style.backgroundInternalProperty);
+        if (!background || background.isEmpty()) {
+            return undefined;
+        }
+
+        // Clip-path
+        if (background.clipPath) {
+            drawClipPath(nativeView, background);
         }
         
         if (background.hasUniformBorder()){


### PR DESCRIPTION
If the border width is set to a value, it cannot be reset to 0 again:

So, 
button.borderWidth = 3; 

and then 
button.borderWidth = 0;

The border of the button will stay 3. 


