### PR TITLE
ImageView clear bitmap only when src is null/undefined

### DIFF
--- a/tns-core-modules/ui/image/image.android.ts
+++ b/tns-core-modules/ui/image/image.android.ts
@@ -66,17 +66,18 @@ export class Image extends ImageBase {
     }
 
     public _createImageSourceFromSrc() {
-        let imageView = this.nativeView;
-        if (imageView) {
-            imageView.setUri(null, 0, 0, false, true);
-        }
-
-        if (!imageView || !this.src) {
+        const imageView = this.nativeView;
+        if (!imageView) {
             return;
         }
 
         let value = this.src;
-        let async = this.loadMode === ASYNC;
+        if (!value) {
+            imageView.setUri(null, 0, 0, false, true);
+            return;
+        }
+
+        const async = this.loadMode === ASYNC;
 
         if (typeof value === "string" || value instanceof String) {
             value = value.trim();


### PR DESCRIPTION
This fix image view losing bitmap when ImageSource was set.
