### PR TITLE
Hdeshev/typescript 2.2

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -22,6 +22,6 @@
     "babylon": "6.8.3",
     "lazy": "1.0.11",
     "nativescript-dev-typescript": "^0.3.0",
-    "typescript": "~2.1.6"
+    "typescript": "~2.2.1"
   }
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -90,6 +90,7 @@ module.exports = function(grunt) {
         var dtsFiles = grunt.file.expand({cwd: srcDir }, [
             "**/*.d.ts",
             //Exclude the d.ts files in the apps folder - these are part of the apps and are already packed there!
+            "!docs-shims.d.ts",
             "!node-tests/**",
             "!org.nativescript.widgets.d.ts",
             "!android17.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/node": "^7.0.5",
     "chai": "3.2.0",
     "concurrently": "^2.1.0",
     "grunt": "1.0.1",
@@ -17,8 +18,8 @@
     "grunt-exec": "1.0.1",
     "grunt-mkdir": "1.0.0",
     "grunt-shell": "2.1.0",
-    "grunt-ts": "6.0.0-beta.11",
     "grunt-simple-mocha": "0.4.1",
+    "grunt-ts": "6.0.0-beta.11",
     "grunt-typedoc": "0.2.4",
     "http-server": "^0.9.0",
     "markdown-snippet-injector": "0.1.1",
@@ -27,8 +28,8 @@
     "shelljs": "^0.7.0",
     "time-grunt": "1.3.0",
     "tslint": "^4.4.2",
-    "typedoc": "0.5.6",
-    "typescript": "~2.1.5"
+    "typedoc": "https://github.com/hdeshev/typedoc/blob/npm/typedoc-no-types.tgz?raw=true",
+    "typescript": "~2.2.1"
   },
   "scripts": {
     "setup": "npm run dev-link-tns-platform-declarations && npm run dev-link-tns-core-modules && npm run dev-link-tests && npm run dev-link-apps",

--- a/tests/app/TKUnit.ts
+++ b/tests/app/TKUnit.ts
@@ -234,8 +234,8 @@ export function assertEqual<T extends { equals?(arg: T): boolean }>(actual: T, e
  * Assert two json like objects are deep equal.
  */
 export function assertDeepEqual(actual, expected, path: any[] = []): void {
-    let typeofActual = typeof actual;
-    let typeofExpected = typeof expected;
+    let typeofActual: string = typeof actual;
+    let typeofExpected: string = typeof expected;
     if (typeofActual !== typeofExpected) {
         throw new Error("At /" + path.join("/") + " types of actual " + typeofActual + " and expected " + typeofExpected + " differ.");
     } else if (typeofActual === "object" || typeofActual === "array") {
@@ -290,8 +290,8 @@ export function assertDeepEqual(actual, expected, path: any[] = []): void {
 }
 
 export function assertDeepSuperset(actual, expected, path: any[] = []): void {
-    let typeofActual = typeof actual;
-    let typeofExpected = typeof expected;
+    let typeofActual: string = typeof actual;
+    let typeofExpected: string = typeof expected;
     if (typeofActual !== typeofExpected) {
         throw new Error("At /" + path.join("/") + " types of actual " + typeofActual + " and expected " + typeofExpected + " differ.");
     } else if (typeofActual === "object" || typeofActual === "array") {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,6 +22,6 @@
     "babylon": "6.8.0",
     "filewalker": "0.1.2",
     "lazy": "1.0.11",
-    "typescript": "~2.1.6"
+    "typescript": "~2.2.1"
   }
 }

--- a/tns-core-modules/declarations.d.ts
+++ b/tns-core-modules/declarations.d.ts
@@ -1,26 +1,5 @@
 ﻿/* tslint:disable:no-unused-variable */
 
-declare class Request {
-    constructor(input: string|Request, init?: RequestInit);
-    method: string;
-    url: string;
-    headers: Headers;
-    context: RequestContext;
-    referrer: string;
-    mode: RequestMode;
-    credentials: RequestCredentials;
-    cache: RequestCache;
-}
-
-interface RequestInit {
-    method?: string;
-    headers?: HeaderInit|{ [index: string]: string };
-    body?: BodyInit;
-    mode?: RequestMode;
-    credentials?: RequestCredentials;
-    cache?: RequestCache;
-}
-
 declare enum RequestContext {
     "audio", "beacon", "cspreport", "download", "embed", "eventsource", "favicon", "fetch",
     "font", "form", "frame", "hyperlink", "iframe", "image", "imageset", "import",
@@ -29,18 +8,14 @@ declare enum RequestContext {
     "xmlhttprequest", "xslt"
 }
 
+// Extend the lib.dom.d.ts Body interface with `formData`
+interface Body {
+    formData() : Promise<FormData>;
+}
+
 declare enum RequestMode { "same-origin", "no-cors", "cors" }
 declare enum RequestCredentials { "omit", "same-origin", "include" }
 declare enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" }
-
-declare class Headers {
-    append(name: string, value: string): void;
-    delete(name: string): void;
-    get(name: string): string;
-    getAll(name: string): Array<string>;
-    has(name: string): boolean;
-    set(name: string, value: string): void;
-}
 
 interface Blob {
     readonly size: number;
@@ -60,41 +35,7 @@ interface BlobPropertyBag {
     endings?: string;
 }
 
-declare class Body {
-    bodyUsed: boolean;
-    /*
-            arrayBuffer(): Promise<ArrayBuffer>;
-            blob(): Promise<Blob>;
-    */
-    formData(): Promise<FormData>;
-    json(): Promise<any>;
-    text(): Promise<string>;
-}
-
-declare class Response extends Body {
-    constructor(body?: BodyInit, init?: ResponseInit);
-    error(): Response;
-    redirect(url: string, status: number): Response;
-    type: ResponseType;
-    url: string;
-    status: number;
-    ok: boolean;
-    statusText: string;
-    headers: Headers;
-    clone(): Response;
-}
-
-declare enum ResponseType { "basic", "cors", "default", "error", "opaque" }
-
-declare class ResponseInit {
-    status: number;
-    statusText: string;
-    headers: HeaderInit;
-}
-
 declare type HeaderInit = Headers|Array<string>;
-declare type BodyInit = Blob|FormData|string;
-declare type RequestInfo = Request|string;
 
 declare function fetch(url: string, init?: RequestInit): Promise<Response>;
 

--- a/tns-core-modules/docs-shims.d.ts
+++ b/tns-core-modules/docs-shims.d.ts
@@ -1,0 +1,68 @@
+declare type Promise<T> = any;
+declare type Set<T> = any;
+declare type Map<K, V> = any;
+
+declare class Request {
+    constructor(input: string|Request, init?: RequestInit);
+    method: string;
+    url: string;
+    headers: Headers;
+    context: RequestContext;
+    referrer: string;
+    mode: RequestMode;
+    credentials: RequestCredentials;
+    cache: RequestCache;
+}
+
+interface RequestInit {
+    method?: string;
+    headers?: HeaderInit|{ [index: string]: string };
+    body?: BodyInit;
+    mode?: RequestMode;
+    credentials?: RequestCredentials;
+    cache?: RequestCache;
+}
+
+declare class Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string;
+    getAll(name: string): Array<string>;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+}
+
+declare class Body {
+    bodyUsed: boolean;
+    /*
+            arrayBuffer(): Promise<ArrayBuffer>;
+            blob(): Promise<Blob>;
+    */
+    formData(): Promise<FormData>;
+    json(): Promise<any>;
+    text(): Promise<string>;
+}
+
+declare class Response extends Body {
+    constructor(body?: BodyInit, init?: ResponseInit);
+    error(): Response;
+    redirect(url: string, status: number): Response;
+    type: ResponseType;
+    url: string;
+    status: number;
+    ok: boolean;
+    statusText: string;
+    headers: Headers;
+    clone(): Response;
+}
+
+declare enum ResponseType { "basic", "cors", "default", "error", "opaque" }
+
+declare class ResponseInit {
+    status: number;
+    statusText: string;
+    headers: HeaderInit;
+}
+
+declare type BodyInit = Blob|FormData|string;
+declare type RequestInfo = Request|string;

--- a/tsconfig.base-dts.json
+++ b/tsconfig.base-dts.json
@@ -7,6 +7,7 @@
         "tns-core-modules/**/*.d.ts"
     ],
     "exclude": [
+        "tns-core-modules/docs-shims.d.ts",
         "tns-platform-declarations/node_modules/",
         "tns-platform-declarations/package/",
         "tns-core-modules/node_modules/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.shared",
     "exclude": [
+        "tns-core-modules/docs-shims.d.ts",
         "tns-platform-declarations/node_modules/",
         "tns-platform-declarations/package/",
         "tns-core-modules/node_modules/",

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -10,6 +10,7 @@
         "experimentalDecorators": true
     },
     "files": [
+        "tns-core-modules/docs-shims.d.ts",
         "tns-core-modules/tns-core-modules.d.ts"
     ]
 }


### PR DESCRIPTION
- Fix typings, remove Request, etc clashes with the new lib.dom.d.ts
- Use a forked build of typedoc if/until TypeStrong/typedoc#434 is accepted.
- Add `docs-shims.d.ts` to make API reference build using TypeScript 2.1 (until TypeDoc fully supports TypeScript 2.2)