### PR TITLE
Implemented feature request: TextField `maxLength` property support.

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -12,6 +12,7 @@ export abstract class EditableTextBase extends TextBase implements EditableTextB
     public editable: boolean;
     public autocorrect: boolean;
     public hint: string;
+    public maxLength: number;
 
     public abstract dismissSoftInput();
 }
@@ -42,3 +43,6 @@ autocorrectProperty.register(EditableTextBase);
 
 export const hintProperty = new Property<EditableTextBase, string>({ name: "hint", defaultValue: "" });
 hintProperty.register(EditableTextBase);
+
+export const maxLengthProperty = new Property<EditableTextBase, number>({ name: "maxLength", defaultValue: -1 });
+maxLengthProperty.register(EditableTextBase);

--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -44,5 +44,5 @@ autocorrectProperty.register(EditableTextBase);
 export const hintProperty = new Property<EditableTextBase, string>({ name: "hint", defaultValue: "" });
 hintProperty.register(EditableTextBase);
 
-export const maxLengthProperty = new Property<EditableTextBase, number>({ name: "maxLength", defaultValue: -1 });
+export const maxLengthProperty = new Property<EditableTextBase, number>({ name: "maxLength", defaultValue: Number.POSITIVE_INFINITY });
 maxLengthProperty.register(EditableTextBase);

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -2,7 +2,7 @@
     EditableTextBase as EditableTextBaseCommon, keyboardTypeProperty,
     returnKeyTypeProperty, editableProperty,
     autocapitalizationTypeProperty, autocorrectProperty, hintProperty,
-    textProperty, placeholderColorProperty, Color
+    textProperty, placeholderColorProperty, Color, maxLengthProperty
 } from "./editable-text-base-common";
 
 import { ad } from "../../utils/utils";
@@ -409,5 +409,9 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         } else {
             this.nativeView.setHintTextColor(value);
         }
+    }
+
+    [maxLengthProperty.setNative](value: number) {
+        this.nativeView.setFilters([new android.text.InputFilter.LengthFilter(+value)]);
     }
 }

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -412,6 +412,21 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     }
 
     [maxLengthProperty.setNative](value: number) {
-        this.nativeView.setFilters([new android.text.InputFilter.LengthFilter(+value)]);
+        let lengthFilter = new android.text.InputFilter.LengthFilter(+value);
+        let filters = this.nativeView.getFilters();
+        let newFilters = [];
+
+        // retain existing filters
+        for (let i = 0; i < filters.length; i++) {
+            newFilters.push(filters[i]);
+            // update an existing length filter
+            if (filters[i] instanceof android.text.InputFilter.LengthFilter) {
+                filters[i] = lengthFilter;
+                return;
+            }
+        }
+        // no current length filter found, so add it
+        newFilters.push(lengthFilter);
+        this.nativeView.setFilters(newFilters);
     }
 }

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
@@ -8,6 +8,7 @@ export const autocapitalizationTypeProperty: Property<EditableTextBase, string>;
 export const autocorrectProperty: Property<EditableTextBase, boolean>;
 export const hintProperty: Property<EditableTextBase, string>;
 export const placeholderColorProperty: CssProperty<Style, Color>;
+export const maxLengthProperty: Property<EditableTextBase, number>;
 
 /**
  * Represents the base class for all editable text views.
@@ -48,6 +49,11 @@ export class EditableTextBase extends TextBase {
      * Gets or sets the placeholder text.
      */
     hint: string;
