### PR TITLE
Pixels ios

### DIFF
--- a/tests/app/ui/label/label-tests.ts
+++ b/tests/app/ui/label/label-tests.ts
@@ -139,8 +139,10 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
 
         if (label.ios) {
             this.waitUntilTestElementLayoutIsValid();
-
-            const expectedValue = 3;
+            let expectedValue = NSString.stringWithString("i").sizeWithAttributes(<any>{
+                [NSFontAttributeName]: UIFont.systemFontOfSize(9)
+            }).width;
+            expectedValue = Math.ceil(utils.layout.toDevicePixels(expectedValue));
             const measuredWidth = label.getMeasuredWidth();
             TKUnit.assertEqual(measuredWidth, expectedValue, "measuredWidth should not be rounded down.");
         }

--- a/tests/app/ui/view/view-tests.ios.ts
+++ b/tests/app/ui/view/view-tests.ios.ts
@@ -5,6 +5,7 @@ import * as color from "color";
 import * as helper from "../helper";
 import * as TKUnit from "../../TKUnit";
 import * as button from "ui/button";
+import * as utils from "utils/utils";
 
 global.moduleMerge(commonTests, exports);
 
@@ -21,7 +22,7 @@ class MyGrid extends grid.GridLayout {
 }
 
 export function getUniformNativeBorderWidth(v: view.View): number {
-    return (<UIView>v.ios).layer.borderWidth;
+    return utils.layout.toDevicePixels((<UIView>v.ios).layer.borderWidth);
 }
 
 export function checkUniformNativeBorderColor(v: view.View): boolean {

--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -248,8 +248,8 @@ export class ActionBar extends ActionBarBase {
                 let navBarSize = navBar.sizeThatFits(CGSizeMake(
                     (widthMode === layout.UNSPECIFIED) ? Number.POSITIVE_INFINITY : width,
                     (heightMode === layout.UNSPECIFIED) ? Number.POSITIVE_INFINITY : height));
-                navBarWidth = navBarSize.width;
-                navBarHeight = navBarSize.height;
+                navBarWidth = layout.toDevicePixels(navBarSize.width);
+                navBarHeight = layout.toDevicePixels(navBarSize.height);
             }
         }
 

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -189,8 +189,8 @@ export class View extends ViewCommon {
 
         let pointInWindow = this.nativeView.convertPointToView(this.nativeView.bounds.origin, null);
         return {
-            x: layout.toDeviceIndependentPixels(pointInWindow.x),
-            y: layout.toDeviceIndependentPixels(pointInWindow.y),
+            x: pointInWindow.x,
+            y: pointInWindow.y
         };
     }
 
@@ -202,8 +202,8 @@ export class View extends ViewCommon {
         let pointInWindow = this.nativeView.convertPointToView(this.nativeView.bounds.origin, null);
         let pointOnScreen = this.nativeView.window.convertPointToWindow(pointInWindow, null);
         return {
-            x: layout.toDeviceIndependentPixels(pointOnScreen.x),
-            y: layout.toDeviceIndependentPixels(pointOnScreen.y),
+            x: pointOnScreen.x,
+            y: pointOnScreen.y
         };
     }
 
@@ -217,8 +217,8 @@ export class View extends ViewCommon {
         let myPointInWindow = this.nativeView.convertPointToView(this.nativeView.bounds.origin, null);
         let otherPointInWindow = otherView.nativeView.convertPointToView(otherView.nativeView.bounds.origin, null);
         return {
-            x: layout.toDeviceIndependentPixels(myPointInWindow.x - otherPointInWindow.x),
-            y: layout.toDeviceIndependentPixels(myPointInWindow.y - otherPointInWindow.y),
+            x: myPointInWindow.x - otherPointInWindow.x,
+            y: myPointInWindow.y - otherPointInWindow.y
         };
     }
 

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -120,8 +120,8 @@ export class View extends ViewCommon {
             }
 
             let nativeSize = view.sizeThatFits(CGSizeMake(width, height));
