### PR TITLE
Git ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ apps/platforms/
 apps/lib/
 apps/hooks/
 apps/node_modules/
+
+package-lock.json


### PR DESCRIPTION
We have decided to fail as early as possible on broken dependencies so we can fix such problems as early as possible. package-lock.json will be very valuable for app and app developers but if we apply this in our repo, we risk to let issues go unnoticed.