### PR TITLE
chore(travis): do not run unit tests app in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,52 +4,16 @@ env:
   - PACKAGE_VERSION=$DATE-$TRAVIS_BUILD_NUMBER
   - PACKAGE_NAME=tns-core-modules
   - NODE_VERSION=6.9.4
-  - EMULATOR_API_VER=21
-  - RUNTIMEVERSION=next
-  - AVD_NAME=Arm$EMULATOR_API_VER
-addons:
-  artifacts:
-    paths:
-    - "$HOME/test-run-results$PACKAGE_VERSION.xml"
-sudo: false
-language: android
+language: node_js
 node_js:
-- 6.9.4
-jdk:
-- oraclejdk8
-android:
-  components:
-  - platform-tools
-  - tools
-  - build-tools-23.0.3
-  - android-$EMULATOR_API_VER
-  - android-23
-  - extra-android-support
-  - extra-android-m2repository
-  - sys-img-armeabi-v7a-android-$EMULATOR_API_VER
+- '6'
 before_script:
-- nvm install $NODE_VERSION
 - npm install -g grunt-cli
 - npm install
-- echo no | android create avd --force -n $AVD_NAME -t android-$EMULATOR_API_VER --abi
-  default/armeabi-v7a -c 12M
-- emulator -avd $AVD_NAME -no-audio -no-window &
-# - android-wait-for-emulator
-- ./build/travis-scripts/android-wait-for-emulator
-- adb shell input keyevent 82 &
 script:
-- jdk_switcher use oraclejdk8
-- grunt default --verbose
+- grunt default
 - FULL_PACKAGE_VERSION=$(node build/version.js)
 - (cd tns-platform-declarations && npm pack)
-- wget -O ./nativescript.tgz "https://s3.amazonaws.com/nativescript-ci/build_result/nativescript.tgz"
-- echo no | npm install -g nativescript.tgz --ignore-scripts
-- tns usage-reporting disable && tns error-reporting disable
-- grunt buildOnlyTestsApp --platform=Android --modulesPath=./bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz --runtimeVersion=$RUNTIMEVERSION --emuPId=.*emulator.* --avd=$AVD_NAME --showEmu=false
-- grunt runOnlyTestsApp --verbose --platform=Android --modulesPath=./bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz --emuPId=.*emulator.* --avd=$AVD_NAME --showEmu=false
-- node ./build/travis-scripts/check-testrun-broken.js
-- adb pull /storage/sdcard/Documents/test-results.xml
-- mv test-results.xml ~/test-run-results$PACKAGE_VERSION.xml
 before_deploy:
 - mv bin/dist/$PACKAGE_NAME-$FULL_PACKAGE_VERSION.tgz ../.deploymentpackage
 - mv build ../


### PR DESCRIPTION
The {N} team's having a hard time maintaining the unit tests app execution in Travis CI.
The main problem is that PROFILING, HTTP, WEB-VIEW tests fail randomly due to timeouts, caused by the unstable environment.
The unit tests app execution remains by default on PRs in {N} Jenkins CI.