### PR TITLE
refactor(css-selector): export createSelector method

### DIFF
--- a/tns-core-modules/ui/styling/css-selector/css-selector.d.ts
+++ b/tns-core-modules/ui/styling/css-selector/css-selector.d.ts
@@ -24,7 +24,7 @@ export interface Declaration {
     value: string;
 }
 
-export class SelectorCore {
+export interface SelectorCore {
     /**
      * Dynamic selectors depend on attributes and pseudo classes.
      */
@@ -74,3 +74,5 @@ export class SelectorsMatch<T extends Node> {
 }
 
 export function fromAstNodes(astRules: parser.Node[]): RuleSet[];
+
+export function createSelector(sel: string): SelectorCore;

--- a/tns-core-modules/ui/styling/css-selector/css-selector.ts
+++ b/tns-core-modules/ui/styling/css-selector/css-selector.ts
@@ -408,7 +408,7 @@ function createDeclaration(decl: cssParser.Declaration): any {
     return { property: decl.property.toLowerCase(), value: decl.value };
 }
 
-function createSelector(sel: string): SimpleSelector | SimpleSelectorSequence | Selector {
+export function createSelector(sel: string): SimpleSelector | SimpleSelectorSequence | Selector {
     try {
         let ast = selectorParser.parse(sel);
         if (ast.length === 0) {

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -419,9 +419,8 @@ function isKeyframe(node: CssNode): node is KeyframesDefinition {
     return node.type === "keyframes";
 }
 
-class InlineSelector extends SelectorCore {
+class InlineSelector implements SelectorCore {
     constructor(ruleSet: RuleSet) {
-        super();
         this.ruleset = ruleSet;
     }
 


### PR DESCRIPTION
The exported method is needed for NativeScript Angular's animation driver

