### PR TITLE
fix: add dom-node declarations

### DIFF
--- a/tns-core-modules/debugger/dom-node.d.ts
+++ b/tns-core-modules/debugger/dom-node.d.ts
@@ -1,0 +1,22 @@
+import { ViewBase } from "../ui/core/view";
+import { CSSComputedStyleProperty } from "./css-agent";
+export declare function getNodeById(id: number): DOMNode;
+export declare class DOMNode {
+    nodeId: any;
+    nodeType: any;
+    nodeName: any;
+    localName: any;
+    nodeValue: string;
+    attributes: string[];
+    viewRef: WeakRef<ViewBase>;
+    constructor(view: ViewBase);
+    loadAttributes(): void;
+    readonly children: DOMNode[];
+    onChildAdded(childView: ViewBase): void;
+    onChildRemoved(view: ViewBase): void;
+    attributeModified(name: string, value: any): void;
+    attributeRemoved(name: string): void;
+    getComputedProperties(): CSSComputedStyleProperty[];
+    dispose(): void;
+    toJSON(): string;
+}


### PR DESCRIPTION
The d.ts is needed because `dom-node` is imported in `text-base.d.ts`