-            nativeWidth = nativeSize.width;
-            nativeHeight = nativeSize.height;
+            nativeWidth = layout.toDevicePixels(nativeSize.width);
+            nativeHeight = layout.toDevicePixels(nativeSize.height);
         }
 
         let measureWidth = Math.max(nativeWidth, this.effectiveMinWidth);
@@ -165,7 +165,7 @@ export class View extends ViewCommon {
 
         let nativeView = this.nativeView;
 
-        let frame = CGRectMake(left, top, right - left, bottom - top);
+        let frame = CGRectMake(layout.toDeviceIndependentPixels(left), layout.toDeviceIndependentPixels(top), layout.toDeviceIndependentPixels(right - left), layout.toDeviceIndependentPixels(bottom - top));
         this._setNativeViewFrame(nativeView, frame);
     }
 

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -369,7 +369,7 @@ export class Frame extends FrameBase {
             !this._ios.controller ||
             !this._ios.controller.navigationBar ||
             this._ios.controller.navigationBar.hidden ||
-            this._ios.controller.navigationBar.frame.origin.y === statusBarHeight) {
+            utils.layout.toDevicePixels(this._ios.controller.navigationBar.frame.origin.y) === statusBarHeight) {
             return;
         }
 
@@ -380,10 +380,10 @@ export class Frame extends FrameBase {
         this._ios.controller.navigationBar.autoresizingMask = UIViewAutoresizing.None;
         this._ios.controller.navigationBar.removeConstraints((<any>this)._ios.controller.navigationBar.constraints);
         this._ios.controller.navigationBar.frame = CGRectMake(
-            this._ios.controller.navigationBar.frame.origin.x,
-            statusBarHeight,
-            this._ios.controller.navigationBar.frame.size.width,
-            this._ios.controller.navigationBar.frame.size.height);
+            utils.layout.toDeviceIndependentPixels(this._ios.controller.navigationBar.frame.origin.x),
+            utils.layout.toDeviceIndependentPixels(statusBarHeight),
+            utils.layout.toDeviceIndependentPixels(this._ios.controller.navigationBar.frame.size.width),
+            utils.layout.toDeviceIndependentPixels(this._ios.controller.navigationBar.frame.size.height));
     }
 }
 

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -6,6 +6,7 @@ import { Page } from "ui/page";
 import { FrameBase, View, application, layout, traceEnabled, traceWrite, traceCategories, isCategorySet } from "./frame-common";
 import { _createIOSAnimatedTransitioning } from "ui/transition";
 import * as uiUtils from "ui/utils";
+import * as utils from "utils/utils";
 
 export * from "./frame-common";
 

--- a/tns-core-modules/ui/html-view/html-view.ios.ts
+++ b/tns-core-modules/ui/html-view/html-view.ios.ts
@@ -45,11 +45,11 @@ export class HtmlView extends HtmlViewBase {
             }
 
             let nativeSize = nativeView.sizeThatFits(CGSizeMake(width, height));
-            let labelWidth = nativeSize.width;
+            let labelWidth = layout.toDevicePixels(nativeSize.width);
 
             labelWidth = Math.min(labelWidth, width);
             let measureWidth = Math.max(labelWidth, this.effectiveMinWidth);
