### PR TITLE
Set text-field and text-view tintColor to textColor (iOS) (fixes #4357)

### DIFF
--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -196,6 +196,7 @@ export class TextField extends TextFieldBase {
         // }
         let color = value instanceof Color ? value.ios : value;
         this.nativeView.textColor = color;
+        this.nativeView.tintColor = color;
     }
 
     [placeholderColorProperty.getDefault](): UIColor {

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -145,6 +145,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
 
             if (color) {
                 this.nativeView.textColor = color.ios;
+                this.nativeView.tintColor = color.ios;
             } else {
                 this.nativeView.textColor = UIColor.blackColor;
             }


### PR DESCRIPTION
As described in #4357, there's a regression from tns 2.5 to 3.0 that affects the color of the blinking cursor (or "caret") on iOS text-field and text-view.

This simple patch brings back the old behaviour that the caret has the same color as the text.
