### PR TITLE
FlexboxLayout profiling and improvements

### DIFF
--- a/apps/app/ui-tests-app/flexbox/flexbox-perf-comparison.xml
+++ b/apps/app/ui-tests-app/flexbox/flexbox-perf-comparison.xml
@@ -7,17 +7,18 @@
         <TabView.items>
             <TabViewItem title="flex-grid">
                 <TabViewItem.view>
-                    <ScrollView style="flex: 1 0; height: 0;">
+                    <ScrollView>
+                        <!-- Fix this: style="flex: 1 0; height: 0;"-->
                         <Repeater id="repeaterFlexGrid" items="{{ $value }}">
                             <Repeater.itemTemplate>
-                                <FlexboxLayout style="flex-flow: row wrap; align-items: center; border-width: 0 0 1 0; border-color: #EEEEEE">
-                                    <Image src="{{ icon }}" style="flex: 0 1; margin: 6 4 4 4; border-width: 1; border-color: gray; border-radius: 16; width: 32; height: 32;" />
-                                    <Label text="{{ title }}" style="flex: 1 0; width: 0; margin: 1 4 0 0;" />
-                                    <Label text="{{ body }}" textWrap="true" style="width: 100%; margin: 4 4 6 4; font-size: 11;" />
-                                    <Image src="~/ui-tests-app/flexbox/icons/thumbsdown.png" style="width: 18; height: 18; margin: 4;" />
-                                    <Label text="{{ up }}" style="flex: 1 0; width: 0; font-size: 13;" />
-                                    <Image src="~/ui-tests-app/flexbox/icons/thumbsup.png" style="width: 18; height: 18; margin: 4;" />
-                                    <Label text="{{ down }}" style="flex: 1 0; width: 0; font-size: 13;" />
+                                <FlexboxLayout flexDirection="row" flexWrap="wrap" alignItems="center" borderWidth="0 0 1 0" borderColor="#EEEEEE">
+                                    <Image src="{{ icon }}" flexGrow="0" flexShrink="1" margin="6 4 4 4" borderWidth="1" borderColor="gray" borderRadius="16" width="32" height="32" />
+                                    <Label text="{{ title }}" flexGrow="1" flexShrink="0" width="0" margin="1 4 0 0" />
+                                    <Label text="{{ body }}" textWrap="true" width="100%" margin="4 4 6 4" fontSize="11" />
+                                    <Image src="~/ui-tests-app/flexbox/icons/thumbsdown.png" width="18" height="18" margin="4" />
+                                    <Label text="{{ up }}" flexGrow="1" flexShrink="0" width="0" fontSize="13" />
+                                    <Image src="~/ui-tests-app/flexbox/icons/thumbsup.png" width="18" height="18" margin="4" />
+                                    <Label text="{{ down }}" flexGrow="1" flexShrink="0" width="0" fontSize="13" />
                                 </FlexboxLayout>
                             </Repeater.itemTemplate>
                         </Repeater>
@@ -45,7 +46,7 @@
             </TabViewItem>
             <TabViewItem title="flex-stack">
                 <TabViewItem.view>
-                    <ScrollView style="flex: 1 0; height: 0;">
+                    <ScrollView>
                         <Repeater id="repeaterFlexStack" items="{{ $value }}">
                             <Repeater.itemTemplate>
                                 <FlexboxLayout flexDirection="column">
@@ -64,7 +65,7 @@
             </TabViewItem>
             <TabViewItem title="stack">
                 <TabViewItem.view>
