### PR TITLE
FIX: Android keyboard

### DIFF
--- a/apps/app/ui-tests-app/issues/issue-2942.ts
+++ b/apps/app/ui-tests-app/issues/issue-2942.ts
@@ -1,11 +1,20 @@
-export function onButtonLoaded(args){
-    if (args.object.android){
+import { ad } from "utils//utils";
+import { isAndroid } from "platform";
+
+export function onButtonLoaded(args) {
+    if (args.object.android) {
         args.object.android.setFocusableInTouchMode(true);
         args.object.android.setFocusable(true);
         args.object.android.setClickable(true);
     }
 }
 
-export function onListViewLoaded(args){
+export function onListViewLoaded(args) {
     args.object.items = [1];
+}
+
+export function hideKeyboard() {
+    if (isAndroid) {
+        ad.dismissSoftInput();
+    }
 }

--- a/apps/app/ui-tests-app/issues/issue-2942.xml
+++ b/apps/app/ui-tests-app/issues/issue-2942.xml
@@ -1,6 +1,7 @@
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
 <StackLayout>
-  <Button height="100" width="100" loaded="onButtonLoaded" text="Click me 3rd (Android)" style.fontSize="8"/>
+  <Button height="50" width="100" text="hide keyboard" onTap="hideKeyboard" style.fontSize="8"/>
+  <Button height="50" width="100" loaded="onButtonLoaded" text="Click me 3rd (Android)" style.fontSize="8"/>
   <ListView loaded="onListViewLoaded">
       <ListView.itemTemplate>
         <StackLayout>

--- a/tns-core-modules/utils/utils.android.ts
+++ b/tns-core-modules/utils/utils.android.ts
@@ -4,7 +4,7 @@
 
 export * from "./utils-common";
 
-import { getNativeApplication } from "application";
+import { getNativeApplication, android as androidApp } from "application";
 
 export module layout {
     let density: number;
@@ -98,10 +98,19 @@ export module ad {
         }
     }
 
-    export function dismissSoftInput(nativeView: android.view.View): void {
+    export function dismissSoftInput(nativeView?: android.view.View): void {
         const inputManager = getInputMethodManager();
-        if (inputManager && nativeView instanceof android.view.View && inputManager.isActive(nativeView)) {
-            inputManager.hideSoftInputFromWindow(nativeView.getWindowToken(), 0);
+        let windowToken: android.os.IIBinder;
+
+        if (nativeView instanceof android.view.View) {
+            windowToken = nativeView.getWindowToken()
+        } else if (androidApp.foregroundActivity instanceof android.app.Activity) {
+            const currentFocus = androidApp.foregroundActivity.getCurrentFocus();
+            windowToken = currentFocus ? currentFocus.getWindowToken() : null;
+        }
+
+        if (inputManager && windowToken) {
+            inputManager.hideSoftInputFromWindow(windowToken, 0);
         }
     }
 

--- a/tns-core-modules/utils/utils.android.ts
+++ b/tns-core-modules/utils/utils.android.ts
@@ -105,8 +105,8 @@ export module ad {
         if (nativeView instanceof android.view.View) {
             windowToken = nativeView.getWindowToken()
         } else if (androidApp.foregroundActivity instanceof android.app.Activity) {
-            const currentFocus = androidApp.foregroundActivity.getCurrentFocus();
-            windowToken = currentFocus ? currentFocus.getWindowToken() : null;
+            const decorView = androidApp.foregroundActivity.getWindow().getDecorView();
+            windowToken = decorView ? decorView.getWindowToken() : null;
         }
 
         if (inputManager && windowToken) {

--- a/tns-core-modules/utils/utils.d.ts
+++ b/tns-core-modules/utils/utils.d.ts
@@ -94,7 +94,7 @@ export module ad {
     /**
      * Hides the soft input method, ususally a soft keyboard.
      */
-    export function dismissSoftInput(nativeView: any /* android.view.View */): void;
+    export function dismissSoftInput(nativeView?: any /* android.view.View */): void;
 
     /**
      * Shows the soft input method, ususally a soft keyboard.


### PR DESCRIPTION
Fixes:
 - Android keyboard does not hide when focusing away from TextView
 -  The `nativeView` parameter of `dismissSoftInput` (from `utils`) is now optional.