### PR TITLE
Add CSS support for line-height

### DIFF
--- a/tests/app/ui/text-view/text-view-tests.ts
+++ b/tests/app/ui/text-view/text-view-tests.ts
@@ -378,6 +378,18 @@ export var testNativeFontSizeFromLocal = function () {
     });
 }
 
+var expectedLineHeight = 10;
+export var testLocalLineHeightFromCss = function () {
+    helper.buildUIAndRunTest(_createTextViewFunc(), function (views: Array<viewModule.View>) {
+        var textView = <textViewModule.TextView>views[0];
+        var page = <pagesModule.Page>views[1];
+
+        page.css = "textview { line-height: " + expectedLineHeight + "; }";
+        var actualResult = textView.style.lineHeight;
+        TKUnit.assert(actualResult === expectedLineHeight, "Actual: " + actualResult + "; Expected: " + expectedLineHeight);
+    });
+}
+
 var expectedColorHex = "#FFFF0000";
 var expectedNormalizedColorHex = "#FF0000";
 export var testLocalColorFromCss = function () {

--- a/tns-core-modules/ui/styling/style-properties.d.ts
+++ b/tns-core-modules/ui/styling/style-properties.d.ts
@@ -86,6 +86,7 @@ export const minWidthProperty: CssProperty<Style, dip | LengthDipUnit | LengthPx
 export const minHeightProperty: CssProperty<Style, dip | LengthDipUnit | LengthPxUnit>;
 export const widthProperty: CssProperty<Style, PercentLength>;
 export const heightProperty: CssProperty<Style, PercentLength>;
+export const lineHeightProperty: CssProperty<Style, number>;
 export const marginProperty: ShorthandProperty<Style, string | PercentLength>;
 export const marginLeftProperty: CssProperty<Style, PercentLength>;
 export const marginRightProperty: CssProperty<Style, PercentLength>;

--- a/tns-core-modules/ui/styling/style/style.d.ts
+++ b/tns-core-modules/ui/styling/style/style.d.ts
@@ -96,6 +96,7 @@ export class Style extends Observable {
     public visibility: Visibility;
 
     public letterSpacing: number;
+    public lineHeight: number;
     public textAlignment: TextAlignment;
     public textDecoration: TextDecoration;
     public textTransform: TextTransform;

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -68,6 +68,7 @@ export class Style extends Observable implements StyleDefinition {
     public visibility: Visibility;
 
     public letterSpacing: number;
+    public lineHeight: number;
     public textAlignment: TextAlignment;
     public textDecoration: TextDecoration;
     public textTransform: TextTransform;

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -55,6 +55,13 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
         this.style.letterSpacing = value;
     }
 
+    get lineHeight(): number {
+        return this.style.lineHeight;
+    }
+    set lineHeight(value: number) {
+        this.style.lineHeight = value;
+    }
+
     get textAlignment(): TextAlignment {
         return this.style.textAlignment;
     }
@@ -203,3 +210,6 @@ textDecorationProperty.register(Style);
 
 export const letterSpacingProperty = new CssProperty<Style, number>({ name: "letterSpacing", cssName: "letter-spacing", defaultValue: 0, affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 letterSpacingProperty.register(Style);
+
+export const lineHeightProperty = new CssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", defaultValue: 0, affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
+lineHeightProperty.register(Style);

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -211,5 +211,5 @@ textDecorationProperty.register(Style);
 export const letterSpacingProperty = new CssProperty<Style, number>({ name: "letterSpacing", cssName: "letter-spacing", defaultValue: 0, affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 letterSpacingProperty.register(Style);
 
-export const lineHeightProperty = new CssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", defaultValue: 0, affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
+export const lineHeightProperty = new CssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 lineHeightProperty.register(Style);

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -5,7 +5,7 @@ import {
     TextBaseCommon, formattedTextProperty, textAlignmentProperty, textDecorationProperty, fontSizeProperty,
     textProperty, textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty,
     paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length,
-    whiteSpaceProperty, FormattedString, layout, Span, Color, isBold
+    whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold
 } from "./text-base-common";
 
 export * from "./text-base-common";
@@ -216,6 +216,10 @@ export class TextBase extends TextBaseCommon {
                 this.nativeView.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
             }
         }
+    }
+
+    [lineHeightProperty.setNative](value: number) {
+        this.nativeView.setLineSpacing(value * layout.getDisplayDensity(), 1);
     }
 
     [fontInternalProperty.getDefault](): android.graphics.Typeface {

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -218,6 +218,9 @@ export class TextBase extends TextBaseCommon {
         }
     }
 
+    [lineHeightProperty.getDefault](): number {
+        return 0;
+    }
     [lineHeightProperty.setNative](value: number) {
         this.nativeView.setLineSpacing(value * layout.getDisplayDensity(), 1);
     }

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -219,7 +219,7 @@ export class TextBase extends TextBaseCommon {
     }
 
     [lineHeightProperty.getDefault](): number {
-        return 0;
+        return this.nativeView.getLineSpacingExtra() / layout.getDisplayDensity();
     }
     [lineHeightProperty.setNative](value: number) {
         this.nativeView.setLineSpacing(value * layout.getDisplayDensity(), 1);

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -2,8 +2,8 @@
 import { Font } from "../styling/font";
 import {
     TextBaseCommon, textProperty, formattedTextProperty, textAlignmentProperty, textDecorationProperty,
-    textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty, FormattedString,
-    Span, Color, isBold
+    textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty, lineHeightProperty,
+    FormattedString, Span, Color, isBold
 } from "./text-base-common";
 
 export * from "./text-base-common";
@@ -92,6 +92,10 @@ export class TextBase extends TextBaseCommon {
         this._setNativeText();
     }
 
+    [lineHeightProperty.setNative](value: number) {
+        this._setNativeText();
+    }
+
     _setNativeText(reset: boolean = false): void {
         if (reset) {
             const nativeView = this.nativeView;
@@ -122,7 +126,7 @@ export class TextBase extends TextBaseCommon {
             attrText.addAttributeValueRange(NSKernAttributeName, this.letterSpacing * this.nativeView.font.pointSize, { location: 0, length: attrText.length });
         }
 
-        if (this.lineHeight !== 0) {
+        if (this.style.lineHeight) {
             const paragraphStyle = NSMutableParagraphStyle.alloc().init();
             paragraphStyle.lineSpacing = this.lineHeight;
             attrText.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, { location: 0, length: attrText.length });
@@ -160,7 +164,7 @@ export class TextBase extends TextBaseCommon {
             dict.set(NSKernAttributeName, style.letterSpacing * this.nativeView.font.pointSize);
         }
 
-        if (style.lineHeight !== 0) {
+        if (style.lineHeight) {
             const paragraphStyle = NSMutableParagraphStyle.alloc().init();
             paragraphStyle.lineSpacing = style.lineHeight;
             dict.set(NSParagraphStyleAttributeName, paragraphStyle);

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -122,6 +122,12 @@ export class TextBase extends TextBaseCommon {
             attrText.addAttributeValueRange(NSKernAttributeName, this.letterSpacing * this.nativeView.font.pointSize, { location: 0, length: attrText.length });
         }
 
+        if (this.lineHeight !== 0) {
+            const paragraphStyle = NSMutableParagraphStyle.alloc().init();
+            paragraphStyle.lineSpacing = this.lineHeight;
+            attrText.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, { location: 0, length: attrText.length });
+        }
+
         if (this.nativeView instanceof UIButton) {
             this.nativeView.setAttributedTitleForState(attrText, UIControlState.Normal);
         }
@@ -152,6 +158,12 @@ export class TextBase extends TextBaseCommon {
 
         if (style.letterSpacing !== 0) {
             dict.set(NSKernAttributeName, style.letterSpacing * this.nativeView.font.pointSize);
+        }
+
+        if (style.lineHeight !== 0) {
+            const paragraphStyle = NSMutableParagraphStyle.alloc().init();
+            paragraphStyle.lineSpacing = style.lineHeight;
+            dict.set(NSParagraphStyleAttributeName, paragraphStyle);
         }
 
         const isTextView = this.nativeView instanceof UITextView;


### PR DESCRIPTION
Implements #1664

Btw, added a density multiplier for Android so spacing is better aligned with iOS, as shown in this screenshot:

<img width="649" alt="screen shot 2017-07-09 at 21 34 23" src="https://user-images.githubusercontent.com/1426370/27997137-2327abba-64f2-11e7-97af-53ef02767995.png">