-            let measureHeight = Math.max(nativeSize.height, this.effectiveMinHeight);
+            let measureHeight = Math.max(layout.toDevicePixels(nativeSize.height), this.effectiveMinHeight);
 
             let widthAndState = View.resolveSizeAndState(measureWidth, width, widthMode, 0);
             let heightAndState = View.resolveSizeAndState(measureHeight, height, heightMode, 0);

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -85,14 +85,14 @@ export class Label extends TextBase implements LabelDefinition {
                 | (heightMode === layout.EXACTLY ? FixedSize.HEIGHT : FixedSize.NONE);
 
             let nativeSize = nativeView.sizeThatFits(CGSizeMake(width, height));
-            let labelWidth = nativeSize.width;
+            let labelWidth = layout.toDevicePixels(nativeSize.width);
 
             if (this.textWrap) {
                 labelWidth = Math.min(labelWidth, width);
             }
 
             let measureWidth = Math.max(labelWidth, this.effectiveMinWidth);
-            let measureHeight = Math.max(nativeSize.height, this.effectiveMinHeight);
+            let measureHeight = Math.max(layout.toDevicePixels(nativeSize.height), this.effectiveMinHeight);
 
             let widthAndState = View.resolveSizeAndState(measureWidth, width, widthMode, 0);
             let heightAndState = View.resolveSizeAndState(measureHeight, height, heightMode, 0);

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
@@ -174,7 +174,7 @@ export class GridLayout extends GridLayoutBase {
 
             actualLength = offset - roundedOffset;
             roundedLength = Math.round(actualLength);
-            columnGroup.rowOrColumn._actualLength = roundedLength;
+            columnGroup.rowOrColumn._actualLength = layout.toDeviceIndependentPixels(roundedLength);
             roundedOffset += roundedLength;
 
             this.columnOffsets.push(roundedOffset);
@@ -191,7 +191,7 @@ export class GridLayout extends GridLayoutBase {
 
             actualLength = offset - roundedOffset;
             roundedLength = Math.round(actualLength);
-            rowGroup.rowOrColumn._actualLength = roundedLength;
+            rowGroup.rowOrColumn._actualLength = layout.toDeviceIndependentPixels(roundedLength);
             roundedOffset += roundedLength;
 
             this.rowOffsets.push(roundedOffset);
@@ -417,7 +417,7 @@ class MeasureHelper {
                 measureSpec.starColumnsCount += columnGroup.rowOrColumn.value;
             }
             else if (columnGroup.getIsAbsolute()) {
-                measureSpec.pixelWidth += columnGroup.rowOrColumn.value;
+                measureSpec.pixelWidth += layout.toDevicePixels(columnGroup.rowOrColumn.value);
             }
         }
 
@@ -442,7 +442,7 @@ class MeasureHelper {
                 measureSpec.starRowsCount += rowGroup.rowOrColumn.value;
             }
             else if (rowGroup.getIsAbsolute()) {
-                measureSpec.pixelHeight += rowGroup.rowOrColumn.value;
+                measureSpec.pixelHeight += layout.toDevicePixels(rowGroup.rowOrColumn.value);
             }
         }
 

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -141,7 +141,7 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
             height = owner._prepareCell(cell, indexPath);
         }
 
-        return height;
+        return layout.toDeviceIndependentPixels(height);
     }
 }
 

--- a/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
@@ -18,8 +18,8 @@ class UIScrollViewDelegateImpl extends NSObject implements UIScrollViewDelegate 
             owner.notify(<ScrollEventData>{
                 object: owner,
                 eventName: ScrollViewBase.scrollEvent,
-                scrollX: owner.horizontalOffset / layout.getDisplayDensity(),
-                scrollY: owner.verticalOffset / layout.getDisplayDensity()
+                scrollX: owner.horizontalOffset,
+                scrollY: owner.verticalOffset
             });
         }
     }
@@ -60,7 +60,7 @@ export class ScrollView extends ScrollViewBase {
             return 0;
         }
 
