### PR TITLE
Support for local snapshots

### DIFF
--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -35,5 +35,12 @@
       "ios": "2.1.1",
       "android": "2.1.1"
     }
+  },
+  "snapshot": {
+    "android": {
+      "tns-java-classes": {
+        "modules": ["ui/frame/activity", "ui/frame/fragment"]
+      }
+    }
   }
 }


### PR DESCRIPTION
In the context of a snapshot, all `__extends` calls are postpone till the app is running on device. However, some native Java classes, created by JS code, needs their JS part to be loaded early as part of the app bootstrapping because their native part is being touched by the system, e.g. `NativeScriptActivity` and `FragmentClass` (or for some other reason). In order to be properly snapshotted every {N} plugin should specify the files which contain such Java classes successors.
