### PR TITLE
Refactor transform animations

### DIFF
--- a/tests/app/ui/animation/css-animation-tests.ts
+++ b/tests/app/ui/animation/css-animation-tests.ts
@@ -431,4 +431,3 @@ function getTransforms(declarations) {
     const [ translate, rotate, scale  ] = [...declarations];
     return { translate, rotate, scale };
 }
-

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -5,7 +5,7 @@
  * @module "matrix"
  */ /** */
 
- import { TransformFunctionsInfo } from "../ui/styling/converters";
+ import { TransformFunctionsInfo } from "../ui/animation/animation";
 
 /**
  * Returns the affine matrix representation of the transformation.

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Contains contains utility methods for transforming css matrixes.
+ * All methods in this module are experimental and
+ * may be changed in a non-major version.
+ * @module "matrix"
+ */ /** */
+
+export type Transformation = {
+    property: TransformationType;
+    value?: TransformationValue;
+};
+
+export type TransformationType = "rotate" |
+    "translate" | "translateX" | "translateY" |
+    "scale" | "scaleX" | "scaleY";
+
+export type TransformationValue = number | {x: number, y: number};
+
+export type TransformFunctionsInfo = {
+    translate: TransformationValue,
+    rotate: number,
+    scale: TransformationValue,
+}
+
+/**
+ * Returns the affine matrix representation of the transformation.
+ * @param transformation Property and value of the transformation.
+ */
+export declare const getTransformMatrix: ({property, value}: Transformation) =>
+    number[];
+
+
+/**
+ * Returns the css matrix representation of
+ * an affine transformation matrix
+ * @param m The flat matrix array to be transformed
+ */
+export declare const matrixArrayToCssMatrix: (m: number[]) => number[];
+
+
+/**
+ * Multiplies two nxn-dimensional matrix arrays
+ * @param n Denotes if the matrices are 2x2-, 3x3-, ..., or nxn- dimensional
+ * @param m1 Left-side matrix array
+ * @param m2 Right-side matrix array
+ */
+export declare function multiplyNDimensionalMatriceArrays(
+    n: number, m1: number[], m2: number[]): number[];
+
+/**
+ * QR decomposition using the Gram–Schmidt process.
+ * Decomposes a css matrix to simple transforms - translate, rotate and scale.
+ * @param matrix The css matrix array to decompose.
+ */
+export function decompose2DTransformMatrix(matrix: number[])
+    : TransformFunctionsInfo;

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -5,7 +5,7 @@
  * @module "matrix"
  */ /** */
 
- import { TransformFunctionsInfo } from "../ui/animation/animation";
+import { TransformFunctionsInfo } from "../ui/animation/animation";
 
 /**
  * Returns the affine matrix representation of the transformation.

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -13,14 +13,12 @@ import { TransformFunctionsInfo } from "../ui/animation/animation";
  */
 export declare const getTransformMatrix: ({property, value}) => number[];
 
-
 /**
  * Returns the css matrix representation of
  * an affine transformation matrix
  * @param m The flat matrix array to be transformed
  */
 export declare const matrixArrayToCssMatrix: (m: number[]) => number[];
-
 
 /**
  * Multiplies two nxn-dimensional matrix arrays

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -5,29 +5,13 @@
  * @module "matrix"
  */ /** */
 
-export type Transformation = {
-    property: TransformationType;
-    value?: TransformationValue;
-};
-
-export type TransformationType = "rotate" |
-    "translate" | "translateX" | "translateY" |
-    "scale" | "scaleX" | "scaleY";
-
-export type TransformationValue = number | {x: number, y: number};
-
-export type TransformFunctionsInfo = {
-    translate: TransformationValue,
-    rotate: number,
-    scale: TransformationValue,
-}
+ import { TransformFunctionsInfo } from "../ui/styling/converters";
 
 /**
  * Returns the affine matrix representation of the transformation.
  * @param transformation Property and value of the transformation.
  */
-export declare const getTransformMatrix: ({property, value}: Transformation) =>
-    number[];
+export declare const getTransformMatrix: ({property, value}) => number[];
 
 
 /**

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -21,13 +21,12 @@ export declare const getTransformMatrix: ({property, value}) => number[];
 export declare const matrixArrayToCssMatrix: (m: number[]) => number[];
 
 /**
- * Multiplies two nxn-dimensional matrix arrays
- * @param n Denotes if the matrices are 2x2-, 3x3-, ..., or nxn- dimensional
+ * Multiplies two two-dimensional affine matrices
+ * https://jsperf.com/array-vs-object-affine-matrices/
  * @param m1 Left-side matrix array
  * @param m2 Right-side matrix array
  */
