### PR TITLE
Standard timers - fix for #4384

### DIFF
--- a/tests/app/timer/timer-tests.ts
+++ b/tests/app/timer/timer-tests.ts
@@ -39,6 +39,23 @@ export function test_setTimeout() {
     TKUnit.assert(completed, "Callback should be called!");
 };
 
+export function test_setTimeout_extraArgs() {
+    let completed: boolean;
+    let rnd: number = Math.random();
+
+    // >> timer-set-zero
+    const id = timer.setTimeout((arg) => {
+        // >> (hide)
+        completed = rnd === arg;
+        // << (hide)
+    }, 0, rnd);
+    // << timer-set-zero
+
+    TKUnit.waitUntilReady(() => completed, 0.5, false);
+    timer.clearTimeout(id);
+    TKUnit.assert(completed, "Callback called with expected argument!");
+};
+
 export function test_setTimeout_callbackCalledAfterSpecifiedTime() {
     let completed = false;
 
@@ -108,6 +125,24 @@ export function test_setInterval_callbackCalledDuringPeriod() {
     TKUnit.waitUntilReady(() => counter >= expected, 0.25, false);
     timer.clearInterval(id);
     TKUnit.assert(counter >= expected, "Callback should be raised at least" + expected + "times! Callback raised " + counter + " times.");
+};
+
+export function test_setInterval_callbackCalledWithExtraArgs() {
+    let counter: number = 0;
+    let expected: number = 4;
+    let rnd: number = Math.random();
+
+    // >> timer-set-expression
+    const id = timer.setInterval((arg) => {
+        // >> (hide)
+        counter += arg === rnd ? 1 : -1;
+        // << (hide)
+    }, 50, rnd);
+    // << timer-set-expression
+
+    TKUnit.waitUntilReady(() => counter >= expected, 0.25, false);
+    timer.clearInterval(id);
+    TKUnit.assert(counter >= expected, "Callback raised " + counter + " times with arguments.");
 };
 
 export function test_setInterval_callbackShouldBeCleared() {

--- a/tns-core-modules/timer/timer.android.ts
+++ b/tns-core-modules/timer/timer.android.ts
@@ -14,9 +14,10 @@ function createHandlerAndGetId(): number {
     return timerId;
 }
 
-export function setTimeout(callback: Function, milliseconds = 0): number {
+export function setTimeout(callback: Function, milliseconds = 0, ...args): number {
     const id = createHandlerAndGetId();
-    const zoneBound = zonedCallback(callback);
+    const invoke = () => callback(...args);
+    const zoneBound = zonedCallback(invoke);
 
     var runnable = new java.lang.Runnable({
         run: () => {
@@ -45,10 +46,11 @@ export function clearTimeout(id: number): void {
     }
 }
 
-export function setInterval(callback: Function, milliseconds = 0): number {
+export function setInterval(callback: Function, milliseconds = 0, ...args): number {
     const id = createHandlerAndGetId();
     const handler = timeoutHandler;
-    const zoneBound = zonedCallback(callback);
+    const invoke = () => callback(...args);
+    const zoneBound = zonedCallback(invoke);
 
     var runnable = new java.lang.Runnable({
         run: () => {

--- a/tns-core-modules/timer/timer.d.ts
+++ b/tns-core-modules/timer/timer.d.ts
@@ -7,8 +7,9 @@
  * Calls a function after a specified delay.
  * @param callback The function to be called.
  * @param milliseconds The time to wait before the function is called. Defaults to 0.
+ * @param args One or more parameter to use once the function is called. Defaults to no parameters.
  */
-export function setTimeout(callback: Function, milliseconds?: number): number;
+export function setTimeout(callback: Function, milliseconds?: number,  ...args: any[]): number;
 
 /**
  * Clears the delay set by a call to the setTimeout function.
@@ -20,8 +21,9 @@ export function clearTimeout(id: number): void;
  * Calls a function repeatedly with a delay between each call.
  * @param callback The function to be called.
  * @param milliseconds The delay between each function call.
+ * @param args One or more parameter to use once the function is called. Defaults to no parameters.
  */
-export function setInterval(callback: Function, milliseconds?: number): number;
+export function setInterval(callback: Function, milliseconds?: number,  ...args: any[]): number;
 
 /**
  * Clears repeated function which was set up by calling setInterval().

--- a/tns-core-modules/timer/timer.ios.ts
+++ b/tns-core-modules/timer/timer.ios.ts
@@ -63,8 +63,9 @@ function createTimerAndGetId(callback: Function, milliseconds: number, shouldRep
     return id;
 }
 
-export function setTimeout(callback: Function, milliseconds = 0): number {
-    return createTimerAndGetId(zonedCallback(callback), milliseconds, false);
+export function setTimeout(callback: Function, milliseconds = 0, ...args): number {
+    let invoke = () => callback(...args);
+    return createTimerAndGetId(zonedCallback(invoke), milliseconds, false);
 }
 
 export function clearTimeout(id: number): void {
@@ -74,8 +75,9 @@ export function clearTimeout(id: number): void {
     }
 }
 
-export function setInterval(callback: Function, milliseconds = 0): number {
-    return createTimerAndGetId(zonedCallback(callback), milliseconds, true);
+export function setInterval(callback: Function, milliseconds = 0, ...args): number {
+    let invoke = () => callback(...args);
+    return createTimerAndGetId(zonedCallback(invoke), milliseconds, true);
 }
 
 export var clearInterval = clearTimeout;


### PR DESCRIPTION
Specifications define timers capable of accepting optional parameters.
https://www.w3.org/TR/2011/WD-html5-20110525/timers.html#timers

This PR goal is to standardize such behavior in NativeScript too.

To help the rest of the community review your change, please ensure:
