### PR TITLE
Fix several angular animation issues

### DIFF
--- a/tns-core-modules/ui/animation/animation.android.ts
+++ b/tns-core-modules/ui/animation/animation.android.ts
@@ -35,7 +35,7 @@ propertyKeys[Properties.rotate] = Symbol(keyPrefix + Properties.rotate);
 propertyKeys[Properties.scale] = Symbol(keyPrefix + Properties.scale);
 propertyKeys[Properties.translate] = Symbol(keyPrefix + Properties.translate);
 
-export function _resolveAnimationCurve(curve: string | CubicBezierAnimationCurve | android.view.animation.Interpolator): android.view.animation.Interpolator {
+export function _resolveAnimationCurve(curve: string | CubicBezierAnimationCurve | android.view.animation.Interpolator | android.view.animation.LinearInterpolator): android.view.animation.Interpolator {
     switch (curve) {
         case "easeIn":
             if (traceEnabled()) {
@@ -70,11 +70,11 @@ export function _resolveAnimationCurve(curve: string | CubicBezierAnimationCurve
             }
             if (curve instanceof CubicBezierAnimationCurve) {
                 return (<any>android).support.v4.view.animation.PathInterpolatorCompat.create(curve.x1, curve.y1, curve.x2, curve.y2);
-            } 
-            else if (curve instanceof android.view.animation.Interpolator) {
+            } else if (curve instanceof android.view.animation.Interpolator) {
                 return curve;
-            }
-            else {
+            } else if ((<any>curve) instanceof android.view.animation.LinearInterpolator) {
+                return <android.view.animation.Interpolator><any>curve;
+            } else {
                 throw new Error(`Invalid animation curve: ${curve}`);
             }
     }

--- a/tns-core-modules/ui/animation/keyframe-animation.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.ts
@@ -212,9 +212,14 @@ export class KeyframeAnimation implements KeyframeAnimationDefinition {
             let animationDef = this.animations[index];
             (<any>animationDef).target = view;
             let animation = new Animation([animationDef]);
+            // Catch the animation cancel to prevent unhandled promise rejection warnings
             animation.play().then(() => {
                 this.animate(view, index + 1, iterations);
-            });
+            }).catch((error: any) => {
+                if (error.message.indexOf("Animation cancelled") < 0) {
+                    throw error;
+                }
+            }); // tslint:disable-line
             this._nativeAnimations.push(animation);
         }
     }

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -122,7 +122,7 @@ export class CssState {
         });
 
         let ruleAnimations: kam.KeyframeAnimationInfo[] = ruleset[animationsSymbol];
-        if (ruleAnimations && view.isLoaded && view.nativeView !== undefined) {
+        if (ruleAnimations) {
             ensureKeyframeAnimationModule();
             for (let animationInfo of ruleAnimations) {
                 let animation = keyframeAnimationModule.KeyframeAnimation.keyframeAnimationFromInfo(animationInfo);


### PR DESCRIPTION
- Not crashing when we get a LinearInterpolator for android curves.
- Always starting animations and not doing that only for fully loaded elements (nothing to start them once the element loads)
- Catch rejections in keyframe child animations to avoid unhandled rejection warnings.

Fixes NativeScript/nativescript-angular#431, NativeScript/nativescript-angular#534