### PR TITLE
Ensure navigation title view is removed if undefined

### DIFF
--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -93,6 +93,8 @@ export class ActionBar extends ActionBarBase {
 
         if (this.titleView && this.titleView.ios) {
             navigationItem.titleView = this.titleView.ios;
+        } else {
+            navigationItem.titleView = null;
         }
 
         // Find previous ViewController in the navigation stack
@@ -119,7 +121,7 @@ export class ActionBar extends ActionBarBase {
             img = fromFileOrResource(this.navigationButton.icon);
         }
 
-        // TODO: This could cause issue when canceling BackEdge gesture - we will change the backIndicator to 
+        // TODO: This could cause issue when canceling BackEdge gesture - we will change the backIndicator to
         // show the one from the old page but the new page will still be visible (because we canceled EdgeBackSwipe gesutre)
         // Consider moving this to new method and call it from - navigationControllerDidShowViewControllerAnimated.
         if (img && img.ios) {
@@ -132,7 +134,7 @@ export class ActionBar extends ActionBarBase {
             navigationBar.backIndicatorTransitionMaskImage = null;
         }
 
-        // Set back button visibility 
+        // Set back button visibility
         if (this.navigationButton) {
             navigationItem.setHidesBackButtonAnimated(!isVisible(this.navigationButton), true);
         }


### PR DESCRIPTION
Thanks to @lfabreges for making the original PR. This is the same PR as #3585, but rebased onto mater.

# Original PR Description:
This small PR is useful to ensure that the titleView is reset when using multiples ActionBar on iOS. Bellow an example with angular and tabs:

First tab:
```xml
<ActionBar *ngIf="selected" class="action-bar" title="{{ 'page.home.title' | L }}">
  <ActionItem (tap)="goToAdd()"
              ios.systemIcon="4" ios.position="right"
              android.systemIcon="ic_menu_add" android.position="actionBar">
  </ActionItem>
</ActionBar>
```

Second tab:
```xml
<ActionBar *ngIf="selected" class="action-bar" title="{{ 'page.search.title' | L }}">
  <SearchBar hint="Search..."></SearchBar>
</ActionBar>
```

If I navigate to the second tab, the search bar is shown, then when I navigate back to the first tab, it isn't removed, this PR ensure that it is.
