### PR TITLE
ListPicker respects color and bckgColor set from CSS

### DIFF
--- a/apps/app/ui-tests-app/css/list-picker.ts
+++ b/apps/app/ui-tests-app/css/list-picker.ts
@@ -1,0 +1,7 @@
+export function loaded(args) {
+    var items = [];
+    for (var i = 0; i < 100; i++) {
+        items.push("name" + i);
+    }
+    args.object.bindingContext = { items: items };
+}

--- a/apps/app/ui-tests-app/css/list-picker.xml
+++ b/apps/app/ui-tests-app/css/list-picker.xml
@@ -1,0 +1,5 @@
+<Page loaded="loaded">
+	<StackLayout>
+		<ListPicker items="{{ items }}" style="color: deeppink; background-color:lightskyblue" />
+	</StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/css/main-page.ts
+++ b/apps/app/ui-tests-app/css/main-page.ts
@@ -37,6 +37,7 @@ export function pageLoaded(args: EventData) {
     examples.set("all-uniform-border", "css/all-uniform-border");
     examples.set("all-non-uniform-border", "css/all-non-uniform-border");
     examples.set("margins-paddings-with-percentage", "css/margins-paddings-with-percentage");
+    examples.set("list-picker", "css/list-picker");
     //examples.set("border-playground", "css/border-playground");
 
     let viewModel = new SubMainPageViewModel(wrapLayout, examples);


### PR DESCRIPTION
So far, ListPicker hasn't respected its color (both for IOS and Android) and background-color (for IOS) properties.

ListPicker {
    color: pink;
    background-color: lightskyblue;
}


