### PR TITLE
Fix: attach android console implementation always when snapshot is enabled

### DIFF
--- a/tns-core-modules/globals/globals.ts
+++ b/tns-core-modules/globals/globals.ts
@@ -125,7 +125,7 @@ if ((<any>global).__snapshot) {
 // if positive - the current device is an Android 
 // so a custom implementation of the global 'console' object is attached.
 // otherwise do nothing on iOS - the NS runtime provides a native 'console' functionality.
-if ((<any>global).android) {
+if ((<any>global).android || (<any>global).__snapshot) {
     const consoleModule = require("console");
     (<any>global).console = new consoleModule.Console();
 }


### PR DESCRIPTION
Follow up of https://github.com/NativeScript/NativeScript/pull/3815

The property that identifies the android platform is not available on the global object when snapshotting, so make sure console object is attached to global.