### PR TITLE
App "displayed" event

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -21,6 +21,7 @@ import { UnhandledErrorEventData, iOSApplication, AndroidApplication, CssChanged
 
 export const launchEvent = "launch";
 export const suspendEvent = "suspend";
+export const displayedEvent = "displayed";
 export const resumeEvent = "resume";
 export const exitEvent = "exit";
 export const lowMemoryEvent = "lowMemory";
@@ -45,6 +46,7 @@ export let ios = undefined;
 export const on: typeof events.on = events.on.bind(events);
 export const off: typeof events.off = events.off.bind(events);
 export const notify: typeof events.notify = events.notify.bind(events);
+export const hasListeners: typeof events.hasListeners = events.hasListeners.bind(events);
 
 let app: iOSApplication | AndroidApplication;
 export function setApplication(instance: iOSApplication | AndroidApplication): void {

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -195,7 +195,9 @@ export function hasListeners(eventName: string): boolean;
 export function on(event: "launch", callback: (args: LaunchEventData) => void, thisArg?: any);
 
 /**
- * This event is raised after the application has launched and was fully drawn.
+ * This event is raised after the application has performed most of its startup actions.
+ * Its intent is to be suitable for measuring app startup times.
+ * @experimental
  */
 export function on(event: "displayed", callback: (args: EventData) => void, thisArg?: any);
 

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -12,6 +12,11 @@ import { NavigationEntry, View, Observable, EventData } from "../ui/frame";
 export var launchEvent: string;
 
 /**
+ * String value used when hooking to displayed event.
+ */
+export var displayedEvent: string;
+
+/**
  * String value used when hooking to uncaughtError event.
  */
 export var uncaughtErrorEvent: string;
@@ -188,6 +193,11 @@ export function hasListeners(eventName: string): boolean;
  * This event is raised on application launchEvent.
  */
 export function on(event: "launch", callback: (args: LaunchEventData) => void, thisArg?: any);
+
+/**
+ * This event is raised after the application has launched and was fully drawn.
+ */
+export function on(event: "displayed", callback: (args: EventData) => void, thisArg?: any);
 
 /**
  * This event is raised when the Application is suspended.

--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -2,7 +2,7 @@
 
 import {
     notify, launchEvent, resumeEvent, suspendEvent, exitEvent, lowMemoryEvent,
-    orientationChangedEvent, setApplication, livesync
+    orientationChangedEvent, setApplication, livesync, displayedEvent
 } from "./application-common";
 
 // First reexport so that app module is initialized.
@@ -15,6 +15,8 @@ import * as utils from "../utils/utils";
 class Responder extends UIResponder {
     //
 }
+
+let displayedOnce = false;
 
 class Window extends UIWindow {
     public content;
@@ -138,7 +140,13 @@ class IOSApplication implements IOSApplicationDefinition {
     }
 
     private didBecomeActive(notification: NSNotification) {
-        notify(<ApplicationEventData>{ eventName: resumeEvent, object: this, ios: utils.ios.getter(UIApplication, UIApplication.sharedApplication) });
+        let ios = utils.ios.getter(UIApplication, UIApplication.sharedApplication);
+        let object = this;
+        notify(<ApplicationEventData>{ eventName: resumeEvent, object, ios });
+        if (!displayedOnce) {
+            notify(<ApplicationEventData>{ eventName: displayedEvent, object, ios });
+            displayedOnce = true;
+        }
     }
 
     private didEnterBackground(notification: NSNotification) {


### PR DESCRIPTION
This event is launched at the latest possible moment I've found that can be used to track app start time. This event takes about 300ms in iOS and about 1 sec. more in Android than the time to "launched".