### PR TITLE
Fixes ios modal layout issue #4151

### DIFF
--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -343,7 +343,7 @@ export class Page extends PageBase {
 
     public requestLayout(): void {
         super.requestLayout();
-        if (!this.parent && this.ios && this.nativeView) {
+        if ((!this.parent || this._modalParent) && this.ios && this.nativeView) {
             this.nativeView.setNeedsLayout();
         }
     }


### PR DESCRIPTION
it needs to be considered for merging.
=
Before 3.0.0, Page class calls setNeedsLayout() by it self. 

After commit:6b61335675587343f053b6f6607eae9e3f7907f1. Page class belongs parent Frame class.  Frame class also calls setNeedsLayout()  on this requestLayout(). 

But in condition a Page is Modal Page , Parent Frame class can't get "nativeView.window' , so the frame class fails to call setNeedsLayout().  And child Page class doesn't call setNeedsLayout() if they have parent property(before 3.0.0, modal page doesn't have parent)

I tried to get window by UIApplication.sharedApplication().delegate.window or UIApplica.....windows.first  in Frame class, but setNeedsLayout() doesn't update modal controls.

I am not expert for ios native application. so I don't know about this behavior.

This PR is just workaround to let Page class calls setNeedsLayout() when it is Modal like before 3.0.0.

I checked this by sample application for issue #4151 and some of my application and seems working fine.
 