### PR TITLE
fix(animations): check if target is present before removing its animation

### DIFF
--- a/tns-core-modules/ui/animation/animation.android.ts
+++ b/tns-core-modules/ui/animation/animation.android.ts
@@ -192,14 +192,20 @@ export class Animation extends AnimationBase {
         this._propertyUpdateCallbacks.forEach(v => v());
         this._disableHardwareAcceleration();
         this._resolveAnimationFinishedPromise();
-        this._target._removeAnimation(this);
+
+        if (this._target) {
+            this._target._removeAnimation(this);
+        }
     }
 
     private _onAndroidAnimationCancel() { // tslint:disable-line 
         this._propertyResetCallbacks.forEach(v => v());
         this._disableHardwareAcceleration();
         this._rejectAnimationFinishedPromise();
-        this._target._removeAnimation(this);
+
+        if (this._target) {
+            this._target._removeAnimation(this);
+        }
     }
 
     private _createAnimators(propertyAnimation: PropertyAnimation): void {


### PR DESCRIPTION
In NativeScript Angular, if the NativeScriptAnimationModule is imported in another
NgModule more than once (which shouldn't be done), the renderer will be instantiated twice. This
causes animations with empty targets to be created. If such animation is
removed, the app will crash. The additional check if the target is present
will prevent this.
