### PR TITLE
Gestures/view circ-dep and examples cleanup

### DIFF
--- a/apps/app/ui-tests-app/layouts/main-page.ts
+++ b/apps/app/ui-tests-app/layouts/main-page.ts
@@ -14,14 +14,12 @@ export function pageLoaded(args: EventData) {
     examples.set("absolute", "layouts/absolute");
     examples.set("dock", "layouts/dock");
     examples.set("grid", "layouts/grid");
-    examples.set("myview", "layouts/myview");
     examples.set("stack", "layouts/stack");
     examples.set("wrap", "layouts/wrap");
 
     examples.set("pabsolute", "layouts-percent/absolute");
     examples.set("pdock", "layouts-percent/dock");
     examples.set("pgrid", "layouts-percent/grid");
-    examples.set("pmyview", "layouts-percent/myview");
     examples.set("pstack", "layouts-percent/stack");
     examples.set("pwrap", "layouts-percent/wrap");
 

--- a/apps/app/ui-tests-app/tab-view/all.xml
+++ b/apps/app/ui-tests-app/tab-view/all.xml
@@ -1,5 +1,5 @@
 <Page>
-  <TabView selectedIndex="1" style="tab-text-color: yellow; color:yellow; selected-tab-text-color: red; background-color: green; tab-background-color: blue;">
+  <TabView selectedIndex="1" style="tab-text-color: yellow; color:yellow; selected-tab-text-color: red; android-selected-tab-highlight-color:red; background-color: green; tab-background-color: blue;">
     <TabView.items>
       <TabViewItem title="First">
         <TabViewItem.view>

--- a/tns-core-modules/ui/gestures/gestures-common.ts
+++ b/tns-core-modules/ui/gestures/gestures-common.ts
@@ -1,7 +1,8 @@
 ﻿import { GestureEventData as GestureEventData, GesturesObserver as GesturesObserverDefinition } from "ui/gestures";
 import { View } from "ui/core/view";
 
-export { View, EventData, layout } from "ui/core/view";
+// Only types:
+export { View, EventData } from "ui/core/view";
 
 export enum GestureTypes {
     tap = 1 << 0,
@@ -74,7 +75,7 @@ export function toString(type: GestureTypes, separator?: string): string {
 }
 
 // NOTE: toString could return the text of multiple GestureTypes.
-// Souldn't fromString do split on separator? and return multiple GestureTypes?
+// Souldn't fromString do split on separator and return multiple GestureTypes?
 export function fromString(type: string): GestureTypes {
     let t = type.trim().toLowerCase();
 

--- a/tns-core-modules/ui/gestures/gestures.android.ts
+++ b/tns-core-modules/ui/gestures/gestures.android.ts
@@ -1,6 +1,9 @@
 ﻿import { GestureEventData, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData } from "ui/gestures";
 import { GesturesObserverBase, toString, TouchAction, GestureStateTypes, GestureTypes, SwipeDirection, 
-    View, layout, EventData } from "./gestures-common";
+    View, EventData } from "./gestures-common";
+
+// Import layout from utils directly to avoid circular references
+import { layout } from "utils/utils";
 
 export * from "./gestures-common";
 


### PR DESCRIPTION
* Gestures circular dependency
* Invalid examples removed
* Added android-highlight to action bar example 