-                    <ScrollView style="flex: 1 0; height: 0;">
+                    <ScrollView>
                         <Repeater id="repeaterStack" items="{{ $value }}">
                             <Repeater.itemTemplate>
                                 <StackLayout>

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
@@ -125,7 +125,7 @@ export class FlexboxLayout extends FlexboxLayoutBase {
         // Omit: super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
         if (this._isOrderChangedFromLastMeasurement) {
-            this._reorderedIndices = this._createReorderedIndices1();
+            this._reorderedIndices = this._createReorderedIndices();
         }
         if (!this._childrenFrozen || this._childrenFrozen.length < this.getChildrenCount()) {
             this._childrenFrozen = new Array(this.getChildrenCount());
@@ -158,44 +158,10 @@ export class FlexboxLayout extends FlexboxLayoutBase {
         return child;
     }
 
-    public addChild(child: View) {
-        let index = this.getChildrenCount(); // Goes last
-        this._reorderedIndices = this._createReorderedIndices2(child, index);
-        super.addChild(child);
-    }
-
-    public insertChild(child: View, index: number): void {
-        this._reorderedIndices = this._createReorderedIndices2(child, index);
-        super.addChild(child);
-    }
-
-    
-    private _createReorderedIndices1(): number[] {
+    private _createReorderedIndices(): number[] {
         let childCount = this.getChildrenCount();
         let orders = this._createOrders(childCount);
         return this._sortOrdersIntoReorderedIndices(childCount, orders);
-    }
-
-    private _createReorderedIndices2(viewBeforeAdded: View, indexForViewBeforeAdded: number): number[] {
-        let childCount: number = this.getChildrenCount();
-        let orders = this._createOrders(childCount);
-        let orderForViewToBeAdded = new Order();
-
-        orderForViewToBeAdded.order = FlexboxLayout.getOrder(viewBeforeAdded);
-
-        if (indexForViewBeforeAdded === -1 || indexForViewBeforeAdded === childCount) {
-            orderForViewToBeAdded.index = childCount;
-        } else if (indexForViewBeforeAdded) {
-            orderForViewToBeAdded.index = indexForViewBeforeAdded;
-            for (let i = indexForViewBeforeAdded; i < childCount; i++) {
-                orders[i].index++;
-            }
-        } else {
-            orderForViewToBeAdded.index = childCount;
-        }
-        orders.push(orderForViewToBeAdded);
-
-        return this._sortOrdersIntoReorderedIndices(childCount + 1, orders);
     }
 
     private _sortOrdersIntoReorderedIndices(childCount: number, orders: Order[]): number[] {

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
@@ -204,8 +204,7 @@ export class FlexboxLayout extends FlexboxLayoutBase {
             if (view === null) {
                 continue;
             }
-            
-            let lp = <CommonLayoutParams>view.style._getValue(nativeLayoutParamsProperty);
+
             if (FlexboxLayout.getOrder(view) !== this._orderCache[i]) {
                 return true;
             }
@@ -415,7 +414,6 @@ export class FlexboxLayout extends FlexboxLayoutBase {
 
     private _checkSizeConstraints(view: View) {
         let needsMeasure = false;
-        let lp = <CommonLayoutParams>view.style._getValue(nativeLayoutParamsProperty);
         let childWidth = view.getMeasuredWidth();
         let childHeight = view.getMeasuredHeight();
 
@@ -755,7 +753,6 @@ export class FlexboxLayout extends FlexboxLayoutBase {
             this._flexLines.forEach(flexLine => {
                 for (let i = 0; i < flexLine.itemCount; i++, viewIndex++) {
                     let view = this._getReorderedChildAt(viewIndex);
-                    let lp = <CommonLayoutParams>view.style._getValue(nativeLayoutParamsProperty);
                     let alignSelf = FlexboxLayout.getAlignSelf(view);
                     if (alignSelf !== AlignSelf.AUTO && alignSelf !== AlignSelf.STRETCH) {
                         continue;

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
@@ -125,7 +125,7 @@ export class FlexboxLayout extends FlexboxLayoutBase {
         // Omit: super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
         if (this._isOrderChangedFromLastMeasurement) {
-            this._reorderedIndices = this._createReorderedIndices();
+            this._reorderedIndices = this._createReorderedIndices1();
         }
         if (!this._childrenFrozen || this._childrenFrozen.length < this.getChildrenCount()) {
             this._childrenFrozen = new Array(this.getChildrenCount());
@@ -160,46 +160,42 @@ export class FlexboxLayout extends FlexboxLayoutBase {
 
     public addChild(child: View) {
         let index = this.getChildrenCount(); // Goes last
-        this._reorderedIndices = this._createReorderedIndices(child, index, FlexboxLayout.getLayoutParams(child));
+        this._reorderedIndices = this._createReorderedIndices2(child, index);
         super.addChild(child);
     }
 
     public insertChild(child: View, index: number): void {
-        this._reorderedIndices = this._createReorderedIndices(child, index, FlexboxLayout.getLayoutParams(child));
+        this._reorderedIndices = this._createReorderedIndices2(child, index);
         super.addChild(child);
     }
 
-    private _createReorderedIndices(viewBeforeAdded: View, indexForViewBeforeAdded: number, paramsForViewBeforeAdded: FlexboxLayout.LayoutParams): number[];
-    private _createReorderedIndices(): number[];
-    private _createReorderedIndices(viewBeforeAdded?: View, indexForViewBeforeAdded?: number, paramsForViewBeforeAdded?: FlexboxLayout.LayoutParams) {
-        if (arguments.length === 0) {
-            let childCount = this.getChildrenCount();
-            let orders = this._createOrders(childCount);
-            return this._sortOrdersIntoReorderedIndices(childCount, orders);
+    
+    private _createReorderedIndices1(): number[] {
+        let childCount = this.getChildrenCount();
+        let orders = this._createOrders(childCount);
+        return this._sortOrdersIntoReorderedIndices(childCount, orders);
+    }
+
+    private _createReorderedIndices2(viewBeforeAdded: View, indexForViewBeforeAdded: number): number[] {
+        let childCount: number = this.getChildrenCount();
+        let orders = this._createOrders(childCount);
+        let orderForViewToBeAdded = new Order();
+
+        orderForViewToBeAdded.order = FlexboxLayout.getOrder(viewBeforeAdded);
+
+        if (indexForViewBeforeAdded === -1 || indexForViewBeforeAdded === childCount) {
+            orderForViewToBeAdded.index = childCount;
+        } else if (indexForViewBeforeAdded) {
+            orderForViewToBeAdded.index = indexForViewBeforeAdded;
+            for (let i = indexForViewBeforeAdded; i < childCount; i++) {
+                orders[i].index++;
+            }
         } else {
-            let childCount: number = this.getChildrenCount();
-            let orders = this._createOrders(childCount);
-            let orderForViewToBeAdded = new Order();
-            if (viewBeforeAdded !== null) {
-                orderForViewToBeAdded.order = paramsForViewBeforeAdded.order;
-            } else {
-                orderForViewToBeAdded.order = 1 /* Default order */;
-            }
-
-            if (indexForViewBeforeAdded === -1 || indexForViewBeforeAdded === childCount) {
-                orderForViewToBeAdded.index = childCount;
-            } else if (indexForViewBeforeAdded) {
-                orderForViewToBeAdded.index = indexForViewBeforeAdded;
-                for (let i = indexForViewBeforeAdded; i < childCount; i++) {
-                    orders[i].index++;
-                }
-            } else {
-                orderForViewToBeAdded.index = childCount;
-            }
-            orders.push(orderForViewToBeAdded);
-
-            return this._sortOrdersIntoReorderedIndices(childCount + 1, orders);
+            orderForViewToBeAdded.index = childCount;
         }
+        orders.push(orderForViewToBeAdded);
+
+        return this._sortOrdersIntoReorderedIndices(childCount + 1, orders);
     }
 
     private _sortOrdersIntoReorderedIndices(childCount: number, orders: Order[]): number[] {


### PR DESCRIPTION
Performance tests showed that the flex box in some cases fall up to 30% slower than grid and stack counterparts. After profiling the problems narrow down to intense use of inline styles and some redundant code. Measurement now shows times like:

iOS 
flexbox-grid: 865
gird: 790
-10%

flex-stack: 710
stack: 675
-5%

Android
flexbox-grid: 1115
gird: 1195
+7%

flexbox-stack: 1039
stack: 960
-10%

Which makes the flex box about 10% slower. This should be acceptable. We should also check if we can speed up inline styles.