+
+    /**
+     * Limits input to a certain number of characters.
+     */
+    maxLength: number;
 
     /**
      * Hides the soft input method, ususally a soft keyboard.

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -1,5 +1,5 @@
 ﻿import { 
-    TextFieldBase, secureProperty, textProperty, hintProperty, colorProperty, placeholderColorProperty, 
+    TextFieldBase, secureProperty, textProperty, hintProperty, colorProperty, placeholderColorProperty, maxLengthProperty,
     Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, _updateCharactersInRangeReplacementString, Color, layout
 } from "./text-field-common";
 
@@ -67,6 +67,10 @@ class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
     public textFieldShouldChangeCharactersInRangeReplacementString(textField: UITextField, range: NSRange, replacementString: string): boolean {
         const owner = this._owner.get();
         if (owner) {
+            if (owner.maxLength > -1 && owner.maxLength <= textField.text.length && replacementString.length > range.length) {
+                return false;
+            }
+
             if (owner.updateTextTrigger === "textChanged") {
                 if (textField.secureTextEntry && this.firstEdit) {
                     textProperty.nativeValueChange(owner, replacementString);
@@ -128,6 +132,7 @@ class UITextFieldImpl extends UITextField {
 export class TextField extends TextFieldBase {
     private _ios: UITextField;
     private _delegate: UITextFieldDelegateImpl;
+    private _maxLength: number = -1;
     nativeView: UITextField;
 
     constructor() {
@@ -233,5 +238,12 @@ export class TextField extends TextFieldBase {
     }
     [paddingLeftProperty.setNative](value: Length) {
         // Padding is realized via UITextFieldImpl.textRectForBounds method
+    }
+
+    [maxLengthProperty.getDefault](): number {
+        return this._maxLength;
+    }
+    [maxLengthProperty.setNative](value: number) {
+        this._maxLength = +value;
     }
 }

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -1,5 +1,5 @@
 ﻿import { 
-    TextFieldBase, secureProperty, textProperty, hintProperty, colorProperty, placeholderColorProperty, maxLengthProperty,
+    TextFieldBase, secureProperty, textProperty, hintProperty, colorProperty, placeholderColorProperty,
     Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, _updateCharactersInRangeReplacementString, Color, layout
 } from "./text-field-common";
 
@@ -67,8 +67,11 @@ class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
     public textFieldShouldChangeCharactersInRangeReplacementString(textField: UITextField, range: NSRange, replacementString: string): boolean {
         const owner = this._owner.get();
         if (owner) {
-            if (owner.maxLength > -1 && owner.maxLength <= textField.text.length && replacementString.length > range.length) {
-                return false;
+            const delta = replacementString.length - range.length;
+            if (delta > 0) {
+                if (textField.text.length + delta > owner.maxLength) {
+                    return false;
+                }
             }
 
             if (owner.updateTextTrigger === "textChanged") {
@@ -132,7 +135,6 @@ class UITextFieldImpl extends UITextField {
 export class TextField extends TextFieldBase {
     private _ios: UITextField;
     private _delegate: UITextFieldDelegateImpl;
-    private _maxLength: number = -1;
     nativeView: UITextField;
 
     constructor() {
@@ -238,12 +240,5 @@ export class TextField extends TextFieldBase {
     }
     [paddingLeftProperty.setNative](value: Length) {
         // Padding is realized via UITextFieldImpl.textRectForBounds method
-    }
-
-    [maxLengthProperty.getDefault](): number {
-        return this._maxLength;
-    }
-    [maxLengthProperty.setNative](value: number) {
-        this._maxLength = +value;
     }
 }

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -2,7 +2,7 @@
 import {
     EditableTextBase, editableProperty, hintProperty, textProperty, colorProperty, placeholderColorProperty,
     borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty,
-    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, maxLengthProperty,
+    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty,
     Length, _updateCharactersInRangeReplacementString, Color, layout
 } from "../editable-text-base";
 
@@ -52,8 +52,11 @@ class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
     public textViewShouldChangeTextInRangeReplacementText(textView: UITextView, range: NSRange, replacementString: string): boolean {
         const owner = this._owner.get();
         if (owner) {
-            if (owner.maxLength > -1 && owner.maxLength <= textView.text.length && replacementString.length > range.length) {
-                return false;
+            const delta = replacementString.length - range.length;
+            if (delta > 0) {
+                if (textView.text.length + delta > owner.maxLength) {
+                    return false;
+                }
             }
 
             if (owner.formattedText) {
@@ -69,7 +72,6 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     private _ios: UITextView;
     private _delegate: UITextViewDelegateImpl;
     private _isShowingHint: boolean;
-    private _maxLength: number = -1;
 
     constructor() {
         super();
@@ -274,13 +276,6 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
         let inset = this.nativeView.textContainerInset;
         let left = layout.toDeviceIndependentPixels(this.effectivePaddingLeft + this.effectiveBorderLeftWidth);
         this.nativeView.textContainerInset = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
-    }
-
-    [maxLengthProperty.getDefault](): number {
-        return this._maxLength;
-    }
-    [maxLengthProperty.setNative](value: number) {
-        this._maxLength = +value;
     }
 }
 

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -2,7 +2,7 @@
 import {
     EditableTextBase, editableProperty, hintProperty, textProperty, colorProperty, placeholderColorProperty,
     borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty,
-    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, 
+    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, maxLengthProperty,
     Length, _updateCharactersInRangeReplacementString, Color, layout
 } from "../editable-text-base";
 
@@ -51,8 +51,14 @@ class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
 
     public textViewShouldChangeTextInRangeReplacementText(textView: UITextView, range: NSRange, replacementString: string): boolean {
         const owner = this._owner.get();
-        if (owner && owner.formattedText) {
-            _updateCharactersInRangeReplacementString(owner.formattedText, range.location, range.length, replacementString);
+        if (owner) {
+            if (owner.maxLength > -1 && owner.maxLength <= textView.text.length && replacementString.length > range.length) {
+                return false;
+            }
+
+            if (owner.formattedText) {
+                _updateCharactersInRangeReplacementString(owner.formattedText, range.location, range.length, replacementString);
+            }
         }
 
         return true;
@@ -63,6 +69,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     private _ios: UITextView;
     private _delegate: UITextViewDelegateImpl;
     private _isShowingHint: boolean;
+    private _maxLength: number = -1;
 
     constructor() {
         super();
@@ -267,6 +274,13 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
         let inset = this.nativeView.textContainerInset;
         let left = layout.toDeviceIndependentPixels(this.effectivePaddingLeft + this.effectiveBorderLeftWidth);
         this.nativeView.textContainerInset = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
+    }
+
+    [maxLengthProperty.getDefault](): number {
+        return this._maxLength;
+    }
+    [maxLengthProperty.setNative](value: number) {
+        this._maxLength = +value;
     }
 }
 


### PR DESCRIPTION
Implements #3614

Based on the code samples @tsonevn supplied. Works like a boss in both `TextField` and `TextView` on iOS and Android.

_I would have loved to add some tests, but for the life of me I can't seem to run them. I tried following the suggestions in the readme's but to no avail._