### PR TITLE
Network Agent implementation (Android)

### DIFF
--- a/tns-core-modules/http/http-request/http-request.android.ts
+++ b/tns-core-modules/http/http-request/http-request.android.ts
@@ -8,6 +8,8 @@ import * as fsModule from "../../file-system";
 // this is imported for definition purposes only
 import * as http from "../../http";
 
+import { NetworkAgent } from "../../debugger/debugger";
+
 export const enum HttpResponseEncoding {
     UTF8,
     GBK
@@ -73,6 +75,11 @@ function onRequestComplete(requestId: number, result: org.nativescript.widgets.A
             pair = jHeaders.get(i);
             addHeader(headers, pair.key, pair.value);
         }
+    }
+
+    // send response data (for requestId) to network debugger
+    if (global.__inspector && global.__inspector.isConnected) {
+        NetworkAgent.responseReceived(requestId, result, headers);
     }
 
     callbacks.resolveCallback({
@@ -193,6 +200,11 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
         try {
             // initialize the options
             var javaOptions = buildJavaOptions(options);
+
+            // send request data to network debugger
+            if (global.__inspector && global.__inspector.isConnected) {
+                NetworkAgent.requestWillBeSent(requestIdCounter, options);
+            }
 
             // remember the callbacks so that we can use them when the CompleteCallback is called
             var callbacks = {

--- a/tns-core-modules/module.d.ts
+++ b/tns-core-modules/module.d.ts
@@ -14,6 +14,7 @@ declare namespace NodeJS {
         Deprecated(target: Object, key?: string | symbol, descriptor?: any): any;
         Experimental(target: Object, key?: string | symbol, descriptor?: any): any;
         __native?: any;
+        __inspector?: any;
         __extends: any;
         __onLiveSync: () => void;
         __onUncaughtError: (error: NativeScriptError) => void;

--- a/tns-platform-declarations/android/org.nativescript.widgets.d.ts
+++ b/tns-platform-declarations/android/org.nativescript.widgets.d.ts
@@ -37,6 +37,8 @@
                         public raw: java.io.ByteArrayOutputStream;
                         public headers: java.util.ArrayList<KeyValuePair>;
                         public statusCode: number;
+                        public statusText: string;
+                        public url: string;
                         public responseAsString: string;
                         public responseAsImage: android.graphics.Bitmap;
                         public error: java.lang.Exception;


### PR DESCRIPTION
Add calls to runtime-exposed methods to communicate with the Network Agent of Chrome DevTools inside the android `http-request` implementation. Method calls to the Network Agent will only be made in debug and when the inspector has been fired up, meaning no overhead should occur when not debugging inside DevTools or VSCode

This PR depends on a small addition in the widgets -> https://github.com/NativeScript/tns-core-modules-widgets/pull/91
