### PR TITLE
Fixes #4514: text/xml responses are now treated as text on iOS

### DIFF
--- a/tests/app/xhr/xhr-tests.ts
+++ b/tests/app/xhr/xhr-tests.ts
@@ -383,3 +383,10 @@ export function test_getResponseHeader() {
 
     TKUnit.assertEqual(xhr.getResponseHeader("Content-Type"), "application/json");
 };
+
+export function test_soap_content_types_recognized_as_text() {
+    const xhr = <any>new XMLHttpRequest();
+
+    TKUnit.assertTrue(xhr.isTextContentType("text/xml"), "text/xml failed to be recognized as a text response type");
+    TKUnit.assertTrue(xhr.isTextContentType("application/xml"), "application/xml failed to be recognized as a text response type");
+};

--- a/tns-core-modules/xhr/xhr.ts
+++ b/tns-core-modules/xhr/xhr.ts
@@ -131,7 +131,8 @@ export class XMLHttpRequest {
     private textTypes: string[] = [
         'text/plain',
         'application/xml',
-        'text/html'
+        'text/html',
+        'text/xml'
     ];
 
     private isTextContentType(contentType: string): boolean {


### PR DESCRIPTION
SOAP APIs return a content-type of "text/xml" which (on iOS) was resulting in a response body of a string-ified NSData object rather than XML. This was because "text/xml" was not recognized as a text response.

Per https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383526

> HTTP applications MUST use the media type "text/xml" according to RFC 2376 [3] when including SOAP entity bodies in HTTP messages.

Before the fix, the included test output

`CONSOLE ERROR file:///app/tns_modules/tns-core-modules/trace/trace.js:165:30: Test: XHR.test_soap_content_types_recognized_as_text FAILED: text/xml failed to be recognized as a text response type`

After the fix, the included test output

`CONSOLE INFO file:///app/tns_modules/tns-core-modules/trace/trace.js:159:29: Test: --- [XHR.test_soap_content_types_recognized_as_text] OK, duration: 0.10`