### PR TITLE
Remove permission request from tests app

### DIFF
--- a/tests/app/app/mainPage.ts
+++ b/tests/app/app/mainPage.ts
@@ -33,27 +33,29 @@ function onNavigatedTo(args) {
     page.content = label;
     args.object.off(Page.navigatedToEvent, onNavigatedTo);
 
-    if (platform.isAndroid && parseInt(platform.device.sdkVersion) >= 23) {
-        let handler = (args: application.AndroidActivityRequestPermissionsEventData) => {
-            application.android.off(application.AndroidApplication.activityRequestPermissionsEvent, handler);
-            if (args.requestCode === 1234 && args.grantResults.length > 0 && args.grantResults[0] === android.content.pm.PackageManager.PERMISSION_GRANTED) {
-                runTests();
-            } else {
-                trace.write("Permission for write to external storage not granted!", trace.categories.Error, trace.messageType.error);
-            }
-        };
+    // Request permission to write test-results.xml file for API >= 23
+    // if (platform.isAndroid && parseInt(platform.device.sdkVersion) >= 23) {
+    //     let handler = (args: application.AndroidActivityRequestPermissionsEventData) => {
+    //         application.android.off(application.AndroidApplication.activityRequestPermissionsEvent, handler);
+    //         if (args.requestCode === 1234 && args.grantResults.length > 0 && args.grantResults[0] === android.content.pm.PackageManager.PERMISSION_GRANTED) {
+    //             runTests();
+    //         } else {
+    //             trace.write("Permission for write to external storage not granted!", trace.categories.Error, trace.messageType.error);
+    //         }
+    //     };
 
-        application.android.on(application.AndroidApplication.activityRequestPermissionsEvent, handler);
+    //     application.android.on(application.AndroidApplication.activityRequestPermissionsEvent, handler);
 
-        if ((<any>android.support.v4.content.ContextCompat).checkSelfPermission(application.android.currentContext, (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE) !== android.content.pm.PackageManager.PERMISSION_GRANTED) {
-            (<any>android.support.v4.app.ActivityCompat).requestPermissions(application.android.currentContext, [(<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE], 1234);
-        } else {
-            runTests();
-        }
-    } else {
-        runTests();
-    }
+    //     if ((<any>android.support.v4.content.ContextCompat).checkSelfPermission(application.android.currentContext, (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE) !== android.content.pm.PackageManager.PERMISSION_GRANTED) {
+    //         (<any>android.support.v4.app.ActivityCompat).requestPermissions(application.android.currentContext, [(<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE], 1234);
+    //     } else {
+    //         runTests();
+    //     }
+    // } else {
+    //     runTests();
+    // }
 
+    runTests();
 }
 export function createPage() {
     return page;


### PR DESCRIPTION
These permissions are not required anymore as the app stopped writing `test-results.xml`.
I leave them commented if needed in future.