-export declare function multiplyNDimensionalMatriceArrays(
-    n: number, m1: number[], m2: number[]): number[];
+export declare function multiplyAffine2d(m1: number[], m2: number[]): number[];
 
 /**
  * QR decomposition using the Gram–Schmidt process.

--- a/tns-core-modules/matrix/matrix.d.ts
+++ b/tns-core-modules/matrix/matrix.d.ts
@@ -1,5 +1,5 @@
 /**
- * Contains contains utility methods for transforming css matrixes.
+ * Contains utility methods for transforming css matrixes.
  * All methods in this module are experimental and
  * may be changed in a non-major version.
  * @module "matrix"

--- a/tns-core-modules/matrix/matrix.ts
+++ b/tns-core-modules/matrix/matrix.ts
@@ -27,13 +27,13 @@ const MAIN_TRANSFORM_MATRIXES = {
 const ALL_TRANSFORM_MATRIXES = {
     "scale": MAIN_TRANSFORM_MATRIXES["scale"],
     "scale3d": MAIN_TRANSFORM_MATRIXES["scale"],
-    "scaleX": x => MAIN_TRANSFORM_MATRIXES["scale"]({x}),
-    "scaleY": y => MAIN_TRANSFORM_MATRIXES["scale"]({y}),
+    "scaleX": ({x}) => MAIN_TRANSFORM_MATRIXES["scale"]({x}),
+    "scaleY": ({y}) => MAIN_TRANSFORM_MATRIXES["scale"]({y}),
 
     "translate": MAIN_TRANSFORM_MATRIXES["translate"],
     "translate3d": MAIN_TRANSFORM_MATRIXES["translate"],
-    "translateX": x => MAIN_TRANSFORM_MATRIXES["translate"]({x}),
-    "translateY": y => MAIN_TRANSFORM_MATRIXES["translate"]({y}),
+    "translateX": ({x}) => MAIN_TRANSFORM_MATRIXES["translate"]({x}),
+    "translateY": ({y}) => MAIN_TRANSFORM_MATRIXES["translate"]({y}),
 
     "rotate": MAIN_TRANSFORM_MATRIXES["rotate"],
 };

--- a/tns-core-modules/matrix/matrix.ts
+++ b/tns-core-modules/matrix/matrix.ts
@@ -1,0 +1,121 @@
+export type Transformation = {
+    property: TransformationType;
+    value?: TransformationValue;
+};
+
+export type TransformationType = "rotate" |
+    "translate" | "translateX" | "translateY" |
+    "scale" | "scaleX" | "scaleY";
+
+export type TransformationValue = number | { x: number, y: number };
+
+export type TransformFunctionsInfo = {
+    translate: TransformationValue,
+    rotate: number,
+    scale: TransformationValue,
+}
+
+export const getTransformMatrix = ({property, value}: Transformation) =>
+    ALL_TRANSFORM_MATRIXES[property](value);
+
+const MAIN_TRANSFORM_MATRIXES = {
+    "scale": ({x = 1, y = 1}) => [
+        x, 0, 0,
+        0, y, 0,
+        0, 0, 1,
+    ],
+    "translate": ({x = 0, y = 0}) => [
+        1, 0, x,
+        0, 1, y,
+        0, 0, 1,
+    ],
+    "rotate": angleInRad => [
+        Math.cos(angleInRad), -Math.sin(angleInRad), 0,
+        Math.sin(angleInRad), Math.cos(angleInRad), 0,
+        0, 0, 1,
+    ],
+};
+
+const ALL_TRANSFORM_MATRIXES = {
+    "scale": a => MAIN_TRANSFORM_MATRIXES["scale"]({x: a, y: a}),
+    "scale3d": a => MAIN_TRANSFORM_MATRIXES["scale"]({x: a, y: a}),
+    "scaleX": x => MAIN_TRANSFORM_MATRIXES["scale"]({x}),
+    "scaleY": y => MAIN_TRANSFORM_MATRIXES["scale"]({y}),
+
+    "translate": a => MAIN_TRANSFORM_MATRIXES["translate"]({x: a, y: a}),
+    "translate3d": a => MAIN_TRANSFORM_MATRIXES["translate"]({x: a, y: a}),
+    "translateX": x => MAIN_TRANSFORM_MATRIXES["translate"]({x}),
+    "translateY": y => MAIN_TRANSFORM_MATRIXES["translate"]({y}),
+
+    "rotate": MAIN_TRANSFORM_MATRIXES["rotate"],
+};
+
+export const matrixArrayToCssMatrix = (m: number[]) => [
+    m[0], m[3], m[1],
+    m[4], m[2], m[5],
+];
+
+export function multiplyNDimensionalMatriceArrays(
+    n: number, m1: number[], m2: number[]): number[] {
+
+    let result = [];
+
+    for (let i = 0; i < n; i += 1) {
+        for (let j = 0; j < n; j += 1) {
+            let sum = 0;
+            for (let k = 0; k < n; k += 1) {
+                sum += m1[i * n + k] * m2[k * n + j];
+            }
+            result[i * n + j] = sum;
+        }
+    }
+
+    return result;
+}
+
+export function decompose2DTransformMatrix(matrix: number[])
+    : TransformFunctionsInfo {
+
+    verifyTransformMatrix(matrix);
+    return {
+        ...getTranslate(matrix),
+        ...getRotate(matrix),
+        ...getScale(matrix),
+    };
+}
+
+function verifyTransformMatrix(matrix: number[]) {
+    if (matrix.length < 6) {
+        throw new Error("Transform matrix should be 2x3.");
+    }
+}
+
+const getTranslate = (matrix: number[]) => ({
+    translate: { x: matrix[4], y: matrix[5] }
+});
+
+function getRotate(matrix: number[]): { rotate: number } {
+    const [A, B] = [...matrix];
+
+    const radians = Math.atan2(B, A);
+    const rotate = radiansToDegrees(radians);
+
+    return {rotate};
+}
+
+function getScale(matrix: number[]): { scale: { x, y } } {
+    const [A, B, C, D] = [...matrix];
+    const determinant = A * D - B * C;
+
+    if (!determinant) {
+        return { scale: { x: 0, y: 0 } };
+    }
+
+    const multiplier = determinant > 0 ? 1 : -1;
+    const x = Math.sqrt(A * A + B * B) * multiplier;
+    const y = (determinant / x) * multiplier;
+
+    return { scale: { x, y } };
+}
+
+const radiansToDegrees = a => a * (180 / Math.PI);

--- a/tns-core-modules/matrix/matrix.ts
+++ b/tns-core-modules/matrix/matrix.ts
@@ -1,21 +1,9 @@
-export type Transformation = {
-    property: TransformationType;
-    value?: TransformationValue;
-};
+import {
+    TransformFunctionsInfo,
+    Pair,
+} from "../ui/animation/animation";
 
-export type TransformationType = "rotate" |
-    "translate" | "translateX" | "translateY" |
-    "scale" | "scaleX" | "scaleY";
-
-export type TransformationValue = number | { x: number, y: number };
-
-export type TransformFunctionsInfo = {
-    translate: TransformationValue,
-    rotate: number,
-    scale: TransformationValue,
-}
-
-export const getTransformMatrix = ({property, value}: Transformation) =>
+export const getTransformMatrix = ({property, value}) =>
     ALL_TRANSFORM_MATRIXES[property](value);
 
 const MAIN_TRANSFORM_MATRIXES = {
@@ -37,13 +25,13 @@ const MAIN_TRANSFORM_MATRIXES = {
 };
 
 const ALL_TRANSFORM_MATRIXES = {
-    "scale": a => MAIN_TRANSFORM_MATRIXES["scale"]({x: a, y: a}),
-    "scale3d": a => MAIN_TRANSFORM_MATRIXES["scale"]({x: a, y: a}),
+    "scale": MAIN_TRANSFORM_MATRIXES["scale"],
+    "scale3d": MAIN_TRANSFORM_MATRIXES["scale"],
     "scaleX": x => MAIN_TRANSFORM_MATRIXES["scale"]({x}),
     "scaleY": y => MAIN_TRANSFORM_MATRIXES["scale"]({y}),
 
-    "translate": a => MAIN_TRANSFORM_MATRIXES["translate"]({x: a, y: a}),
-    "translate3d": a => MAIN_TRANSFORM_MATRIXES["translate"]({x: a, y: a}),
+    "translate": MAIN_TRANSFORM_MATRIXES["translate"],
+    "translate3d": MAIN_TRANSFORM_MATRIXES["translate"],
     "translateX": x => MAIN_TRANSFORM_MATRIXES["translate"]({x}),
     "translateY": y => MAIN_TRANSFORM_MATRIXES["translate"]({y}),
 
@@ -77,11 +65,11 @@ export function decompose2DTransformMatrix(matrix: number[])
     : TransformFunctionsInfo {
 
     verifyTransformMatrix(matrix);
-    return {
-        ...getTranslate(matrix),
-        ...getRotate(matrix),
-        ...getScale(matrix),
-    };
+    return Object.assign({}, 
+        getTranslate(matrix),
+        getRotate(matrix),
+        getScale(matrix)
+    );
 }
 
 function verifyTransformMatrix(matrix: number[]) {
@@ -90,7 +78,7 @@ function verifyTransformMatrix(matrix: number[]) {
     }
 }
 
-const getTranslate = (matrix: number[]) => ({
+const getTranslate = (matrix: number[]): { translate: Pair} => ({
     translate: { x: matrix[4], y: matrix[5] }
 });
 
@@ -103,7 +91,7 @@ function getRotate(matrix: number[]): { rotate: number } {
     return {rotate};
 }
 
-function getScale(matrix: number[]): { scale: { x, y } } {
+function getScale(matrix: number[]): { scale: Pair } {
     const [A, B, C, D] = [...matrix];
     const determinant = A * D - B * C;
 

--- a/tns-core-modules/matrix/matrix.ts
+++ b/tns-core-modules/matrix/matrix.ts
@@ -1,7 +1,4 @@
-import {
-    TransformFunctionsInfo,
-    Pair,
-} from "../ui/animation/animation";
+import { TransformFunctionsInfo } from "../ui/animation/animation";
 
 import { radiansToDegrees, degreesToRadians } from "../utils/number-utils";
 

--- a/tns-core-modules/matrix/matrix.ts
+++ b/tns-core-modules/matrix/matrix.ts
@@ -32,22 +32,15 @@ export const matrixArrayToCssMatrix = (m: number[]) => [
     m[4], m[2], m[5],
 ];
 
-export function multiplyNDimensionalMatriceArrays(
-    n: number, m1: number[], m2: number[]): number[] {
-
-    let result = [];
-
-    for (let i = 0; i < n; i += 1) {
-        for (let j = 0; j < n; j += 1) {
-            let sum = 0;
-            for (let k = 0; k < n; k += 1) {
-                sum += m1[i * n + k] * m2[k * n + j];
-            }
-            result[i * n + j] = sum;
-        }
-    }
-
-    return result;
+export function multiplyAffine2d(m1: number[], m2: number[]): number[] {
+    return [
+        m1[0] * m2[0] + m1[1] * m2[3],
+        m1[0] * m2[1] + m1[1] * m2[4],
+        m1[0] * m2[2] + m1[1] * m2[5] + m1[2],
+        m1[3] * m2[0] + m1[4] * m2[3],
+        m1[3] * m2[1] + m1[4] * m2[4],
+        m1[3] * m2[2] + m1[4] * m2[5] + m1[5]
+    ]
 }
 
 export function decompose2DTransformMatrix(matrix: number[])

--- a/tns-core-modules/matrix/package.json
+++ b/tns-core-modules/matrix/package.json
@@ -1,0 +1,6 @@
+{
+  "name" : "matrix",
+  "main" : "matrix",
+  "types" : "matrix.d.ts",
+  "nativescript": {}
+}

--- a/tns-core-modules/ui/animation/animation.d.ts
+++ b/tns-core-modules/ui/animation/animation.d.ts
@@ -83,6 +83,36 @@ export interface Pair {
     y: number;
 }
 
+/**
+ * Defines a key-value pair for css transformation
+ */
+export type Transformation = {
+    property: TransformationType;
+    value: TransformationValue;
+};
+
+/**
+ * Defines possible css transformations
+ */
+export type TransformationType = "rotate" |
+    "translate" | "translateX" | "translateY" |
+    "scale" | "scaleX" | "scaleY";
+
+/**
+ * Defines possible css transformation values
+ */
+export type TransformationValue = Pair | number;
+
+/**
+ * Defines full information for css transformation
+ */
+export type TransformFunctionsInfo = {
+    translate: TransformationValue,
+    rotate: number,
+    scale: TransformationValue,
+}
+
+
 export interface Cancelable {
     cancel(): void;
 }

