### PR TITLE
Fix animation's "Reset"

### DIFF
--- a/tns-core-modules/ui/animation/animation.android.ts
+++ b/tns-core-modules/ui/animation/animation.android.ts
@@ -92,6 +92,7 @@ export class Animation extends AnimationBase {
     constructor(animationDefinitions: Array<AnimationDefinitionInternal>, playSequentially?: boolean) {
         super(animationDefinitions, playSequentially);
 
+        this._valueSource = "animation";
         if (animationDefinitions.length > 0 && animationDefinitions[0].valueSource !== undefined) {
             this._valueSource = animationDefinitions[0].valueSource;
         }
@@ -275,7 +276,7 @@ export class Animation extends AnimationBase {
                 animator.addUpdateListener(new android.animation.ValueAnimator.AnimatorUpdateListener({
                     onAnimationUpdate(animator: android.animation.ValueAnimator) {
                         let argb = (<java.lang.Integer>animator.getAnimatedValue()).intValue();
-                        propertyAnimation.target.style[backgroundColorProperty.cssName] = new Color(argb);
+                        propertyAnimation.target.style[setLocal ? backgroundColorProperty.name : backgroundColorProperty.keyframe] = new Color(argb);
                     }
                 }));
 

--- a/tns-core-modules/ui/animation/animation.ios.ts
+++ b/tns-core-modules/ui/animation/animation.ios.ts
@@ -153,6 +153,7 @@ export class Animation extends AnimationBase {
     constructor(animationDefinitions: Array<AnimationDefinitionInternal>, playSequentially?: boolean) {
         super(animationDefinitions, playSequentially);
 
+        this._valueSource = "animation";
         if (animationDefinitions.length > 0 && animationDefinitions[0].valueSource !== undefined) {
             this._valueSource = animationDefinitions[0].valueSource;
         }

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -339,7 +339,7 @@ export class View extends ViewCommon {
         return this.nativeView.getAlpha();
     }
     [opacityProperty.setNative](value: number) {
-        this.nativeView.setAlpha(value);
+        this.nativeView.setAlpha(float(value));
     }
 
     [horizontalAlignmentProperty.getDefault](): HorizontalAlignment {


### PR DESCRIPTION
Animations were always played as keyframes and kept overriding the local values. Android setAlpha has deprecated int overload, now it is guided to use the float one. Android background color was animated using css values instead of local or the keyframe one.
