### PR TITLE
Do not dismiss keyboard on android, when text-field has return key type set to 'next'

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -37,11 +37,11 @@ export class EditableTextBase extends common.EditableTextBase {
                 }
                 var selectionStart = owner.android.getSelectionStart();
                 owner.android.removeTextChangedListener(owner._textWatcher);
-                
+
                 //RemoveThisDoubleCall
                 owner.style._updateTextDecoration();
                 owner.style._updateTextTransform();
-                
+
                 owner.android.addTextChangedListener(owner._textWatcher);
                 owner.android.setSelection(selectionStart);
             },
@@ -105,15 +105,18 @@ export class EditableTextBase extends common.EditableTextBase {
                         actionId === android.view.inputmethod.EditorInfo.IME_ACTION_GO ||
                         actionId === android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH ||
                         actionId === android.view.inputmethod.EditorInfo.IME_ACTION_SEND ||
-                        actionId === android.view.inputmethod.EditorInfo.IME_ACTION_NEXT ||
                         (event && event.getKeyCode() === android.view.KeyEvent.KEYCODE_ENTER)) {
-                        
+
                         // If it is TextField, close the keyboard. If it is TextView, do not close it since the TextView is multiline
                         // https://github.com/NativeScript/NativeScript/issues/3111
                         if (textView.getMaxLines() === 1){
                             owner.dismissSoftInput();
                         }
                         owner._onReturnPress();
+                    }
+                    // If action is ACTION_NEXT then do not close keyboard
+                    if (actionId === android.view.inputmethod.EditorInfo.IME_ACTION_NEXT) {
+                      owner._onReturnPress();
                     }
                 }
 
@@ -313,4 +316,4 @@ export class EditableTextBase extends common.EditableTextBase {
             this.android.setKeyListener(null);
         }
     }
-}  
+}


### PR DESCRIPTION
When text-field has returnKeyType set to 'next', keyboard disapears when tap 'next' button, and second text-field is focused. This PR changes this behavior. Now keyboard is not dismissed after tap.