### PR TITLE
Fix the travis PR build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ env:
   - PACKAGE_NAME=tns-core-modules
   - NODE_VERSION=5.10.1
   - EMULATOR_API_VER=21
-  - RUNTIMEVERSION=next
+    # HACK: revert to `next` runtime as soon as the console.log issue is fixed
+  - RUNTIMEVERSION=2.5.0
   - AVD_NAME=Arm$EMULATOR_API_VER
 addons:
   artifacts:

--- a/build/run-testsapp.grunt.js
+++ b/build/run-testsapp.grunt.js
@@ -52,6 +52,7 @@ module.exports = {
 
             workingDir:".testsapprun",
             testsAppName:"TestsApp",
+            tnsCoreModulesSource: pathModule.resolve("./tns-core-modules"),
             applicationDir: pathModule.join(".testsapprun", "TestsApp"),
             appDir: pathModule.join(".testsapprun", "TestsApp", "app"),
             pathToApk: "./platforms/android/build/outputs/apk/TestsApp-debug.apk",
@@ -203,6 +204,11 @@ module.exports = {
                 "npm-i-modules": {
                     cmd: "npm i " + pathModule.relative(localCfg.applicationDir, localCfg.modulesPath),
                     cwd: localCfg.applicationDir
+                },
+                "npm-i-widgets": {
+                    // HACK: switch to @next when it gets switched to the 3.0 branch
+                    cmd: "npm i tns-core-modules-widgets@rc",
+                    cwd: localCfg.applicationDir
                 }
             },
             shell: {
@@ -254,7 +260,6 @@ module.exports = {
         grunt.loadNpmTasks("grunt-mkdir");
         grunt.loadNpmTasks("grunt-contrib-clean");
         grunt.loadNpmTasks("grunt-contrib-copy");
-        grunt.loadNpmTasks("grunt-untar");
 
         var getPlatformSpecificTask = function(templatedTaskName) {
             return templatedTaskName.replace(/\{platform\}/, localCfg.platform);
@@ -296,6 +301,7 @@ module.exports = {
             "copy:testsAppToRunDir",
             "clean:modules",
             "exec:npm-i-modules",
+            "exec:npm-i-widgets",
             "copy:modulesToDir",
             "clean:tempExtractedModules",
 


### PR DESCRIPTION
- Use tns-core-modules-widgets@rc
- Pin to android runtime 2.5.0 since the `next` build currently has an issue that eats `console.log` messages.