### PR TITLE
Set text-field and text-view tintColor to textColor (iOS) (fixes #4357) EXTENDED

### DIFF
--- a/apps/app/ui-tests-app/text-view/hint-text-color.xml
+++ b/apps/app/ui-tests-app/text-view/hint-text-color.xml
@@ -6,14 +6,14 @@
         <Label text="TextView:" />
         <TextView hint="nothing" fontSize="18" />
         <TextView hint="placeholder-color"  style="placeholder-color: green;" fontSize="18" />
-        <TextView hint="color" style="color: blue;" fontSize="18" />
-        <TextView hint="both" style="color: blue; placeholder-color: green;" fontSize="18" />
+        <TextView hint="color" style="color: brown;" fontSize="18" />
+        <TextView hint="both" style="color: brown; placeholder-color: green;" fontSize="18" />
 
         <Label text="TextField:" />
         <TextField hint="nothing" fontSize="18" />
         <TextField hint="placeholder-color"  style="placeholder-color: green;" fontSize="18" />
-        <TextField hint="color" style="color: blue;" fontSize="18" />
-        <TextField hint="both" style="color: blue; placeholder-color: green;" fontSize="18" />
+        <TextField hint="color" style="color: brown;" fontSize="18" />
+        <TextField hint="both" style="color: brown; placeholder-color: green;" fontSize="18" />
 
         <StackLayout orientation="horizontal">
         <Button id="btnSetText" text="set text" tap="setText" width="80"/>

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -1,4 +1,4 @@
-﻿import { 
+﻿import {
     TextFieldBase, secureProperty, textProperty, hintProperty, colorProperty, placeholderColorProperty,
     Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, _updateCharactersInRangeReplacementString, Color, layout
 } from "./text-field-common";
@@ -48,7 +48,7 @@ class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
         this.firstEdit = false;
         const owner = this._owner.get();
         if (owner) {
-            textProperty.nativeValueChange(owner,  '');
+            textProperty.nativeValueChange(owner, '');
         }
 
         return true;
@@ -82,7 +82,7 @@ class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
                 else {
                     if (range.location <= textField.text.length) {
                         const newText = NSString.stringWithString(textField.text).stringByReplacingCharactersInRangeWithString(range, replacementString);
-                        textProperty.nativeValueChange(owner,  newText);
+                        textProperty.nativeValueChange(owner, newText);
                     }
                 }
             }
@@ -181,22 +181,23 @@ export class TextField extends TextFieldBase {
         this.nativeView.secureTextEntry = value;
     }
 
-    [colorProperty.getDefault](): UIColor {
+    [colorProperty.getDefault](): { textColor: UIColor, tintColor: UIColor } {
         // return this.nativeView.tintColor;
-        return this.nativeView.textColor;
+        console.log("----> TextField: colorProperty.getDefault: " + this.nativeView.textColor)
+        return {
+            textColor: this.nativeView.textColor,
+            tintColor: this.nativeView.tintColor
+        };
     }
-    [colorProperty.setNative](value: UIColor | Color) {
-        // NOTE: Do we need this code? We have placeholderColor.
-        // let nativeValue = this.nativeView;
-        // if (this.isShowingHint && value) {
-        //     nativeValue.textColor = value.colorWithAlphaComponent(0.22);
-        // } else {
-        //     nativeValue.textColor = value;
-        //     nativeValue.tintColor = value;
-        // }
-        let color = value instanceof Color ? value.ios : value;
-        this.nativeView.textColor = color;
-        this.nativeView.tintColor = color;
+    [colorProperty.setNative](value: Color | { textColor: UIColor, tintColor: UIColor }) {
+        if (value instanceof Color) {
+            let color = value instanceof Color ? value.ios : value;
+            this.nativeView.textColor = color;
+            this.nativeView.tintColor = color;
+        } else {
+            this.nativeView.textColor = value.textColor;
+            this.nativeView.tintColor = value.tintColor;
+        }
     }
 
     [placeholderColorProperty.getDefault](): UIColor {

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -196,6 +196,7 @@ export class TextField extends TextFieldBase {
         // }
         let color = value instanceof Color ? value.ios : value;
         this.nativeView.textColor = color;
+        this.nativeView.tintColor = color;
     }
 
     [placeholderColorProperty.getDefault](): UIColor {

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -135,7 +135,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
             if (placeholderColor) {
                 this.nativeView.textColor = placeholderColor.ios;
             } else if (color) {
-                // Use semi-transparent vesion of color for back-compatibility 
+                // Use semi-transparent version of color for back-compatibility 
                 this.nativeView.textColor = color.ios.colorWithAlphaComponent(0.22);
             } else {
                 this.nativeView.textColor = UIColor.blackColor.colorWithAlphaComponent(0.22);
@@ -147,7 +147,8 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
                 this.nativeView.textColor = color.ios;
                 this.nativeView.tintColor = color.ios;
             } else {
-                this.nativeView.textColor = UIColor.blackColor;
+                this.nativeView.textColor = null;
+                this.nativeView.tintColor = null;
             }
         }
     }

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -145,6 +145,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
 
             if (color) {
                 this.nativeView.textColor = color.ios;
+                this.nativeView.tintColor = color.ios;
             } else {
                 this.nativeView.textColor = UIColor.blackColor;
             }


### PR DESCRIPTION
Original PR by @dturing (#4357):

> The Caret (blinking cursor line) in TextViews is always blue on iOS. It should be a separate CSS property, or be the same as the text color.
> 
> This had been tackled with #1013 a long time ago, but seems to have regressed?
> 
> Setting .tintColor as well as .textColor in [Line 198 of text-field.ios.ts](https://github.com/NativeScript/NativeScript/blob/master/tns-core-modules/ui/text-field/text-field.ios.ts#L198) (as seen in the commented-out line 195) seems to fix this.
