### PR TITLE
FIX: Crash when setting autocapitalizationType=allCharacters in xml 

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -38,7 +38,7 @@ editableProperty.register(EditableTextBase);
 export const updateTextTriggerProperty = new Property<EditableTextBase, UpdateTextTrigger>({ name: "updateTextTrigger", defaultValue: "textChanged" });
 updateTextTriggerProperty.register(EditableTextBase);
 
-const autocapitalizationTypeConverter = makeParser<AutocapitalizationType>(makeValidator<AutocapitalizationType>("none", "words", "sentences", "allCharacters"));
+const autocapitalizationTypeConverter = makeParser<AutocapitalizationType>(makeValidator<AutocapitalizationType>("none", "words", "sentences", "allcharacters"));
 
 export const autocapitalizationTypeProperty = new Property<EditableTextBase, AutocapitalizationType>({ name: "autocapitalizationType", defaultValue: "sentences", valueConverter: autocapitalizationTypeConverter });
 autocapitalizationTypeProperty.register(EditableTextBase);

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -321,14 +321,14 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         }
     }
 
-    [autocapitalizationTypeProperty.getDefault](): "none" | "words" | "sentences" | "allCharacters" | string {
+    [autocapitalizationTypeProperty.getDefault](): "none" | "words" | "sentences" | "allcharacters" | string {
         let inputType = this.nativeView.getInputType();
         if ((inputType & android.text.InputType.TYPE_TEXT_FLAG_CAP_WORDS) === android.text.InputType.TYPE_TEXT_FLAG_CAP_WORDS) {
             return "words";
         } else if ((inputType & android.text.InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) === android.text.InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) {
             return "sentences";
         } else if ((inputType & android.text.InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) === android.text.InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) {
-            return "allCharacters";
+            return "allcharacters";
         } else {
             return inputType.toString();
         }
@@ -347,7 +347,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
             case "sentences":
                 inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_CAP_SENTENCES; //16384(0x00040000) 15th bit
                 break;
-            case "allCharacters":
+            case "allcharacters":
                 inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS; //4096 (0x00010000) 13th bit
                 break;
             default:

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
@@ -48,7 +48,7 @@ export class EditableTextBase extends TextBase {
 export type KeyboardType = "datetime" | "phone" | "number" | "url" | "email";
 export type ReturnKeyType = "done" | "next" | "go" | "search" | "send";
 export type UpdateTextTrigger = "focusLost" | "textChanged";
-export type AutocapitalizationType = "none" | "words" | "sentences" | "allCharacters";
+export type AutocapitalizationType = "none" | "words" | "sentences" | "allcharacters";
 
 export const keyboardTypeProperty: Property<EditableTextBase, KeyboardType>;
 export const returnKeyTypeProperty: Property<EditableTextBase, ReturnKeyType>;

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
@@ -120,7 +120,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         this.nativeView.returnKeyType = newValue;
     }
 
-    [autocapitalizationTypeProperty.getDefault](): "none" | "words" | "sentences" | "allCharacters" {
+    [autocapitalizationTypeProperty.getDefault](): "none" | "words" | "sentences" | "allcharacters" {
         let autocapitalizationType = this.nativeView.autocapitalizationType;
         switch (autocapitalizationType) {
             case UITextAutocapitalizationType.None:
@@ -133,13 +133,13 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 return "sentences";
 
             case UITextAutocapitalizationType.AllCharacters:
-                return "allCharacters";
+                return "allcharacters";
 
             default:
                 throw new Error("Invalid autocapitalizationType value:" + autocapitalizationType);
         }
     }
-    [autocapitalizationTypeProperty.setNative](value: "none" | "words" | "sentences" | "allCharacters") {
+    [autocapitalizationTypeProperty.setNative](value: "none" | "words" | "sentences" | "allcharacters") {
         let newValue: UITextAutocapitalizationType;
         switch (value) {
             case "none":
@@ -151,7 +151,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
             case "sentences":
                 newValue = UITextAutocapitalizationType.Sentences;
                 break;
-            case "allCharacters":
+            case "allcharacters":
                 newValue = UITextAutocapitalizationType.AllCharacters;
                 break;
             default:

--- a/tns-core-modules/ui/enums/enums.ts
+++ b/tns-core-modules/ui/enums/enums.ts
@@ -108,7 +108,7 @@ export module AutocapitalizationType {
     export var none: string = "none";
     export var words: string = "words";
     export var sentences: string = "sentences";
-    export var allCharacters: string = "allCharacters";
+    export var allCharacters: string = "allcharacters";
 }
 
 export module NavigationBarVisibility {


### PR DESCRIPTION
Property values should be lowercased to pass validation.