### PR TITLE
[do not merge] Performance improvements after profiling the iOS flexbox example

### DIFF
--- a/tests/app/ui/styling/style-properties-tests.ts
+++ b/tests/app/ui/styling/style-properties-tests.ts
@@ -603,9 +603,12 @@ function test_native_font(style: "normal" | "italic", weight: "100" | "200" | "3
         fontNameSuffix += "Italic";
     }
 
-    if (testView.ios) {
-        TKUnit.assertEqual((<UIButton>testView.ios).titleLabel.font.fontName.toLowerCase(), (fontName + "-" + fontNameSuffix).toLowerCase(), "native font " + weight + " " + style);
-    }
+    helper.buildUIAndRunTest(testView, function (views: Array<View>) {
+        if (isIOS) {
+            TKUnit.assertEqual((<UIButton>testView.ios).titleLabel.font.fontName.toLowerCase(), (fontName + "-" + fontNameSuffix).toLowerCase(), "native font " + weight + " " + style);
+        }
+    });
+
     //TODO: If needed add tests for other platforms
 }
 

--- a/tests/app/ui/view/view-tests.ios.ts
+++ b/tests/app/ui/view/view-tests.ios.ts
@@ -87,6 +87,8 @@ export function testBackgroundInternalChangedOnceOnResize() {
 export function test_automation_text_set_to_native() {
     var newButton = new button.Button();
     newButton.automationText = "Button1";
-    TKUnit.assertEqual((<UIView>newButton.ios).accessibilityIdentifier, "Button1", "accessibilityIdentifier not set to native view.");
-    TKUnit.assertEqual((<UIView>newButton.ios).accessibilityLabel, "Button1", "accessibilityIdentifier not set to native view.");
+    helper.buildUIAndRunTest(newButton, function (views: Array<view.View>) {
+        TKUnit.assertEqual((<UIView>newButton.ios).accessibilityIdentifier, "Button1", "accessibilityIdentifier not set to native view.");
+        TKUnit.assertEqual((<UIView>newButton.ios).accessibilityLabel, "Button1", "accessibilityIdentifier not set to native view.");
+    });
 }

--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -101,7 +101,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
             const changed: boolean = equalityComparer ? !equalityComparer(currentValue, unboxedValue) : currentValue !== unboxedValue;
 
             if (wrapped || changed) {
-                const setNativeValue = this.nativeView && this[setNative];
+                const setNativeValue = this._nativeViewCreated && this[setNative];
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {
@@ -159,7 +159,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
                     valueChanged(owner, currentValue, value);
                 }
 
-                if (owner.nativeView && !(defaultValueKey in owner)) {
+                if (owner._nativeViewCreated && !(defaultValueKey in owner)) {
                     owner[defaultValueKey] = owner[getDefault] ? owner[getDefault]() : defaultValue;
                 }
 
@@ -246,7 +246,7 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
             const changed: boolean = equalityComparer ? !equalityComparer(currentValue, unboxedValue) : currentValue !== unboxedValue;
 
             if (wrapped || changed) {
-                const setNativeValue = this.nativeView && this[setNative];
+                const setNativeValue = this._nativeViewCreated && this[setNative];
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {
@@ -432,7 +432,7 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
 
             if (changed) {
                 const view = this.view;
-                const setNativeValue = view.nativeView && view[setNative];
+                const setNativeValue = view._nativeViewCreated && view[setNative];
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {
@@ -502,7 +502,7 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
 
             if (changed) {
                 const view = this.view;
-                const setNativeValue = view.nativeView && view[setNative];
+                const setNativeValue = view._nativeViewCreated && view[setNative];
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {
@@ -677,7 +677,7 @@ export class CssAnimationProperty<T extends Style, U> {
                         if (valueChanged) {
                             valueChanged(this, prev, next);
                         }
-                        if (this.view.nativeView && this.view[setNative]) {
+                        if (this.view._nativeViewCreated && this.view[setNative]) {
                             this.view[setNative](next);
                         }
                         if (this.hasListeners(eventName)) {
@@ -786,7 +786,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 
             if (changed) {
                 const view = this.view;
-                const setNativeValue = view.nativeView && view[setNative];
+                const setNativeValue = view._nativeViewCreated && view[setNative];
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -96,6 +96,10 @@ export abstract class ViewBase extends Observable {
      * @private
      */
     _defaultPaddingLeft: number;
+    /**
+     * @private
+     */
+    _nativeViewCreated: boolean;
     //@endprivate
 
     public effectiveMinWidth: number;

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -176,6 +176,8 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     _oldRight: number;
     _oldBottom: number;
 
+    _nativeViewCreated: boolean;
+
     public effectiveMinWidth: number;
     public effectiveMinHeight: number;
     public effectiveWidth: number;
@@ -681,18 +683,16 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
                 this.nativeView = this._iosView = nativeView;
             }
         }
-
         this.initNativeView();
+
+        this._nativeViewCreated = !!this.nativeView;
+        if (this._nativeViewCreated) {
+            initNativeView(this);
+        }
 
         if (this.parent) {
             let nativeIndex = this.parent._childIndexToNativeChildIndex(atIndex);
             this._isAddedToNativeVisualTree = this.parent._addViewToNativeVisualTree(this, nativeIndex);
-        }
-
-        if (this.nativeView) {
-            if (currentNativeView !== this.nativeView) {
-                initNativeView(this);
-            }
         }
 
         this.eachChild((child) => {
@@ -731,6 +731,8 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         }
 
         this.disposeNativeView();
+
+        this._nativeViewCreated = false;
 
         if (isAndroid) {
             this.nativeView = null;
@@ -865,6 +867,7 @@ ViewBase.prototype._defaultPaddingBottom = 0;
 ViewBase.prototype._defaultPaddingLeft = 0;
 
 ViewBase.prototype._batchUpdateScope = 0;
+ViewBase.prototype._nativeViewCreated = false;
 
 export const bindingContextProperty = new InheritedProperty<ViewBase, any>({ name: "bindingContext" });
 bindingContextProperty.register(ViewBase);

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -214,6 +214,7 @@ export class TabViewItem extends TabViewItemBase {
 
     public setNativeView(textView: android.widget.TextView): void {
         this.nativeView = textView;
+        this._nativeViewCreated = !!textView;
         if (textView) {
             initNativeView(this);
         }


### PR DESCRIPTION
The native property updates are not suspended while the view is initialised and the views end up consuming too much time creating backgrounds for iOS. Background color is created 4 times when border width is set, 4 times when corner radius is set and 2 more times for border and background color setters. The PRs _nativeViewCreated flags is intended to suspend updates for a while (from the View constructor to the time createNativeView is called) but the implementation is weak as some Views set nativeView using means other than createNativeView/resetNativeView pair (e.g. TabView assigns TabViewItems nativeView, probably segmented bar does too).   