### PR TITLE
Fixes TabView icons changes.

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -87,7 +87,7 @@ function initializeNativeClasses() {
             container.removeView(nativeView);
 
             // Note: this.owner._removeView will clear item.view.nativeView.
-            // So call this after the native instance is removed form the container. 
+            // So call this after the native instance is removed form the container.
             // if (item.view.parent === this.owner) {
             //     this.owner._removeView(item.view);
             // }
@@ -209,7 +209,9 @@ export class TabViewItem extends TabViewItemBase {
     public _update(): void {
         const tv = this.nativeView;
         if (tv) {
-            const tabLayout = <org.nativescript.widgets.TabLayout>tv.getParent();
+            const tabLayout = <org.nativescript.widgets.TabLayout>tv.getParent().getParent().getParent();
+            this.tabItemSpec = createTabItemSpec(this);
+
             tabLayout.updateItemAt(this.index, this.tabItemSpec);
         }
     }
@@ -313,7 +315,7 @@ export class TabView extends TabViewBase {
         const listener = new PageChangedListener(this);
         (<any>viewPager).addOnPageChangeListener(listener);
         (<any>viewPager).listener = listener;
-        
+
         const adapter = new PagerAdapter(this, null);
         viewPager.setAdapter(adapter);
         (<any>viewPager).adapter = adapter;


### PR DESCRIPTION
This Fixes/Implements #4138 .

This issue has two fixes; the first is that the item is now a couple levels deeper in the hierarchy; so we have to go up a couple parents to get to the actual TabView root controller in NS 3.    

The second issue; is even though we change the itemSource value, the item assigned to this tab view was never refreshed; so we call the function that recreates the tabview item with the new values.

