### PR TITLE
ListView disappearing styles on back navigation (Angular)

### DIFF
--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -238,8 +238,6 @@ export class ViewBase extends Observable implements ViewBaseDefinition {
     }
 
     public onUnloaded() {
-        this._styleScope = null;
-        this._setCssState(null);
         this._unloadEachChild();
         this._isLoaded = false;
         this._emit("unloaded");
@@ -259,6 +257,8 @@ export class ViewBase extends Observable implements ViewBaseDefinition {
         const scope = this._styleScope;
         if (scope) {
             scope.applySelectors(this);
+        } else {
+            this._setCssState(null);
         }
     }
 
@@ -538,6 +538,9 @@ export class ViewBase extends Observable implements ViewBaseDefinition {
      */
     public _removeViewCore(view: ViewBase) {
         // TODO: Discuss this.
+        if (this._styleScope === view._styleScope) {
+            view._setStyleScope(null);
+        }
         if (view.isLoaded) {
             view.onUnloaded();
         }

--- a/tns-core-modules/ui/list-view/list-view.android.ts
+++ b/tns-core-modules/ui/list-view/list-view.android.ts
@@ -79,7 +79,7 @@ export class ListView extends ListViewBase {
         }
 
         // clear bindingContext when it is not observable because otherwise bindings to items won't reevaluate
-        this._realizedItems.forEach((view, nativeView, map) => {
+        this._realizedItems.forEach((view, nativeView) => {
             if (!(view.bindingContext instanceof Observable)) {
                 view.bindingContext = null;
             }
@@ -104,7 +104,7 @@ export class ListView extends ListViewBase {
     }
 
     public eachChildView(callback: (child: View) => boolean): void {
-        this._realizedItems.forEach((view, nativeView, map) => {
+        this._realizedItems.forEach((view, nativeView) => {
             if (view.parent instanceof ListView) {
                 callback(view);
             }
@@ -119,9 +119,9 @@ export class ListView extends ListViewBase {
 
     public _dumpRealizedTemplates() {
         console.log(`Realized Templates:`);
-        this._realizedTemplates.forEach((value, index, map) => {
+        this._realizedTemplates.forEach((value, index) => {
             console.log(`\t${index}:`);
-            value.forEach((value, index, map) => {
+            value.forEach((value, index) => {
                 console.log(`\t\t${index.hashCode()}: ${value}`);
             });
         });
@@ -130,7 +130,7 @@ export class ListView extends ListViewBase {
 
     private clearRealizedCells(): void {
         // clear the cache
-        this._realizedItems.forEach((view, nativeView, map) => {
+        this._realizedItems.forEach((view, nativeView) => {
             if (view.parent) {
                 // This is to clear the StackLayout that is used to wrap non LayoutBase & ProxyViewContainer instances.
                 if (!(view.parent instanceof ListView)) {


### PR DESCRIPTION
Fix disappearing list item styles when navigating back to a page.

Clear style scope when removing views instead of the `unload` event.