### PR TITLE
Fix: ActionBar update in IOS with modal dialogs

### DIFF
--- a/apps/app/ui-tests-app/action-bar/main-page.ts
+++ b/apps/app/ui-tests-app/action-bar/main-page.ts
@@ -18,6 +18,8 @@ export function pageLoaded(args: EventData) {
     examples.set("actionItemPosition", "action-bar/action-item-position");
     examples.set("actBGCss", "action-bar/background-css");
     examples.set("actTransparentBgCss", "action-bar/transparent-bg-css");
+    examples.set("modalHiddenActBar", "action-bar/modal-test-hidden-action-bar");
+    examples.set("modalShownActBar", "action-bar/modal-test-with-action-bar");
 
     let viewModel = new SubMainPageViewModel(wrapLayout, examples);
     page.bindingContext = viewModel;

--- a/apps/app/ui-tests-app/action-bar/modal-page-hidden-action-bar.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-page-hidden-action-bar.ts
@@ -1,0 +1,11 @@
+import { ShownModallyData } from "tns-core-modules/ui/page";
+
+let closeCallback: Function;
+
+export function onShownModally(args: ShownModallyData) {
+    closeCallback = args.closeCallback;
+}
+
+export function onTap() {
+    closeCallback("sample text");
+}

--- a/apps/app/ui-tests-app/action-bar/modal-page-hidden-action-bar.xml
+++ b/apps/app/ui-tests-app/action-bar/modal-page-hidden-action-bar.xml
@@ -1,0 +1,5 @@
+<Page showingModally="onShownModally" actionBarHidden="true">
+    <StackLayout id="layout" >
+        <Button text="Close" tap="onTap" />
+    </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/action-bar/modal-page.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-page.ts
@@ -1,0 +1,11 @@
+import { ShownModallyData } from "tns-core-modules/ui/page";
+
+let closeCallback: Function;
+
+export function onShownModally(args: ShownModallyData) {
+    closeCallback = args.closeCallback;
+}
+
+export function onTap() {
+    closeCallback("sample text");
+}

--- a/apps/app/ui-tests-app/action-bar/modal-page.xml
+++ b/apps/app/ui-tests-app/action-bar/modal-page.xml
@@ -1,0 +1,5 @@
+<Page showingModally="onShownModally">
+    <StackLayout id="layout" >
+        <Button text="Close" tap="onTap" />
+    </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/action-bar/modal-test-hidden-action-bar.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-test-hidden-action-bar.ts
@@ -1,0 +1,13 @@
+import { EventData } from "tns-core-modules/data/observable";
+import { Page } from "tns-core-modules/ui/page";
+import { topmost } from "tns-core-modules/ui/frame";
+
+export function btnClick(args: EventData) {
+    (<Page>args.object).page.showModal("ui-tests-app/action-bar/modal-page", "", function (arg: string) {
+        // ...
+    }, true);
+}
+
+export function btnBack(args: EventData) {
+    topmost().goBack();
+}

--- a/apps/app/ui-tests-app/action-bar/modal-test-hidden-action-bar.xml
+++ b/apps/app/ui-tests-app/action-bar/modal-test-hidden-action-bar.xml
@@ -1,0 +1,6 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" actionBarHidden="true">
+  <StackLayout>
+    <button text="Open Modal" tap="btnClick" />
+    <button text="Go Back" tap="btnBack" />
+  </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/action-bar/modal-test-with-action-bar.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-test-with-action-bar.ts
@@ -1,0 +1,13 @@
+import { EventData } from "tns-core-modules/data/observable";
+import { Page } from "tns-core-modules/ui/page";
+import { topmost } from "tns-core-modules/ui/frame";
+
+export function btnClick(args: EventData) {
+    (<Page>args.object).page.showModal("ui-tests-app/action-bar/modal-page-hidden-action-bar", "", function (arg: string) {
+        // ...
+    }, true);
+}
+
+export function btnBack(args: EventData) {
+    topmost().goBack();
+}

--- a/apps/app/ui-tests-app/action-bar/modal-test-with-action-bar.xml
+++ b/apps/app/ui-tests-app/action-bar/modal-test-with-action-bar.xml
@@ -1,0 +1,15 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd">
+  <Page.actionBar>
+      <ActionBar backgroundColor="green" title="Main View" icon="">
+          <NavigationButton text="Back" icon="" tap="" />
+          <ActionBar.actionItems>
+              <ActionItem icon="" text="Left" tap="" ios.position="left" />
+              <ActionItem icon="" text="Right" tap="" ios.position="right" />
+          </ActionBar.actionItems>
+      </ActionBar>
+  </Page.actionBar>
+  <StackLayout>
+    <button text="Open Modal" tap="btnClick" />
+    <button text="Go Back" tap="btnBack" />
+  </StackLayout>
+</Page>

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -45,7 +45,7 @@ export class Frame extends FrameBase {
         super();
         this._ios = new iOSFrame(this);
         this.nativeView = this._ios.controller.view;
-        
+
         // When there is a 40px high "in-call" status bar, nobody moves the navigationBar top from 20 to 40 and it remains underneath the status bar.
         let frameRef = new WeakRef(this);
         application.ios.addNotificationObserver(UIApplicationDidChangeStatusBarFrameNotification, (notification: NSNotification) => {
@@ -201,6 +201,10 @@ export class Frame extends FrameBase {
     public _updateActionBar(page?: Page, disableNavBarAnimation: boolean = false): void {
 
         super._updateActionBar(page);
+
+        if (page && this.currentPage && this.currentPage.modal === page) {
+            return;
+        }
 
         page = page || this.currentPage;
         let newValue = this._getNavBarVisible(page);


### PR DESCRIPTION
Related to #4157 and #4141
Fixes action bar incorrectly updating when showing modal dialogs in IOS.
Two ui tests scenarios added in `ui-tests-app`:
* (#4141) Go to `action-bar -> modalShownActBar` page. Open and then close the modal. The action bar should be visible after closing.
* (#4157) Go to `action-bar -> modalHiddenActBar` page. Open and then close the modal. The action bar should remain hidden after closing.

CC @SvetoslavTsenov @tsonevn 
