### PR TITLE
xhr: include cookies in the XHR response header

### DIFF
--- a/tns-core-modules/xhr/xhr.ts
+++ b/tns-core-modules/xhr/xhr.ts
@@ -200,10 +200,7 @@ export class XMLHttpRequest {
         let result = "";
 
         for (let i in this._headers) {
-            // Cookie headers are excluded
-            if (i !== "set-cookie" && i !== "set-cookie2") {
-                result += i + ": " + this._headers[i] + "\r\n";
-            }
+            result += i + ": " + this._headers[i] + "\r\n";
         }
         return result.substr(0, result.length - 2);
     }


### PR DESCRIPTION
Implements: Provides the app with  `set-cookie` and `set-cookie2` besides `Set-Cookie` and `Set-Cookie2`, so app can implement its own cookie jar. This is useful to retain session between app start/stop cycle. 

Tests: No unit tests, because there was no unit tests for XHR Cookies initially, and the patch is trivial.

