### PR TITLE
Fixing Button text alignment behavior

### DIFF
--- a/tns-core-modules/ui/button/button.ios.ts
+++ b/tns-core-modules/ui/button/button.ios.ts
@@ -145,16 +145,16 @@ export class Button extends ButtonBase {
 
     [textAlignmentProperty.setNative](value: TextAlignment) {
         switch (value) {
-            case "left":
-                this.nativeView.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Left;
-                break;
-            case "initial":
-            case "center":
-                this.nativeView.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Center;
-                break;
-            case "right":
-                this.nativeView.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Right;
-                break;
+           case "left":
+              this.nativeView.titleLabel.textAlignment = NSTextAlignment.Left;
+              break;
+           case "initial":
+           case "center":
+              this.nativeView.titleLabel.textAlignment = NSTextAlignment.Center;
+              break;
+           case "right":
+              this.nativeView.titleLabel.textAlignment = NSTextAlignment.Right;
+              break;
         }
     }
 


### PR DESCRIPTION
This change switches iOS Button text alignment from using the generic `nativeView.contentHorizontalAlignment` to using the Button's `nativeView.titleLabel.textAlignment`. This change allows text in a Button to properly center align when wrapped on to multiple lines. Left and Right alignment behavior are unchanged, but using new syntax for consistency.

Fixes/Implements #4266.

