### PR TITLE
Fix: IOS text view hint should never show while editing

### DIFF
--- a/apps/app/ui-tests-app/issues/issue-3354.ts
+++ b/apps/app/ui-tests-app/issues/issue-3354.ts
@@ -1,0 +1,4 @@
+export function clear(args) {
+    const tv = args.object.page.getViewById("tv");
+    tv.text= "";
+}

--- a/apps/app/ui-tests-app/issues/issue-3354.xml
+++ b/apps/app/ui-tests-app/issues/issue-3354.xml
@@ -1,0 +1,6 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd">
+    <StackLayout class="p-20">
+        <TextView id="tv" text="" hint="the hint" ></TextView>
+        <Button text="clear text" tap="clear"></Button>
+    </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/issues/main-page.ts
+++ b/apps/app/ui-tests-app/issues/main-page.ts
@@ -23,6 +23,7 @@ export function pageLoaded(args: EventData) {
     examples.set("1639", "issues/issue-1639");
     examples.set("1657-ios", "issues/issue-1657-ios");
     examples.set("tabview-with-scrollview_4022","issues/tabview-with-scrollview_4022");
+    examples.set("3354-ios", "issues/issue-3354");
 
     let viewModel = new SubMainPageViewModel(wrapLayout, examples);
     page.bindingContext = viewModel;

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -71,7 +71,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     private _ios: UITextView;
     private _delegate: UITextViewDelegateImpl;
     private _isShowingHint: boolean;
-    public _isEditing: boolean = false;
+    public _isEditing: boolean;
 
     constructor() {
         super();

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -2,7 +2,7 @@
 import {
     EditableTextBase, editableProperty, hintProperty, textProperty, colorProperty, placeholderColorProperty,
     borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty,
-    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, 
+    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty,
     Length, _updateCharactersInRangeReplacementString, Color, layout
 } from "../editable-text-base";
 
@@ -28,6 +28,13 @@ class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
         return true;
     }
 
+    public textViewDidBeginEditing(textView: UITextView) {
+        var owner = this._owner.get();
+        if (owner) {
+            owner._isEditing = true;
+        }
+    }
+
     public textViewDidEndEditing(textView: UITextView) {
         const owner = this._owner.get();
         if (owner) {
@@ -35,6 +42,7 @@ class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
                 textProperty.nativeValueChange(owner, textView.text);
             }
 
+            owner._isEditing = false;
             owner.dismissSoftInput();
             owner._refreshHintState(owner.hint, textView.text);
         }
@@ -63,6 +71,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     private _ios: UITextView;
     private _delegate: UITextViewDelegateImpl;
     private _isShowingHint: boolean;
+    public _isEditing: boolean = false;
 
     constructor() {
         super();
@@ -96,9 +105,10 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
         if (this.formattedText) {
             return;
         }
+
         if (text !== null && text !== undefined && text !== '') {
             this.showText();
-        } else if (hint !== null && hint !== undefined && hint !== '') {
+        } else if (!this._isEditing && hint !== null && hint !== undefined && hint !== '') {
             this.showHint(hint);
         } else {
             this._isShowingHint = false;


### PR DESCRIPTION
Related to #3354 
UI test added as this involves keyboard focus. Steps to reproduce in ui-tests-app:
1. Go to `issues->3354-ios`
2. Type some text in the text-view
3. Click the `clear` button. 

**Expected result:** The focus remains inside the text-view, but the text is cleared.
**Result before the fix:** The focus remains inside the text-view, however the hint text is shown instead.

cc: @SvetoslavTsenov @vchimev 