### PR TITLE
Always attach console implementation on android

### DIFF
--- a/tns-core-modules/globals/globals.ts
+++ b/tns-core-modules/globals/globals.ts
@@ -121,7 +121,11 @@ if ((<any>global).__snapshot) {
     registerOnGlobalContext("fetch", "fetch");
 }
 
-if (!(<any>global).console) {
+// check whether the 'android' namespace is exposed
+// if positive - the current device is an Android 
+// so a custom implementation of the global 'console' object is attached.
+// otherwise do nothing on iOS - the NS runtime provides a native 'console' functionality.
+if ((<any>global).android) {
     const consoleModule = require("console");
     (<any>global).console = new consoleModule.Console();
 }


### PR DESCRIPTION
Recent fixes in the android debugger forced that the same v8 (javascript) context is used in both user code execution and devtools inspector. That meant that attaching a debugger (building in debug configuration) will apply predefined properties to the global object (`console` being one). This would cause the check in `globals` module to fail when checking whether to initialize the custom implementation. 

The proposed changes ensure that the modules' console implementation will always be used when running on Android devices, while still not polluting the iOS's global object.