### PR TITLE
xhr: include cookies in the XHR response reader

### DIFF
--- a/tns-core-modules/xhr/xhr.ts
+++ b/tns-core-modules/xhr/xhr.ts
@@ -199,10 +199,7 @@ export class XMLHttpRequest {
         let result = "";
 
         for (let i in this._headers) {
-            // Cookie headers are excluded
-            if (i !== "set-cookie" && i !== "set-cookie2") {
-                result += i + ": " + this._headers[i] + "\r\n";
-            }
+            result += i + ": " + this._headers[i] + "\r\n";
         }
         return result.substr(0, result.length - 2);
     }


### PR DESCRIPTION
Alloy cookies to be visible to the app, so it can save them across app start/stop cycle.