### PR TITLE
switch in iOS cannot have different size than 51/31. Setting it in on…

### DIFF
--- a/tns-core-modules/ui/switch/switch.ios.ts
+++ b/tns-core-modules/ui/switch/switch.ios.ts
@@ -37,6 +37,8 @@ export class Switch extends SwitchBase {
         this._handler = SwitchChangeHandlerImpl.initWithOwner(new WeakRef(this));
         nativeView.addTargetActionForControlEvents(this._handler, "valueChanged", UIControlEvents.ValueChanged);
         this.nativeView = nativeView;
+        this.width = 51;
+        this.height = 31;
     }
 
     get ios(): UISwitch {


### PR DESCRIPTION
…Measure is late.

Fix https://github.com/NativeScript/NativeScript/issues/4175
