### PR TITLE
Add option to have http.request() not follow HTTP 3xx redirections

### DIFF
--- a/tns-core-modules/http/http-request.android.ts
+++ b/tns-core-modules/http/http-request.android.ts
@@ -155,6 +155,9 @@ function buildJavaOptions(options: http.HttpRequestOptions) {
     if (types.isNumber(options.timeout)) {
         javaOptions.timeout = options.timeout;
     }
+    if (types.isBoolean(options.dontFollowRedirects)) {
+        javaOptions.dontFollowRedirects = options.dontFollowRedirects;
+    }
 
     if (options.headers) {
         var arrayList = new java.util.ArrayList<org.nativescript.widgets.Async.Http.KeyValuePair>();

--- a/tns-core-modules/http/http.d.ts
+++ b/tns-core-modules/http/http.d.ts
@@ -89,6 +89,11 @@ declare module "http" {
      * Gets or sets the request timeout in milliseconds.
      */
     timeout?: number;
+
+    /**
+     * Gets or sets wether to *not* follow server's redirection responses.
+     */
+    dontFollowRedirects?: boolean;
   }
 
   /**

--- a/tns-platform-declarations/android/org.nativescript.widgets.d.ts
+++ b/tns-platform-declarations/android/org.nativescript.widgets.d.ts
@@ -30,6 +30,7 @@
                         public timeout: number;
                         public screenWidth: number;
                         public screenHeight: number;
+                        public dontFollowRedirects: boolean;
                     }
 
                     export class RequestResult {


### PR DESCRIPTION
This implements the option to have http.request() not follow server's 3xx redirection replies
but instead return the exact redirection code and headers.

* on iOS, it uses a different NSURLSession instance for non-following request,
  with a NSURLSessionTaskDelegate implementing URLSessionTaskWillPerformHTTPRedirection...

* on Android, it passes the option on to org.nativescript.widgets.Async.Http;
  requires a related [feature in tns-core-modules-widgets](https://github.com/dturing/tns-core-modules-widgets/commit/a8bfd4babd3cd6e55cf03d070a15b0f43a4745b3) to work

