### PR TITLE
Export set function for cssFile and resources.

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -34,6 +34,10 @@ export var mainEntry: frame.NavigationEntry;
 
 export var cssFile: string = "app.css"
 
+export function setCssFileName(cssFileName: string) {
+    cssFile = cssFileName;
+}
+
 export var appSelectors: RuleSet[] = [];
 export var additionalSelectors: RuleSet[] = [];
 export var cssSelectors: RuleSet[] = [];
@@ -41,6 +45,10 @@ export var cssSelectorVersion: number = 0;
 export var keyframes: any = {};
 
 export var resources: any = {};
+
+export function setResources(res: any) {
+    resources = res;
+}
 
 export var onUncaughtError: (error: definition.NativeScriptError) => void = undefined;
 

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -117,10 +117,20 @@ declare module "application" {
     export var resources: any;
 
     /**
+     * Sets application level static resources.
+     */
+    export function setResources(resources: any);
+
+    /**
      * The application level css file name (starting from the application root). Used to set css across all pages.
      * Css will be applied for every page and page css will be applied after.
      */
     export var cssFile: string;
+
+    /**
+     * Sets css file name for the application. 
+     */
+    export function setCssFileName(cssFile: string);
 
     //@private
     export var appSelectors: RuleSet[];


### PR DESCRIPTION
Added functions for setting NS application `cssFile` and `resources`, because with es6 these fields can be used only in read-only mode.

