### PR TITLE
Pin typescript dependency to 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "time-grunt": "1.3.0",
     "tslint": "^3.15.1",
     "typedoc": "0.4.5",
-    "typescript": "^2.0.3"
+    "typescript": "~2.0.10"
   },
   "scripts": {
     "setup": "npm run dev-link-tns-platform-declarations && npm run dev-link-tns-core-modules && npm run dev-link-tests && npm run dev-link-apps",

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,6 +22,6 @@
     "babylon": "6.8.0",
     "filewalker": "0.1.2",
     "lazy": "1.0.11",
-    "typescript": "^2.0.3"
+    "typescript": "~2.0.10"
   }
 }


### PR DESCRIPTION
Works around an incompatibility between TypeScript 2.1 and the android runtime tools.