### PR TITLE
fix(livesync): attach __onLiveSyncCore to global

### DIFF
--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -24,7 +24,7 @@ function onLivesync(args: EventData): void {
         }
 
         try {
-            reloadPage();
+            g.__onLiveSyncCore();
         } catch (ex) {
             // Show the error as modal page, save reference to the page in global context.
             g.errorPage = parse(`<Page><ScrollView><Label text="${ex}" textWrap="true" style="color: red;" /></ScrollView></Page>`);
@@ -73,6 +73,9 @@ export function reloadPage(): void {
         frame.navigate(newEntry);
     }
 }
+
+// attach on global, so it can be overwritten in NativeScript Angular
+(<any>global).__onLiveSyncCore = reloadPage;
 
 export function resolvePageFromEntry(entry: NavigationEntry): Page {
     let page: Page;


### PR DESCRIPTION
That method needs to be exposed because it's used in NativeScript Angular (https://github.com/NativeScript/nativescript-angular/blob/master/nativescript-angular/platform-common.ts#L91).