### PR TITLE
Change onReturnPress to non abstract

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -139,7 +139,9 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
     public abstract _configureEditText(editText: android.widget.EditText): void;
 
-    public abstract _onReturnPress(): void;
+    public _onReturnPress(): void {
+        //
+    }
 
     public createNativeView() {
         initializeEditTextListeners();


### PR DESCRIPTION
so that TextView doesn’t throw exception when Return is pressed.

Fix https://github.com/NativeScript/NativeScript/issues/4123