### PR TITLE
Fix unitests on API <20

### DIFF
--- a/tests/app/ui/helper.ts
+++ b/tests/app/ui/helper.ts
@@ -285,7 +285,10 @@ export function nativeView_recycling_test(createNew: () => View, createLayout?: 
     if (first.typeName !== "SearchBar") {
         // There are way too many differences in native methods for search-bar.
         // There are too many methods that just throw for newly created views in API lvl 19 and 17
-        TKUnit.waitUntilReady(() => layout.isLayoutValid);
+        if (sdkVersion < 21) {
+            TKUnit.waitUntilReady(() => layout.isLayoutValid);
+        }
+
         compareUsingReflection(newer, first);
     }
 
@@ -322,6 +325,7 @@ function compareUsingReflection(recycledNativeView: View, newNativeView: View): 
             || name === 'getY'
             || name.includes('getMeasured')
             || name === 'toString';
+
         if (skip || method.getParameterTypes().length > 0) {
             continue;
         }

--- a/tests/app/ui/helper.ts
+++ b/tests/app/ui/helper.ts
@@ -282,9 +282,10 @@ export function nativeView_recycling_test(createNew: () => View, createLayout?: 
     layout.addChild(newer);
     layout.addChild(first);
 
-    if (first.typeName !== "SearchBar" && sdkVersion > 19) {
+    if (first.typeName !== "SearchBar") {
         // There are way too many differences in native methods for search-bar.
-        // There are too many methods that just throw for newly created views in API lvl 19 and 17 
+        // There are too many methods that just throw for newly created views in API lvl 19 and 17
+        TKUnit.waitUntilReady(() => layout.isLayoutValid);
         compareUsingReflection(newer, first);
     }
 
@@ -311,6 +312,15 @@ function compareUsingReflection(recycledNativeView: View, newNativeView: View): 
             || name === 'getId'
             || name === 'hasFocus'
             || name === 'isDirty'
+            || name === 'getLeft'
+            || name === 'getTop'
+            || name === 'getRight'
+            || name === 'getBottom'
+            || name === 'getWidth'
+            || name === 'getHeight'
+            || name === 'getX'
+            || name === 'getY'
+            || name.includes('getMeasured')
             || name === 'toString';
         if (skip || method.getParameterTypes().length > 0) {
             continue;


### PR DESCRIPTION
Some of these methods depends on the parent Layout. In the tests we are using `FlexboxLayout` as parent so items are positioned on different rectangle.