### PR TITLE
Android Network Agent fix

### DIFF
--- a/tns-core-modules/debugger/debugger.ts
+++ b/tns-core-modules/debugger/debugger.ts
@@ -166,10 +166,12 @@ export namespace NetworkAgent {
     function mimeTypeToType(mimeType: string): string {
         let type: string = "Document";
 
-        if (mimeType.indexOf("image") === 0) {
-            type = "Image";
-        } else if (mimeType.indexOf("javascript") !== -1 || mimeType.indexOf("json") !== -1) {
-            type = "Script";
+        if (mimeType) {
+            if (mimeType.indexOf("image") === 0) {
+                type = "Image";
+            } else if (mimeType.indexOf("javascript") !== -1 || mimeType.indexOf("json") !== -1) {
+                type = "Script";
+            }
         }
 
         return type;


### PR DESCRIPTION
Check if mimeType is defined before assuming the response's Document type.

Otherwise navigating to a page that returns no `content-type` header in the response will result in application crash.
