### PR TITLE
text-decoration won’t be applied to edit-text

### DIFF
--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -320,8 +320,8 @@ function printRunTestStats() {
     testFile.writeTextSync(testFileContent.join(""));
 
     finalMessage += "\n" + "Test results: " + testFilePath;
-    finalMessage += "\n" + "----------------- ";
-    finalMessage += "\n" + "Slow tests: ";
+    // finalMessage += "\n" + "----------------- ";
+    // finalMessage += "\n" + "Slow tests: ";
     // slowTests.forEach((message, i, arr) => {
     //     TKUnit.write(message, messageType.error);
     //     finalMessage += "\n" + message;

--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -322,10 +322,10 @@ function printRunTestStats() {
     finalMessage += "\n" + "Test results: " + testFilePath;
     finalMessage += "\n" + "----------------- ";
     finalMessage += "\n" + "Slow tests: ";
-    slowTests.forEach((message, i, arr) => {
-        TKUnit.write(message, messageType.error);
-        finalMessage += "\n" + message;
-    });
+    // slowTests.forEach((message, i, arr) => {
+    //     TKUnit.write(message, messageType.error);
+    //     finalMessage += "\n" + message;
+    // });
 
     let stack = new StackLayout();
     let btn = new Button();

--- a/tests/app/ui/styling/style-properties-tests.ts
+++ b/tests/app/ui/styling/style-properties-tests.ts
@@ -729,7 +729,7 @@ export const test_setting_label_textTransform_sets_native = function () {
 };
 
 export const test_setting_textField_textTransform_sets_native = function () {
-    if (isAndroid) {
+    if (isIOS) {
         const testView = new TextField();
         testView.text = initial;
         testView.style.textTransform = "capitalize";
@@ -739,7 +739,7 @@ export const test_setting_textField_textTransform_sets_native = function () {
 };
 
 export const test_setting_textView_textTransform_sets_native = function () {
-    if (isAndroid) {
+    if (isIOS) {
         const testView = new TextView();
         testView.text = initial;
         testView.style.textTransform = "capitalize";
@@ -766,7 +766,7 @@ export const test_setting_label_textTransform_and_textDecoration_sets_native = f
 };
 
 export const test_setting_textField_textTransform_and_textDecoration_sets_native = function () {
-    if (isAndroid) {
+    if (isIOS) {
         const testView = new TextField();
         testView.text = initial;
         testView.style.textTransform = "capitalize";
@@ -777,7 +777,7 @@ export const test_setting_textField_textTransform_and_textDecoration_sets_native
 };
 
 export const test_setting_textView_textTransform_and_textDecoration_sets_native = function () {
-    if (isAndroid) {
+    if (isIOS) {
         const testView = new TextView();
         testView.text = initial;
         testView.style.textTransform = "capitalize";

--- a/tests/app/ui/styling/style-properties-tests.ts
+++ b/tests/app/ui/styling/style-properties-tests.ts
@@ -729,19 +729,23 @@ export const test_setting_label_textTransform_sets_native = function () {
 };
 
 export const test_setting_textField_textTransform_sets_native = function () {
-    const testView = new TextField();
-    testView.text = initial;
-    testView.style.textTransform = "capitalize";
+    if (isAndroid) {
+        const testView = new TextField();
+        testView.text = initial;
+        testView.style.textTransform = "capitalize";
 
-    executeTransformTest(testView, androidText, iOSText);
+        executeTransformTest(testView, androidText, iOSText);
+    }
 };
 
 export const test_setting_textView_textTransform_sets_native = function () {
-    const testView = new TextView();
-    testView.text = initial;
-    testView.style.textTransform = "capitalize";
+    if (isAndroid) {
+        const testView = new TextView();
+        testView.text = initial;
+        testView.style.textTransform = "capitalize";
 
-    executeTransformTest(testView, androidText, iOSText);
+        executeTransformTest(testView, androidText, iOSText);
+    }
 };
 
 export const test_setting_button_textTransform_sets_native = function () {
@@ -762,21 +766,25 @@ export const test_setting_label_textTransform_and_textDecoration_sets_native = f
 };
 
 export const test_setting_textField_textTransform_and_textDecoration_sets_native = function () {
-    const testView = new TextField();
-    testView.text = initial;
-    testView.style.textTransform = "capitalize";
-    testView.style.textDecoration = "underline";
+    if (isAndroid) {
+        const testView = new TextField();
+        testView.text = initial;
+        testView.style.textTransform = "capitalize";
+        testView.style.textDecoration = "underline";
 
-    executeTransformTest(testView, androidText, iOSText);
+        executeTransformTest(testView, androidText, iOSText);
+    }
 };
 
 export const test_setting_textView_textTransform_and_textDecoration_sets_native = function () {
-    const testView = new TextView();
-    testView.text = initial;
-    testView.style.textTransform = "capitalize";
-    testView.style.textDecoration = "underline";
+    if (isAndroid) {
+        const testView = new TextView();
+        testView.text = initial;
+        testView.style.textTransform = "capitalize";
+        testView.style.textDecoration = "underline";
 
-    executeTransformTest(testView, androidText, iOSText);
+        executeTransformTest(testView, androidText, iOSText);
+    }
 };
 
 export const test_setting_button_textTransform_and_textDecoration_sets_native = function () {

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -2,7 +2,7 @@
     EditableTextBase as EditableTextBaseCommon, keyboardTypeProperty,
     returnKeyTypeProperty, editableProperty,
     autocapitalizationTypeProperty, autocorrectProperty, hintProperty,
-    textProperty, placeholderColorProperty, Color
+    textProperty, placeholderColorProperty, Color, textTransformProperty
 } from "./editable-text-base-common";
 
 import { ad } from "../../utils/utils";
@@ -409,5 +409,9 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         } else {
             this.nativeView.setHintTextColor(value);
         }
+    }
+
+    [textTransformProperty.setNative](value: "default") {
+        //
     }
 }


### PR DESCRIPTION
Default implementation use `setTransformationMethod` which throws exception in android. On top of that`getTransformation` is not called when user is typing so we can't change the text. A possible implementation would be to use `InputType`