### PR TITLE
Fix: TextAlign initial value

### DIFF
--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -109,7 +109,7 @@ export class TextBase extends TextBaseCommon {
     }
 
     [textAlignmentProperty.getDefault](): TextAlignment {
-        return "left";
+        return "initial";
     }
     [textAlignmentProperty.setNative](value: TextAlignment) {
         let verticalGravity = this.nativeView.getGravity() & android.view.Gravity.VERTICAL_GRAVITY_MASK;


### PR DESCRIPTION
The default value of `text-align` should be initial. This way you can reset property properly.