### PR TITLE
Order property is not respected if set more than once

### DIFF
--- a/tests/app/ui/layouts/flexbox-layout-tests.ts
+++ b/tests/app/ui/layouts/flexbox-layout-tests.ts
@@ -184,8 +184,6 @@ const noop = () => {
     // no operation
 };
 
-// TODO: Order tests!
-
 function test<U extends { root: View }>(ui: () => U, setup: (ui: U) => void, test: (ui: U) => void): () => void {
     return () => {
         let i = ui();
@@ -1604,6 +1602,72 @@ export const testFlexBasisPercent_nowrap_flexDirection_column = test(
         let totalHeight = height(text1) + height(text2) + height(text3);
 
         check(totalHeight >= height(flexbox) - 3 || totalHeight <= height(flexbox) + 3);
+    }
+);
+
+let activity_order_test= () => getViews(
+    `<FlexboxLayout id="flexbox" width="360" height="300" backgroundColor="gray">
+        <Label id="text1" order="2" width="160" height="120" text="1" backgroundColor="red" />
+        <Label id="text2" order="3" width="160" height="120" text="2" backgroundColor="green" />
+        <Label id="text3" order="1" width="160" height="120" text="3" backgroundColor="blue" />
+    </FlexboxLayout>`
+);
+
+export const testOrder = test(
+    activity_order_test,
+    noop,
+    ({root, flexbox, text1, text2, text3}) => {
+        equal(FlexboxLayout.getOrder(text1), 2);
+        equal(FlexboxLayout.getOrder(text2), 3);
+        equal(FlexboxLayout.getOrder(text3), 1);
+    }
+);
+
+let activity_order_set_runtime_test= () => getViews(
+    `<FlexboxLayout id="flexbox" width="360" height="300" backgroundColor="gray">
+        <Label id="text1" width="160" height="120" text="1" backgroundColor="red" />
+        <Label id="text2" width="160" height="120" text="2" backgroundColor="green" />
+        <Label id="text3" width="160" height="120" text="3" backgroundColor="blue" />
+    </FlexboxLayout>`
+);
+
+export const testOrder_set_runtime = test(
+    activity_order_set_runtime_test,
+    ({flexbox, text1, text2, text3}) => {
+       FlexboxLayout.setOrder(text1, 3);
+       FlexboxLayout.setOrder(text2, 1);
+       FlexboxLayout.setOrder(text3, 2);
+    },
+    ({root, flexbox, text1, text2, text3}) => {
+        equal(FlexboxLayout.getOrder(text1), 3);
+        equal(FlexboxLayout.getOrder(text2), 1);
+        equal(FlexboxLayout.getOrder(text3), 2);
+    }
+);
+
+export const testOrder_changed_runtime = test(
+    activity_order_set_runtime_test,
+    ({flexbox, text1, text2, text3}) => {
+       FlexboxLayout.setOrder(text1, 3);
+       FlexboxLayout.setOrder(text2, 1);
+       FlexboxLayout.setOrder(text3, 2);
+
+        helper.buildUIAndRunTest(flexbox, () => {
+            waitUntilTestElementLayoutIsValid(flexbox);
+            FlexboxLayout.setOrder(text1, 1);
+            FlexboxLayout.setOrder(text2, 2);
+            FlexboxLayout.setOrder(text3, 3);
+        });
+    },
+    ({root, flexbox, text1, text2, text3}) => {
+        equal(FlexboxLayout.getOrder(text1), 1);
+        equal(FlexboxLayout.getOrder(text2), 2);
+        equal(FlexboxLayout.getOrder(text3), 3);
+        
+        // verify views are visually displayed at the right position, not only that their order property is correct.
+        equal(text1, flexbox.getChildAt(0));
+        equal(text2, flexbox.getChildAt(1));
+        equal(text3, flexbox.getChildAt(2));
     }
 );
 

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
@@ -244,6 +244,8 @@ export abstract class FlexboxLayoutBase extends LayoutBase {
     abstract _setNativeJustifyContent(justifyContent: JustifyContent);
     abstract _setNativeAlignItems(alignItems: AlignItems);
     abstract _setNativeAlignContent(alignContent: AlignContent);
+
+    abstract _invalidateOrdersCache();
 }
 
 const flexboxAffectsLayout = isAndroid ? PropertyMetadataSettings.None : PropertyMetadataSettings.AffectsLayout;

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
@@ -23,6 +23,9 @@ function setLayoutParamsProperty(view: View, setter: (lp: org.nativescript.widge
 
 export function _onNativeOrderPropertyChanged(view: View, newValue: number): void {
     setLayoutParamsProperty(view, lp => lp.order = newValue);
+    if (view.parent && view.parent instanceof FlexboxLayout && view.parent.android) {
+        view.parent.android.invalidateOrdersCache();
+    }
 }
 
 export function _onNativeFlexGrowPropertyChanged(view: View, newValue: number): void {
@@ -104,6 +107,10 @@ export class FlexboxLayout extends FlexboxLayoutBase {
 
     public _createUI() {
         this._layout = new org.nativescript.widgets.FlexboxLayout(this._context);
+    }
+
+    _invalidateOrdersCache() {
+        this._nativeView.invalidateOrdersCache();
     }
 
     _setNativeFlexDirection(flexDirection: FlexDirection) {

--- a/tns-platform-declarations/android/org.nativescript.widgets.d.ts
+++ b/tns-platform-declarations/android/org.nativescript.widgets.d.ts
@@ -267,6 +267,8 @@
                 public getAlignContent(): number;
                 public setAlignContent(value: number);
 
+                public invalidateOrdersCache(): void;
+
                 public static FLEX_DIRECTION_ROW: number;
                 public static FLEX_DIRECTION_ROW_REVERSE: number;
                 public static FLEX_DIRECTION_COLUMN: number;


### PR DESCRIPTION
Items are not reordered on changing the order property more than once. For example:
1. Step 1:
   FlexboxLayout.setOrder(text1, 3);
   FlexboxLayout.setOrder(text2, 1);
   FlexboxLayout.setOrder(text3, 2);

2. Step 2: 
    FlexboxLayout.setOrder(text1, 1);
    FlexboxLayout.setOrder(text2, 2);
    FlexboxLayout.setOrder(text3, 3);


The order property of the item will be respected - FlexboxLayout.getOrder(text1) will return the second value, but the item will not be reordered and will be arranged in the previous position.