### PR TITLE
Fix webpack project compilation for TypeScript 2.1.

### DIFF
--- a/tns-core-modules/module.d.ts
+++ b/tns-core-modules/module.d.ts
@@ -18,6 +18,7 @@ declare namespace NodeJS {
         __onLiveSync: () => void;
         __onUncaughtError: (error: NativeScriptError) => void;
         TNS_WEBPACK?: boolean;
+        __requireOverride?: (name: string, dir: string) => any;
     }
 }
 


### PR DESCRIPTION
Add __requireOverride as an optional `global` member.

Related to #3642 