### PR TITLE
Fix for issue #3181 of cursor position for secure text-field in Android

### DIFF
--- a/tns-core-modules/ui/text-field/text-field.android.ts
+++ b/tns-core-modules/ui/text-field/text-field.android.ts
@@ -8,6 +8,7 @@ function onSecurePropertyChanged(data: dependencyObservable.PropertyChangeData) 
         return;
     }
 
+    var cursorPosition = textField.android.getSelectionStart();
     var currentInputType = textField.android.getInputType();
     var currentClass = currentInputType & android.text.InputType.TYPE_MASK_CLASS;
     var currentFlags = currentInputType & android.text.InputType.TYPE_MASK_FLAGS;
@@ -35,6 +36,7 @@ function onSecurePropertyChanged(data: dependencyObservable.PropertyChangeData) 
     }
     
     textField.android.setInputType(newInputType);
+    textField.android.setSelection(cursorPosition);
 }
 
 // register the setNativeValue callbacks


### PR DESCRIPTION
In android if we toggle the `secure` property of `text-field`, the cursor position was getting reset to first character. 

This PR solves that issue by setting cursor position after setting `inputType`.

Find more details at #3181.