-        return Math.max(0, this.nativeView.contentSize.width - this.nativeView.bounds.size.width) / layout.getDisplayDensity();
+        return Math.max(0, this.nativeView.contentSize.width - this.nativeView.bounds.size.width);
     }
 
     get scrollableHeight(): number {
@@ -68,7 +68,7 @@ export class ScrollView extends ScrollViewBase {
             return 0;
         }
 
-        return Math.max(0, this.nativeView.contentSize.height - this.nativeView.bounds.size.height) / layout.getDisplayDensity();
+        return Math.max(0, this.nativeView.contentSize.height - this.nativeView.bounds.size.height);
     }
 
     get ios(): UIView {
@@ -116,7 +116,10 @@ export class ScrollView extends ScrollViewBase {
                 childSize = View.measureChild(this, child, layout.makeMeasureSpec(0, layout.UNSPECIFIED), heightMeasureSpec);
             }
 
-            this.nativeView.contentSize = CGSizeMake(childSize.measuredWidth, childSize.measuredHeight);
+            let w = layout.toDeviceIndependentPixels(childSize.measuredWidth);
+            let h = layout.toDeviceIndependentPixels(childSize.measuredHeight);
+            this.nativeView.contentSize = CGSizeMake(w, h);
+
             this._contentMeasuredWidth = Math.max(childSize.measuredWidth, this.effectiveMinWidth * density);
             this._contentMeasuredHeight = Math.max(childSize.measuredHeight, this.effectiveMinHeight * density);
         }