--- a/tns-core-modules/ui/animation/animation.d.ts
+++ b/tns-core-modules/ui/animation/animation.d.ts
@@ -76,14 +76,6 @@ export class CubicBezierAnimationCurve {
 }
 
 /**
- * Defines a pair of values (horizontal and vertical) for translate and scale animations.
- */
-export interface Pair {
-    x: number;
-    y: number;
-}
-
-/**
  * Defines a key-value pair for css transformation
  */
 export type Transformation = {
@@ -104,6 +96,14 @@ export type TransformationType = "rotate" |
 export type TransformationValue = Pair | number;
 
 /**
+ * Defines a pair of values (horizontal and vertical) for translate and scale animations.
+ */
+export interface Pair {
+    x: number;
+    y: number;
+}
+
+/**
  * Defines full information for css transformation
  */
 export type TransformFunctionsInfo = {
@@ -111,7 +111,6 @@ export type TransformFunctionsInfo = {
     rotate: number,
     scale: TransformationValue,
 }
-
 
 export interface Cancelable {
     cancel(): void;

--- a/tns-core-modules/ui/animation/animation.d.ts
+++ b/tns-core-modules/ui/animation/animation.d.ts
@@ -107,9 +107,9 @@ export interface Pair {
  * Defines full information for css transformation
  */
 export type TransformFunctionsInfo = {
-    translate: TransformationValue,
+    translate: Pair,
     rotate: number,
-    scale: TransformationValue,
+    scale: Pair,
 }
 
 export interface Cancelable {

--- a/tns-core-modules/ui/animation/keyframe-animation.d.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.d.ts
@@ -4,6 +4,8 @@
 
 import { View } from "../core/view";
 
+export declare const ANIMATION_PROPERTIES;
+
 export interface Keyframes {
     name: string;
     keyframes: Array<UnparsedKeyframe>;

--- a/tns-core-modules/ui/animation/keyframe-animation.d.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.d.ts
@@ -4,6 +4,16 @@
 
 import { View } from "../core/view";
 
+export interface Keyframes {
+    name: string;
+    keyframes: Array<UnparsedKeyframe>;
+}
+
+export interface UnparsedKeyframe {
+    values: Array<any>;
+    declarations: Array<KeyframeDeclaration>;
+}
+
 export interface KeyframeDeclaration {
     property: string;
     value: any;

--- a/tns-core-modules/ui/animation/keyframe-animation.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.ts
@@ -1,9 +1,11 @@
 // Definitions.
 import {
+    Keyframes as KeyframesDefinition,
+    UnparsedKeyframe as UnparsedKeyframeDefinition,
     KeyframeDeclaration as KeyframeDeclarationDefinition,
     KeyframeInfo as KeyframeInfoDefinition,
     KeyframeAnimationInfo as KeyframeAnimationInfoDefinition,
-    KeyframeAnimation as KeyframeAnimationDefinition
+    KeyframeAnimation as KeyframeAnimationDefinition,
 } from "./keyframe-animation";
 
 import { View, Color } from "../core/view";
@@ -17,6 +19,16 @@ import {
     translateXProperty, translateYProperty,
     rotateProperty, opacityProperty
 } from "../styling/style-properties";
+
+export class Keyframes implements KeyframesDefinition {
+    name: string;
+    keyframes: Array<UnparsedKeyframe>;
+}
+
+export class UnparsedKeyframe implements UnparsedKeyframeDefinition {
+    values: Array<any>;
+    declarations: Array<KeyframeDeclaration>;
+}
 
 export class KeyframeDeclaration implements KeyframeDeclarationDefinition {
     public property: string;

--- a/tns-core-modules/ui/styling/converters.ts
+++ b/tns-core-modules/ui/styling/converters.ts
@@ -15,7 +15,7 @@ import {
 import { Color } from "../../color";
 import { CubicBezierAnimationCurve } from "../animation";
 
-const TRANSFORM_SPLITTER = new RegExp(/(.+?)\((.*?)\)/g);
+const TRANSFORM_SPLITTER = new RegExp(/\s*(.+?)\((.*?)\)/g);
 const TRANSFORMATIONS = Object.freeze([
     "rotate",
     "translate",

--- a/tns-core-modules/ui/styling/converters.ts
+++ b/tns-core-modules/ui/styling/converters.ts
@@ -1,7 +1,11 @@
-﻿import {
-    TransformFunctionsInfo,
+﻿import { 
     Transformation,
+    TransformationType,
     TransformationValue,
+    TransformFunctionsInfo,
+} from "../animation/animation";
+
+import {
     decompose2DTransformMatrix,
     getTransformMatrix,
     matrixArrayToCssMatrix,
@@ -11,7 +15,24 @@
 import { Color } from "../../color";
 import { CubicBezierAnimationCurve } from "../animation";
 
-const TRANSFORM_SPLITTER = new RegExp(/([a-zA-Z\-]+)\((.*?)\)/g);
+const TRANSFORM_SPLITTER = new RegExp(/(.+?)\((.*?)\)/g);
+const TRANSFORMATIONS = Object.freeze([
+    "rotate",
+    "translate",
+    "translate3d",
+    "translateX",
+    "translateY",
+    "scale",
+    "scale3d",
+    "scaleX",
+    "scaleY",
+]);
+
+const IDENTITY_TRANSFORM = Object.freeze({
+    translate: { x: 0, y: 0 },
+    rotate: 0,
+    scale: { x: 1, y: 1 },
+});
 
 export function colorConverter(value: string): Color {
     return new Color(value);
@@ -95,44 +116,48 @@ export function animationTimingFunctionConverter(value: string): Object {
 }
 
 export function transformConverter(text: string): TransformFunctionsInfo {
-    if (text === "none" || text === "") {
-        return {
-            translate: { x: 0, y: 0 },
-            rotate: 0,
-            scale: { x: 1, y: 1 },
-        };
+    const transformations = parseTransformString(text);
+    if (text === "none" || text === "" || !transformations.length) {
+        return IDENTITY_TRANSFORM;
     }
 
-    const affineMatrix = parseTransformString(text)
-        .map(getTransformMatrix)
+   const affineMatrix = transformations.map(getTransformMatrix)
         .reduce((m1, m2) => multiplyNDimensionalMatriceArrays(3, m1, m2))
    const cssMatrix = matrixArrayToCssMatrix(affineMatrix)
 
    return decompose2DTransformMatrix(cssMatrix);
 }
 
+
+// using general regex and manually checking the matched
+// properties is faster than using more specific regex
+// https://jsperf.com/cssparse
 export function parseTransformString(text: string): Transformation[] {
     let matches: Transformation[] = [];
     let match;
 
     while ((match = TRANSFORM_SPLITTER.exec(text)) !== null) {
         const property = match[1];
-        const value = convertTransformValue(match[2]);
+        const value = convertTransformValue(property, match[2]);
 
-        matches.push({ property, value });
+        if (TRANSFORMATIONS.indexOf(property) !== -1) {
+            matches.push({ property, value });
+        }
     }
 
     return matches;
 }
 
-function convertTransformValue(stringValue: string): TransformationValue {
-    const [x, y] = stringValue.split(",").map(parseFloat);
+function convertTransformValue(property: string, stringValue: string)
+    : TransformationValue {
 
-    if (x && y) {
-        return { x, y };
-    } else {
+    const [x, y = x] = stringValue.split(",").map(parseFloat);
+
+    if (property === "rotate") {
         return stringValue.slice(-3) === "rad" ? x : degreesToRadians(x);
-     }
+    }
+
+    return { x, y };
 }
 
 const degreesToRadians = a => a * (Math.PI / 180);

--- a/tns-core-modules/ui/styling/converters.ts
+++ b/tns-core-modules/ui/styling/converters.ts
@@ -1,64 +1,13 @@
-﻿import { 
-    Transformation,
-    TransformationType,
-    TransformationValue,
-    TransformFunctionsInfo,
-} from "../animation/animation";
+﻿import { AnimationCurve } from "../enums";
 
-import {
-    decompose2DTransformMatrix,
-    getTransformMatrix,
-    matrixArrayToCssMatrix,
-    multiplyNDimensionalMatriceArrays,
-} from "../../matrix";
-
-import { Color } from "../../color";
-import { CubicBezierAnimationCurve } from "../animation";
-
-import { hasDuplicates } from "../../utils/utils";
-import { radiansToDegrees } from "../../utils/number-utils";
-
-const IDENTITY_TRANSFORMATION = {
-    translate: { x: 0, y: 0 },
-    rotate: 0,
-    scale: { x: 1, y: 1 },
-};
-
-const TRANSFORM_SPLITTER = new RegExp(/\s*(.+?)\((.*?)\)/g);
-const TRANSFORMATIONS = Object.freeze([
-    "rotate",
-    "translate",
-    "translate3d",
-    "translateX",
-    "translateY",
-    "scale",
-    "scale3d",
-    "scaleX",
-    "scaleY",
-]);
-
-export function colorConverter(value: string): Color {
-    return new Color(value);
-}
-
-export function floatConverter(value: string): number {
-    // TODO: parse different unit types
-    const result: number = parseFloat(value);
-    return result;
-}
-
-export function fontSizeConverter(value: string): number {
-    return floatConverter(value);
-}
-
-export const numberConverter = parseFloat;
-
-export function opacityConverter(value: string): number {
-    let result = parseFloat(value);
-    result = Math.max(0.0, result);
-    result = Math.min(1.0, result);
-    return result;
-}
+const STYLE_CURVE_MAP = Object.freeze({
+    "ease": AnimationCurve.ease,
+    "linear": AnimationCurve.linear,
+    "ease-in": AnimationCurve.easeIn,
+    "ease-out": AnimationCurve.easeOut,
+    "ease-in-out": AnimationCurve.easeInOut,
+    "spring": AnimationCurve.spring,
+});
 
 export function timeConverter(value: string): number {
     let result = parseFloat(value);
@@ -69,127 +18,36 @@ export function timeConverter(value: string): number {
     return Math.max(0.0, result);
 }
 
-export function bezieArgumentConverter(value: string): number {
+export function animationTimingFunctionConverter(value: string): any {
+    return value ?
+        STYLE_CURVE_MAP[value] || parseCubicBezierCurve(value) :
+        AnimationCurve.ease;
+}
+
+function parseCubicBezierCurve(value: string) {
+    const coordsString = /\((.*?)\)/.exec(value);
+    const coords = coordsString && coordsString[1]
+        .split(",")
+        .map(stringToBezieCoords);
+
+    if (value.startsWith("cubic-bezier") &&
+        coordsString &&
+        coords.length === 4) {
+
+        const [x1, x2, y1, y2] = [...coords];
+        return AnimationCurve.cubicBezier(x1, x2, y1, y2);
+    } else {
+        throw new Error(`Invalid value for animation: ${value}`);
+    }
+}
+
+function stringToBezieCoords(value: string): number {
     let result = parseFloat(value);
-    result = Math.max(0.0, result);
-    result = Math.min(1.0, result);
-    return result;
-}
-
-export function animationTimingFunctionConverter(value: string): Object {
-    let result: Object = "ease";
-    switch (value) {
-        case "ease":
-            result = "ease";
-            break;
-        case "linear":
-            result = "linear";
-            break;
-        case "ease-in":
-            result = "easeIn";
-            break;
-        case "ease-out":
-            result = "easeOut";
-            break;
-        case "ease-in-out":
-            result = "easeInOut";
-            break;
-        case "spring":
-            result = "spring";
-            break;
-        default:
-            if (value.indexOf("cubic-bezier(") === 0) {
-                let bezierArr = value.substring(13).split(/[,]+/);
-                if (bezierArr.length !== 4) {
-                    throw new Error("Invalid value for animation: " + value);
-                }
-
-                result = new CubicBezierAnimationCurve(bezieArgumentConverter(bezierArr[0]),
-                    bezieArgumentConverter(bezierArr[1]),
-                    bezieArgumentConverter(bezierArr[2]),
-                    bezieArgumentConverter(bezierArr[3]));
-            }
-            else {
-                throw new Error("Invalid value for animation: " + value);
-            }
-            break;
+    if (result < 0) {
+        return 0;
+    } else if (result > 1) {
+        return 1;
     }
 
     return result;
 }
-
-const STYLE_TRANSFORMATION_MAP = Object.freeze({
-    "scale": value => ({ property: "scale", value }),
-    "scale3d": value => ({ property: "scale", value }),
-    "scaleX": ({x}) => ({ property: "scale", value: { x, y: IDENTITY_TRANSFORMATION.scale.y } }),
-    "scaleY": ({y}) => ({ property: "scale", value: { y, x: IDENTITY_TRANSFORMATION.scale.x } }),
-
-    "translate": value => ({ property: "translate", value }),
-    "translate3d": value => ({ property: "translate", value }),
-    "translateX": ({x}) => ({ property: "translate", value: { x, y: IDENTITY_TRANSFORMATION.translate.y } }),
-    "translateY": ({y}) => ({ property: "translate", value: { y, x: IDENTITY_TRANSFORMATION.translate.x } }),
-
-    "rotate": value => ({ property: "rotate", value }),
-});
-
-export function transformConverter(text: string): TransformFunctionsInfo {
-    const transformations = parseTransformString(text);
-
-    if (text === "none" || text === "" || !transformations.length) {
-        return IDENTITY_TRANSFORMATION;
-    }
-
-    const usedTransforms = transformations.map(t => t.property);
-    if (!hasDuplicates(usedTransforms)) {
-        const fullTransformations = Object.assign({}, IDENTITY_TRANSFORMATION);
-        transformations.forEach(transform => {
-            fullTransformations[transform.property] = transform.value;
-        });
-
-        return fullTransformations;
-    }
-
-   const affineMatrix = transformations
-        .map(getTransformMatrix)
-        .reduce((m1, m2) => multiplyNDimensionalMatriceArrays(3, m1, m2))
-   const cssMatrix = matrixArrayToCssMatrix(affineMatrix)
-
-   return decompose2DTransformMatrix(cssMatrix);
-}
-
-
-// using general regex and manually checking the matched
-// properties is faster than using more specific regex
-// https://jsperf.com/cssparse
-export function parseTransformString(text: string): Transformation[] {
-    let matches: Transformation[] = [];
-    let match;
-
-    while ((match = TRANSFORM_SPLITTER.exec(text)) !== null) {
-        const property = match[1];
-        const value = convertTransformValue(property, match[2]);
-
-        if (TRANSFORMATIONS.indexOf(property) !== -1) {
-            matches.push(normalizeTransformation({ property, value }));
-        }
-    }
-
-    return matches;
-}
-
-function normalizeTransformation({ property, value }: Transformation) { 
-    return STYLE_TRANSFORMATION_MAP[property](value);
-}
-
-function convertTransformValue(property: string, stringValue: string)
-    : TransformationValue {
-
-    const [x, y = x] = stringValue.split(",").map(parseFloat);
-
-    if (property === "rotate") {
-        return stringValue.slice(-3) === "rad" ? radiansToDegrees(x) : x;
-    }
-
-    return y ? { x, y } : x;
-}
-

--- a/tns-core-modules/ui/styling/css-animation-parser.ts
+++ b/tns-core-modules/ui/styling/css-animation-parser.ts
@@ -119,35 +119,26 @@ function keyframeAnimationsFromCSSProperty(value: any, animations: Array<Keyfram
 
 function parseKeyframeDeclarations(keyframe: Object): Array<KeyframeDeclaration> {
     let declarations = {};
-    let transforms = { scale: undefined, translate: undefined };
     for (let declaration of (<any>keyframe).declarations) {
         let propertyName = declaration.property;
         let value = declaration.value;
+
         if (propertyName === "opacity") {
             declarations[propertyName] = parseFloat(value);
-        }
+        } else if (propertyName === "transform") {
 
-        else if (propertyName === "transform") {
             const transformations = transformConverter(value);
-            declarations = {...declarations, ...transformations};
-            console.log("TRANSFORMATIONS ---------------------")
-            console.dir(transformations)
-            console.log("---------------------")
+            Object.assign(declarations, transformations);
             delete declarations[propertyName];
-        }
-        else if (propertyName === "backgroundColor" || propertyName === "background-color") {
+        } else if (propertyName === "backgroundColor" || propertyName === "background-color") {
+
             declarations["backgroundColor"] = new Color(value);
         }
         else {
             declarations[propertyName] = value;
         }
     }
-    if (transforms.scale !== undefined) {
-        declarations["scale"] = transforms.scale;
-    }
-    if (transforms.translate !== undefined) {
-        declarations["translate"] = transforms.translate;
-    }
+
     let array = new Array<KeyframeDeclaration>();
     for (let declaration in declarations) {
         let keyframeDeclaration = <KeyframeDeclaration>{};
@@ -155,5 +146,6 @@ function parseKeyframeDeclarations(keyframe: Object): Array<KeyframeDeclaration>
         keyframeDeclaration.value = declarations[declaration];
         array.push(keyframeDeclaration);
     }
+
     return array;
 }

--- a/tns-core-modules/ui/styling/css-animation-parser.ts
+++ b/tns-core-modules/ui/styling/css-animation-parser.ts
@@ -1,6 +1,13 @@
 import { Pair } from "../animation";
 import { Color } from "../../color";
-import { KeyframeAnimationInfo, KeyframeInfo, KeyframeDeclaration } from "../animation/keyframe-animation";
+
+import {
+    KeyframeAnimationInfo,
+    KeyframeDeclaration,
+    KeyframeInfo,
+    Keyframes,
+    UnparsedKeyframe,
+} from "../animation/keyframe-animation";
 import { timeConverter, numberConverter, transformConverter, animationTimingFunctionConverter } from "../styling/converters";
 
 let animationProperties = {
@@ -38,9 +45,9 @@ export class CssAnimationParser {
         return animations.length === 0 ? undefined : animations;
     }
 
-    public static keyframesArrayFromCSS(cssKeyframes: Object): Array<KeyframeInfo> {
+    public static keyframesArrayFromCSS(cssKeyframes: Keyframes): Array<KeyframeInfo> {
         let parsedKeyframes = new Array<KeyframeInfo>();
-        for (let keyframe of (<any>cssKeyframes).keyframes) {
+        for (let keyframe of cssKeyframes.keyframes) {
             let declarations = parseKeyframeDeclarations(keyframe);
             for (let time of keyframe.values) {
                 if (time === "from") {
@@ -64,7 +71,7 @@ export class CssAnimationParser {
                     current.duration = time;
                     parsedKeyframes[time] = current;
                 }
-                for (let declaration of <any>keyframe.declarations) {
+                for (let declaration of keyframe.declarations) {
                     if (declaration.property === "animation-timing-function") {
                         current.curve = animationTimingFunctionConverter(declaration.value);
                     }
@@ -117,9 +124,9 @@ function keyframeAnimationsFromCSSProperty(value: any, animations: Array<Keyfram
     }
 }
 
-function parseKeyframeDeclarations(keyframe: Object): Array<KeyframeDeclaration> {
+function parseKeyframeDeclarations(keyframe: UnparsedKeyframe): Array<KeyframeDeclaration> {
     let declarations = {};
-    for (let declaration of (<any>keyframe).declarations) {
+    for (let declaration of keyframe.declarations) {
         let propertyName = declaration.property;
         let value = declaration.value;
 

--- a/tns-core-modules/ui/styling/css-animation-parser.ts
+++ b/tns-core-modules/ui/styling/css-animation-parser.ts
@@ -1,62 +1,62 @@
-import { Pair } from "../animation";
-import { Color } from "../../color";
+import { CssAnimationProperty } from "../core/properties";
 
 import {
     KeyframeAnimationInfo,
     KeyframeDeclaration,
     KeyframeInfo,
-    Keyframes,
     UnparsedKeyframe,
 } from "../animation/keyframe-animation";
-import { timeConverter, numberConverter, transformConverter, animationTimingFunctionConverter } from "../styling/converters";
+import { timeConverter, animationTimingFunctionConverter } from "../styling/converters";
 
-let animationProperties = {
-    "animation-name": (info, declaration) => info.name = declaration.value,
-    "animation-duration": (info, declaration) => info.duration = timeConverter(declaration.value),
-    "animation-delay": (info, declaration) => info.delay = timeConverter(declaration.value),
-    "animation-timing-function": (info, declaration) => info.curve = animationTimingFunctionConverter(declaration.value),
-    "animation-iteration-count": (info, declaration) => declaration.value === "infinite" ? info.iterations = Number.MAX_VALUE : info.iterations = numberConverter(declaration.value),
-    "animation-direction": (info, declaration) => info.isReverse = declaration.value === "reverse",
-    "animation-fill-mode": (info, declaration) => info.isForwards = declaration.value === "forwards"
-};
+import { transformConverter } from "../styling/style-properties";
+
+const ANIMATION_PROPERTY_HANDLERS = Object.freeze({
+    "animation-name": (info, value) => info.name = value,
+    "animation-duration": (info, value) => info.duration = timeConverter(value),
+    "animation-delay": (info, value) => info.delay = timeConverter(value),
+    "animation-timing-function": (info, value) => info.curve = animationTimingFunctionConverter(value),
+    "animation-iteration-count": (info, value) => info.iterations = value === "infinite" ? Number.MAX_VALUE : parseFloat(value),
+    "animation-direction": (info, value) => info.isReverse = value === "reverse",
+    "animation-fill-mode": (info, value) => info.isForwards = value === "forwards"
+});
 
 export class CssAnimationParser {
     public static keyframeAnimationsFromCSSDeclarations(declarations: { property: string, value: string }[]): Array<KeyframeAnimationInfo> {
-        let animations: Array<KeyframeAnimationInfo> = new Array<KeyframeAnimationInfo>();
-        let animationInfo: KeyframeAnimationInfo = undefined;
         if (declarations === null || declarations === undefined) {
             return undefined;
         }
-        for (let declaration of declarations) {
-            if (declaration.property === "animation") {
-                keyframeAnimationsFromCSSProperty(declaration.value, animations);
-            }
-            else {
-                let propertyHandler = animationProperties[declaration.property];
+
+        let animations = new Array<KeyframeAnimationInfo>();
+        let animationInfo: KeyframeAnimationInfo = undefined;
+
+        declarations.forEach(({ property, value }) => {
+            if (property === "animation") {
+                keyframeAnimationsFromCSSProperty(value, animations);
+            } else {
+                const propertyHandler = ANIMATION_PROPERTY_HANDLERS[property];
                 if (propertyHandler) {
                     if (animationInfo === undefined) {
                         animationInfo = new KeyframeAnimationInfo();
                         animations.push(animationInfo);
                     }
-                    propertyHandler(animationInfo, declaration);
+                    propertyHandler(animationInfo, value);
                 }
             }
-        }
+        });
+
         return animations.length === 0 ? undefined : animations;
     }
 
-    public static keyframesArrayFromCSS(cssKeyframes: Keyframes): Array<KeyframeInfo> {
+    public static keyframesArrayFromCSS(keyframes: Array<UnparsedKeyframe>): Array<KeyframeInfo> {
         let parsedKeyframes = new Array<KeyframeInfo>();
-        for (let keyframe of cssKeyframes.keyframes) {
-            let declarations = parseKeyframeDeclarations(keyframe);
+        for (let keyframe of keyframes) {
+            let declarations = parseKeyframeDeclarations(keyframe.declarations);
             for (let time of keyframe.values) {
                 if (time === "from") {
                     time = 0;
-                }
-                else if (time === "to") {
+                } else if (time === "to") {
                     time = 1;
-                }
-                else {
+                } else {
                     time = parseFloat(time) / 100;
                     if (time < 0) {
                         time = 0;
@@ -124,35 +124,22 @@ function keyframeAnimationsFromCSSProperty(value: any, animations: Array<Keyfram
     }
 }
 
-function parseKeyframeDeclarations(keyframe: UnparsedKeyframe): Array<KeyframeDeclaration> {
-    let declarations = {};
-    for (let declaration of keyframe.declarations) {
-        let propertyName = declaration.property;
-        let value = declaration.value;
+function parseKeyframeDeclarations(unparsedKeyframeDeclarations: Array<KeyframeDeclaration>)
+    : Array<KeyframeDeclaration> {
 
-        if (propertyName === "opacity") {
-            declarations[propertyName] = parseFloat(value);
-        } else if (propertyName === "transform") {
+    const declarations = unparsedKeyframeDeclarations
+        .reduce((declarations, { property: unparsedProperty, value: unparsedValue }) => {
+            const property = CssAnimationProperty._getByCssName(unparsedProperty);
 
-            const transformations = transformConverter(value);
-            Object.assign(declarations, transformations);
-            delete declarations[propertyName];
-        } else if (propertyName === "backgroundColor" || propertyName === "background-color") {
+            if (typeof unparsedProperty === "string" && property && property._valueConverter) {
+                declarations[property.name] = property._valueConverter(<string>unparsedValue);
+            } else if (typeof unparsedValue === "string" && unparsedProperty === "transform") {
+                const transformations = transformConverter(unparsedValue);
+                Object.assign(declarations, transformations);
+            }
 
-            declarations["backgroundColor"] = new Color(value);
-        }
-        else {
-            declarations[propertyName] = value;
-        }
-    }
+            return declarations;
+        }, {});
 
-    let array = new Array<KeyframeDeclaration>();
-    for (let declaration in declarations) {
-        let keyframeDeclaration = <KeyframeDeclaration>{};
-        keyframeDeclaration.property = declaration;
-        keyframeDeclaration.value = declarations[declaration];
-        array.push(keyframeDeclaration);
-    }
-
-    return array;
+    return Object.keys(declarations).map(property => ({ property, value: declarations[property] }));
 }

--- a/tns-core-modules/ui/styling/style-properties.d.ts
+++ b/tns-core-modules/ui/styling/style-properties.d.ts
@@ -2,6 +2,7 @@
  * @module "ui/styling/style-properties"
  */ /** */
 
+import { TransformFunctionsInfo, } from "../animation/animation";
 import { Color } from "../../color";
 import { Style, CssProperty, CssAnimationProperty, ShorthandProperty, InheritedCssProperty } from "../core/properties";
 import { Font, FontStyle, FontWeight } from "./font";
@@ -47,6 +48,8 @@ export const scaleXProperty: CssAnimationProperty<Style, number>;
 export const scaleYProperty: CssAnimationProperty<Style, number>;
 export const translateXProperty: CssAnimationProperty<Style, dip>;
 export const translateYProperty: CssAnimationProperty<Style, dip>;
+
+export function transformConverter(text: string): TransformFunctionsInfo;
 
 export const clipPathProperty: CssProperty<Style, string>;
 export const colorProperty: InheritedCssProperty<Style, Color>;

--- a/tns-core-modules/ui/styling/style-properties.d.ts
+++ b/tns-core-modules/ui/styling/style-properties.d.ts
@@ -2,7 +2,7 @@
  * @module "ui/styling/style-properties"
  */ /** */
 
-import { TransformFunctionsInfo, } from "../animation/animation";
+import { TransformFunctionsInfo } from "../animation/animation";
 import { Color } from "../../color";
 import { Style, CssProperty, CssAnimationProperty, ShorthandProperty, InheritedCssProperty } from "../core/properties";
 import { Font, FontStyle, FontWeight } from "./font";

--- a/tns-core-modules/ui/styling/style-properties.ts
+++ b/tns-core-modules/ui/styling/style-properties.ts
@@ -24,7 +24,7 @@ import {
     decompose2DTransformMatrix,
     getTransformMatrix,
     matrixArrayToCssMatrix,
-    multiplyNDimensionalMatriceArrays,
+    multiplyAffine2d,
 } from "../../matrix";
 
 export type LengthDipUnit = { readonly unit: "dip", readonly value: dip };
@@ -503,7 +503,7 @@ export function transformConverter(text: string): TransformFunctionsInfo {
 
    const affineMatrix = transformations
         .map(getTransformMatrix)
-        .reduce((m1, m2) => multiplyNDimensionalMatriceArrays(3, m1, m2))
+        .reduce(multiplyAffine2d)
    const cssMatrix = matrixArrayToCssMatrix(affineMatrix)
 
    return decompose2DTransformMatrix(cssMatrix);

--- a/tns-core-modules/ui/styling/style-properties.ts
+++ b/tns-core-modules/ui/styling/style-properties.ts
@@ -468,65 +468,20 @@ const STYLE_TRANSFORMATION_MAP = Object.freeze({
 });
 
 function convertToTransform(value: string): [CssProperty<any, any>, any][] {
-    let newTransform = value === unsetValue ? { "none": "none" } : transformConverter(value);
-    let array = [];
-    let values: Array<string>;
-    for (let transform in newTransform) {
-        switch (transform) {
-            case "scaleX":
-                array.push([scaleXProperty, newTransform[transform]]);
-                break;
-            case "scaleY":
-                array.push([scaleYProperty, newTransform[transform]]);
-                break;
-            case "scale":
-            case "scale3d":
-                values = newTransform[transform].split(",");
-                if (values.length >= 2) {
-                    array.push([scaleXProperty, values[0]]);
-                    array.push([scaleYProperty, values[1]]);
-                }
-                else if (values.length === 1) {
-                    array.push([scaleXProperty, values[0]]);
-                    array.push([scaleYProperty, values[0]]);
-                }
-                break;
-            case "translateX":
-                array.push([translateXProperty, newTransform[transform]]);
-                break;
-            case "translateY":
-                array.push([translateYProperty, newTransform[transform]]);
-                break;
-            case "translate":
-            case "translate3d":
-                values = newTransform[transform].split(",");
-                if (values.length >= 2) {
-                    array.push([translateXProperty, values[0]]);
-                    array.push([translateYProperty, values[1]]);
-                }
-                else if (values.length === 1) {
-                    array.push([translateXProperty, values[0]]);
-                    array.push([translateYProperty, values[0]]);
-                }
-                break;
-            case "rotate":
-                let text = newTransform[transform];
-                let val = parseFloat(text);
-                if (text.slice(-3) === "rad") {
-                    val = val * (180.0 / Math.PI);
-                }
-                array.push([rotateProperty, val]);
-                break;
-            case "none":
-                array.push([scaleXProperty, 1]);
-                array.push([scaleYProperty, 1]);
-                array.push([translateXProperty, 0]);
-                array.push([translateYProperty, 0]);
-                array.push([rotateProperty, 0]);
-                break;
-        }
+    if (value === unsetValue) {
+        value = "none";
     }
-    return array;
+
+    const { translate, rotate, scale } = transformConverter(value);
+    return [
+        [translateXProperty, translate.x],
+        [translateYProperty, translate.y],
+
+        [scaleXProperty, scale.x],
+        [scaleYProperty, scale.y],
+
+        [rotateProperty, rotate],
+    ];
 }
 
 export function transformConverter(text: string): TransformFunctionsInfo {

--- a/tns-core-modules/utils/number-utils.ts
+++ b/tns-core-modules/utils/number-utils.ts
@@ -1,4 +1,4 @@
-﻿var epsilon = 1E-05;
+﻿const epsilon = 1E-05;
 
 export function areClose(value1: number, value2: number): boolean {
     return (Math.abs(value1 - value2) < epsilon);
@@ -27,3 +27,7 @@ export function greaterThanZero(value: Object): boolean {
 export function notNegative(value: Object): boolean {
     return (<number>value) >= 0;
 }
+
+export const radiansToDegrees = (a: number) => a * (180 / Math.PI);
+
+export const degreesToRadians = (a: number) => a * (Math.PI / 180);

--- a/tns-core-modules/utils/utils-common.ts
+++ b/tns-core-modules/utils/utils-common.ts
@@ -153,3 +153,11 @@ export function merge(left, right, compareFunc) {
 
     return result;
 }
+
+export function hasDuplicates(arr: Array<any>): boolean {
+    return arr.length !== eliminateDuplicates(arr).length;
+}
+
+export function eliminateDuplicates(arr: Array<any>): Array<any> {
+    return Array.from(new Set(arr));
+}

--- a/tns-core-modules/utils/utils.d.ts
+++ b/tns-core-modules/utils/utils.d.ts
@@ -270,3 +270,16 @@ export function convertString(value: any): any
  * @param compareFunc - function that will be used to compare two elements of the array
  */
 export function mergeSort(arr: Array<any>, compareFunc: (a: any, b: any) => number): Array<any>
+
+/**
+ * 
+ * Checks if array has any duplicate elements.
+ * @param arr - The array to be checked.
+ */
+export function hasDuplicates(arr: Array<any>): boolean;
+
+/**
+ * Removes duplicate elements from array.
+ * @param arr - The array.
+ */
+export function eliminateDuplicates(arr: Array<any>): Array<any>;


### PR DESCRIPTION
- adds `matrix` module for converting css transform properties (the supported affinities - translate, rotate and scale) to transformation matrices. 2623925
- modifies transformation converter behavior for cases with more than one affinity of the same type (ex. `translateX(100) translateY(200)` or `scale(2) rotate(45) scale(1.5)`):
  - each affinity is converted to the corresponding augmented matrix and then all matrices are multiplied (left to right). [code](https://github.com/NativeScript/NativeScript/pull/4296/files#diff-5308e29352c0da58fcb9ad6905f4e1f5R549)
  - finally, the resulting matrix is [decomposed](https://github.com/NativeScript/NativeScript/pull/4296/files#diff-057b4f11a58d469d455312c92fd30c42R53) and [`TransformFunctionsInfo`](https://github.com/NativeScript/NativeScript/pull/4296/files#diff-577c74342bb722d12462cbfc5c9193bfR109) is returned.
- adds a few new tests for css animations b69f7b1
- moves the transform converter to style-properties
- adds a few typings to keyframe animations parsing and refactors the css-animation-parser module

follow up: use transformation matrices instead of decomposed affinities for the animations in android and ios.