--- a/tns-core-modules/ui/styling/background.ios.ts
+++ b/tns-core-modules/ui/styling/background.ios.ts
@@ -36,7 +36,7 @@ export module ios {
             const layer = nativeView.layer;
             const borderColor = background.getUniformBorderColor();
             layer.borderColor = !borderColor ? undefined : borderColor.ios.CGColor;
-            layer.borderWidth = background.getUniformBorderWidth();
+            layer.borderWidth = layout.toDeviceIndependentPixels(background.getUniformBorderWidth());
             layer.cornerRadius = background.getUniformBorderRadius();
         }
         else {
@@ -177,10 +177,10 @@ function drawNonUniformBorders(nativeView: NativeView, background: Background) {
         right: layerSize.width
     };
 
-    const top = background.borderTopWidth;
-    const right = background.borderRightWidth;
-    const bottom = background.borderBottomWidth;
-    const left = background.borderLeftWidth;
+    const top = layout.toDeviceIndependentPixels(background.borderTopWidth);
+    const right = layout.toDeviceIndependentPixels(background.borderRightWidth);
+    const bottom = layout.toDeviceIndependentPixels(background.borderBottomWidth);
+    const left = layout.toDeviceIndependentPixels(background.borderLeftWidth);
 
     const lto: Point = { x: nativeViewLayerBounds.left, y: nativeViewLayerBounds.top };// left-top-outside
     const lti: Point = { x: nativeViewLayerBounds.left + left, y: nativeViewLayerBounds.top + top }; // left-top-inside

--- a/tns-core-modules/ui/switch/switch.ios.ts
+++ b/tns-core-modules/ui/switch/switch.ios.ts
@@ -56,8 +56,8 @@ export class Switch extends SwitchBase {
         this.width = nativeSize.width;
         this.height = nativeSize.height;
 
-        let widthAndState = layout.makeMeasureSpec(nativeSize.width, layout.EXACTLY);
-        let heightAndState = layout.makeMeasureSpec(nativeSize.height, layout.EXACTLY);
+        let widthAndState = layout.makeMeasureSpec(layout.toDevicePixels(nativeSize.width), layout.EXACTLY);
+        let heightAndState = layout.makeMeasureSpec(layout.toDevicePixels(nativeSize.height), layout.EXACTLY);
         this.setMeasuredDimension(widthAndState, heightAndState);
     }
 

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -347,9 +347,10 @@ export class TabView extends TabViewBase {
     }
 
     private static measureHelper(nativeView: UIView, width: number, widthMode: number, height: number, heightMode: number): CGSize {
-        return nativeView.sizeThatFits(CGSizeMake(
+        const size = nativeView.sizeThatFits(CGSizeMake(
             (widthMode === layout.UNSPECIFIED) ? Number.POSITIVE_INFINITY : width,
             (heightMode === layout.UNSPECIFIED) ? Number.POSITIVE_INFINITY : height));
+        return { width: layout.toDevicePixels(size.width), height: layout.toDevicePixels(size.height) };
     }
 
     private _updateIOSTabBarColorsAndFonts(): void {

--- a/tns-core-modules/ui/utils.ios.ts
+++ b/tns-core-modules/ui/utils.ios.ts
@@ -18,7 +18,8 @@ export module ios {
         }
 
         var statusFrame = app.statusBarFrame;
-        return Math.min(statusFrame.size.width, statusFrame.size.height);
+        let min = Math.min(statusFrame.size.width, statusFrame.size.height);
+        return utils.layout.toDevicePixels(min);
     }
 
     export function _layoutRootView(rootView: View, parentBounds: CGRect) {
@@ -27,8 +28,8 @@ export module ios {
         }
 
         let size = parentBounds.size;
-        let width = size.width;
-        let height = size.height;
+        let width = utils.layout.toDevicePixels(size.width);
+        let height = utils.layout.toDevicePixels(size.height);
 
         var superview = (<UIView>rootView._nativeView).superview;
         var superViewRotationRadians;
@@ -38,8 +39,8 @@ export module ios {
 
         if (utils.ios.MajorVersion < 8 && utils.ios.isLandscape() && !superViewRotationRadians) {
             // in iOS 7 when in landscape we switch width with height because on device they don't change even when rotated.
-            width = size.height;
-            height = size.width;
+            width = utils.layout.toDevicePixels(size.width);
+            height = utils.layout.toDevicePixels(size.height);
         }
 
         var origin = parentBounds.origin;

--- a/tns-core-modules/ui/utils.ios.ts
+++ b/tns-core-modules/ui/utils.ios.ts
@@ -37,12 +37,6 @@ export module ios {
             superViewRotationRadians = atan2f(superview.transform.b, superview.transform.a);
         }
 
-        if (utils.ios.MajorVersion < 8 && utils.ios.isLandscape() && !superViewRotationRadians) {
-            // in iOS 7 when in landscape we switch width with height because on device they don't change even when rotated.
-            width = utils.layout.toDevicePixels(size.width);
-            height = utils.layout.toDevicePixels(size.height);
-        }
-
         var origin = parentBounds.origin;
         var left = origin.x;
         var top = origin.y;

--- a/tns-core-modules/utils/utils.ios.ts
+++ b/tns-core-modules/utils/utils.ios.ts
@@ -5,6 +5,8 @@ import {
 
 export * from "./utils-common";
 
+let mainScreenScale;
+
 function isOrientationLandscape(orientation: number) {
     return orientation === UIDeviceOrientation.LandscapeLeft || orientation === UIDeviceOrientation.LandscapeRight;
 }
@@ -18,15 +20,15 @@ export module layout {
     }
 
     export function getDisplayDensity(): number {
-        return 1;
+        return mainScreenScale;
     }
 
     export function toDevicePixels(value: number): number {
-        return value * getDisplayDensity();
+        return value * mainScreenScale;
     }
 
     export function toDeviceIndependentPixels(value: number): number {
-        return value / getDisplayDensity();
+        return value / mainScreenScale;
     }
 }
 
@@ -120,3 +122,5 @@ class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UI
         return this.getViewController().view.frame;
     }
 }
+
+mainScreenScale = ios.getter(UIScreen, UIScreen.mainScreen).scale;


### PR DESCRIPTION
Length offers both dip and px as units but px so far behaved as dip in iOS. This PR aims to resolve 1px on retina display (@2, @3) to 1/2 dip or 1/3 dip respectively. All native APIs use dip, {N} layouts work in px, some APIs like the GridLayout that support rows and columns still support just dip and as such some actual sizes return dips. Effective values are supposed to work in px. Layout rounding will now round to px even when sizes are specified in px.