### PR TITLE
recycling now happens only if nativeView and android properties are...

### DIFF
--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -359,7 +359,7 @@ function showReportPage(finalMessage: string) {
     if (page.android) {
         setTimeout(() => {
             messageContainer.dismissSoftInput();
-            (<android.view.View>messageContainer.nativeView).scrollTo(0, 0);
+            (<android.view.View>messageContainer.nativeViewProtected).scrollTo(0, 0);
         });
     }
 }

--- a/tests/app/ui/action-bar/action-bar-tests.android.ts
+++ b/tests/app/ui/action-bar/action-bar-tests.android.ts
@@ -11,7 +11,7 @@ export function test_actionItem_visibility() {
     actionItem.text = "Test";
     const page = actionTestsCommon.createPageAndNavigate();
     page.actionBar.actionItems.addItem(actionItem);
-    const toolbar = <android.support.v7.widget.Toolbar>page.actionBar.nativeView;
+    const toolbar = <android.support.v7.widget.Toolbar>page.actionBar.nativeViewProtected;
     const menu = toolbar.getMenu();
 
     TKUnit.assertTrue(menu.hasVisibleItems(), "Visibility does not work");
@@ -25,7 +25,7 @@ export function test_navigationButton_visibility() {
     const page = actionTestsCommon.createPageAndNavigate();
     page.actionBar.navigationButton = actionItem;
 
-    const toolbar = <android.support.v7.widget.Toolbar>page.actionBar.nativeView;
+    const toolbar = <android.support.v7.widget.Toolbar>page.actionBar.nativeViewProtected;
 
     TKUnit.assertNotNull(toolbar.getNavigationIcon(), "Visibility does not work");
     actionItem.visibility = Visibility.collapse;

--- a/tests/app/ui/activity-indicator/activity-indicator-tests.ts
+++ b/tests/app/ui/activity-indicator/activity-indicator-tests.ts
@@ -55,7 +55,7 @@ if (platform.device.os === platform.platformNames.ios) {
         ai.color = new color.Color("red");
 
         function testAction(views: Array<viewModule.View>) {
-            TKUnit.assertEqual(ai.color.ios.CGColor, ai.nativeView.color.CGColor, "ai.color");
+            TKUnit.assertEqual(ai.color.ios.CGColor, ai.nativeViewProtected.color.CGColor, "ai.color");
         };
 
         helper.buildUIAndRunTest(ai, testAction);

--- a/tests/app/ui/helper.ts
+++ b/tests/app/ui/helper.ts
@@ -261,8 +261,8 @@ export function nativeView_recycling_test(createNew: () => View, createLayout?: 
     const test = createNew();
 
     // Make sure we are not reusing a native views.
-    first.recycleNativeView = false;
-    test.recycleNativeView = false;
+    first.recycleNativeView = "never";
+    test.recycleNativeView = "never";
 
     page.content = layout;
 
@@ -273,12 +273,12 @@ export function nativeView_recycling_test(createNew: () => View, createLayout?: 
     // Needed so we can reset formattedText
     test["secure"] = false;
 
-    const nativeView = test.nativeView;
+    const nativeView = test.nativeViewProtected;
     // Mark so we reuse the native views.
-    test.recycleNativeView = true;
+    test.recycleNativeView = "always";
     layout.removeChild(test);
     const newer = createNew();
-    newer.recycleNativeView = true;
+    newer.recycleNativeView = "always";
     layout.addChild(newer);
     layout.addChild(first);
 
@@ -288,7 +288,7 @@ export function nativeView_recycling_test(createNew: () => View, createLayout?: 
         compareUsingReflection(newer, first);
     }
 
-    TKUnit.assertEqual(newer.nativeView, nativeView, "nativeView not reused.");
+    TKUnit.assertEqual(newer.nativeViewProtected, nativeView, "nativeView not reused.");
     checkDefaults(newer, first, props, nativeGetters || defaultNativeGetters);
     checkDefaults(newer, first, styleProps, nativeGetters || defaultNativeGetters);
 
@@ -297,8 +297,8 @@ export function nativeView_recycling_test(createNew: () => View, createLayout?: 
 }
 
 function compareUsingReflection(recycledNativeView: View, newNativeView: View): void {
-    const recycled: android.view.View = recycledNativeView.nativeView;
-    const newer: android.view.View = newNativeView.nativeView;
+    const recycled: android.view.View = recycledNativeView.nativeViewProtected;
+    const newer: android.view.View = newNativeView.nativeViewProtected;
     TKUnit.assertNotEqual(recycled, newer);
     const methods = newer.getClass().getMethods();
     for (let i = 0, length = methods.length; i < length; i++) {

--- a/tests/app/ui/layouts/common-layout-tests.ts
+++ b/tests/app/ui/layouts/common-layout-tests.ts
@@ -30,7 +30,7 @@ export function percent_support_nativeLayoutParams_are_correct(test: testModule.
 
     test.waitUntilTestElementLayoutIsValid();
 
-    let lp = getNativeLayoutParams(btn.nativeView);
+    let lp = getNativeLayoutParams(btn.nativeViewProtected);
     TKUnit.assertEqual(lp.width, 100, "width");
     TKUnit.assertEqual(lp.widthPercent, -1, "widthPercent");
     TKUnit.assertEqual(lp.height, 100, "height");

--- a/tests/app/ui/layouts/layout-helper.android.ts
+++ b/tests/app/ui/layouts/layout-helper.android.ts
@@ -66,18 +66,18 @@ class NativeGridLayout extends org.nativescript.widgets.GridLayout {
 }
 
 export class MyButton extends Button implements def.MyButton {
-    nativeView: NativeButton;
+    nativeViewProtected: NativeButton;
 
     public createNativeView() {
         return new NativeButton(this._context, this);
     }
 
     public initNativeView(): void {
-        this.nativeView.owner = this;
+        this.nativeViewProtected.owner = this;
     }
 
     public disposeNativeView() {
-        this.nativeView.owner = undefined;
+        this.nativeViewProtected.owner = undefined;
     }
 
     public measureCount: number = 0;
@@ -102,35 +102,35 @@ export class MyButton extends Button implements def.MyButton {
     }
 
     get layoutWidth(): number {
-        return this.nativeView.getWidth();
+        return this.nativeViewProtected.getWidth();
     }
 
     get layoutHeight(): number {
-        return this.nativeView.getHeight();
+        return this.nativeViewProtected.getHeight();
     }
 
     get layoutLeft(): number {
-        return this.nativeView.getLeft();
+        return this.nativeViewProtected.getLeft();
     }
 
     get layoutTop(): number {
-        return this.nativeView.getTop();
+        return this.nativeViewProtected.getTop();
     }
 }
 
 export class MyStackLayout extends StackLayout implements def.MyStackLayout {
-    nativeView: NativeStackLayout;
+    nativeViewProtected: NativeStackLayout;
 
     public createNativeView() {
         return new NativeStackLayout(this._context, this);
     }
 
     public initNativeView(): void {
-        this.nativeView.owner = this;
+        this.nativeViewProtected.owner = this;
     }
 
     public disposeNativeView() {
-        this.nativeView.owner = undefined;
+        this.nativeViewProtected.owner = undefined;
     }
 
     public measureCount: number = 0;
@@ -155,35 +155,35 @@ export class MyStackLayout extends StackLayout implements def.MyStackLayout {
     }
 
     get layoutWidth(): number {
-        return this.nativeView.getWidth();
+        return this.nativeViewProtected.getWidth();
     }
 
     get layoutHeight(): number {
-        return this.nativeView.getHeight();
+        return this.nativeViewProtected.getHeight();
     }
 
     get layoutLeft(): number {
-        return this.nativeView.getLeft();
+        return this.nativeViewProtected.getLeft();
     }
 
     get layoutTop(): number {
-        return this.nativeView.getTop();
+        return this.nativeViewProtected.getTop();
     }
 }
 
 export class MyGridLayout extends GridLayout implements def.MyGridLayout {
-    nativeView: NativeGridLayout;
+    nativeViewProtected: NativeGridLayout;
 
     public createNativeView() {
         return new NativeGridLayout(this._context, this);
     }
 
     public initNativeView(): void {
-        this.nativeView.owner = this;
+        this.nativeViewProtected.owner = this;
     }
 
     public disposeNativeView() {
-        this.nativeView.owner = undefined;
+        this.nativeViewProtected.owner = undefined;
     }
 
     public measureCount: number = 0;
@@ -208,19 +208,19 @@ export class MyGridLayout extends GridLayout implements def.MyGridLayout {
     }
 
     get layoutWidth(): number {
-        return this.nativeView.getWidth();
+        return this.nativeViewProtected.getWidth();
     }
 
     get layoutHeight(): number {
-        return this.nativeView.getHeight();
+        return this.nativeViewProtected.getHeight();
     }
 
     get layoutLeft(): number {
-        return this.nativeView.getLeft();
+        return this.nativeViewProtected.getLeft();
     }
 
     get layoutTop(): number {
-        return this.nativeView.getTop();
+        return this.nativeViewProtected.getTop();
     }
 }
 

--- a/tests/app/ui/lifecycle/pages/button-counter.ts
+++ b/tests/app/ui/lifecycle/pages/button-counter.ts
@@ -19,4 +19,4 @@ export class Button extends button.Button {
         super._redrawNativeBackground(value);
     }
 }
-Button.prototype.recycleNativeView = false;
+Button.prototype.recycleNativeView = "never";

--- a/tests/app/ui/list-picker/list-picker-tests-native.android.ts
+++ b/tests/app/ui/list-picker/list-picker-tests-native.android.ts
@@ -1,7 +1,7 @@
 ﻿import * as listPickerModule from "tns-core-modules/ui/list-picker";
 
 export function getNativeItemsCount(listPicker: listPickerModule.ListPicker): number {
-    var maxValue = listPicker.nativeView.getMaxValue();
+    var maxValue = listPicker.nativeViewProtected.getMaxValue();
 
     if (listPicker.items.length === 0 && maxValue === 0) {
         return 0;
@@ -12,6 +12,6 @@ export function getNativeItemsCount(listPicker: listPickerModule.ListPicker): nu
 
 export function selectNativeItem(listPicker: listPickerModule.ListPicker, index: number): void {
     var oldIndex = listPicker.selectedIndex;
-    listPicker.nativeView.setValue(index);
-    listPicker.nativeView.valueChangedListener.onValueChange(listPicker.android, oldIndex, index);
+    listPicker.nativeViewProtected.setValue(index);
+    listPicker.nativeViewProtected.valueChangedListener.onValueChange(listPicker.android, oldIndex, index);
 }

--- a/tests/app/ui/list-picker/list-picker-tests.ts
+++ b/tests/app/ui/list-picker/list-picker-tests.ts
@@ -186,7 +186,7 @@ export var test_Android_MaxValueIsOneLessThanItemsCount = function () {
         var listPicker = <listPickerModule.ListPicker>views[0];
         listPicker.items = ["One", "Two", "Three"];
         var expectedValue = listPicker.items.length - 1;
-        var actualValue = listPicker.nativeView.getMaxValue();
+        var actualValue = listPicker.nativeViewProtected.getMaxValue();
         TKUnit.assertEqual(actualValue, expectedValue);
     });
 }
@@ -199,7 +199,7 @@ export var test_Android_WhenItemsAreEmptyNativeControlDoesNotShowZero = function
     helper.buildUIAndRunTest(_createListPicker(), function (views: Array<viewModule.View>) {
         var listPicker = <listPickerModule.ListPicker>views[0];
         var expectedValue = " ";
-        var actualValue = listPicker.nativeView.editText.getText().toString();
+        var actualValue = listPicker.nativeViewProtected.editText.getText().toString();
         TKUnit.assertEqual(actualValue, expectedValue);
     });
 }
@@ -213,7 +213,7 @@ export var test_Android_WhenBoundToSingleElementArrayEditTextIsUpdatedProperly =
         var listPicker = <listPickerModule.ListPicker>views[0];
         listPicker.items = ["One"];
         var expectedValue = "One";
-        var actualValue = listPicker.nativeView.editText.getText().toString();
+        var actualValue = listPicker.nativeViewProtected.editText.getText().toString();
         TKUnit.assertEqual(actualValue, expectedValue);
     });
 }
@@ -228,7 +228,7 @@ export var test_Android_WhenSelectedIndexChangesEditTextIsUpdatedProperly = func
         listPicker.items = ["One", "Two"];
         listPicker.selectedIndex = 1;
         var expectedValue = "Two";
-        var actualValue = listPicker.nativeView.editText.getText().toString();
+        var actualValue = listPicker.nativeViewProtected.editText.getText().toString();
         TKUnit.assertEqual(actualValue, expectedValue);
     });
 }

--- a/tests/app/ui/page/page-tests-common.ts
+++ b/tests/app/ui/page/page-tests-common.ts
@@ -385,9 +385,9 @@ export function test_page_backgroundColor_is_white() {
     helper.navigate(factory);
     let whiteColor = new Color("white");
     if (platform.isIOS) {
-        TKUnit.assertTrue(whiteColor.ios.CGColor.isEqual(page.nativeView.backgroundColor.CGColor), "page default backgroundColor should be white");
+        TKUnit.assertTrue(whiteColor.ios.CGColor.isEqual(page.nativeViewProtected.backgroundColor.CGColor), "page default backgroundColor should be white");
     } else {
-        TKUnit.assertEqual(page.nativeView.getBackground().getColor(), whiteColor.android, "page default backgroundColor should be white");
+        TKUnit.assertEqual(page.nativeViewProtected.getBackground().getColor(), whiteColor.android, "page default backgroundColor should be white");
     }
 }
 

--- a/tests/app/ui/page/page-tests.android.ts
+++ b/tests/app/ui/page/page-tests.android.ts
@@ -50,7 +50,7 @@ export function test_NavigateToNewPage_WithAndroidCache() {
 
     TKUnit.assertNull(label._context, "InnerControl._context should not be set after navigate back.");
     TKUnit.assertNull(label.android, "InnerControl.android should not be set after navigate back.");
-    TKUnit.assertNull(label.nativeView, "InnerControl.nativeView hould not be set after navigate back.");
+    TKUnit.assertNull(label.nativeViewProtected, "InnerControl.nativeView hould not be set after navigate back.");
     TKUnit.assertFalse(label.isLoaded, "InnerControl.isLoaded should become false after navigating back");
     TKUnit.assertFalse(label._isAddedToNativeVisualTree, "InnerControl._isAddedToNativeVisualTree should not be true after navigating back");
 }
@@ -71,7 +71,7 @@ export function test_NavigateToNewPage_InnerControl() {
 
     TKUnit.assertNull(label._context, "InnerControl._context should be undefined after navigate back.");
     TKUnit.assertNull(label.android, "InnerControl.android should be undefined after navigate back.");
-    TKUnit.assertNull(label.nativeView, "InnerControl.nativeView should be undefined after navigate back.");
+    TKUnit.assertNull(label.nativeViewProtected, "InnerControl.nativeView should be undefined after navigate back.");
     TKUnit.assertFalse(label.isLoaded, "InnerControl.isLoaded should become false after navigating back");
     TKUnit.assertFalse(label._isAddedToNativeVisualTree, "InnerControl._isAddedToNativeVisualTree should become false after navigating back");
 }

--- a/tests/app/ui/placeholder/placeholder-tests.ts
+++ b/tests/app/ui/placeholder/placeholder-tests.ts
@@ -42,9 +42,9 @@ export function test_placeholder_creatingView() {
 
     function testAction(views: Array<viewModule.View>) {
         if (isIOS) {
-            TKUnit.assert(p.nativeView instanceof UITextView, "nativeView property should be UITextView. Current value: " + p.nativeView);
+            TKUnit.assert(p.nativeViewProtected instanceof UITextView, "nativeView property should be UITextView. Current value: " + p.nativeViewProtected);
         } else if (isAndroid) {
-            TKUnit.assert(p.nativeView instanceof android.widget.TextView, "Native view should be android.widget.TextView. Current value: " + p.nativeView);
+            TKUnit.assert(p.nativeViewProtected instanceof android.widget.TextView, "Native view should be android.widget.TextView. Current value: " + p.nativeViewProtected);
         }
     };
 

--- a/tests/app/ui/segmented-bar/segmented-bar-tests-native.android.ts
+++ b/tests/app/ui/segmented-bar/segmented-bar-tests-native.android.ts
@@ -15,7 +15,7 @@ export function checkNativeItemsTextColor(bar: segmentedBarModule.SegmentedBar):
     // }
 
     for (let i = 0, itemsLength = bar.items.length; i < itemsLength; i++) {
-        let textView = <android.widget.TextView>bar.items[0].nativeView;
+        let textView = <android.widget.TextView>bar.items[0].nativeViewProtected;
         isValid = bar.color && bar.color.android === textView.getCurrentTextColor();
     }
 

--- a/tests/app/ui/segmented-bar/segmented-bar-tests-native.ios.ts
+++ b/tests/app/ui/segmented-bar/segmented-bar-tests-native.ios.ts
@@ -1,19 +1,19 @@
 ﻿import * as segmentedBarModule from "tns-core-modules/ui/segmented-bar";
 
 export function getNativeItemsCount(bar: segmentedBarModule.SegmentedBar): number {
-    return (<UISegmentedControl>bar.nativeView).numberOfSegments;
+    return (<UISegmentedControl>bar.nativeViewProtected).numberOfSegments;
 }
 
 export function checkNativeItemsTextColor(bar: segmentedBarModule.SegmentedBar): boolean {
     var isValid = true;
 
-    var attrs = (<UISegmentedControl>bar.nativeView).titleTextAttributesForState(UIControlState.Normal);
+    var attrs = (<UISegmentedControl>bar.nativeViewProtected).titleTextAttributesForState(UIControlState.Normal);
     isValid = bar.color && attrs && attrs.valueForKey(NSForegroundColorAttributeName) === bar.color.ios;
 
     return isValid;
 }
 
 export function setNativeSelectedIndex(bar: segmentedBarModule.SegmentedBar, index: number): void {
-    (<UISegmentedControl>bar.nativeView).selectedSegmentIndex = index;
-    (<UISegmentedControl>bar.nativeView).sendActionsForControlEvents(UIControlEvents.ValueChanged);
+    (<UISegmentedControl>bar.nativeViewProtected).selectedSegmentIndex = index;
+    (<UISegmentedControl>bar.nativeViewProtected).sendActionsForControlEvents(UIControlEvents.ValueChanged);
 }

--- a/tests/app/ui/switch/switch-tests.ts
+++ b/tests/app/ui/switch/switch-tests.ts
@@ -142,7 +142,7 @@ export function test_binding_value_to_model() {
 
 function getNativeValue(mySwitch: switchModule.Switch): boolean {
     if (platform.isAndroid) {
-        const nativeView: android.widget.Switch = mySwitch.nativeView;
+        const nativeView: android.widget.Switch = mySwitch.nativeViewProtected;
         return nativeView.isChecked();
     } else if (mySwitch.ios) {
         return mySwitch.ios.on;
@@ -151,7 +151,7 @@ function getNativeValue(mySwitch: switchModule.Switch): boolean {
 
 function setNativeValue(mySwitch: switchModule.Switch, value: boolean) {
     if (platform.isAndroid) {
-        const nativeView: android.widget.Switch = mySwitch.nativeView;
+        const nativeView: android.widget.Switch = mySwitch.nativeViewProtected;
         nativeView.setChecked(value);
     }
     else if (mySwitch.ios) {

--- a/tests/app/ui/view/view-tests-common.ts
+++ b/tests/app/ui/view/view-tests-common.ts
@@ -14,7 +14,7 @@ import * as helper from "../../ui/helper";
 import * as observable from "tns-core-modules/data/observable";
 import * as bindable from "tns-core-modules/ui/core/bindable";
 import * as definition from "./view-tests";
-import { isIOS } from "tns-core-modules/platform";
+import { isIOS, isAndroid } from "tns-core-modules/platform";
 
 export function test_eachDescendant() {
     const test = function (views: Array<View>) {
@@ -350,8 +350,8 @@ class TestView extends Layout {
     private _nativeView;
     constructor(public name: string) {
         super();
-        this._nativeView = this.nativeView;
-        this.nativeView = undefined;
+        this._nativeView = this.nativeViewProtected;
+        this.nativeViewProtected = undefined;
     }
 
     public createNativeView() {
@@ -578,7 +578,7 @@ export function test_NativeSetter_called_when_add_and_remove() {
 export function test_NativeSetter_called_when_add_and_remove_and_recycled() {
     const firstView = new TestView("firstView");
     const secondView = new TestView("secondView");
-    secondView.recycleNativeView = !isIOS;
+    secondView.recycleNativeView = isAndroid ? "always" : "never";
     secondView.customCssProperty = "testCssValue";
     secondView.custom = "testViewValue";
 

--- a/tns-core-modules/ui/action-bar/action-bar.android.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.android.ts
@@ -108,7 +108,7 @@ export class NavigationButton extends ActionItem {
 
 export class ActionBar extends ActionBarBase {
     private _android: AndroidActionBarSettings;
-    public nativeView: android.support.v7.widget.Toolbar;
+    public nativeViewProtected: android.support.v7.widget.Toolbar;
 
     constructor() {
         super();
@@ -142,11 +142,11 @@ export class ActionBar extends ActionBarBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        (<any>this.nativeView).menuItemClickListener.owner = this;
+        (<any>this.nativeViewProtected).menuItemClickListener.owner = this;
     }
 
     public disposeNativeView() {
-        (<any>this.nativeView).menuItemClickListener.owner = null;
+        (<any>this.nativeViewProtected).menuItemClickListener.owner = null;
         super.disposeNativeView();
     }
 
@@ -156,19 +156,19 @@ export class ActionBar extends ActionBarBase {
     }
 
     public update() {
-        if (!this.nativeView) {
+        if (!this.nativeViewProtected) {
             return;
         }
 
         const page = this.page;
         if (!page.frame || !page.frame._getNavBarVisible(page)) {
-            this.nativeView.setVisibility(android.view.View.GONE);
+            this.nativeViewProtected.setVisibility(android.view.View.GONE);
 
             // If action bar is hidden - no need to fill it with items.
             return;
         }
 
-        this.nativeView.setVisibility(android.view.View.VISIBLE);
+        this.nativeViewProtected.setVisibility(android.view.View.VISIBLE);
 
         // Add menu items
         this._addActionItems();
@@ -216,16 +216,16 @@ export class ActionBar extends ActionBarBase {
                 // Try to look in the system resources.
                 const systemResourceId = getSystemResourceId(systemIcon);
                 if (systemResourceId) {
-                    this.nativeView.setNavigationIcon(systemResourceId);
+                    this.nativeViewProtected.setNavigationIcon(systemResourceId);
                 }
             }
             else if (navButton.icon) {
                 let drawableOrId = getDrawableOrResourceId(navButton.icon, appResources);
-                this.nativeView.setNavigationIcon(drawableOrId);
+                this.nativeViewProtected.setNavigationIcon(drawableOrId);
             }
 
             let navBtn = new WeakRef(navButton);
-            this.nativeView.setNavigationOnClickListener(new android.view.View.OnClickListener({
+            this.nativeViewProtected.setNavigationOnClickListener(new android.view.View.OnClickListener({
                 onClick: function (v) {
                     let owner = navBtn.get();
                     if (owner) {
@@ -235,7 +235,7 @@ export class ActionBar extends ActionBarBase {
             }));
         }
         else {
-            this.nativeView.setNavigationIcon(null);
+            this.nativeViewProtected.setNavigationIcon(null);
         }
     }
 
@@ -246,16 +246,16 @@ export class ActionBar extends ActionBarBase {
             if (icon !== undefined) {
                 let drawableOrId = getDrawableOrResourceId(icon, appResources);
                 if (drawableOrId) {
-                    this.nativeView.setLogo(drawableOrId);
+                    this.nativeViewProtected.setLogo(drawableOrId);
                 }
             }
             else {
                 let defaultIcon = application.android.nativeApp.getApplicationInfo().icon;
-                this.nativeView.setLogo(defaultIcon);
+                this.nativeViewProtected.setLogo(defaultIcon);
             }
         }
         else {
-            this.nativeView.setLogo(null);
+            this.nativeViewProtected.setLogo(null);
         }
     }
 
@@ -264,20 +264,20 @@ export class ActionBar extends ActionBarBase {
             // No title view - show the title
             let title = this.title;
             if (title !== undefined) {
-                this.nativeView.setTitle(title);
+                this.nativeViewProtected.setTitle(title);
             } else {
                 let appContext = application.android.context;
                 let appInfo = appContext.getApplicationInfo();
                 let appLabel = appContext.getPackageManager().getApplicationLabel(appInfo);
                 if (appLabel) {
-                    this.nativeView.setTitle(appLabel);
+                    this.nativeViewProtected.setTitle(appLabel);
                 }
             }
         }
     }
 
     public _addActionItems() {
-        let menu = this.nativeView.getMenu();
+        let menu = this.nativeViewProtected.getMenu();
         let items = this.actionItems.getVisibleItems();
 
         menu.clear();
@@ -326,13 +326,13 @@ export class ActionBar extends ActionBarBase {
     }
 
     public _onTitlePropertyChanged() {
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             this._updateTitleAndTitleView();
         }
     }
 
     public _onIconPropertyChanged() {
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             this._updateIcon();
         }
     }
@@ -340,12 +340,12 @@ export class ActionBar extends ActionBarBase {
     public _addViewToNativeVisualTree(child: View, atIndex: number = Number.MAX_VALUE): boolean {
         super._addViewToNativeVisualTree(child);
 
-        if (this.nativeView && child.nativeView) {
-            if (atIndex >= this.nativeView.getChildCount()) {
-                this.nativeView.addView(child.nativeView);
+        if (this.nativeViewProtected && child.nativeViewProtected) {
+            if (atIndex >= this.nativeViewProtected.getChildCount()) {
+                this.nativeViewProtected.addView(child.nativeViewProtected);
             }
             else {
-                this.nativeView.addView(child.nativeView, atIndex);
+                this.nativeViewProtected.addView(child.nativeViewProtected, atIndex);
             }
             return true;
         }
@@ -356,13 +356,13 @@ export class ActionBar extends ActionBarBase {
     public _removeViewFromNativeVisualTree(child: View): void {
         super._removeViewFromNativeVisualTree(child);
 
-        if (this.nativeView && child.nativeView) {
-            this.nativeView.removeView(child.nativeView);
+        if (this.nativeViewProtected && child.nativeViewProtected) {
+            this.nativeViewProtected.removeView(child.nativeViewProtected);
         }
     }
 
     [colorProperty.getDefault](): number {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!defaultTitleTextColor) {
             let tv: android.widget.TextView = getAppCompatTextView(nativeView);
             if (!tv) {
@@ -385,17 +385,17 @@ export class ActionBar extends ActionBarBase {
     }
     [colorProperty.setNative](value: number | Color) {
         const color = value instanceof Color ? value.android : value;
-        this.nativeView.setTitleTextColor(color);
+        this.nativeViewProtected.setTitleTextColor(color);
     }
 
     [flatProperty.setNative](value: boolean) {
         const compat = <any>android.support.v4.view.ViewCompat;
         if (compat.setElevation) {
             if (value) {
-                compat.setElevation(this.nativeView, 0);
+                compat.setElevation(this.nativeViewProtected, 0);
             } else {
                 const val = DEFAULT_ELEVATION * layout.getDisplayDensity();
-                compat.setElevation(this.nativeView, val);
+                compat.setElevation(this.nativeViewProtected, val);
             }
         }
     }
@@ -412,7 +412,7 @@ function getAppCompatTextView(toolbar: android.support.v7.widget.Toolbar): typeo
     return null;
 }
 
-ActionBar.prototype.recycleNativeView = true;
+ActionBar.prototype.recycleNativeView = "auto";
 
 let defaultTitleTextColor: number;
 

--- a/tns-core-modules/ui/activity-indicator/activity-indicator-common.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator-common.ts
@@ -7,7 +7,7 @@ export class ActivityIndicatorBase extends View implements ActivityIndicatorDefi
     public busy: boolean;
 }
 
-ActivityIndicatorBase.prototype.recycleNativeView = true;
+ActivityIndicatorBase.prototype.recycleNativeView = "auto";
 
 export const busyProperty = new Property<ActivityIndicatorBase, boolean>({ name: "busy", defaultValue: false, valueConverter: booleanConverter });
 busyProperty.register(ActivityIndicatorBase);

--- a/tns-core-modules/ui/activity-indicator/activity-indicator.android.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator.android.ts
@@ -3,7 +3,7 @@
 export * from "./activity-indicator-common";
 
 export class ActivityIndicator extends ActivityIndicatorBase {
-    nativeView: android.widget.ProgressBar;
+    nativeViewProtected: android.widget.ProgressBar;
 
     public createNativeView() {
         const progressBar =  new android.widget.ProgressBar(this._context);
@@ -17,7 +17,7 @@ export class ActivityIndicator extends ActivityIndicatorBase {
     }
     [busyProperty.setNative](value: boolean) {
         if (this.visibility === Visibility.VISIBLE) {
-            this.nativeView.setVisibility(value ? android.view.View.VISIBLE : android.view.View.INVISIBLE);
+            this.nativeViewProtected.setVisibility(value ? android.view.View.VISIBLE : android.view.View.INVISIBLE);
         }
     }
 
@@ -27,13 +27,13 @@ export class ActivityIndicator extends ActivityIndicatorBase {
     [visibilityProperty.setNative](value: Visibility) {
         switch (value) {
             case Visibility.VISIBLE:
-                this.nativeView.setVisibility(this.busy ? android.view.View.VISIBLE : android.view.View.INVISIBLE);
+                this.nativeViewProtected.setVisibility(this.busy ? android.view.View.VISIBLE : android.view.View.INVISIBLE);
                 break;
             case Visibility.HIDDEN:
-                this.nativeView.setVisibility(android.view.View.INVISIBLE);
+                this.nativeViewProtected.setVisibility(android.view.View.INVISIBLE);
                 break;
             case Visibility.COLLAPSE:
-                this.nativeView.setVisibility(android.view.View.GONE);
+                this.nativeViewProtected.setVisibility(android.view.View.GONE);
                 break;
             default: 
                 throw new Error(`Invalid visibility value: ${value}. Valid values are: "${Visibility.VISIBLE}", "${Visibility.HIDDEN}", "${Visibility.COLLAPSE}".`);
@@ -45,9 +45,9 @@ export class ActivityIndicator extends ActivityIndicatorBase {
     }
     [colorProperty.setNative](value: number | Color) {
         if (value instanceof Color) {
-            this.nativeView.getIndeterminateDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+            this.nativeViewProtected.getIndeterminateDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
         } else {
-            this.nativeView.getIndeterminateDrawable().clearColorFilter();
+            this.nativeViewProtected.getIndeterminateDrawable().clearColorFilter();
         }
     }
 }

--- a/tns-core-modules/ui/activity-indicator/activity-indicator.ios.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator.ios.ts
@@ -3,28 +3,28 @@ import { ActivityIndicatorBase, busyProperty, colorProperty, Color } from "./act
 export * from "./activity-indicator-common";
 
 export class ActivityIndicator extends ActivityIndicatorBase {
-    nativeView: UIActivityIndicatorView;
+    nativeViewProtected: UIActivityIndicatorView;
 
     constructor() {
         super();
-        this.nativeView = UIActivityIndicatorView.alloc().initWithActivityIndicatorStyle(UIActivityIndicatorViewStyle.Gray);
-        this.nativeView.hidesWhenStopped = true;
+        this.nativeViewProtected = UIActivityIndicatorView.alloc().initWithActivityIndicatorStyle(UIActivityIndicatorViewStyle.Gray);
+        this.nativeViewProtected.hidesWhenStopped = true;
     }
 
     get ios(): UIActivityIndicatorView {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     [busyProperty.getDefault](): boolean {
-        if ((<any>this.nativeView).isAnimating) {
-            return (<any>this.nativeView).isAnimating();
+        if ((<any>this.nativeViewProtected).isAnimating) {
+            return (<any>this.nativeViewProtected).isAnimating();
         }
         else {
-            return this.nativeView.animating;
+            return this.nativeViewProtected.animating;
         }
     }
     [busyProperty.setNative](value: boolean) {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (value) {
             nativeView.startAnimating();
         } else {
@@ -37,9 +37,9 @@ export class ActivityIndicator extends ActivityIndicatorBase {
     }
 
     [colorProperty.getDefault](): UIColor {
-        return this.nativeView.color;
+        return this.nativeViewProtected.color;
     }
     [colorProperty.setNative](value: UIColor | Color) {
-        this.nativeView.color = value instanceof Color ? value.ios : value;
+        this.nativeViewProtected.color = value instanceof Color ? value.ios : value;
     }
 }

--- a/tns-core-modules/ui/animation/animation.android.ts
+++ b/tns-core-modules/ui/animation/animation.android.ts
@@ -209,7 +209,7 @@ export class Animation extends AnimationBase {
     }
 
     private _createAnimators(propertyAnimation: PropertyAnimation): void {
-        if (!propertyAnimation.target.nativeView) {
+        if (!propertyAnimation.target.nativeViewProtected) {
             return;
         }
 
@@ -232,7 +232,7 @@ export class Animation extends AnimationBase {
         this._target = propertyAnimation.target;
 
         let nativeArray;
-        const nativeView = <android.view.View>propertyAnimation.target.nativeView;
+        const nativeView = <android.view.View>propertyAnimation.target.nativeViewProtected;
         const animators = new Array<android.animation.Animator>();
         const propertyUpdateCallbacks = new Array<Function>();
         const propertyResetCallbacks = new Array<Function>();
@@ -273,7 +273,7 @@ export class Animation extends AnimationBase {
                     } else {
                         propertyAnimation.target.style[opacityProperty.keyframe] = originalValue1;
                     }
-                    if (propertyAnimation.target.nativeView) {
+                    if (propertyAnimation.target.nativeViewProtected) {
                         propertyAnimation.target[opacityProperty.setNative](propertyAnimation.target.style.opacity);
                     }
                 }));
@@ -306,7 +306,7 @@ export class Animation extends AnimationBase {
                         propertyAnimation.target.style[backgroundColorProperty.keyframe] = originalValue1;
                     }
                     
-                    if (propertyAnimation.target.nativeView && propertyAnimation.target[backgroundColorProperty.setNative]) {
+                    if (propertyAnimation.target.nativeViewProtected && propertyAnimation.target[backgroundColorProperty.setNative]) {
                         propertyAnimation.target[backgroundColorProperty.setNative](propertyAnimation.target.style.backgroundColor);
                     }
                 }));
@@ -346,7 +346,7 @@ export class Animation extends AnimationBase {
                         propertyAnimation.target.style[translateYProperty.keyframe] = originalValue2;
                     }
 
-                    if (propertyAnimation.target.nativeView) {
+                    if (propertyAnimation.target.nativeViewProtected) {
                         propertyAnimation.target[translateXProperty.setNative](propertyAnimation.target.style.translateX);
                         propertyAnimation.target[translateYProperty.setNative](propertyAnimation.target.style.translateY);
                     }
@@ -391,7 +391,7 @@ export class Animation extends AnimationBase {
                         propertyAnimation.target.style[scaleYProperty.keyframe] = originalValue2;
                     }
 
-                    if (propertyAnimation.target.nativeView) {
+                    if (propertyAnimation.target.nativeViewProtected) {
                         propertyAnimation.target[scaleXProperty.setNative](propertyAnimation.target.style.scaleX);
                         propertyAnimation.target[scaleYProperty.setNative](propertyAnimation.target.style.scaleY);
                     }
@@ -419,7 +419,7 @@ export class Animation extends AnimationBase {
                         propertyAnimation.target.style[rotateProperty.keyframe] = originalValue1;
                     }
                     
-                    if (propertyAnimation.target.nativeView) {
+                    if (propertyAnimation.target.nativeViewProtected) {
                         propertyAnimation.target[rotateProperty.setNative](propertyAnimation.target.style.rotate);
                     }
                 }));
@@ -468,7 +468,7 @@ export class Animation extends AnimationBase {
 
     private _enableHardwareAcceleration() {
         for (let i = 0, length = this._propertyAnimations.length; i < length; i++) {
-            let cache = <CacheLayerType>this._propertyAnimations[i].target.nativeView;
+            let cache = <CacheLayerType>this._propertyAnimations[i].target.nativeViewProtected;
             if (cache) {
                 let layerType = cache.getLayerType();
                 if (layerType !== android.view.View.LAYER_TYPE_HARDWARE) {
@@ -481,7 +481,7 @@ export class Animation extends AnimationBase {
 
     private _disableHardwareAcceleration() {
         for (let i = 0, length = this._propertyAnimations.length; i < length; i++) {
-            let cache = <CacheLayerType>this._propertyAnimations[i].target.nativeView;
+            let cache = <CacheLayerType>this._propertyAnimations[i].target.nativeViewProtected;
             if (cache && cache.layerType !== undefined) {
                 cache.setLayerType(cache.layerType, null);
                 cache.layerType = undefined;

--- a/tns-core-modules/ui/animation/animation.ios.ts
+++ b/tns-core-modules/ui/animation/animation.ios.ts
@@ -224,7 +224,7 @@ export class Animation extends AnimationBase {
         let length = this._mergedPropertyAnimations.length;
         for (; i < length; i++) {
             let propertyAnimation = this._mergedPropertyAnimations[i];
-            propertyAnimation.target.nativeView.layer.removeAllAnimations();
+            propertyAnimation.target.nativeViewProtected.layer.removeAllAnimations();
             if (propertyAnimation._propertyResetCallback) {
                 propertyAnimation._propertyResetCallback(propertyAnimation._originalValue, this._valueSource);
             }
@@ -260,7 +260,7 @@ export class Animation extends AnimationBase {
 
     private static _getNativeAnimationArguments(animation: PropertyAnimationInfo, valueSource: "animation" | "keyframe"): AnimationInfo {
 
-        let nativeView = <UIView>animation.target.nativeView;
+        let nativeView = <UIView>animation.target.nativeViewProtected;
         let propertyNameToAnimate = animation.property;
         let value = animation.value;
         let originalValue;
@@ -382,7 +382,7 @@ export class Animation extends AnimationBase {
 
     private static _createNativeAnimation(propertyAnimations: Array<PropertyAnimation>, index: number, playSequentially: boolean, args: AnimationInfo, animation: PropertyAnimation, valueSource: "animation" | "keyframe", finishedCallback: (cancelled?: boolean) => void) {
 
-        let nativeView = <UIView>animation.target.nativeView;
+        let nativeView = <UIView>animation.target.nativeViewProtected;
         let nativeAnimation = CABasicAnimation.animationWithKeyPath(args.propertyNameToAnimate);
         nativeAnimation.fromValue = args.fromValue;
         nativeAnimation.toValue = args.toValue;
@@ -416,7 +416,7 @@ export class Animation extends AnimationBase {
 
     private static _createNativeSpringAnimation(propertyAnimations: Array<PropertyAnimationInfo>, index: number, playSequentially: boolean, args: AnimationInfo, animation: PropertyAnimationInfo, valueSource: "animation" | "keyframe", finishedCallback: (cancelled?: boolean) => void) {
 
-        let nativeView = <UIView>animation.target.nativeView;
+        let nativeView = <UIView>animation.target.nativeViewProtected;
 
         let callback = undefined;
         let nextAnimation;
@@ -596,7 +596,7 @@ export function _getTransformMismatchErrorMessage(view: View): string {
     result = CGAffineTransformRotate(result, (view.rotate || 0) * Math.PI / 180);
     result = CGAffineTransformScale(result, view.scaleX || 1, view.scaleY || 1);
     let viewTransform = NSStringFromCGAffineTransform(result);
-    let nativeTransform = NSStringFromCGAffineTransform(view.nativeView.transform);
+    let nativeTransform = NSStringFromCGAffineTransform(view.nativeViewProtected.transform);
 
     if (viewTransform !== nativeTransform) {
         return "View and Native transforms do not match. View: " + viewTransform + "; Native: " + nativeTransform;

--- a/tns-core-modules/ui/border/border.ts
+++ b/tns-core-modules/ui/border/border.ts
@@ -41,4 +41,4 @@ export class Border extends ContentView implements BorderDefinition {
     }
 }
 
-Border.prototype.recycleNativeView = true;
+Border.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/button/button-common.ts
+++ b/tns-core-modules/ui/button/button-common.ts
@@ -18,4 +18,4 @@ export abstract class ButtonBase extends TextBase implements ButtonDefinition {
     }
 }
 
-ButtonBase.prototype.recycleNativeView = true;
+ButtonBase.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/button/button.android.ts
+++ b/tns-core-modules/ui/button/button.android.ts
@@ -39,7 +39,7 @@ function initializeClickListener(): void {
 }
 
 export class Button extends ButtonBase {
-    nativeView: android.widget.Button;
+    nativeViewProtected: android.widget.Button;
 
     private _stateListAnimator: any;
     private _highlightedHandler: (args: TouchGestureEventData) => void;
@@ -55,13 +55,13 @@ export class Button extends ButtonBase {
     }
 
     public initNativeView(): void {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         (<any>nativeView).clickListener.owner = this;
         super.initNativeView();
     }
 
     public disposeNativeView() {
-        (<any>this.nativeView).clickListener.owner = null;
+        (<any>this.nativeViewProtected).clickListener.owner = null;
         super.disposeNativeView();
     }
 
@@ -69,7 +69,7 @@ export class Button extends ButtonBase {
         super.resetNativeView();
 
         if (this._stateListAnimator && APILEVEL >= 21) {
-            (<any>this.nativeView).setStateListAnimator(this._stateListAnimator);
+            (<any>this.nativeViewProtected).setStateListAnimator(this._stateListAnimator);
             this._stateListAnimator = undefined;
         }
     }
@@ -97,41 +97,41 @@ export class Button extends ButtonBase {
         return { value: this._defaultPaddingTop, unit: "px" }
     }
     [paddingTopProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
     }
 
     [paddingRightProperty.getDefault](): Length {
         return { value: this._defaultPaddingRight, unit: "px" }
     }
     [paddingRightProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
     }
 
     [paddingBottomProperty.getDefault](): Length {
         return { value: this._defaultPaddingBottom, unit: "px" }
     }
     [paddingBottomProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
     }
 
     [paddingLeftProperty.getDefault](): Length {
         return { value: this._defaultPaddingLeft, unit: "px" }
     }
     [paddingLeftProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
     }
 
     [zIndexProperty.setNative](value: number) {
         // API >= 21
         if (APILEVEL >= 21) {
-            const nativeView = this.nativeView;
+            const nativeView = this.nativeViewProtected;
             if (!this._stateListAnimator) {
                 this._stateListAnimator = (<any>nativeView).getStateListAnimator();
             }
             (<any>nativeView).setStateListAnimator(null);
         }
 
-        org.nativescript.widgets.ViewHelper.setZIndex(this.nativeView, value);
+        org.nativescript.widgets.ViewHelper.setZIndex(this.nativeViewProtected, value);
     }
 
     [textAlignmentProperty.setNative](value: TextAlignment) {

--- a/tns-core-modules/ui/button/button.ios.ts
+++ b/tns-core-modules/ui/button/button.ios.ts
@@ -9,21 +9,21 @@ import {
 export * from "./button-common";
 
 export class Button extends ButtonBase {
-    public nativeView: UIButton;
+    public nativeViewProtected: UIButton;
 
     private _tapHandler: NSObject;
     private _stateChangedHandler: ControlStateChangeListener;
 
     constructor() {
         super();
-        this.nativeView = UIButton.buttonWithType(UIButtonType.System);
+        this.nativeViewProtected = UIButton.buttonWithType(UIButtonType.System);
 
         this._tapHandler = TapHandlerImpl.initWithOwner(new WeakRef(this));
-        this.nativeView.addTargetActionForControlEvents(this._tapHandler, "tap", UIControlEvents.TouchUpInside);
+        this.nativeViewProtected.addTargetActionForControlEvents(this._tapHandler, "tap", UIControlEvents.TouchUpInside);
     }
 
     get ios() {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public onUnloaded() {
@@ -37,7 +37,7 @@ export class Button extends ButtonBase {
     _updateHandler(subscribe: boolean) {
         if (subscribe) {
             if (!this._stateChangedHandler) {
-                this._stateChangedHandler = new ControlStateChangeListener(this.nativeView, (s: string) => {
+                this._stateChangedHandler = new ControlStateChangeListener(this.nativeViewProtected, (s: string) => {
                     this._goToVisualState(s);
                 });
             }
@@ -49,120 +49,120 @@ export class Button extends ButtonBase {
 
     [borderTopWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.top,
+            value: this.nativeViewProtected.contentEdgeInsets.top,
             unit: "px"
         };
     }
     [borderTopWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let top = layout.toDeviceIndependentPixels(this.effectivePaddingTop + this.effectiveBorderTopWidth);
-        this.nativeView.contentEdgeInsets = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.contentEdgeInsets = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
     }
 
     [borderRightWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.right,
+            value: this.nativeViewProtected.contentEdgeInsets.right,
             unit: "px"
         };
     }
     [borderRightWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let right = layout.toDeviceIndependentPixels(this.effectivePaddingRight + this.effectiveBorderRightWidth);
-        this.nativeView.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
+        this.nativeViewProtected.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
     }
 
     [borderBottomWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.bottom,
+            value: this.nativeViewProtected.contentEdgeInsets.bottom,
             unit: "px"
         };
     }
     [borderBottomWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let bottom = layout.toDeviceIndependentPixels(this.effectivePaddingBottom + this.effectiveBorderBottomWidth);
-        this.nativeView.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
+        this.nativeViewProtected.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
     }
 
     [borderLeftWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.left,
+            value: this.nativeViewProtected.contentEdgeInsets.left,
             unit: "px"
         };
     }
     [borderLeftWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let left = layout.toDeviceIndependentPixels(this.effectivePaddingLeft + this.effectiveBorderLeftWidth);
-        this.nativeView.contentEdgeInsets = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.contentEdgeInsets = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
     }
 
     [paddingTopProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.top,
+            value: this.nativeViewProtected.contentEdgeInsets.top,
             unit: "px"
         };
     }
     [paddingTopProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let top = layout.toDeviceIndependentPixels(this.effectivePaddingTop + this.effectiveBorderTopWidth);
-        this.nativeView.contentEdgeInsets = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.contentEdgeInsets = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
     }
 
     [paddingRightProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.right,
+            value: this.nativeViewProtected.contentEdgeInsets.right,
             unit: "px"
         };
     }
     [paddingRightProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let right = layout.toDeviceIndependentPixels(this.effectivePaddingRight + this.effectiveBorderRightWidth);
-        this.nativeView.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
+        this.nativeViewProtected.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
     }
 
     [paddingBottomProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.bottom,
+            value: this.nativeViewProtected.contentEdgeInsets.bottom,
             unit: "px"
         };
     }
     [paddingBottomProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let bottom = layout.toDeviceIndependentPixels(this.effectivePaddingBottom + this.effectiveBorderBottomWidth);
-        this.nativeView.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
+        this.nativeViewProtected.contentEdgeInsets = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
     }
 
     [paddingLeftProperty.getDefault](): Length {
         return {
-            value: this.nativeView.contentEdgeInsets.left,
+            value: this.nativeViewProtected.contentEdgeInsets.left,
             unit: "px"
         };
     }
     [paddingLeftProperty.setNative](value: Length) {
-        let inset = this.nativeView.contentEdgeInsets;
+        let inset = this.nativeViewProtected.contentEdgeInsets;
         let left = layout.toDeviceIndependentPixels(this.effectivePaddingLeft + this.effectiveBorderLeftWidth);
-        this.nativeView.contentEdgeInsets = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.contentEdgeInsets = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
     }
 
     [textAlignmentProperty.setNative](value: TextAlignment) {
         switch (value) {
             case "left":
-                this.nativeView.titleLabel.textAlignment = NSTextAlignment.Left;
-                this.nativeView.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+                this.nativeViewProtected.titleLabel.textAlignment = NSTextAlignment.Left;
+                this.nativeViewProtected.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Left;
                 break;
             case "initial":
             case "center":
-                this.nativeView.titleLabel.textAlignment = NSTextAlignment.Center;
-                this.nativeView.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Center;
+                this.nativeViewProtected.titleLabel.textAlignment = NSTextAlignment.Center;
+                this.nativeViewProtected.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Center;
                 break;
             case "right":
-                this.nativeView.titleLabel.textAlignment = NSTextAlignment.Right;
-                this.nativeView.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Right;
+                this.nativeViewProtected.titleLabel.textAlignment = NSTextAlignment.Right;
+                this.nativeViewProtected.contentHorizontalAlignment = UIControlContentHorizontalAlignment.Right;
                 break;
         }
     }
 
     [whiteSpaceProperty.setNative](value: WhiteSpace) {
-        const nativeView = this.nativeView.titleLabel;
+        const nativeView = this.nativeViewProtected.titleLabel;
         switch (value) {
             case "normal":
                 nativeView.lineBreakMode = NSLineBreakMode.ByWordWrapping;
@@ -183,7 +183,7 @@ export class Button extends ButtonBase {
             return super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         }
 
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (nativeView) {
             const width = layout.getMeasureSpecSize(widthMeasureSpec);
             const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);

--- a/tns-core-modules/ui/content-view/content-view.ts
+++ b/tns-core-modules/ui/content-view/content-view.ts
@@ -92,4 +92,4 @@ export class ContentView extends CustomLayoutView implements ContentViewDefiniti
     }
 }
 
-ContentView.prototype.recycleNativeView = true;
+ContentView.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -191,7 +191,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
                     valueChanged(owner, oldValue, value);
                 }
 
-                if (owner.nativeView && !(defaultValueKey in owner)) {
+                if (owner.nativeViewProtected && !(defaultValueKey in owner)) {
                     owner[defaultValueKey] = owner[getDefault] ? owner[getDefault]() : defaultValue;
                 }
 

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -143,11 +143,12 @@ export abstract class ViewBase extends Observable {
     /**
      * read-only. If you want to set out-of-band the nativeView use the setNativeView method.
      */
+    public nativeViewProtected: any;
+    public recycleNativeView: "always" | "never" | "auto";
+
     public nativeView: any;
-
     public bindingContext: any;
-    public recycleNativeView: boolean;
-
+   
     /**
      * Gets the name of the constructor function for this instance. E.g. for a Button class this will return "Button".
      */

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -59,7 +59,7 @@ function initializeTouchListener(): void {
                 });
             }
 
-            let nativeView = owner.nativeView;
+            let nativeView = owner.nativeViewProtected;
             if (!nativeView || !nativeView.onTouchEvent) {
                 return false;
             }
@@ -76,7 +76,7 @@ export class View extends ViewCommon {
     private touchListenerIsSet: boolean;
     private touchListener: android.view.View.OnTouchListener;
 
-    nativeView: android.view.View;
+    nativeViewProtected: android.view.View;
 
     // TODO: Implement unobserve that detach the touchListener.
     observe(type: GestureTypes, callback: (args: GestureEventData) => void, thisArg?: any): void {
@@ -95,9 +95,9 @@ export class View extends ViewCommon {
     @profile
     public onUnloaded() {
         if (this.touchListenerIsSet) {
-            this.nativeView.setOnTouchListener(null);
+            this.nativeViewProtected.setOnTouchListener(null);
             this.touchListenerIsSet = false;
-            this.nativeView.setClickable(this._isClickable);
+            this.nativeViewProtected.setClickable(this._isClickable);
         }
 
         this._cancelAllAnimations();
@@ -110,19 +110,19 @@ export class View extends ViewCommon {
 
     public initNativeView(): void {
         super.initNativeView();
-        this._isClickable = this.nativeView.isClickable();
+        this._isClickable = this.nativeViewProtected.isClickable();
     }
 
     private setOnTouchListener() {
-        if (this.nativeView && this.hasGestureObservers()) {
+        if (this.nativeViewProtected && this.hasGestureObservers()) {
             this.touchListenerIsSet = true;
-            if (this.nativeView.setClickable) {
-                this.nativeView.setClickable(true);
+            if (this.nativeViewProtected.setClickable) {
+                this.nativeViewProtected.setClickable(true);
             }
 
             initializeTouchListener();
             this.touchListener = this.touchListener || new TouchListener(this);
-            this.nativeView.setOnTouchListener(this.touchListener);
+            this.nativeViewProtected.setOnTouchListener(this.touchListener);
         }
     }
 
@@ -131,24 +131,24 @@ export class View extends ViewCommon {
     }
 
     get isLayoutValid(): boolean {
-        if (this.nativeView) {
-            return !this.nativeView.isLayoutRequested();
+        if (this.nativeViewProtected) {
+            return !this.nativeViewProtected.isLayoutRequested();
         }
 
         return false;
     }
 
     public layoutNativeView(left: number, top: number, right: number, bottom: number): void {
-        if (this.nativeView) {
-            this.nativeView.layout(left, top, right, bottom);
+        if (this.nativeViewProtected) {
+            this.nativeViewProtected.layout(left, top, right, bottom);
         }
     }
 
     @profile
     public requestLayout(): void {
         super.requestLayout();
-        if (this.nativeView) {
-            return this.nativeView.requestLayout();
+        if (this.nativeViewProtected) {
+            return this.nativeViewProtected.requestLayout();
         }
     }
 
@@ -163,7 +163,7 @@ export class View extends ViewCommon {
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        let view = this.nativeView;
+        let view = this.nativeViewProtected;
         if (view) {
             view.measure(widthMeasureSpec, heightMeasureSpec);
             this.setMeasuredDimension(view.getMeasuredWidth(), view.getMeasuredHeight());
@@ -171,19 +171,19 @@ export class View extends ViewCommon {
     }
 
     public onLayout(left: number, top: number, right: number, bottom: number): void {
-        let view = this.nativeView;
+        let view = this.nativeViewProtected;
         if (view) {
             this.layoutNativeView(left, top, right, bottom);
         }
     }
 
     _getCurrentLayoutBounds(): { left: number; top: number; right: number; bottom: number } {
-        if (this.nativeView && !this.isCollapsed) {
+        if (this.nativeViewProtected && !this.isCollapsed) {
             return {
-                left: this.nativeView.getLeft(),
-                top: this.nativeView.getTop(),
-                right: this.nativeView.getRight(),
-                bottom: this.nativeView.getBottom()
+                left: this.nativeViewProtected.getLeft(),
+                top: this.nativeViewProtected.getTop(),
+                right: this.nativeViewProtected.getRight(),
+                bottom: this.nativeViewProtected.getBottom()
             };
         } else {
             return { left: 0, top: 0, right: 0, bottom: 0 };
@@ -191,36 +191,36 @@ export class View extends ViewCommon {
     }
 
     public getMeasuredWidth(): number {
-        if (this.nativeView) {
-            return this.nativeView.getMeasuredWidth();
+        if (this.nativeViewProtected) {
+            return this.nativeViewProtected.getMeasuredWidth();
         }
 
         return super.getMeasuredWidth();
     }
 
     public getMeasuredHeight(): number {
-        if (this.nativeView) {
-            return this.nativeView.getMeasuredHeight();
+        if (this.nativeViewProtected) {
+            return this.nativeViewProtected.getMeasuredHeight();
         }
 
         return super.getMeasuredHeight();
     }
 
     public focus(): boolean {
-        if (this.nativeView) {
-            return this.nativeView.requestFocus();
+        if (this.nativeViewProtected) {
+            return this.nativeViewProtected.requestFocus();
         }
 
         return false;
     }
 
     public getLocationInWindow(): Point {
-        if (!this.nativeView || !this.nativeView.getWindowToken()) {
+        if (!this.nativeViewProtected || !this.nativeViewProtected.getWindowToken()) {
             return undefined;
         }
 
         let nativeArray = (<any>Array).create("int", 2);
-        this.nativeView.getLocationInWindow(nativeArray);
+        this.nativeViewProtected.getLocationInWindow(nativeArray);
         return {
             x: layout.toDeviceIndependentPixels(nativeArray[0]),
             y: layout.toDeviceIndependentPixels(nativeArray[1]),
@@ -228,12 +228,12 @@ export class View extends ViewCommon {
     }
 
     public getLocationOnScreen(): Point {
-        if (!this.nativeView || !this.nativeView.getWindowToken()) {
+        if (!this.nativeViewProtected || !this.nativeViewProtected.getWindowToken()) {
             return undefined;
         }
 
         let nativeArray = (<any>Array).create("int", 2);
-        this.nativeView.getLocationOnScreen(nativeArray);
+        this.nativeViewProtected.getLocationOnScreen(nativeArray);
         return {
             x: layout.toDeviceIndependentPixels(nativeArray[0]),
             y: layout.toDeviceIndependentPixels(nativeArray[1]),
@@ -241,16 +241,16 @@ export class View extends ViewCommon {
     }
 
     public getLocationRelativeTo(otherView: ViewCommon): Point {
-        if (!this.nativeView || !this.nativeView.getWindowToken() ||
-            !otherView.nativeView || !otherView.nativeView.getWindowToken() ||
-            this.nativeView.getWindowToken() !== otherView.nativeView.getWindowToken()) {
+        if (!this.nativeViewProtected || !this.nativeViewProtected.getWindowToken() ||
+            !otherView.nativeViewProtected || !otherView.nativeViewProtected.getWindowToken() ||
+            this.nativeViewProtected.getWindowToken() !== otherView.nativeViewProtected.getWindowToken()) {
             return undefined;
         }
 
         let myArray = (<any>Array).create("int", 2);
-        this.nativeView.getLocationOnScreen(myArray);
+        this.nativeViewProtected.getLocationOnScreen(myArray);
         let otherArray = (<any>Array).create("int", 2);
-        otherView.nativeView.getLocationOnScreen(otherArray);
+        otherView.nativeViewProtected.getLocationOnScreen(otherArray);
         return {
             x: layout.toDeviceIndependentPixels(myArray[0] - otherArray[0]),
             y: layout.toDeviceIndependentPixels(myArray[1] - otherArray[1]),
@@ -279,45 +279,45 @@ export class View extends ViewCommon {
     }
 
     [isEnabledProperty.setNative](value: boolean) {
-        this.nativeView.setEnabled(value);
+        this.nativeViewProtected.setEnabled(value);
     }
 
     [originXProperty.getDefault](): number {
-        return this.nativeView.getPivotX();
+        return this.nativeViewProtected.getPivotX();
     }
     [originXProperty.setNative](value: number) {
-        org.nativescript.widgets.OriginPoint.setX(this.nativeView, value);
+        org.nativescript.widgets.OriginPoint.setX(this.nativeViewProtected, value);
     }
 
     [originYProperty.getDefault](): number {
-        return this.nativeView.getPivotY();
+        return this.nativeViewProtected.getPivotY();
     }
     [originYProperty.setNative](value: number) {
-        org.nativescript.widgets.OriginPoint.setY(this.nativeView, value);
+        org.nativescript.widgets.OriginPoint.setY(this.nativeViewProtected, value);
     }
 
     [automationTextProperty.getDefault](): string {
-        return this.nativeView.getContentDescription();
+        return this.nativeViewProtected.getContentDescription();
     }
     [automationTextProperty.setNative](value: string) {
-        this.nativeView.setContentDescription(value);
+        this.nativeViewProtected.setContentDescription(value);
     }
 
     [isUserInteractionEnabledProperty.setNative](value: boolean) {
         if (!value) {
             initializeDisabledListener();
             // User interaction is disabled -- we stop it and we do not care whether someone wants to listen for gestures.
-            this.nativeView.setOnTouchListener(disableUserInteractionListener);
+            this.nativeViewProtected.setOnTouchListener(disableUserInteractionListener);
         } else {
             this.setOnTouchListener();
             if (!this.touchListenerIsSet) {
-                this.nativeView.setOnTouchListener(null);
+                this.nativeViewProtected.setOnTouchListener(null);
             }
         }
     }
 
     [visibilityProperty.getDefault](): Visibility {
-        let nativeVisibility = this.nativeView.getVisibility();
+        let nativeVisibility = this.nativeViewProtected.getVisibility();
         switch (nativeVisibility) {
             case android.view.View.VISIBLE:
                 return "visible";
@@ -332,13 +332,13 @@ export class View extends ViewCommon {
     [visibilityProperty.setNative](value: Visibility) {
         switch (value) {
             case "visible":
-                this.nativeView.setVisibility(android.view.View.VISIBLE);
+                this.nativeViewProtected.setVisibility(android.view.View.VISIBLE);
                 break;
             case "hidden":
-                this.nativeView.setVisibility(android.view.View.INVISIBLE);
+                this.nativeViewProtected.setVisibility(android.view.View.INVISIBLE);
                 break;
             case "collapse":
-                this.nativeView.setVisibility(android.view.View.GONE);
+                this.nativeViewProtected.setVisibility(android.view.View.GONE);
                 break;
             default:
                 throw new Error(`Invalid visibility value: ${value}. Valid values are: visible, hidden, collapse.`);
@@ -346,17 +346,17 @@ export class View extends ViewCommon {
     }
 
     [opacityProperty.getDefault](): number {
-        return this.nativeView.getAlpha();
+        return this.nativeViewProtected.getAlpha();
     }
     [opacityProperty.setNative](value: number) {
-        this.nativeView.setAlpha(float(value));
+        this.nativeViewProtected.setAlpha(float(value));
     }
 
     [horizontalAlignmentProperty.getDefault](): HorizontalAlignment {
-        return <HorizontalAlignment>org.nativescript.widgets.ViewHelper.getHorizontalAlignment(this.nativeView);
+        return <HorizontalAlignment>org.nativescript.widgets.ViewHelper.getHorizontalAlignment(this.nativeViewProtected);
     }
     [horizontalAlignmentProperty.setNative](value: HorizontalAlignment) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
         // Set only if params gravity exists.
         if (lp.gravity !== undefined) {
@@ -391,10 +391,10 @@ export class View extends ViewCommon {
     }
 
     [verticalAlignmentProperty.getDefault](): VerticalAlignment {
-        return <VerticalAlignment>org.nativescript.widgets.ViewHelper.getVerticalAlignment(this.nativeView);
+        return <VerticalAlignment>org.nativescript.widgets.ViewHelper.getVerticalAlignment(this.nativeViewProtected);
     }
     [verticalAlignmentProperty.setNative](value: VerticalAlignment) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
         // Set only if params gravity exists.
         if (lp.gravity !== undefined) {
@@ -429,34 +429,34 @@ export class View extends ViewCommon {
     }
 
     [rotateProperty.setNative](value: number) {
-        org.nativescript.widgets.ViewHelper.setRotate(this.nativeView, float(value));
+        org.nativescript.widgets.ViewHelper.setRotate(this.nativeViewProtected, float(value));
     }
 
     [scaleXProperty.setNative](value: number) {
-        org.nativescript.widgets.ViewHelper.setScaleX(this.nativeView, float(value));
+        org.nativescript.widgets.ViewHelper.setScaleX(this.nativeViewProtected, float(value));
     }
 
     [scaleYProperty.setNative](value: number) {
-        org.nativescript.widgets.ViewHelper.setScaleY(this.nativeView, float(value));
+        org.nativescript.widgets.ViewHelper.setScaleY(this.nativeViewProtected, float(value));
     }
 
     [translateXProperty.setNative](value: dip) {
-        org.nativescript.widgets.ViewHelper.setTranslateX(this.nativeView, layout.toDevicePixels(value));
+        org.nativescript.widgets.ViewHelper.setTranslateX(this.nativeViewProtected, layout.toDevicePixels(value));
     }
 
     [translateYProperty.setNative](value: dip) {
-        org.nativescript.widgets.ViewHelper.setTranslateY(this.nativeView, layout.toDevicePixels(value));
+        org.nativescript.widgets.ViewHelper.setTranslateY(this.nativeViewProtected, layout.toDevicePixels(value));
     }
 
     [zIndexProperty.getDefault](): number {
         return 0;
     }
     [zIndexProperty.setNative](value: number) {
-        org.nativescript.widgets.ViewHelper.setZIndex(this.nativeView, value);
+        org.nativescript.widgets.ViewHelper.setZIndex(this.nativeViewProtected, value);
     }
 
     [backgroundInternalProperty.getDefault](): android.graphics.drawable.Drawable {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const drawable = nativeView.getBackground();
         return drawable ? drawable.getConstantState().newDrawable(nativeView.getResources()) : null;
     }
@@ -465,7 +465,7 @@ export class View extends ViewCommon {
     }
 
     [minWidthProperty.setNative](value: Length) {
-        if (this.parent instanceof CustomLayoutView && this.parent.nativeView) {
+        if (this.parent instanceof CustomLayoutView && this.parent.nativeViewProtected) {
             this.parent._setChildMinWidthNative(this);
         } else {
             this._setMinWidthNative(this.minWidth);
@@ -473,7 +473,7 @@ export class View extends ViewCommon {
     }
 
     [minHeightProperty.setNative](value: Length) {
-        if (this.parent instanceof CustomLayoutView && this.parent.nativeView) {
+        if (this.parent instanceof CustomLayoutView && this.parent.nativeViewProtected) {
             this.parent._setChildMinHeightNative(this);
         } else {
             this._setMinHeightNative(this.minHeight);
@@ -484,7 +484,7 @@ export class View extends ViewCommon {
         if (value instanceof Background) {
             androidBackground.onBackgroundOrBorderPropertyChanged(this);
         } else {
-            const nativeView = this.nativeView;
+            const nativeView = this.nativeViewProtected;
             org.nativescript.widgets.ViewHelper.setBackground(nativeView, value);
             nativeView.setPadding(this._defaultPaddingLeft, this._defaultPaddingTop, this._defaultPaddingRight, this._defaultPaddingBottom);
 
@@ -499,7 +499,7 @@ export class View extends ViewCommon {
 }
 
 export class CustomLayoutView extends View implements CustomLayoutViewDefinition {
-    nativeView: android.view.ViewGroup;
+    nativeViewProtected: android.view.ViewGroup;
 
     public createNativeView() {
         return new org.nativescript.widgets.ContentLayout(this._context);
@@ -508,11 +508,11 @@ export class CustomLayoutView extends View implements CustomLayoutViewDefinition
     public _addViewToNativeVisualTree(child: ViewCommon, atIndex: number = -1): boolean {
         super._addViewToNativeVisualTree(child);
 
-        if (this.nativeView && child.nativeView) {
+        if (this.nativeViewProtected && child.nativeViewProtected) {
             if (traceEnabled()) {
                 traceWrite(`${this}.nativeView.addView(${child}.nativeView, ${atIndex})`, traceCategories.VisualTreeEvents);
             }
-            this.nativeView.addView(child.nativeView, atIndex);
+            this.nativeViewProtected.addView(child.nativeViewProtected, atIndex);
             if (child instanceof View) {
                 this._updateNativeLayoutParams(child);
             }
@@ -538,8 +538,8 @@ export class CustomLayoutView extends View implements CustomLayoutViewDefinition
     public _removeViewFromNativeVisualTree(child: ViewCommon): void {
         super._removeViewFromNativeVisualTree(child);
 
-        const nativeView = this.nativeView;
-        const childView = child.nativeView;
+        const nativeView = this.nativeViewProtected;
+        const childView = child.nativeViewProtected;
         if (nativeView && childView) {
             nativeView.removeView(childView);
             if (traceEnabled()) {
@@ -573,7 +573,7 @@ function createNativePercentLengthProperty(options: NativePercentLengthPropertyO
                 setPercent = options.setPercent || percentNotSupported;
                 options = null;
             }
-            const value = getPixels(this.nativeView);
+            const value = getPixels(this.nativeViewProtected);
             if (value == auto) { // tslint:disable-line
                 return "auto";
             } else {
@@ -590,15 +590,15 @@ function createNativePercentLengthProperty(options: NativePercentLengthPropertyO
                 options = null;
             }
             if (length == "auto") { // tslint:disable-line
-                setPixels(this.nativeView, auto);
+                setPixels(this.nativeViewProtected, auto);
             } else if (typeof length === "number") {
-                setPixels(this.nativeView, layout.round(layout.toDevicePixels(length)));
+                setPixels(this.nativeViewProtected, layout.round(layout.toDevicePixels(length)));
             } else if (length.unit == "dip") { // tslint:disable-line
-                setPixels(this.nativeView, layout.round(layout.toDevicePixels(length.value)));
+                setPixels(this.nativeViewProtected, layout.round(layout.toDevicePixels(length.value)));
             } else if (length.unit == "px") { // tslint:disable-line
-                setPixels(this.nativeView, layout.round(length.value));
+                setPixels(this.nativeViewProtected, layout.round(length.value));
             } else if (length.unit == "%") { // tslint:disable-line
-                setPercent(this.nativeView, length.value);
+                setPercent(this.nativeViewProtected, length.value);
             } else {
                 throw new Error(`Unsupported PercentLength ${length}`);
             }

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -22,7 +22,7 @@ const PFLAG_MEASURED_DIMENSION_SET = 1 << 1;
 const PFLAG_LAYOUT_REQUIRED = 1 << 2;
 
 export class View extends ViewCommon {
-    nativeView: UIView;
+    nativeViewProtected: UIView;
     private _hasTransfrom = false;
     private _privateFlags: number = PFLAG_LAYOUT_REQUIRED | PFLAG_FORCE_LAYOUT;
     private _cachedFrame: CGRect;
@@ -113,7 +113,7 @@ export class View extends ViewCommon {
 
     @profile
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        const view = this.nativeView;
+        const view = this.nativeViewProtected;
         const width = layout.getMeasureSpecSize(widthMeasureSpec);
         const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);
 
@@ -163,11 +163,11 @@ export class View extends ViewCommon {
     }
 
     public layoutNativeView(left: number, top: number, right: number, bottom: number): void {
-        if (!this.nativeView) {
+        if (!this.nativeViewProtected) {
             return;
         }
 
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
 
         let frame = CGRectMake(layout.toDeviceIndependentPixels(left), layout.toDeviceIndependentPixels(top), layout.toDeviceIndependentPixels(right - left), layout.toDeviceIndependentPixels(bottom - top));
         this._setNativeViewFrame(nativeView, frame);
@@ -187,11 +187,11 @@ export class View extends ViewCommon {
     }
 
     public getLocationInWindow(): Point {
-        if (!this.nativeView || !this.nativeView.window) {
+        if (!this.nativeViewProtected || !this.nativeViewProtected.window) {
             return undefined;
         }
 
-        let pointInWindow = this.nativeView.convertPointToView(this.nativeView.bounds.origin, null);
+        let pointInWindow = this.nativeViewProtected.convertPointToView(this.nativeViewProtected.bounds.origin, null);
         return {
             x: pointInWindow.x,
             y: pointInWindow.y
@@ -199,12 +199,12 @@ export class View extends ViewCommon {
     }
 
     public getLocationOnScreen(): Point {
-        if (!this.nativeView || !this.nativeView.window) {
+        if (!this.nativeViewProtected || !this.nativeViewProtected.window) {
             return undefined;
         }
 
-        let pointInWindow = this.nativeView.convertPointToView(this.nativeView.bounds.origin, null);
-        let pointOnScreen = this.nativeView.window.convertPointToWindow(pointInWindow, null);
+        let pointInWindow = this.nativeViewProtected.convertPointToView(this.nativeViewProtected.bounds.origin, null);
+        let pointOnScreen = this.nativeViewProtected.window.convertPointToWindow(pointInWindow, null);
         return {
             x: pointOnScreen.x,
             y: pointOnScreen.y
@@ -212,14 +212,14 @@ export class View extends ViewCommon {
     }
 
     public getLocationRelativeTo(otherView: ViewDefinition): Point {
-        if (!this.nativeView || !this.nativeView.window ||
-            !otherView.nativeView || !otherView.nativeView.window ||
-            this.nativeView.window !== otherView.nativeView.window) {
+        if (!this.nativeViewProtected || !this.nativeViewProtected.window ||
+            !otherView.nativeViewProtected || !otherView.nativeViewProtected.window ||
+            this.nativeViewProtected.window !== otherView.nativeViewProtected.window) {
             return undefined;
         }
 
-        let myPointInWindow = this.nativeView.convertPointToView(this.nativeView.bounds.origin, null);
-        let otherPointInWindow = otherView.nativeView.convertPointToView(otherView.nativeView.bounds.origin, null);
+        let myPointInWindow = this.nativeViewProtected.convertPointToView(this.nativeViewProtected.bounds.origin, null);
+        let otherPointInWindow = otherView.nativeViewProtected.convertPointToView(otherView.nativeViewProtected.bounds.origin, null);
         return {  
             x: myPointInWindow.x - otherPointInWindow.x,
             y: myPointInWindow.y - otherPointInWindow.y
@@ -227,7 +227,7 @@ export class View extends ViewCommon {
     }
 
     private _onSizeChanged(): void {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (!nativeView) {
             return;
         }
@@ -253,13 +253,13 @@ export class View extends ViewCommon {
         newTransform = CGAffineTransformTranslate(newTransform, this.translateX, this.translateY);
         newTransform = CGAffineTransformRotate(newTransform, rotate * Math.PI / 180);
         newTransform = CGAffineTransformScale(newTransform, scaleX, scaleY);
-        if (!CGAffineTransformEqualToTransform(this.nativeView.transform, newTransform)) {
+        if (!CGAffineTransformEqualToTransform(this.nativeViewProtected.transform, newTransform)) {
             let updateSuspended = this._isPresentationLayerUpdateSuspeneded();
             if (!updateSuspended) {
                 CATransaction.begin();
             }
-            this.nativeView.transform = newTransform;
-            this._hasTransfrom = this.nativeView && !CGAffineTransformEqualToTransform(this.nativeView.transform, CGAffineTransformIdentity);
+            this.nativeViewProtected.transform = newTransform;
+            this._hasTransfrom = this.nativeViewProtected && !CGAffineTransformEqualToTransform(this.nativeViewProtected.transform, CGAffineTransformIdentity);
             if (!updateSuspended) {
                 CATransaction.commit();
             }
@@ -268,9 +268,9 @@ export class View extends ViewCommon {
 
     public updateOriginPoint(originX: number, originY: number) {
         let newPoint = CGPointMake(originX, originY);
-        this.nativeView.layer.anchorPoint = newPoint;
+        this.nativeViewProtected.layer.anchorPoint = newPoint;
         if (this._cachedFrame) {
-            this._setNativeViewFrame(this.nativeView, this._cachedFrame);
+            this._setNativeViewFrame(this.nativeViewProtected, this._cachedFrame);
         }
     }
 
@@ -290,56 +290,56 @@ export class View extends ViewCommon {
     }
 
     [isEnabledProperty.getDefault](): boolean {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         return nativeView instanceof UIControl ? nativeView.enabled : true;
     }
     [isEnabledProperty.setNative](value: boolean) {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (nativeView instanceof UIControl) {
             nativeView.enabled = value;
         }
     }
 
     [originXProperty.getDefault](): number {
-        return this.nativeView.layer.anchorPoint.x;
+        return this.nativeViewProtected.layer.anchorPoint.x;
     }
     [originXProperty.setNative](value: number) {
         this.updateOriginPoint(value, this.originY);
     }
 
     [originYProperty.getDefault](): number {
-        return this.nativeView.layer.anchorPoint.y;
+        return this.nativeViewProtected.layer.anchorPoint.y;
     }
     [originYProperty.setNative](value: number) {
         this.updateOriginPoint(this.originX, value);
     }
 
     [automationTextProperty.getDefault](): string {
-        return this.nativeView.accessibilityLabel;
+        return this.nativeViewProtected.accessibilityLabel;
     }
     [automationTextProperty.setNative](value: string) {
-        this.nativeView.accessibilityIdentifier = value;
-        this.nativeView.accessibilityLabel = value;
+        this.nativeViewProtected.accessibilityIdentifier = value;
+        this.nativeViewProtected.accessibilityLabel = value;
     }
 
     [isUserInteractionEnabledProperty.getDefault](): boolean {
-        return this.nativeView.userInteractionEnabled;
+        return this.nativeViewProtected.userInteractionEnabled;
     }
     [isUserInteractionEnabledProperty.setNative](value: boolean) {
-        this.nativeView.userInteractionEnabled = value;
+        this.nativeViewProtected.userInteractionEnabled = value;
     }
 
     [visibilityProperty.getDefault](): Visibility {
-        return this.nativeView.hidden ? Visibility.COLLAPSE : Visibility.VISIBLE;
+        return this.nativeViewProtected.hidden ? Visibility.COLLAPSE : Visibility.VISIBLE;
     }
     [visibilityProperty.setNative](value: Visibility) {
         switch (value) {
             case Visibility.VISIBLE:
-                this.nativeView.hidden = false;
+                this.nativeViewProtected.hidden = false;
                 break;
             case Visibility.HIDDEN:
             case Visibility.COLLAPSE:
-                this.nativeView.hidden = true;
+                this.nativeViewProtected.hidden = true;
                 break;
             default:
                 throw new Error(`Invalid visibility value: ${value}. Valid values are: "${Visibility.VISIBLE}", "${Visibility.HIDDEN}", "${Visibility.COLLAPSE}".`);
@@ -347,10 +347,10 @@ export class View extends ViewCommon {
     }
 
     [opacityProperty.getDefault](): number {
-        return this.nativeView.alpha;
+        return this.nativeViewProtected.alpha;
     }
     [opacityProperty.setNative](value: number) {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         let updateSuspended = this._isPresentationLayerUpdateSuspeneded();
         if (!updateSuspended) {
             CATransaction.begin();
@@ -400,11 +400,11 @@ export class View extends ViewCommon {
         return 0;
     }
     [zIndexProperty.setNative](value: number) {
-        this.nativeView.layer.zPosition = value;
+        this.nativeViewProtected.layer.zPosition = value;
     }
 
     [backgroundInternalProperty.getDefault](): UIColor {
-        return this.nativeView.backgroundColor;
+        return this.nativeViewProtected.backgroundColor;
     }
     [backgroundInternalProperty.setNative](value: UIColor | Background) {
         this._nativeBackgroundState = "invalid";
@@ -420,10 +420,10 @@ export class View extends ViewCommon {
         }
 
         if (value instanceof UIColor) {
-            this.nativeView.backgroundColor = value;
+            this.nativeViewProtected.backgroundColor = value;
         } else {
             ios.createBackgroundUIColor(this, (color: UIColor) => {
-                this.nativeView.backgroundColor = color;
+                this.nativeViewProtected.backgroundColor = color;
             });
             this._setNativeClipToBounds();
         }
@@ -437,22 +437,22 @@ export class View extends ViewCommon {
 
     _setNativeClipToBounds() {
         let backgroundInternal = this.style.backgroundInternal;
-        this.nativeView.clipsToBounds = backgroundInternal.hasBorderWidth() || backgroundInternal.hasBorderRadius();
+        this.nativeViewProtected.clipsToBounds = backgroundInternal.hasBorderWidth() || backgroundInternal.hasBorderRadius();
     }
 }
 View.prototype._nativeBackgroundState = "unset";
 
 export class CustomLayoutView extends View {
 
-    nativeView: UIView;
+    nativeViewProtected: UIView;
 
     constructor() {
         super();
-        this.nativeView = UIView.new();
+        this.nativeViewProtected = UIView.new();
     }
 
     get ios(): UIView {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
@@ -462,8 +462,8 @@ export class CustomLayoutView extends View {
     public _addViewToNativeVisualTree(child: View, atIndex: number): boolean {
         super._addViewToNativeVisualTree(child, atIndex);
 
-        const parentNativeView = this.nativeView;
-        const childNativeView = child.nativeView;
+        const parentNativeView = this.nativeViewProtected;
+        const childNativeView = child.nativeViewProtected;
 
         if (parentNativeView && childNativeView) {
             if (typeof atIndex !== "number" || atIndex >= parentNativeView.subviews.count) {
@@ -481,8 +481,8 @@ export class CustomLayoutView extends View {
     public _removeViewFromNativeVisualTree(child: View): void {
         super._removeViewFromNativeVisualTree(child);
 
-        if (child.nativeView) {
-            child.nativeView.removeFromSuperview();
+        if (child.nativeViewProtected) {
+            child.nativeViewProtected.removeFromSuperview();
         }
     }
 }

--- a/tns-core-modules/ui/date-picker/date-picker-common.ts
+++ b/tns-core-modules/ui/date-picker/date-picker-common.ts
@@ -12,7 +12,7 @@ export class DatePickerBase extends View implements DatePickerDefinition {
     public date: Date;
 }
 
-DatePickerBase.prototype.recycleNativeView = true;
+DatePickerBase.prototype.recycleNativeView = "auto";
 
 export const yearProperty = new Property<DatePickerBase, number>({ name: "year", valueConverter: (v) => parseInt(v) });
 yearProperty.register(DatePickerBase);

--- a/tns-core-modules/ui/date-picker/date-picker.android.ts
+++ b/tns-core-modules/ui/date-picker/date-picker.android.ts
@@ -51,7 +51,7 @@ function initializeDateChangedListener(): void {
 }
 
 export class DatePicker extends DatePickerBase {
-    nativeView: android.widget.DatePicker;
+    nativeViewProtected: android.widget.DatePicker;
 
     public createNativeView() {
         initializeDateChangedListener();
@@ -65,16 +65,16 @@ export class DatePicker extends DatePickerBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        (<any>this.nativeView).listener.owner = this;
+        (<any>this.nativeViewProtected).listener.owner = this;
     }
 
     public disposeNativeView() {
-        (<any>this.nativeView).listener.owner = null;
+        (<any>this.nativeViewProtected).listener.owner = null;
         super.disposeNativeView();
     }
 
     private updateNativeDate(): void {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const year = typeof this.year === "number" ? this.year : nativeView.getYear();
         const month = typeof this.month === "number" ? (this.month - 1) : nativeView.getMonth();
         const day = typeof this.day === "number" ? this.day : nativeView.getDayOfMonth();
@@ -82,38 +82,38 @@ export class DatePicker extends DatePickerBase {
     }
 
     [yearProperty.getDefault](): number {
-        return this.nativeView.getYear();
+        return this.nativeViewProtected.getYear();
     }
     [yearProperty.setNative](value: number) {
-        if (this.nativeView.getYear() !== value) {
+        if (this.nativeViewProtected.getYear() !== value) {
             this.updateNativeDate();
         }
     }
 
     [monthProperty.getDefault](): number {
-        return this.nativeView.getMonth();
+        return this.nativeViewProtected.getMonth();
     }
     [monthProperty.setNative](value: number) {
-        if (this.nativeView.getMonth() !== (value - 1)) {
+        if (this.nativeViewProtected.getMonth() !== (value - 1)) {
             this.updateNativeDate();
         }
     }
 
     [dayProperty.getDefault](): number {
-        return this.nativeView.getDayOfMonth();
+        return this.nativeViewProtected.getDayOfMonth();
     }
     [dayProperty.setNative](value: number) {
-        if (this.nativeView.getDayOfMonth() !== value) {
+        if (this.nativeViewProtected.getDayOfMonth() !== value) {
             this.updateNativeDate();
         }
     }
 
     [dateProperty.getDefault](): Date {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         return new Date(nativeView.getYear(), nativeView.getMonth(), nativeView.getDayOfMonth());
     }
     [dateProperty.setNative](value: Date) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView.getDayOfMonth() !== value.getDay()
             || nativeView.getMonth() !== value.getMonth()
             || nativeView.getYear() !== value.getFullYear()) {
@@ -122,18 +122,18 @@ export class DatePicker extends DatePickerBase {
     }
 
     [maxDateProperty.getDefault](): number {
-        return this.nativeView.getMaxDate();
+        return this.nativeViewProtected.getMaxDate();
     }
     [maxDateProperty.setNative](value: Date | number) {
         const newValue = value instanceof Date ? value.getTime() : value;
-        this.nativeView.setMaxDate(newValue);
+        this.nativeViewProtected.setMaxDate(newValue);
     }
 
     [minDateProperty.getDefault](): number {
-        return this.nativeView.getMinDate();
+        return this.nativeViewProtected.getMinDate();
     }
     [minDateProperty.setNative](value: Date | number) {
         const newValue = value instanceof Date ? value.getTime() : value;
-        this.nativeView.setMinDate(newValue);
+        this.nativeViewProtected.setMinDate(newValue);
     }
 }

--- a/tns-core-modules/ui/date-picker/date-picker.ios.ts
+++ b/tns-core-modules/ui/date-picker/date-picker.ios.ts
@@ -9,57 +9,57 @@ export * from "./date-picker-common";
 
 export class DatePicker extends DatePickerBase {
     private _changeHandler: NSObject;
-    public nativeView: UIDatePicker;
+    public nativeViewProtected: UIDatePicker;
 
     constructor() {
         super();
 
-        this.nativeView = UIDatePicker.new();
-        this.nativeView.datePickerMode = UIDatePickerMode.Date;
+        this.nativeViewProtected = UIDatePicker.new();
+        this.nativeViewProtected.datePickerMode = UIDatePickerMode.Date;
 
         this._changeHandler = UIDatePickerChangeHandlerImpl.initWithOwner(new WeakRef(this));
-        this.nativeView.addTargetActionForControlEvents(this._changeHandler, "valueChanged", UIControlEvents.ValueChanged);
+        this.nativeViewProtected.addTargetActionForControlEvents(this._changeHandler, "valueChanged", UIControlEvents.ValueChanged);
     }
 
     get ios(): UIDatePicker {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     [yearProperty.getDefault](): number {
-        return this.nativeView.date.getFullYear();
+        return this.nativeViewProtected.date.getFullYear();
     }
     [yearProperty.setNative](value: number) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         let comps = ios.getter(NSCalendar, NSCalendar.currentCalendar).componentsFromDate(NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay, picker.date);
         comps.year = value;
         this.date = new Date(comps.year, comps.month - 1, comps.day);
     }
 
     [monthProperty.getDefault](): number {
-        return this.nativeView.date.getMonth();
+        return this.nativeViewProtected.date.getMonth();
     }
     [monthProperty.setNative](value: number) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         let comps = ios.getter(NSCalendar, NSCalendar.currentCalendar).componentsFromDate(NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay, picker.date);
         comps.month = value;
         this.date = new Date(comps.year, comps.month - 1, comps.day);
     }
 
     [dayProperty.getDefault](): number {
-        return this.nativeView.date.getDay();
+        return this.nativeViewProtected.date.getDay();
     }
     [dayProperty.setNative](value: number) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         let comps = ios.getter(NSCalendar, NSCalendar.currentCalendar).componentsFromDate(NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay, picker.date);
         comps.day = value;
         this.date = new Date(comps.year, comps.month - 1, comps.day);
     }
 
     [dateProperty.getDefault](): Date {
-        return this.nativeView.date;
+        return this.nativeViewProtected.date;
     }
     [dateProperty.setNative](value: Date) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         let comps = ios.getter(NSCalendar, NSCalendar.currentCalendar).componentsFromDate(NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay, picker.date);
         comps.year = value.getFullYear();
         comps.month = value.getMonth() + 1;
@@ -68,28 +68,28 @@ export class DatePicker extends DatePickerBase {
     }
 
     [maxDateProperty.getDefault](): Date {
-        return this.nativeView.maximumDate;
+        return this.nativeViewProtected.maximumDate;
     }
     [maxDateProperty.setNative](value: Date) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         let nsDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000);
         picker.maximumDate = <any>nsDate;
     }
 
     [minDateProperty.getDefault](): Date {
-        return this.nativeView.minimumDate;
+        return this.nativeViewProtected.minimumDate;
     }
     [minDateProperty.setNative](value: Date) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         let nsDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000);
         picker.minimumDate = <any>nsDate;
     }
 
     [colorProperty.getDefault](): UIColor {
-        return this.nativeView.valueForKey("textColor");
+        return this.nativeViewProtected.valueForKey("textColor");
     }
     [colorProperty.setNative](value: Color | UIColor) {
-        let picker = this.nativeView;
+        let picker = this.nativeViewProtected;
         picker.setValueForKey(value instanceof Color ? value.ios : value, "textColor");
     }
 }

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -131,7 +131,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     _dirtyTextAccumulator: string;
     /* tslint:enable */
 
-    nativeView: android.widget.EditText;
+    nativeViewProtected: android.widget.EditText;
     private _keyListenerCache: android.text.method.KeyListener;
     private _inputType: number;
 
@@ -158,37 +158,37 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         (<any>nativeView).listener.owner = this;
         this._inputType = nativeView.getInputType();
     }
 
     public disposeNativeView(): void {
         super.disposeNativeView();
-        (<any>this.nativeView).listener.owner = null;
+        (<any>this.nativeViewProtected).listener.owner = null;
         this._keyListenerCache = null;
     }
 
     public resetNativeView(): void {
         super.resetNativeView();
-        this.nativeView.setInputType(this._inputType);
+        this.nativeViewProtected.setInputType(this._inputType);
     }
 
     public dismissSoftInput() {
-        ad.dismissSoftInput(this.nativeView);
+        ad.dismissSoftInput(this.nativeViewProtected);
     }
 
     public focus(): boolean {
         const result = super.focus();
         if (result) {
-            ad.showSoftInput(this.nativeView);
+            ad.showSoftInput(this.nativeViewProtected);
         }
 
         return result;
     }
 
     public _setInputType(inputType: number): void {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         try {
             this._changeFromCode = true;
             nativeView.setInputType(inputType);
@@ -221,7 +221,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     }
 
     [keyboardTypeProperty.getDefault](): number {
-        return this.nativeView.getInputType();
+        return this.nativeViewProtected.getInputType();
     }
     [keyboardTypeProperty.setNative](value: "datetime" | "phone" | "number" | "url" | "email" | number) {
         let newInputType;
@@ -255,7 +255,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     }
 
     [returnKeyTypeProperty.getDefault](): "done" | "next" | "go" | "search" | "send" | string {
-        let ime = this.nativeView.getImeOptions();
+        let ime = this.nativeViewProtected.getImeOptions();
         switch (ime) {
             case android.view.inputmethod.EditorInfo.IME_ACTION_DONE:
                 return "done";
@@ -304,11 +304,11 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 break;
         }
 
-        this.nativeView.setImeOptions(newImeOptions);
+        this.nativeViewProtected.setImeOptions(newImeOptions);
     }
 
     [editableProperty.setNative](value: boolean) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (value) {
             nativeView.setKeyListener(this._keyListenerCache);
         } else {
@@ -320,7 +320,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     }
 
     [autocapitalizationTypeProperty.getDefault](): "none" | "words" | "sentences" | "allcharacters" | string {
-        let inputType = this.nativeView.getInputType();
+        let inputType = this.nativeViewProtected.getInputType();
         if ((inputType & android.text.InputType.TYPE_TEXT_FLAG_CAP_WORDS) === android.text.InputType.TYPE_TEXT_FLAG_CAP_WORDS) {
             return "words";
         } else if ((inputType & android.text.InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) === android.text.InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) {
@@ -332,7 +332,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         }
     }
     [autocapitalizationTypeProperty.setNative](value: string) {
-        let inputType = this.nativeView.getInputType();
+        let inputType = this.nativeViewProtected.getInputType();
         inputType = inputType & ~28672; //28672 (0x00070000) 13,14,15bits (111 0000 0000 0000)
 
         switch (value) {
@@ -363,7 +363,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     }
 
     [autocorrectProperty.getDefault](): boolean {
-        let autocorrect = this.nativeView.getInputType();
+        let autocorrect = this.nativeViewProtected.getInputType();
         if ((autocorrect & android.text.InputType.TYPE_TEXT_FLAG_AUTO_CORRECT) === android.text.InputType.TYPE_TEXT_FLAG_AUTO_CORRECT) {
             return true;
         }
@@ -371,7 +371,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         return false;
     }
     [autocorrectProperty.setNative](value: boolean) {
-        let inputType = this.nativeView.getInputType();
+        let inputType = this.nativeViewProtected.getInputType();
         switch (value) {
             case true:
                 inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE;
@@ -392,19 +392,19 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     }
 
     [hintProperty.getDefault](): string {
-        return this.nativeView.getHint();
+        return this.nativeViewProtected.getHint();
     }
     [hintProperty.setNative](value: string) {
         const text = (value === null || value === undefined) ? null : value.toString();
-        this.nativeView.setHint(text);
+        this.nativeViewProtected.setHint(text);
     }
 
     [placeholderColorProperty.getDefault](): android.content.res.ColorStateList {
-        return this.nativeView.getHintTextColors();
+        return this.nativeViewProtected.getHintTextColors();
     }
     [placeholderColorProperty.setNative](value: Color | android.content.res.ColorStateList) {
         const color = value instanceof Color ? value.android : value;
-        this.nativeView.setHintTextColor(<any>color);
+        this.nativeViewProtected.setHintTextColor(<any>color);
     }
 
     [textTransformProperty.setNative](value: "default") {
@@ -413,10 +413,10 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
     [maxLengthProperty.setNative](value: number) {
         if (value === Number.POSITIVE_INFINITY) {
-            this.nativeView.setFilters([]);
+            this.nativeViewProtected.setFilters([]);
         } else {
             const lengthFilter = new android.text.InputFilter.LengthFilter(value);
-            const filters = this.nativeView.getFilters();
+            const filters = this.nativeViewProtected.getFilters();
             const newFilters = [];
 
             // retain existing filters
@@ -428,7 +428,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
             }
 
             newFilters.push(lengthFilter);
-            this.nativeView.setFilters(newFilters);
+            this.nativeViewProtected.setFilters(newFilters);
         }
     }
 }

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
@@ -7,14 +7,14 @@
 export * from "./editable-text-base-common";
 
 export abstract class EditableTextBase extends EditableTextBaseCommon {
-    public nativeView: UITextField | UITextView;
+    public nativeViewProtected: UITextField | UITextView;
     public dismissSoftInput() {
-        this.nativeView.resignFirstResponder();
+        this.nativeViewProtected.resignFirstResponder();
         this.notify({ eventName: EditableTextBase.blurEvent, object: this });
     }
 
     [keyboardTypeProperty.getDefault](): "datetime"| "phone" | "number" | "url" | "email" | string {
-        let keyboardType = this.nativeView.keyboardType;
+        let keyboardType = this.nativeViewProtected.keyboardType;
         switch (keyboardType) {
             case UIKeyboardType.NumbersAndPunctuation:
                 return "number";
@@ -65,11 +65,11 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 break;
         }
 
-        this.nativeView.keyboardType = newKeyboardType;
+        this.nativeViewProtected.keyboardType = newKeyboardType;
     }
 
     [returnKeyTypeProperty.getDefault](): "done" | "next" | "go" | "search" | "send" | string {
-        let returnKeyType = this.nativeView.returnKeyType;
+        let returnKeyType = this.nativeViewProtected.returnKeyType;
         switch (returnKeyType) {
             case UIReturnKeyType.Done:
                 return "done";
@@ -118,11 +118,11 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 break;
         }
 
-        this.nativeView.returnKeyType = newValue;
+        this.nativeViewProtected.returnKeyType = newValue;
     }
 
     [autocapitalizationTypeProperty.getDefault](): "none" | "words" | "sentences" | "allcharacters" {
-        let autocapitalizationType = this.nativeView.autocapitalizationType;
+        let autocapitalizationType = this.nativeViewProtected.autocapitalizationType;
         switch (autocapitalizationType) {
             case UITextAutocapitalizationType.None:
                 return "none";
@@ -160,11 +160,11 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 break;
         }
 
-        this.nativeView.autocapitalizationType = newValue;
+        this.nativeViewProtected.autocapitalizationType = newValue;
     }
 
     [autocorrectProperty.getDefault](): boolean | number {
-        let autocorrectionType = this.nativeView.autocorrectionType;
+        let autocorrectionType = this.nativeViewProtected.autocorrectionType;
         switch (autocorrectionType) {
             case UITextAutocorrectionType.Yes:
                 return true;
@@ -184,7 +184,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
             newValue = UITextAutocorrectionType.No;
         }
 
-        this.nativeView.autocorrectionType = newValue;
+        this.nativeViewProtected.autocorrectionType = newValue;
     }
 }
 

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -306,7 +306,7 @@ export class Frame extends FrameBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        this._android.rootViewGroup = this.nativeView;
+        this._android.rootViewGroup = this.nativeViewProtected;
         this._android.rootViewGroup.setId(this._containerViewId);
     }
 
@@ -713,7 +713,7 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
             return label;
         }
 
-        return page.nativeView;
+        return page.nativeViewProtected;
     }
 
     @profile
@@ -815,7 +815,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 
         // Initialize native visual tree;
         rootView._setupUI(activity);
-        activity.setContentView(rootView.nativeView, new org.nativescript.widgets.CommonLayoutParams());
+        activity.setContentView(rootView.nativeViewProtected, new org.nativescript.widgets.CommonLayoutParams());
         // frameId is negative w
         if (frame) {
             frame.navigate(navParam);

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -45,7 +45,7 @@ export class Frame extends FrameBase {
     constructor() {
         super();
         this._ios = new iOSFrame(this);
-        this.nativeView = this._ios.controller.view;
+        this.nativeViewProtected = this._ios.controller.view;
 
         // When there is a 40px high "in-call" status bar, nobody moves the navigationBar top from 20 to 40 and it remains underneath the status bar.
         let frameRef = new WeakRef(this);
@@ -276,7 +276,7 @@ export class Frame extends FrameBase {
     public requestLayout(): void {
         super.requestLayout();
         // Invalidate our Window so that layout is triggered again.
-        let window = this.nativeView.window;
+        let window = this.nativeViewProtected.window;
         if (window) {
             window.setNeedsLayout();
         }
@@ -364,7 +364,7 @@ export class Frame extends FrameBase {
 
     public remeasureFrame(): void {
         this.requestLayout();
-        let window: UIWindow = this.nativeView.window;
+        let window: UIWindow = this.nativeViewProtected.window;
         if (window) {
             window.layoutIfNeeded();
         }

--- a/tns-core-modules/ui/gestures/gestures.ios.ts
+++ b/tns-core-modules/ui/gestures/gestures.ios.ts
@@ -107,8 +107,8 @@ export class GesturesObserver extends GesturesObserverBase {
     private _attach(target: View, type: GestureTypes) {
         this._detach();
 
-        if (target && target.nativeView && target.nativeView.addGestureRecognizer) {
-            let nativeView = <UIView>target.nativeView;
+        if (target && target.nativeViewProtected && target.nativeViewProtected.addGestureRecognizer) {
+            let nativeView = <UIView>target.nativeViewProtected;
 
             if (type & GestureTypes.tap) {
                 nativeView.addGestureRecognizer(this._createRecognizer(GestureTypes.tap));
@@ -129,7 +129,7 @@ export class GesturesObserver extends GesturesObserverBase {
 
             if (type & GestureTypes.pan) {
                 nativeView.addGestureRecognizer(this._createRecognizer(GestureTypes.pan, args => {
-                    this._executeCallback(_getPanData(args, target.nativeView));
+                    this._executeCallback(_getPanData(args, target.nativeViewProtected));
                 }));
             }
 
@@ -168,11 +168,11 @@ export class GesturesObserver extends GesturesObserverBase {
     }
 
     private _detach() {
-        if (this.target && this.target.nativeView) {
+        if (this.target && this.target.nativeViewProtected) {
             for (let name in this._recognizers) {
                 if (this._recognizers.hasOwnProperty(name)) {
                     let item = <RecognizerCache>this._recognizers[name];
-                    this.target.nativeView.removeGestureRecognizer(item.recognizer);
+                    this.target.nativeViewProtected.removeGestureRecognizer(item.recognizer);
 
                     item.recognizer = null;
                     item.target = null;
@@ -288,7 +288,7 @@ function _getSwipeDirection(direction: UISwipeGestureRecognizerDirection): Swipe
 
 function _getPinchData(args: GestureEventData): PinchGestureEventData {
     let recognizer = <UIPinchGestureRecognizer>args.ios;
-    let center = recognizer.locationInView(args.view.nativeView);
+    let center = recognizer.locationInView(args.view.nativeViewProtected);
 
     return <PinchGestureEventData>{
         type: args.type,
@@ -386,7 +386,7 @@ class Pointer implements Pointer {
     private _location: CGPoint;
     private get location(): CGPoint {
         if (!this._location) {
-            this._location = this.ios.locationInView(this._view.nativeView);
+            this._location = this.ios.locationInView(this._view.nativeViewProtected);
         }
 
         return this._location;
@@ -470,10 +470,10 @@ class TouchGestureEventData implements TouchGestureEventData {
     }
 
     getX(): number {
-        return this.getMainPointer().locationInView(this.view.nativeView).x;
+        return this.getMainPointer().locationInView(this.view.nativeViewProtected).x;
     }
 
     getY(): number {
-        return this.getMainPointer().locationInView(this.view.nativeView).y
+        return this.getMainPointer().locationInView(this.view.nativeViewProtected).y
     }
 }

--- a/tns-core-modules/ui/html-view/html-view-common.ts
+++ b/tns-core-modules/ui/html-view/html-view-common.ts
@@ -7,7 +7,7 @@ export class HtmlViewBase extends View implements HtmlViewDefinition {
     public html: string;
 }
 
-HtmlViewBase.prototype.recycleNativeView = true;
+HtmlViewBase.prototype.recycleNativeView = "auto";
 
 // TODO: Can we use Label.ios optimization for affectsLayout???
 export const htmlProperty = new Property<HtmlViewBase, string>({ name: "html", defaultValue: "", affectsLayout: true });

--- a/tns-core-modules/ui/html-view/html-view.android.ts
+++ b/tns-core-modules/ui/html-view/html-view.android.ts
@@ -5,7 +5,7 @@
 export * from "./html-view-common";
 
 export class HtmlView extends HtmlViewBase {
-    nativeView: android.widget.TextView;
+    nativeViewProtected: android.widget.TextView;
 
     public createNativeView() {
         return new android.widget.TextView(this._context);
@@ -13,7 +13,7 @@ export class HtmlView extends HtmlViewBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
 
         // This makes the html <a href...> work
         nativeView.setLinksClickable(true);
@@ -22,7 +22,7 @@ export class HtmlView extends HtmlViewBase {
 
     public resetNativeView(): void {
         super.resetNativeView();
-        this.nativeView.setAutoLinkMask(0);
+        this.nativeViewProtected.setAutoLinkMask(0);
     }
 
     [htmlProperty.getDefault](): string {
@@ -36,7 +36,7 @@ export class HtmlView extends HtmlViewBase {
         if (value.search(/<a\s/i) >= 0) {
             mask = 0;
         }
-        this.nativeView.setAutoLinkMask(mask);
-        this.nativeView.setText(<any>android.text.Html.fromHtml(value));
+        this.nativeViewProtected.setAutoLinkMask(mask);
+        this.nativeViewProtected.setText(<any>android.text.Html.fromHtml(value));
     }
 }

--- a/tns-core-modules/ui/html-view/html-view.ios.ts
+++ b/tns-core-modules/ui/html-view/html-view.ios.ts
@@ -5,7 +5,7 @@
 export * from "./html-view-common";
 
 export class HtmlView extends HtmlViewBase {
-    nativeView: UITextView;
+    nativeViewProtected: UITextView;
 
     constructor() {
         super();
@@ -16,15 +16,15 @@ export class HtmlView extends HtmlViewBase {
         nativeView.userInteractionEnabled = true;
         nativeView.dataDetectorTypes = UIDataDetectorTypes.All;
 
-        this.nativeView = nativeView;
+        this.nativeViewProtected = nativeView;
     }
 
     get ios(): UITextView {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             const width = layout.getMeasureSpecSize(widthMeasureSpec);
             const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);
@@ -51,6 +51,6 @@ export class HtmlView extends HtmlViewBase {
     [htmlProperty.setNative](value: string) {
         const htmlString = NSString.stringWithString(value + "");
         const nsData = htmlString.dataUsingEncoding(NSUnicodeStringEncoding);
-        this.nativeView.attributedText = NSAttributedString.alloc().initWithDataOptionsDocumentAttributesError(nsData, <any>{ [NSDocumentTypeDocumentAttribute]: NSHTMLTextDocumentType }, null);
+        this.nativeViewProtected.attributedText = NSAttributedString.alloc().initWithDataOptionsDocumentAttributesError(nsData, <any>{ [NSDocumentTypeDocumentAttribute]: NSHTMLTextDocumentType }, null);
     }
 }

--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -100,7 +100,7 @@ export abstract class ImageBase extends View implements ImageDefinition {
     }
 }
 
-ImageBase.prototype.recycleNativeView = true;
+ImageBase.prototype.recycleNativeView = "auto";
 
 export const imageSourceProperty = new Property<ImageBase, ImageSource>({ name: "imageSource" });
 imageSourceProperty.register(ImageBase);

--- a/tns-core-modules/ui/image/image.android.ts
+++ b/tns-core-modules/ui/image/image.android.ts
@@ -40,7 +40,7 @@ function initializeImageLoadedListener() {
 }
 
 export class Image extends ImageBase {
-    nativeView: org.nativescript.widgets.ImageView;
+    nativeViewProtected: org.nativescript.widgets.ImageView;
 
     public decodeWidth = 0;
     public decodeHeight = 0;
@@ -62,21 +62,21 @@ export class Image extends ImageBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        (<any>this.nativeView).listener.owner = this;
+        (<any>this.nativeViewProtected).listener.owner = this;
     }
 
     public disposeNativeView() {
-        (<any>this.nativeView).listener.owner = null;
+        (<any>this.nativeViewProtected).listener.owner = null;
         super.disposeNativeView();
     }
 
     public resetNativeView(): void {
         super.resetNativeView();
-        this.nativeView.setImageMatrix(new android.graphics.Matrix());        
+        this.nativeViewProtected.setImageMatrix(new android.graphics.Matrix());        
     }
 
     public _createImageSourceFromSrc(value: string | ImageSource) {
-        const imageView = this.nativeView;
+        const imageView = this.nativeViewProtected;
         if (!imageView) {
             return;
         }
@@ -121,17 +121,17 @@ export class Image extends ImageBase {
     [stretchProperty.setNative](value: "none" | "aspectFill" | "aspectFit" | "fill") {
         switch (value) {
             case "aspectFit":
-                this.nativeView.setScaleType(android.widget.ImageView.ScaleType.FIT_CENTER);
+                this.nativeViewProtected.setScaleType(android.widget.ImageView.ScaleType.FIT_CENTER);
                 break;
             case "aspectFill":
-                this.nativeView.setScaleType(android.widget.ImageView.ScaleType.CENTER_CROP);
+                this.nativeViewProtected.setScaleType(android.widget.ImageView.ScaleType.CENTER_CROP);
                 break;
             case "fill":
-                this.nativeView.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
+                this.nativeViewProtected.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
                 break;
             case "none":
             default:
-                this.nativeView.setScaleType(android.widget.ImageView.ScaleType.MATRIX);
+                this.nativeViewProtected.setScaleType(android.widget.ImageView.ScaleType.MATRIX);
                 break;
         }
     }
@@ -141,9 +141,9 @@ export class Image extends ImageBase {
     }
     [tintColorProperty.setNative](value: Color) {
         if (value === undefined) {
-            this.nativeView.clearColorFilter();
+            this.nativeViewProtected.clearColorFilter();
         } else {
-            this.nativeView.setColorFilter(value.android);
+            this.nativeViewProtected.setColorFilter(value.android);
         }
     }
 
@@ -151,7 +151,7 @@ export class Image extends ImageBase {
         return undefined;
     }
     [imageSourceProperty.setNative](value: ImageSource) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (value && value.android) {
             const rotation = value.rotationAngle ? value.rotationAngle : 0;
             nativeView.setRotationAngle(rotation);

--- a/tns-core-modules/ui/image/image.ios.ts
+++ b/tns-core-modules/ui/image/image.ios.ts
@@ -14,7 +14,7 @@ export class Image extends ImageBase {
         super();
 
         //TODO: Think of unified way of setting all the default values.
-        this.nativeView = this._ios = UIImageView.new();
+        this.nativeViewProtected = this._ios = UIImageView.new();
         this._ios.contentMode = UIViewContentMode.ScaleAspectFit;
         this._ios.userInteractionEnabled = true;
         this._setNativeClipToBounds();

--- a/tns-core-modules/ui/label/label.android.ts
+++ b/tns-core-modules/ui/label/label.android.ts
@@ -7,7 +7,7 @@ export * from "../text-base";
 let TextView: typeof android.widget.TextView;
 
 export class Label extends TextBase implements LabelDefinition {
-    nativeView: android.widget.TextView;
+    nativeViewProtected: android.widget.TextView;
 
     get textWrap(): boolean {
         return this.style.whiteSpace === "normal";
@@ -30,7 +30,7 @@ export class Label extends TextBase implements LabelDefinition {
 
     public initNativeView(): void {
         super.initNativeView();
-        const textView = this.nativeView;
+        const textView = this.nativeViewProtected;
         textView.setSingleLine(true);
         textView.setEllipsize(android.text.TextUtils.TruncateAt.END);
     }
@@ -43,4 +43,4 @@ export class Label extends TextBase implements LabelDefinition {
 }
 
 Label.prototype._isSingleLine = true;
-Label.prototype.recycleNativeView = true;
+Label.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -19,18 +19,18 @@ enum FixedSize {
 }
 
 export class Label extends TextBase implements LabelDefinition {
-    nativeView: TNSLabel;
+    nativeViewProtected: TNSLabel;
     private _fixedSize: FixedSize;
 
     constructor() {
         super();
 
-        this.nativeView = TNSLabel.new();
-        this.nativeView.userInteractionEnabled = true;
+        this.nativeViewProtected = TNSLabel.new();
+        this.nativeViewProtected.userInteractionEnabled = true;
     }
 
     get ios(): TNSLabel {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     get textWrap(): boolean {
@@ -56,7 +56,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (nativeView) {
             const width = layout.getMeasureSpecSize(widthMeasureSpec);
             const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);
@@ -85,7 +85,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [whiteSpaceProperty.setNative](value: WhiteSpace) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         switch (value) {
             case "normal":
                 nativeView.lineBreakMode = NSLineBreakMode.ByWordWrapping;
@@ -103,7 +103,7 @@ export class Label extends TextBase implements LabelDefinition {
         if (value instanceof Background) {
             ios.createBackgroundUIColor(this, (color: UIColor) => {
                 const cgColor = color ? color.CGColor : null;
-                this.nativeView.layer.backgroundColor = cgColor;
+                this.nativeViewProtected.layer.backgroundColor = cgColor;
             }, true);
         }
 
@@ -111,7 +111,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [borderTopWidthProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const border = nativeView.borderThickness;
         nativeView.borderThickness = {
             top: layout.toDeviceIndependentPixels(this.effectiveBorderTopWidth),
@@ -122,7 +122,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [borderRightWidthProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const border = nativeView.borderThickness;
         nativeView.borderThickness = {
             top: border.top,
@@ -133,7 +133,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [borderBottomWidthProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const border = nativeView.borderThickness;
         nativeView.borderThickness = {
             top: border.top,
@@ -144,7 +144,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [borderLeftWidthProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const border = nativeView.borderThickness;
         nativeView.borderThickness = {
             top: border.top,
@@ -155,7 +155,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [paddingTopProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const padding = nativeView.padding;
         nativeView.padding = {
             top: layout.toDeviceIndependentPixels(this.effectivePaddingTop),
@@ -166,7 +166,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [paddingRightProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const padding = nativeView.padding;
         nativeView.padding = {
             top: padding.top,
@@ -177,7 +177,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [paddingBottomProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const padding = nativeView.padding;
         nativeView.padding = {
             top: padding.top,
@@ -188,7 +188,7 @@ export class Label extends TextBase implements LabelDefinition {
     }
 
     [paddingLeftProperty.setNative](value: Length) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         const padding = nativeView.padding;
         nativeView.padding = {
             top: padding.top,
@@ -199,4 +199,4 @@ export class Label extends TextBase implements LabelDefinition {
     }
 }
 
-Label.prototype.recycleNativeView = true;
+Label.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout-common.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout-common.ts
@@ -43,7 +43,7 @@ export class AbsoluteLayoutBase extends LayoutBase implements AbsoluteLayoutDefi
     }
 }
 
-AbsoluteLayoutBase.prototype.recycleNativeView = true;
+AbsoluteLayoutBase.prototype.recycleNativeView = "auto";
 
 export const leftProperty = new Property<View, Length>({
     name: "left", defaultValue: zeroLength,

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.android.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.android.ts
@@ -4,7 +4,7 @@ export * from "./absolute-layout-common";
 
 function makeNativeSetter<T>(setter: (this: View, lp: org.nativescript.widgets.CommonLayoutParams, value: T) => void) {
     return function(this: View, value: T) {
-        const nativeView: android.view.View = this.nativeView;
+        const nativeView: android.view.View = this.nativeViewProtected;
         const lp = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
         if (lp instanceof org.nativescript.widgets.CommonLayoutParams) {
             setter.call(this, lp, value);
@@ -17,7 +17,7 @@ View.prototype[topProperty.setNative] = makeNativeSetter<number>(function(this: 
 View.prototype[leftProperty.setNative] = makeNativeSetter<number>(function(this: View, lp, value) { lp.left = Length.toDevicePixels(value, 0) });
 
 export class AbsoluteLayout extends AbsoluteLayoutBase {
-    nativeView: org.nativescript.widgets.AbsoluteLayout;
+    nativeViewProtected: org.nativescript.widgets.AbsoluteLayout;
 
     public createNativeView() {
         return new org.nativescript.widgets.AbsoluteLayout(this._context);

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout-common.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout-common.ts
@@ -27,7 +27,7 @@ export class DockLayoutBase extends LayoutBase implements DockLayoutDefinition {
     }
 }
 
-DockLayoutBase.prototype.recycleNativeView = true;
+DockLayoutBase.prototype.recycleNativeView = "auto";
 
 const dockConverter = makeParser<Dock>(makeValidator<Dock>("left", "top", "right", "bottom"));
 export const dockProperty = new Property<View, Dock>({

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout.android.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout.android.ts
@@ -3,7 +3,7 @@
 export * from "./dock-layout-common";
 
 View.prototype[dockProperty.setNative] = function(this: View, value: "left" | "top" | "right" | "bottom") {
-    const nativeView: android.view.View = this.nativeView;
+    const nativeView: android.view.View = this.nativeViewProtected;
     const lp = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
     if (lp instanceof org.nativescript.widgets.CommonLayoutParams) {
         switch (value) {
@@ -32,7 +32,7 @@ View.prototype[dockProperty.setNative] = function(this: View, value: "left" | "t
 }
 
 export class DockLayout extends DockLayoutBase {
-    nativeView: org.nativescript.widgets.DockLayout;
+    nativeViewProtected: org.nativescript.widgets.DockLayout;
 
     public createNativeView() {
         return new org.nativescript.widgets.DockLayout(this._context);
@@ -42,6 +42,6 @@ export class DockLayout extends DockLayoutBase {
         return true;
     }
     [stretchLastChildProperty.setNative](value: boolean) {
-        this.nativeView.setStretchLastChild(value);
+        this.nativeViewProtected.setStretchLastChild(value);
     }
 }

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
@@ -209,7 +209,7 @@ export abstract class FlexboxLayoutBase extends LayoutBase {
     }
 }
 
-FlexboxLayoutBase.prototype.recycleNativeView = true;
+FlexboxLayoutBase.prototype.recycleNativeView = "auto";
 
 export const flexDirectionProperty = new CssProperty<Style, FlexDirection>({ name: "flexDirection", cssName: "flex-direction", defaultValue: FlexDirection.ROW, affectsLayout: isIOS, valueConverter: FlexDirection.parse });
 flexDirectionProperty.register(Style);

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
@@ -17,7 +17,7 @@ let widgetLayoutParams: typeof org.nativescript.widgets.FlexboxLayout.LayoutPara
 
 function makeNativeSetter<T>(setter: (lp: org.nativescript.widgets.FlexboxLayout.LayoutParams, value: T) => void) {
     return function (this: View, value: T) {
-        const nativeView: android.view.View = this.nativeView;
+        const nativeView: android.view.View = this.nativeViewProtected;
         const lp = nativeView.getLayoutParams() || new widgetLayoutParams();
         if (lp instanceof widgetLayoutParams) {
             setter(lp, value);
@@ -80,7 +80,7 @@ const alignSelfMap = {
 }
 
 export class FlexboxLayout extends FlexboxLayoutBase {
-    nativeView: org.nativescript.widgets.FlexboxLayout;
+    nativeViewProtected: org.nativescript.widgets.FlexboxLayout;
 
     constructor() {
         super();
@@ -96,60 +96,60 @@ export class FlexboxLayout extends FlexboxLayoutBase {
 
     public resetNativeView(): void {
         super.resetNativeView();
-        (<any>this.nativeView).invalidateOrdersCache();   
+        (<any>this.nativeViewProtected).invalidateOrdersCache();   
     }
 
     [flexDirectionProperty.getDefault](): FlexDirection {
         return flexDirectionProperty.defaultValue;
     }
     [flexDirectionProperty.setNative](flexDirection: FlexDirection) {
-        this.nativeView.setFlexDirection(flexDirectionMap[flexDirection]);
+        this.nativeViewProtected.setFlexDirection(flexDirectionMap[flexDirection]);
     }
 
     [flexWrapProperty.getDefault](): FlexWrap {
         return flexWrapProperty.defaultValue;
     }
     [flexWrapProperty.setNative](flexWrap: FlexWrap) {
-        this.nativeView.setFlexWrap(flexWrapMap[flexWrap]);
+        this.nativeViewProtected.setFlexWrap(flexWrapMap[flexWrap]);
     }
 
     [justifyContentProperty.getDefault](): JustifyContent {
         return justifyContentProperty.defaultValue;
     }
     [justifyContentProperty.setNative](justifyContent: JustifyContent) {
-        this.nativeView.setJustifyContent(justifyContentMap[justifyContent]);
+        this.nativeViewProtected.setJustifyContent(justifyContentMap[justifyContent]);
     }
 
     [alignItemsProperty.getDefault](): AlignItems {
         return alignItemsProperty.defaultValue;
     }
     [alignItemsProperty.setNative](alignItems: AlignItems) {
-        this.nativeView.setAlignItems(alignItemsMap[alignItems]);
+        this.nativeViewProtected.setAlignItems(alignItemsMap[alignItems]);
     }
 
     [alignContentProperty.getDefault](): AlignContent {
         return alignContentProperty.defaultValue;
     }
     [alignContentProperty.setNative](alignContent: AlignContent) {
-        this.nativeView.setAlignContent(alignContentMap[alignContent]);
+        this.nativeViewProtected.setAlignContent(alignContentMap[alignContent]);
     }
 
     public _updateNativeLayoutParams(child: View): void {
         super._updateNativeLayoutParams(child);
 
-        const lp = <org.nativescript.widgets.FlexboxLayout.LayoutParams>child.nativeView.getLayoutParams();
+        const lp = <org.nativescript.widgets.FlexboxLayout.LayoutParams>child.nativeViewProtected.getLayoutParams();
         const style = child.style;
         lp.order = style.order;
         lp.flexGrow = style.flexGrow;
         lp.flexShrink = style.flexShrink;
         lp.wrapBefore = style.flexWrapBefore;
         lp.alignSelf = alignSelfMap[style.alignSelf];
-        child.nativeView.setLayoutParams(lp);
+        child.nativeViewProtected.setLayoutParams(lp);
     }
 
     public _setChildMinWidthNative(child: View): void {
         child._setMinWidthNative(0);
-        const nativeView = child.nativeView;
+        const nativeView = child.nativeViewProtected;
         const lp = nativeView.getLayoutParams();
         if (lp instanceof widgetLayoutParams) {
             lp.minWidth = Length.toDevicePixels(child.style.minWidth, 0);
@@ -159,7 +159,7 @@ export class FlexboxLayout extends FlexboxLayoutBase {
 
     public _setChildMinHeightNative(child: View): void {
         child._setMinHeightNative(0);
-        const nativeView = child.nativeView;
+        const nativeView = child.nativeViewProtected;
         const lp = nativeView.getLayoutParams();
         if (lp instanceof widgetLayoutParams) {
             lp.minHeight = Length.toDevicePixels(child.style.minHeight, 0);

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
@@ -305,7 +305,7 @@ export class GridLayoutBase extends LayoutBase implements GridLayoutDefinition {
     }
 }
 
-GridLayoutBase.prototype.recycleNativeView = true;
+GridLayoutBase.prototype.recycleNativeView = "auto";
 
 export const columnProperty = new Property<View, number>({
     name: "col", defaultValue: 0,

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.android.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.android.ts
@@ -7,7 +7,7 @@ export * from "./grid-layout-common";
 
 function makeNativeSetter<T>(setter: (lp: org.nativescript.widgets.CommonLayoutParams, value: T) => void) {
     return function(this: View, value: T) {
-        const nativeView: android.view.View = this.nativeView;
+        const nativeView: android.view.View = this.nativeViewProtected;
         const lp = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
         if (lp instanceof org.nativescript.widgets.CommonLayoutParams) {
             setter(lp, value);
@@ -50,7 +50,7 @@ export class ItemSpec extends ItemSpecBase {
 }
 
 export class GridLayout extends GridLayoutBase {
-    nativeView: org.nativescript.widgets.GridLayout;
+    nativeViewProtected: org.nativescript.widgets.GridLayout;
 
     public createNativeView() {
         return new org.nativescript.widgets.GridLayout(this._context);
@@ -79,32 +79,32 @@ export class GridLayout extends GridLayoutBase {
     }
 
     public _onRowAdded(itemSpec: ItemSpec) {
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             const nativeSpec = createNativeSpec(itemSpec);
             itemSpec.nativeSpec = nativeSpec;
-            this.nativeView.addRow(nativeSpec);
+            this.nativeViewProtected.addRow(nativeSpec);
         }
     }
 
     public _onColumnAdded(itemSpec: ItemSpec) {
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             const nativeSpec = createNativeSpec(itemSpec);
             itemSpec.nativeSpec = nativeSpec;
-            this.nativeView.addColumn(nativeSpec);
+            this.nativeViewProtected.addColumn(nativeSpec);
         }
     }
 
     public _onRowRemoved(itemSpec: ItemSpec, index: number) {
         itemSpec.nativeSpec = null;
-        if (this.nativeView) {
-            this.nativeView.removeRowAt(index);
+        if (this.nativeViewProtected) {
+            this.nativeViewProtected.removeRowAt(index);
         }
     }
 
     public _onColumnRemoved(itemSpec: ItemSpec, index: number) {
         itemSpec.nativeSpec = null;
-        if (this.nativeView) {
-            this.nativeView.removeColumnAt(index);
+        if (this.nativeViewProtected) {
+            this.nativeViewProtected.removeColumnAt(index);
         }
     }
 

--- a/tns-core-modules/ui/layouts/layout-base.android.ts
+++ b/tns-core-modules/ui/layouts/layout-base.android.ts
@@ -29,27 +29,27 @@ export class LayoutBase extends LayoutBaseCommon {
         return { value: this._defaultPaddingTop, unit: "px" };
     }
     [paddingTopProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
     }
 
     [paddingRightProperty.getDefault](): Length {
         return { value: this._defaultPaddingRight, unit: "px" };
     }
     [paddingRightProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
     }
 
     [paddingBottomProperty.getDefault](): Length {
         return { value: this._defaultPaddingBottom, unit: "px" };
     }
     [paddingBottomProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
     }
 
     [paddingLeftProperty.getDefault](): Length {
         return { value: this._defaultPaddingLeft, unit: "px" };
     }
     [paddingLeftProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
     }
 }

--- a/tns-core-modules/ui/layouts/layout-base.ios.ts
+++ b/tns-core-modules/ui/layouts/layout-base.ios.ts
@@ -3,7 +3,7 @@
 export * from "./layout-base-common";
 
 export class LayoutBase extends LayoutBaseCommon {
-    nativeView: UIView;
+    nativeViewProtected: UIView;
     
     [clipToBoundsProperty.getDefault](): boolean {
         return false;
@@ -14,7 +14,7 @@ export class LayoutBase extends LayoutBaseCommon {
 
     _setNativeClipToBounds() {
         if (this.clipToBounds) {
-            this.nativeView.clipsToBounds = true;
+            this.nativeViewProtected.clipsToBounds = true;
         } else {
             super._setNativeClipToBounds();
         }

--- a/tns-core-modules/ui/layouts/layout.android.ts
+++ b/tns-core-modules/ui/layouts/layout.android.ts
@@ -37,7 +37,7 @@ function initializeNativeViewGroup() {
 }
 
 export class Layout extends LayoutBase implements LayoutDefinition {
-    nativeView: android.view.ViewGroup;
+    nativeViewProtected: android.view.ViewGroup;
     _measuredWidth: number;
     _measuredHeight: number;
 
@@ -48,18 +48,18 @@ export class Layout extends LayoutBase implements LayoutDefinition {
 
     public initNativeView(): void {
         super.initNativeView();
-        (<any>this.nativeView)[OWNER] = this;
+        (<any>this.nativeViewProtected)[OWNER] = this;
     }
 
     public disposeNativeView() {
-         (<any>this.nativeView)[OWNER] = undefined;
+         (<any>this.nativeViewProtected)[OWNER] = undefined;
         super.disposeNativeView();
     }
 
     public measure(widthMeasureSpec: number, heightMeasureSpec: number): void {
         this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
 
-        const view = this.nativeView;
+        const view = this.nativeViewProtected;
         if (view) {
             if (traceEnabled()) {
                 traceWrite(`${this} :measure: ${layout.measureSpecToString(widthMeasureSpec)}, ${layout.measureSpecToString(heightMeasureSpec)}`, traceCategories.Layout);
@@ -71,7 +71,7 @@ export class Layout extends LayoutBase implements LayoutDefinition {
     public layout(left: number, top: number, right: number, bottom: number): void {
         this._setCurrentLayoutBounds(left, top, right, bottom);
 
-        var view = this.nativeView;
+        var view = this.nativeViewProtected;
         if (view) {
             this.layoutNativeView(left, top, right, bottom);
             if (traceEnabled()) {

--- a/tns-core-modules/ui/layouts/layout.ios.ts
+++ b/tns-core-modules/ui/layouts/layout.ios.ts
@@ -3,15 +3,15 @@ import { LayoutBase } from "./layout-base";
 
 export * from "./layout-base";
 export class Layout extends LayoutBase implements LayoutDefinition {
-    nativeView: UIView;
+    nativeViewProtected: UIView;
 
     constructor() {
         super();
-        this.nativeView = UIView.new();
+        this.nativeViewProtected = UIView.new();
     }
 
     get ios(): UIView {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout-common.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout-common.ts
@@ -7,7 +7,7 @@ export class StackLayoutBase extends LayoutBase implements StackLayoutDefinition
     public orientation: Orientation;
 }
 
-StackLayoutBase.prototype.recycleNativeView = true;
+StackLayoutBase.prototype.recycleNativeView = "auto";
 
 const converter = makeParser<Orientation>(makeValidator("horizontal", "vertical"));
 

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout.android.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout.android.ts
@@ -3,13 +3,13 @@
 export * from "./stack-layout-common";
 
 export class StackLayout extends StackLayoutBase {
-    nativeView: org.nativescript.widgets.StackLayout;
+    nativeViewProtected: org.nativescript.widgets.StackLayout;
 
     public createNativeView() {
          return new org.nativescript.widgets.StackLayout(this._context);
     }
 
     [orientationProperty.setNative](value: "horizontal" | "vertical") {
-        this.nativeView.setOrientation(value === "vertical" ? org.nativescript.widgets.Orientation.vertical : org.nativescript.widgets.Orientation.horizontal)
+        this.nativeViewProtected.setOrientation(value === "vertical" ? org.nativescript.widgets.Orientation.vertical : org.nativescript.widgets.Orientation.horizontal)
     }
 }

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout-common.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout-common.ts
@@ -11,7 +11,7 @@ export class WrapLayoutBase extends LayoutBase implements WrapLayoutDefinition {
     public effectiveItemHeight: number;
 }
 
-WrapLayoutBase.prototype.recycleNativeView = true;
+WrapLayoutBase.prototype.recycleNativeView = "auto";
 
 export const itemWidthProperty = new Property<WrapLayoutBase, Length>({
     name: "itemWidth", defaultValue: "auto", affectsLayout: isIOS, valueConverter: (v) => Length.parse(v),

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.android.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.android.ts
@@ -3,21 +3,21 @@
 export * from "./wrap-layout-common";
 
 export class WrapLayout extends WrapLayoutBase {
-    nativeView: org.nativescript.widgets.WrapLayout;
+    nativeViewProtected: org.nativescript.widgets.WrapLayout;
 
     public createNativeView() {
          return new org.nativescript.widgets.WrapLayout(this._context);
     }
 
     [orientationProperty.setNative](value: "horizontal" | "vertical") {
-        this.nativeView.setOrientation(value === "vertical" ? org.nativescript.widgets.Orientation.vertical : org.nativescript.widgets.Orientation.horizontal)
+        this.nativeViewProtected.setOrientation(value === "vertical" ? org.nativescript.widgets.Orientation.vertical : org.nativescript.widgets.Orientation.horizontal)
     }
 
     [itemWidthProperty.setNative](value: Length) {
-        this.nativeView.setItemWidth(Length.toDevicePixels(value, -1));
+        this.nativeViewProtected.setItemWidth(Length.toDevicePixels(value, -1));
     }
 
     [itemHeightProperty.setNative](value: Length) {
-        this.nativeView.setItemHeight(Length.toDevicePixels(value, -1));
+        this.nativeViewProtected.setItemHeight(Length.toDevicePixels(value, -1));
     }
 }

--- a/tns-core-modules/ui/list-picker/list-picker-common.ts
+++ b/tns-core-modules/ui/list-picker/list-picker-common.ts
@@ -20,7 +20,7 @@ export class ListPickerBase extends View implements ListPickerDefinition {
     }
 }
 
-ListPickerBase.prototype.recycleNativeView = true;
+ListPickerBase.prototype.recycleNativeView = "auto";
 
 export const selectedIndexProperty = new CoercibleProperty<ListPickerBase, number>({
     name: "selectedIndex", defaultValue: -1,

--- a/tns-core-modules/ui/list-picker/list-picker.android.ts
+++ b/tns-core-modules/ui/list-picker/list-picker.android.ts
@@ -69,7 +69,7 @@ function getSelectorWheelPaint(picker: android.widget.NumberPicker): android.gra
 }
 
 export class ListPicker extends ListPickerBase {
-    nativeView: android.widget.NumberPicker;
+    nativeViewProtected: android.widget.NumberPicker;
     private _selectorWheelPaint: android.graphics.Paint;
 
     public createNativeView() {
@@ -100,7 +100,7 @@ export class ListPicker extends ListPickerBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         this._selectorWheelPaint = getSelectorWheelPaint(nativeView);
         (<any>nativeView).formatter.owner = this;
         (<any>nativeView).valueChangedListener.owner = this;
@@ -117,14 +117,14 @@ export class ListPicker extends ListPickerBase {
     }
 
     public disposeNativeView() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         (<any>nativeView).formatter.owner = null;
         (<any>nativeView).valueChangedListener.owner = null;
         super.disposeNativeView();
     }
 
     private _fixNumberPickerRendering() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         //HACK: Force the stubborn NumberPicker to render correctly when we have 0 or 1 items.
         nativeView.setFormatter(null);
         nativeView.setFormatter((<any>nativeView).formatter); //Force the NumberPicker to call our Formatter 
@@ -142,7 +142,7 @@ export class ListPicker extends ListPickerBase {
     }
     [selectedIndexProperty.setNative](value: number) {
         if (value >= 0) {
-            this.nativeView.setValue(value);
+            this.nativeViewProtected.setValue(value);
         }
     }
 
@@ -151,7 +151,7 @@ export class ListPicker extends ListPickerBase {
     }
     [itemsProperty.setNative](value: any[] | ItemsSource) {
         let maxValue = value && value.length > 0 ? value.length - 1 : 0;
-        this.nativeView.setMaxValue(maxValue);
+        this.nativeViewProtected.setMaxValue(maxValue);
         this._fixNumberPickerRendering();
 
         // Coerce selected index after we have set items to native view.
@@ -159,7 +159,7 @@ export class ListPicker extends ListPickerBase {
     }
 
     [colorProperty.getDefault](): { wheelColor: number, textColor: number } {
-	const editText = (<any>this.nativeView).editText;
+	const editText = (<any>this.nativeViewProtected).editText;
         return {
             wheelColor: this._selectorWheelPaint.getColor(),
             textColor: editText ? editText.getTextColors().getDefaultColor() : -1
@@ -176,7 +176,7 @@ export class ListPicker extends ListPickerBase {
         }
 
         this._selectorWheelPaint.setColor(wheelColor);
-        const editText = (<any>this.nativeView).editText;
+        const editText = (<any>this.nativeViewProtected).editText;
         if (editText) {
             editText.setTextColor(color);
         }

--- a/tns-core-modules/ui/list-picker/list-picker.ios.ts
+++ b/tns-core-modules/ui/list-picker/list-picker.ios.ts
@@ -12,7 +12,7 @@ export class ListPicker extends ListPickerBase {
     constructor() {
         super();
 
-        this.nativeView = this._ios = UIPickerView.new();
+        this.nativeViewProtected = this._ios = UIPickerView.new();
         this._ios.dataSource = this._dataSource = ListPickerDataSource.initWithOwner(new WeakRef(this));
         this._delegate = ListPickerDelegateImpl.initWithOwner(new WeakRef(this));
     }

--- a/tns-core-modules/ui/list-view/list-view-common.ts
+++ b/tns-core-modules/ui/list-view/list-view-common.ts
@@ -129,7 +129,7 @@ export abstract class ListViewBase extends View implements ListViewDefinition {
         rowHeightProperty.coerce(this);
     }
 }
-ListViewBase.prototype.recycleNativeView = true;
+ListViewBase.prototype.recycleNativeView = "auto";
 
 export interface ListViewBase {
     on(eventNames: string, callback: (data: EventData) => void, thisArg?: any);
@@ -188,7 +188,7 @@ export const rowHeightProperty = new CoercibleProperty<ListViewBase, Length>({
     name: "rowHeight", defaultValue: defaultRowHeight, equalityComparer: Length.equals,
     coerceValue: (target, value) => {
         // We coerce to default value if we don't have display density.
-        return target.nativeView ? value : defaultRowHeight;
+        return target.nativeViewProtected ? value : defaultRowHeight;
     },
     valueChanged: (target, oldValue, newValue) => {
         target._effectiveRowHeight = Length.toDevicePixels(newValue, autoEffectiveRowHeight);

--- a/tns-core-modules/ui/list-view/list-view.android.ts
+++ b/tns-core-modules/ui/list-view/list-view.android.ts
@@ -43,7 +43,7 @@ function initializeItemClickListener(): void {
 }
 
 export class ListView extends ListViewBase {
-    nativeView: android.widget.ListView;
+    nativeViewProtected: android.widget.ListView;
 
     private _androidViewId: number = -1;
 
@@ -77,7 +77,7 @@ export class ListView extends ListViewBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         (<any>nativeView).itemClickListener.owner = this;
         const adapter = (<any>nativeView).adapter;
         adapter.owner = this;
@@ -89,7 +89,7 @@ export class ListView extends ListViewBase {
     }
 
     public disposeNativeView() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         nativeView.setAdapter(null);
         (<any>nativeView).itemClickListener.owner = null;
         (<any>nativeView).adapter.owner = null;
@@ -98,7 +98,7 @@ export class ListView extends ListViewBase {
     }
 
     public refresh() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView || !nativeView.getAdapter()) {
             return;
         }
@@ -114,7 +114,7 @@ export class ListView extends ListViewBase {
     }
 
     public scrollToIndex(index: number) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             nativeView.setSelection(index);
         }
@@ -166,14 +166,14 @@ export class ListView extends ListViewBase {
     }
 
     [separatorColorProperty.getDefault](): { dividerHeight: number, divider: android.graphics.drawable.Drawable } {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         return {
             dividerHeight: nativeView.getDividerHeight(),
             divider: nativeView.getDivider()
         };
     }
     [separatorColorProperty.setNative](value: Color | { dividerHeight: number, divider: android.graphics.drawable.Drawable }) {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (value instanceof Color) {
             nativeView.setDivider(new android.graphics.drawable.ColorDrawable(value.android));
             nativeView.setDividerHeight(1);
@@ -192,7 +192,7 @@ export class ListView extends ListViewBase {
             this._itemTemplatesInternal = this._itemTemplatesInternal.concat(value);
         }
 
-        this.nativeView.setAdapter(new ListViewAdapterClass(this));
+        this.nativeViewProtected.setAdapter(new ListViewAdapterClass(this));
         this.refresh();
     }
 }
@@ -293,13 +293,13 @@ function ensureListViewAdapterClass() {
                     if (args.view instanceof LayoutBase &&
                         !(args.view instanceof ProxyViewContainer)) {
                         this.owner._addView(args.view);
-                        convertView = args.view.nativeView;
+                        convertView = args.view.nativeViewProtected;
                     } else {
                         let sp = new StackLayout();
                         sp.addChild(args.view);
                         this.owner._addView(sp);
 
-                        convertView = sp.nativeView;
+                        convertView = sp.nativeViewProtected;
                     }
                 }
 

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -209,7 +209,7 @@ export class ListView extends ListViewBase {
 
     constructor() {
         super();
-        this.nativeView = this._ios = UITableView.new();
+        this.nativeViewProtected = this._ios = UITableView.new();
         this._ios.registerClassForCellReuseIdentifier(ListViewCell.class(), this._defaultTemplate.key);
         this._ios.autoresizingMask = UIViewAutoresizing.None;
         this._ios.estimatedRowHeight = DEFAULT_HEIGHT;
@@ -361,15 +361,15 @@ export class ListView extends ListViewBase {
                 cell.owner = new WeakRef(view);
             } else if (cell.view !== view) {
                 this._removeContainer(cell);
-                (<UIView>cell.view.nativeView).removeFromSuperview();
+                (<UIView>cell.view.nativeViewProtected).removeFromSuperview();
                 cell.owner = new WeakRef(view);
             }
 
             this._prepareItem(view, indexPath.row);
             this._map.set(cell, view);
             // We expect that views returned from itemLoading are new (e.g. not reused).
-            if (view && !view.parent && view.nativeView) {
-                cell.contentView.addSubview(view.nativeView);
+            if (view && !view.parent && view.nativeViewProtected) {
+                cell.contentView.addSubview(view.nativeViewProtected);
                 this._addView(view);
             }
 

--- a/tns-core-modules/ui/page/page.android.ts
+++ b/tns-core-modules/ui/page/page.android.ts
@@ -40,13 +40,13 @@ function initializeDialogFragment() {
             this._owner.verticalAlignment = this._fullscreen ? "stretch" : "middle";
             this._owner.actionBarHidden = true;
 
-            const nativeView = <android.view.View>this._owner.nativeView;
+            const nativeView = <android.view.View>this._owner.nativeViewProtected;
             let layoutParams = nativeView.getLayoutParams();
             if (!layoutParams) {
                 layoutParams = new org.nativescript.widgets.CommonLayoutParams();
                 nativeView.setLayoutParams(layoutParams);
             }
-            dialog.setContentView(this._owner.nativeView, layoutParams);
+            dialog.setContentView(this._owner.nativeViewProtected, layoutParams);
 
             const window = dialog.getWindow();
             window.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
@@ -88,7 +88,7 @@ function initializeDialogFragment() {
 }
 
 export class Page extends PageBase {
-    nativeView: org.nativescript.widgets.GridLayout;
+    nativeViewProtected: org.nativescript.widgets.GridLayout;
     private _isBackNavigation = false;
 
     public createNativeView() {
@@ -100,12 +100,12 @@ export class Page extends PageBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        this.nativeView.setBackgroundColor(-1); // White color.
+        this.nativeViewProtected.setBackgroundColor(-1); // White color.
     }
 
     public _addViewToNativeVisualTree(child: View, atIndex?: number): boolean {
         // Set the row property for the child 
-        if (this.nativeView && child.nativeView) {
+        if (this.nativeViewProtected && child.nativeViewProtected) {
             if (child instanceof ActionBar) {
                 GridLayout.setRow(child, 0);
                 child.horizontalAlignment = "stretch";

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -90,7 +90,7 @@ class UIViewControllerImpl extends UIViewController {
         if (modalParent) {
             // if inside horizontally compact environment - fullScreen will be forced
             let isFullScreen = !owner._UIModalPresentationFormSheet ||
-                (modalParent.nativeView.traitCollection.horizontalSizeClass === UIUserInterfaceSizeClass.Compact);
+                (modalParent.nativeViewProtected.traitCollection.horizontalSizeClass === UIUserInterfaceSizeClass.Compact);
 
             let frame = isFullScreen ? getter(UIScreen, UIScreen.mainScreen).bounds : this.view.frame;
             let size = frame.size;
@@ -326,7 +326,7 @@ class UIViewControllerImpl extends UIViewController {
 }
 
 export class Page extends PageBase {
-    nativeView: UIView;
+    nativeViewProtected: UIView;
 
     private _ios: UIViewControllerImpl;
     public _enableLoadedEvents: boolean;
@@ -338,14 +338,14 @@ export class Page extends PageBase {
     constructor() {
         super();
         this._ios = UIViewControllerImpl.initWithOwner(new WeakRef(this));
-        this.nativeView = this._ios.view;
-        this.nativeView.backgroundColor = new Color("white").ios;
+        this.nativeViewProtected = this._ios.view;
+        this.nativeViewProtected.backgroundColor = new Color("white").ios;
     }
 
     public requestLayout(): void {
         super.requestLayout();
-        if ((!this.parent || this._modalParent) && this.ios && this.nativeView) {
-            this.nativeView.setNeedsLayout();
+        if ((!this.parent || this._modalParent) && this.ios && this.nativeViewProtected) {
+            this.nativeViewProtected.setNeedsLayout();
         }
     }
 

--- a/tns-core-modules/ui/progress/progress-common.ts
+++ b/tns-core-modules/ui/progress/progress-common.ts
@@ -27,7 +27,7 @@ export class ProgressBase extends View implements ProgressDefinition {
     // }
 }
 
-ProgressBase.prototype.recycleNativeView = true;
+ProgressBase.prototype.recycleNativeView = "auto";
 
 /**
  * Represents the observable property backing the value property of each Progress instance.

--- a/tns-core-modules/ui/progress/progress.android.ts
+++ b/tns-core-modules/ui/progress/progress.android.ts
@@ -8,7 +8,7 @@ export * from "./progress-common";
 const R_ATTR_PROGRESS_BAR_STYLE_HORIZONTAL = 0x01010078;
 
 export class Progress extends ProgressBase {
-    nativeView: android.widget.ProgressBar;
+    nativeViewProtected: android.widget.ProgressBar;
 
     public createNativeView() {
         return new android.widget.ProgressBar(this._context, null, R_ATTR_PROGRESS_BAR_STYLE_HORIZONTAL);
@@ -18,21 +18,21 @@ export class Progress extends ProgressBase {
         return 0;
     }
     [valueProperty.setNative](value: number) {
-        this.nativeView.setProgress(value);
+        this.nativeViewProtected.setProgress(value);
     }
 
     [maxValueProperty.getDefault](): number {
         return 100;
     }
     [maxValueProperty.setNative](value: number) {
-        this.nativeView.setMax(value);
+        this.nativeViewProtected.setMax(value);
     }
 
     [colorProperty.getDefault](): android.graphics.drawable.Drawable {
         return null;
     }
     [colorProperty.setNative](value: Color) {
-        let progressDrawable = this.nativeView.getProgressDrawable();
+        let progressDrawable = this.nativeViewProtected.getProgressDrawable();
         if (!progressDrawable) {
             return;
         }
@@ -48,7 +48,7 @@ export class Progress extends ProgressBase {
         return null;
     }
     [backgroundColorProperty.setNative](value: Color) {
-        let progressDrawable = this.nativeView.getProgressDrawable();
+        let progressDrawable = this.nativeViewProtected.getProgressDrawable();
         if (!progressDrawable) {
             return;
         }

--- a/tns-core-modules/ui/progress/progress.ios.ts
+++ b/tns-core-modules/ui/progress/progress.ios.ts
@@ -10,7 +10,7 @@ export class Progress extends ProgressBase {
 
     constructor() {
         super();
-        this.nativeView = this._ios = UIProgressView.new();
+        this.nativeViewProtected = this._ios = UIProgressView.new();
     }
     
     get ios(): UIProgressView {

--- a/tns-core-modules/ui/proxy-view-container/proxy-view-container.ts
+++ b/tns-core-modules/ui/proxy-view-container/proxy-view-container.ts
@@ -13,7 +13,7 @@ export class ProxyViewContainer extends LayoutBase implements ProxyViewContainer
 
     constructor() {
         super();
-        this.nativeView = undefined;
+        this.nativeViewProtected = undefined;
     }
     
     // No native view for proxy container.

--- a/tns-core-modules/ui/repeater/repeater.ts
+++ b/tns-core-modules/ui/repeater/repeater.ts
@@ -120,7 +120,7 @@ export class Repeater extends CustomLayoutView implements RepeaterDefinition {
 
 }
 
-Repeater.prototype.recycleNativeView = true;
+Repeater.prototype.recycleNativeView = "auto";
 
 /**
  * Represents the item template property of each ListView instance.

--- a/tns-core-modules/ui/scroll-view/scroll-view.android.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.android.ts
@@ -4,12 +4,12 @@ import { ScrollViewBase, layout, scrollBarIndicatorVisibleProperty } from "./scr
 export * from "./scroll-view-common";
 
 export class ScrollView extends ScrollViewBase {
-    nativeView: org.nativescript.widgets.VerticalScrollView | org.nativescript.widgets.HorizontalScrollView;
+    nativeViewProtected: org.nativescript.widgets.VerticalScrollView | org.nativescript.widgets.HorizontalScrollView;
     private _androidViewId: number = -1;
     private handler: android.view.ViewTreeObserver.OnScrollChangedListener;
 
     get horizontalOffset(): number {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView) {
             return 0;
         }
@@ -18,7 +18,7 @@ export class ScrollView extends ScrollViewBase {
     }
 
     get verticalOffset(): number {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView) {
             return 0;
         }
@@ -27,7 +27,7 @@ export class ScrollView extends ScrollViewBase {
     }
 
     get scrollableWidth(): number {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView || this.orientation !== "horizontal") {
             return 0;
         }
@@ -36,7 +36,7 @@ export class ScrollView extends ScrollViewBase {
     }
 
     get scrollableHeight(): number {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView || this.orientation !== "vertical") {
             return 0;
         }
@@ -49,14 +49,14 @@ export class ScrollView extends ScrollViewBase {
     }
     [scrollBarIndicatorVisibleProperty.setNative](value: boolean) {
         if (this.orientation === "horizontal") {
-            this.nativeView.setHorizontalScrollBarEnabled(value);
+            this.nativeViewProtected.setHorizontalScrollBarEnabled(value);
         } else {
-            this.nativeView.setVerticalScrollBarEnabled(value);
+            this.nativeViewProtected.setVerticalScrollBarEnabled(value);
         }   
     }
 
     public scrollToVerticalOffset(value: number, animated: boolean) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView && this.orientation === "vertical") {
             value *= layout.getDisplayDensity();
 
@@ -69,7 +69,7 @@ export class ScrollView extends ScrollViewBase {
     }
 
     public scrollToHorizontalOffset(value: number, animated: boolean) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView && this.orientation === "horizontal") {
             value *= layout.getDisplayDensity();
 
@@ -92,7 +92,7 @@ export class ScrollView extends ScrollViewBase {
     }
 
     public _onOrientationChanged() {
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             const parent = this.parent;
             if (parent) {
                 parent._removeView(this);
@@ -112,13 +112,13 @@ export class ScrollView extends ScrollViewBase {
             }
         });
 
-        this.nativeView.getViewTreeObserver().addOnScrollChangedListener(this.handler);
+        this.nativeViewProtected.getViewTreeObserver().addOnScrollChangedListener(this.handler);
     }
 
     private _lastScrollX: number = -1;
     private _lastScrollY: number = -1;
     private _onScrollChanged() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             // Event is only raised if the scroll values differ from the last time in order to wokraround a native Android bug.
             // https://github.com/NativeScript/NativeScript/issues/2362
@@ -138,9 +138,9 @@ export class ScrollView extends ScrollViewBase {
     }
 
     protected dettachNative() {
-        this.nativeView.getViewTreeObserver().removeOnScrollChangedListener(this.handler);
+        this.nativeViewProtected.getViewTreeObserver().removeOnScrollChangedListener(this.handler);
         this.handler = null;
     }
 }
 
-ScrollView.prototype.recycleNativeView = false;
+ScrollView.prototype.recycleNativeView = "never";

--- a/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
@@ -28,45 +28,45 @@ class UIScrollViewDelegateImpl extends NSObject implements UIScrollViewDelegate 
 }
 
 export class ScrollView extends ScrollViewBase {
-    public nativeView: UIScrollView;
+    public nativeViewProtected: UIScrollView;
     private _contentMeasuredWidth: number = 0;
     private _contentMeasuredHeight: number = 0;
     private _delegate: UIScrollViewDelegateImpl;
 
     constructor() {
         super();
-        this.nativeView = UIScrollView.new();
+        this.nativeViewProtected = UIScrollView.new();
         this._setNativeClipToBounds();
     }
 
     _setNativeClipToBounds() {
         // Always set clipsToBounds for scroll-view
-        this.nativeView.clipsToBounds = true;
+        this.nativeViewProtected.clipsToBounds = true;
     }
 
     protected attachNative() {
         this._delegate = UIScrollViewDelegateImpl.initWithOwner(new WeakRef(this));
-        this.nativeView.delegate = this._delegate;
+        this.nativeViewProtected.delegate = this._delegate;
     }
 
     protected dettachNative() {
-        this.nativeView.delegate = null;
+        this.nativeViewProtected.delegate = null;
     }
 
     protected updateScrollBarVisibility(value) {
         if (this.orientation === "horizontal") {
-            this.nativeView.showsHorizontalScrollIndicator = value;
+            this.nativeViewProtected.showsHorizontalScrollIndicator = value;
         } else {
-            this.nativeView.showsVerticalScrollIndicator = value;
+            this.nativeViewProtected.showsVerticalScrollIndicator = value;
         } 
     }
 
     get horizontalOffset(): number {
-        return this.nativeView.contentOffset.x;
+        return this.nativeViewProtected.contentOffset.x;
     }
 
     get verticalOffset(): number {
-        return this.nativeView.contentOffset.y;
+        return this.nativeViewProtected.contentOffset.y;
     }
 
     get scrollableWidth(): number {
@@ -74,7 +74,7 @@ export class ScrollView extends ScrollViewBase {
             return 0;
         }
 
-        return Math.max(0, this.nativeView.contentSize.width - this.nativeView.bounds.size.width);
+        return Math.max(0, this.nativeViewProtected.contentSize.width - this.nativeViewProtected.bounds.size.width);
     }
 
     get scrollableHeight(): number {
@@ -82,7 +82,7 @@ export class ScrollView extends ScrollViewBase {
             return 0;
         }
 
-        return Math.max(0, this.nativeView.contentSize.height - this.nativeView.bounds.size.height);
+        return Math.max(0, this.nativeViewProtected.contentSize.height - this.nativeViewProtected.bounds.size.height);
     }
 
     [scrollBarIndicatorVisibleProperty.getDefault](): boolean {
@@ -93,20 +93,20 @@ export class ScrollView extends ScrollViewBase {
     }
 
     get ios(): UIView {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public scrollToVerticalOffset(value: number, animated: boolean) {
         if (this.orientation === "vertical") {
-            const bounds = this.nativeView.bounds.size;
-            this.nativeView.scrollRectToVisibleAnimated(CGRectMake(0, value, bounds.width, bounds.height), animated);
+            const bounds = this.nativeViewProtected.bounds.size;
+            this.nativeViewProtected.scrollRectToVisibleAnimated(CGRectMake(0, value, bounds.width, bounds.height), animated);
         }
     }
 
     public scrollToHorizontalOffset(value: number, animated: boolean) {
         if (this.orientation === "horizontal") {
-            const bounds = this.nativeView.bounds.size;
-            this.nativeView.scrollRectToVisibleAnimated(CGRectMake(value, 0, bounds.width, bounds.height), animated);
+            const bounds = this.nativeViewProtected.bounds.size;
+            this.nativeViewProtected.scrollRectToVisibleAnimated(CGRectMake(value, 0, bounds.width, bounds.height), animated);
         }
     }
 
@@ -135,7 +135,7 @@ export class ScrollView extends ScrollViewBase {
 
             let w = layout.toDeviceIndependentPixels(childSize.measuredWidth);
             let h = layout.toDeviceIndependentPixels(childSize.measuredHeight);
-            this.nativeView.contentSize = CGSizeMake(w, h);
+            this.nativeViewProtected.contentSize = CGSizeMake(w, h);
 
             this._contentMeasuredWidth = Math.max(childSize.measuredWidth, this.effectiveMinWidth * density);
             this._contentMeasuredHeight = Math.max(childSize.measuredHeight, this.effectiveMinHeight * density);
@@ -165,4 +165,4 @@ export class ScrollView extends ScrollViewBase {
     }
 }
 
-ScrollView.prototype.recycleNativeView = true;
+ScrollView.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/search-bar/search-bar-common.ts
+++ b/tns-core-modules/ui/search-bar/search-bar-common.ts
@@ -14,7 +14,7 @@ export abstract class SearchBarBase extends View implements SearchBarDefinition 
     public abstract dismissSoftInput();
 }
 
-SearchBarBase.prototype.recycleNativeView = true;
+SearchBarBase.prototype.recycleNativeView = "auto";
 
 export const textProperty = new Property<SearchBarBase, string>({ name: "text", defaultValue: "", affectsLayout: isIOS });
 textProperty.register(SearchBarBase);

--- a/tns-core-modules/ui/search-bar/search-bar.android.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.android.ts
@@ -76,18 +76,18 @@ function initializeNativeClasses(): void {
 }
 
 export class SearchBar extends SearchBarBase {
-    nativeView: android.support.v7.widget.SearchView;
+    nativeViewProtected: android.support.v7.widget.SearchView;
     private _searchTextView: android.widget.TextView;
     private _searchPlate: android.widget.LinearLayout;
 
     public dismissSoftInput() {
-        ad.dismissSoftInput(this.nativeView);
+        ad.dismissSoftInput(this.nativeViewProtected);
     }
 
     public focus(): boolean {
         let result = super.focus();
         if (result) {
-            ad.showSoftInput(this.nativeView);
+            ad.showSoftInput(this.nativeViewProtected);
         }
 
         return result;
@@ -111,13 +111,13 @@ export class SearchBar extends SearchBarBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.closeListener.owner = this;
         nativeView.queryTextListener.owner = this;
     }
 
     public disposeNativeView() {
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.closeListener.owner = null;
         nativeView.queryTextListener.owner = null;
         this._searchPlate = null;
@@ -127,7 +127,7 @@ export class SearchBar extends SearchBarBase {
 
     [backgroundColorProperty.getDefault](): number {
         // TODO: Why do we get DrawingCacheBackgroundColor but set backgroundColor?????
-        const result = this.nativeView.getDrawingCacheBackgroundColor();
+        const result = this.nativeViewProtected.getDrawingCacheBackgroundColor();
         return result;
     }
     [backgroundColorProperty.setNative](value: Color) {
@@ -138,7 +138,7 @@ export class SearchBar extends SearchBarBase {
             color = value.android;
         }
 
-        this.nativeView.setBackgroundColor(color);
+        this.nativeViewProtected.setBackgroundColor(color);
         const searchPlate = this._getSearchPlate();
         searchPlate.setBackgroundColor(color);
     }
@@ -183,16 +183,16 @@ export class SearchBar extends SearchBarBase {
     }
     [textProperty.setNative](value: string) {
         const text = (value === null || value === undefined) ? '' : value.toString();
-        this.nativeView.setQuery(text, false);
+        this.nativeViewProtected.setQuery(text, false);
     }
     [hintProperty.getDefault](): string {
         return null;
     }
     [hintProperty.setNative](value: string) {
         if (value === null || value === undefined) {
-            this.nativeView.setQueryHint(null);
+            this.nativeViewProtected.setQueryHint(null);
         } else {
-            this.nativeView.setQueryHint(value.toString());
+            this.nativeViewProtected.setQueryHint(value.toString());
         }
     }
     [textFieldBackgroundColorProperty.getDefault](): android.graphics.drawable.Drawable {
@@ -219,9 +219,9 @@ export class SearchBar extends SearchBarBase {
 
     private _getTextView(): android.widget.TextView {
         if (!this._searchTextView) {
-            const pkgName = this.nativeView.getContext().getPackageName();
-            const id = this.nativeView.getContext().getResources().getIdentifier("search_src_text", "id", pkgName);
-            this._searchTextView = <android.widget.TextView>this.nativeView.findViewById(id);
+            const pkgName = this.nativeViewProtected.getContext().getPackageName();
+            const id = this.nativeViewProtected.getContext().getResources().getIdentifier("search_src_text", "id", pkgName);
+            this._searchTextView = <android.widget.TextView>this.nativeViewProtected.findViewById(id);
         }
 
         return this._searchTextView;
@@ -229,9 +229,9 @@ export class SearchBar extends SearchBarBase {
 
     private _getSearchPlate(): android.widget.LinearLayout {
         if (!this._searchPlate) {
-            const pkgName = this.nativeView.getContext().getPackageName();
-            const id = this.nativeView.getContext().getResources().getIdentifier("search_plate", "id", pkgName);
-            this._searchPlate = <android.widget.LinearLayout>this.nativeView.findViewById(id);
+            const pkgName = this.nativeViewProtected.getContext().getPackageName();
+            const id = this.nativeViewProtected.getContext().getResources().getIdentifier("search_plate", "id", pkgName);
+            this._searchPlate = <android.widget.LinearLayout>this.nativeViewProtected.findViewById(id);
         }
 
         return this._searchPlate;

--- a/tns-core-modules/ui/search-bar/search-bar.ios.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.ios.ts
@@ -61,7 +61,7 @@ export class SearchBar extends SearchBarBase {
     constructor() {
         super();
 
-        this.nativeView = this._ios = UISearchBar.new();
+        this.nativeViewProtected = this._ios = UISearchBar.new();
         this._delegate = UISearchBarDelegateImpl.initWithOwner(new WeakRef(this));
     }
 

--- a/tns-core-modules/ui/segmented-bar/segmented-bar-common.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar-common.ts
@@ -59,7 +59,7 @@ export abstract class SegmentedBarBase extends View implements SegmentedBarDefin
                 this._addView(item);
             }
 
-            if (this.nativeView) {
+            if (this.nativeViewProtected) {
                 this[itemsProperty.setNative](items);
             }
         }
@@ -94,7 +94,7 @@ export interface SegmentedBarBase {
     on(event: "selectedIndexChanged", callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any);
 }
 
-SegmentedBarBase.prototype.recycleNativeView = true;
+SegmentedBarBase.prototype.recycleNativeView = "auto";
 
 /**
  * Gets or sets the selected index dependency property of the SegmentedBar.

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.android.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.android.ts
@@ -90,12 +90,12 @@ function initializeNativeClasses(): void {
 }
 
 export class SegmentedBarItem extends SegmentedBarItemBase {
-    nativeView: android.widget.TextView;
+    nativeViewProtected: android.widget.TextView;
 
     public setupNativeView(tabIndex: number): void {
         // TabHost.TabSpec.setIndicator DOES NOT WORK once the title has been set.
         // http://stackoverflow.com/questions/2935781/modify-tab-indicator-dynamically-in-android
-        const titleTextView = <android.widget.TextView>this.parent.nativeView.getTabWidget().getChildAt(tabIndex).findViewById(TITLE_TEXT_VIEW_ID);
+        const titleTextView = <android.widget.TextView>this.parent.nativeViewProtected.getTabWidget().getChildAt(tabIndex).findViewById(TITLE_TEXT_VIEW_ID);
 
         this.setNativeView(titleTextView);
         if (titleTextView) {
@@ -107,7 +107,7 @@ export class SegmentedBarItem extends SegmentedBarItemBase {
 
     private titleDirty: boolean;
     public _update(): void {
-        const tv = this.nativeView;
+        const tv = this.nativeViewProtected;
         if (tv) {
             let title = this.title;
             title = (title === null || title === undefined) ? "" : title;
@@ -119,37 +119,37 @@ export class SegmentedBarItem extends SegmentedBarItemBase {
     }
 
     [colorProperty.getDefault](): number {
-        return this.nativeView.getCurrentTextColor();
+        return this.nativeViewProtected.getCurrentTextColor();
     }
     [colorProperty.setNative](value: Color | number) {
         const color = value instanceof Color ? value.android : value;
-        this.nativeView.setTextColor(color);
+        this.nativeViewProtected.setTextColor(color);
     }
 
     [fontSizeProperty.getDefault](): { nativeSize: number } {
-        return { nativeSize: this.nativeView.getTextSize() };
+        return { nativeSize: this.nativeViewProtected.getTextSize() };
     }
     [fontSizeProperty.setNative](value: number | { nativeSize: number }) {
         if (typeof value === "number") {
-            this.nativeView.setTextSize(value);
+            this.nativeViewProtected.setTextSize(value);
         } else {
-            this.nativeView.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
+            this.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
         }
     }
 
     [fontInternalProperty.getDefault](): android.graphics.Typeface {
-        return this.nativeView.getTypeface();
+        return this.nativeViewProtected.getTypeface();
     }
     [fontInternalProperty.setNative](value: Font | android.graphics.Typeface) {
-        this.nativeView.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
+        this.nativeViewProtected.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
     }
 
     [selectedBackgroundColorProperty.getDefault](): android.graphics.drawable.Drawable.ConstantState {
-        const viewGroup = <android.view.ViewGroup>this.nativeView.getParent();
+        const viewGroup = <android.view.ViewGroup>this.nativeViewProtected.getParent();
         return viewGroup.getBackground().getConstantState();
     }
     [selectedBackgroundColorProperty.setNative](value: Color | android.graphics.drawable.Drawable.ConstantState) {
-        const viewGroup = <android.view.ViewGroup>this.nativeView.getParent();
+        const viewGroup = <android.view.ViewGroup>this.nativeViewProtected.getParent();
         if (value instanceof Color) {
             const color = value.android;
             const backgroundDrawable = viewGroup.getBackground();
@@ -174,7 +174,7 @@ export class SegmentedBarItem extends SegmentedBarItemBase {
 }
 
 export class SegmentedBar extends SegmentedBarBase {
-    nativeView: android.widget.TabHost;
+    nativeViewProtected: android.widget.TabHost;
     private _tabContentFactory: android.widget.TabHost.TabContentFactory;
     private _addingTab: boolean;
 
@@ -211,19 +211,19 @@ export class SegmentedBar extends SegmentedBarBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = this;
         this._tabContentFactory = this._tabContentFactory || new TabContentFactory(this);
     }
 
     public disposeNativeView() {
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = null;
         super.disposeNativeView();
     }
 
     private insertTab(tabItem: SegmentedBarItem, index: number): void {
-        const tabHost = this.nativeView;
+        const tabHost = this.nativeViewProtected;
         const tab = tabHost.newTabSpec(index + "");
         tab.setIndicator(tabItem.title + "");
         tab.setContent(this._tabContentFactory);
@@ -238,14 +238,14 @@ export class SegmentedBar extends SegmentedBarBase {
         return -1;
     }
     [selectedIndexProperty.setNative](value: number) {
-        this.nativeView.setCurrentTab(value);
+        this.nativeViewProtected.setCurrentTab(value);
     }
 
     [itemsProperty.getDefault](): SegmentedBarItem[] {
         return null;
     }
     [itemsProperty.setNative](value: SegmentedBarItem[]) {
-        this.nativeView.clearAllTabs();
+        this.nativeViewProtected.clearAllTabs();
 
         const newItems = value;
         if (newItems) {

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
@@ -26,7 +26,7 @@ export class SegmentedBar extends SegmentedBarBase {
 
     constructor() {
         super();
-        this.nativeView = this._ios = UISegmentedControl.new();
+        this.nativeViewProtected = this._ios = UISegmentedControl.new();
 
         this._selectionHandler = SelectionHandlerImpl.initWithOwner(new WeakRef(this));
         this._ios.addTargetActionForControlEvents(this._selectionHandler, "selected", UIControlEvents.ValueChanged);

--- a/tns-core-modules/ui/slider/slider-common.ts
+++ b/tns-core-modules/ui/slider/slider-common.ts
@@ -10,7 +10,7 @@ export class SliderBase extends View implements SliderDefinition {
     public maxValue: number;
 }
 
-SliderBase.prototype.recycleNativeView = true;
+SliderBase.prototype.recycleNativeView = "auto";
 
 /**
  * Represents the observable property backing the value property of each Slider instance.

--- a/tns-core-modules/ui/slider/slider.android.ts
+++ b/tns-core-modules/ui/slider/slider.android.ts
@@ -46,7 +46,7 @@ function initializeSeekBarChangeListener(): void {
 
 export class Slider extends SliderBase {
     _supressNativeValue: boolean;
-    nativeView: android.widget.SeekBar;
+    nativeViewProtected: android.widget.SeekBar;
 
     public createNativeView() {
         initializeSeekBarChangeListener();
@@ -59,19 +59,19 @@ export class Slider extends SliderBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = this;
     }
 
     public disposeNativeView() {
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = null;
         super.disposeNativeView();
     }
 
     public resetNativeView(): void {
         super.resetNativeView();
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         nativeView.setMax(100);
         nativeView.setProgress(0);
         nativeView.setKeyProgressIncrement(1);
@@ -84,7 +84,7 @@ export class Slider extends SliderBase {
      */
     private setNativeValuesSilently(newValue: number, newMaxValue: number) {
         this._supressNativeValue = true;
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         try {
             nativeView.setMax(newMaxValue);
             nativeView.setProgress(newValue);
@@ -117,9 +117,9 @@ export class Slider extends SliderBase {
     }
     [colorProperty.setNative](value: number | Color) {
         if (value instanceof Color) {
-            this.nativeView.getThumb().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+            this.nativeViewProtected.getThumb().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
         } else {
-            this.nativeView.getThumb().clearColorFilter();
+            this.nativeViewProtected.getThumb().clearColorFilter();
         }
     }
 
@@ -128,9 +128,9 @@ export class Slider extends SliderBase {
     }
     [backgroundColorProperty.setNative](value: number | Color) {
         if (value instanceof Color) {
-            this.nativeView.getProgressDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+            this.nativeViewProtected.getProgressDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
         } else {
-            this.nativeView.getProgressDrawable().clearColorFilter();
+            this.nativeViewProtected.getProgressDrawable().clearColorFilter();
         }
     }
 

--- a/tns-core-modules/ui/slider/slider.ios.ts
+++ b/tns-core-modules/ui/slider/slider.ios.ts
@@ -36,7 +36,7 @@ export class Slider extends SliderBase {
 
     constructor() {
         super();
-        this.nativeView = this._ios = UISlider.new();
+        this.nativeViewProtected = this._ios = UISlider.new();
 
         // default values
         this._ios.minimumValue = 0;

--- a/tns-core-modules/ui/styling/background.android.ts
+++ b/tns-core-modules/ui/styling/background.android.ts
@@ -31,13 +31,13 @@ export module ad {
     }
 
     export function onBackgroundOrBorderPropertyChanged(view: View) {
-        const nativeView = <android.view.View>view.nativeView;
+        const nativeView = <android.view.View>view.nativeViewProtected;
         if (!nativeView) {
             return;
         }
 
         const background = view.style.backgroundInternal;
-        const cache = <CacheLayerType>view.nativeView;
+        const cache = <CacheLayerType>view.nativeViewProtected;
         const drawable = nativeView.getBackground();
         const androidView = <any>view as AndroidView;
         // use undefined as not set. getBackground will never return undefined only Drawable or null;
@@ -111,7 +111,7 @@ function fromBase64(source: string): android.graphics.Bitmap {
 
 const pattern: RegExp = /url\(('|")(.*?)\1\)/;
 function refreshBorderDrawable(this: void, view: View, borderDrawable: org.nativescript.widgets.BorderDrawable) {
-    const nativeView = <android.view.View>view.nativeView;
+    const nativeView = <android.view.View>view.nativeViewProtected;
     const context = nativeView.getContext();
 
     const background = view.style.backgroundInternal;

--- a/tns-core-modules/ui/styling/background.ios.ts
+++ b/tns-core-modules/ui/styling/background.ios.ts
@@ -34,7 +34,7 @@ const symbolUrl = Symbol("backgroundImageUrl");
 export module ios {
     export function createBackgroundUIColor(view: View, callback: (uiColor: UIColor) => void, flip?: boolean): void {
         const background = view.style.backgroundInternal;
-        const nativeView = <NativeView>view.nativeView;
+        const nativeView = <NativeView>view.nativeViewProtected;
 
         if (nativeView.hasNonUniformBorder) {
             clearNonUniformBorders(nativeView);
@@ -286,7 +286,7 @@ function uiColorFromImage(img: UIImage, view: View, callback: (uiColor: UIColor)
         return;
     }
 
-    const nativeView = view.nativeView as UIView;
+    const nativeView = view.nativeViewProtected as UIView;
     const frame = nativeView.frame;
     const boundsWidth = view.scaleX ? frame.size.width / view.scaleX : frame.size.width;
     const boundsHeight = view.scaleY ? frame.size.height / view.scaleY : frame.size.height;

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -130,7 +130,7 @@ export class CssState {
     }
 
     public playPendingKeyframeAnimations() {
-        if (this._pendingKeyframeAnimations && this.view.nativeView) {
+        if (this._pendingKeyframeAnimations && this.view.nativeViewProtected) {
             this._pendingKeyframeAnimations.forEach(s => this.playKeyframeAnimationsFromRuleSet(s.ruleset));
             this._pendingKeyframeAnimations = null;
         }

--- a/tns-core-modules/ui/switch/switch-common.ts
+++ b/tns-core-modules/ui/switch/switch-common.ts
@@ -7,7 +7,7 @@ export class SwitchBase extends View implements SwitchDefinition {
     public checked: boolean;
 }
 
-SwitchBase.prototype.recycleNativeView = true;
+SwitchBase.prototype.recycleNativeView = "auto";
 
 export const checkedProperty = new Property<SwitchBase, boolean>({ name: "checked", defaultValue: false, valueConverter: booleanConverter });
 checkedProperty.register(SwitchBase);

--- a/tns-core-modules/ui/switch/switch.android.ts
+++ b/tns-core-modules/ui/switch/switch.android.ts
@@ -32,7 +32,7 @@ function initializeCheckedChangeListener(): void {
 }
 
 export class Switch extends SwitchBase {
-    nativeView: android.widget.Switch;
+    nativeViewProtected: android.widget.Switch;
     public checked: boolean;
 
     public createNativeView() {
@@ -46,12 +46,12 @@ export class Switch extends SwitchBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = this;
     }
 
     public disposeNativeView() {
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = null;
         super.disposeNativeView();
     }
@@ -60,7 +60,7 @@ export class Switch extends SwitchBase {
         return false;
     }
     [checkedProperty.setNative](value: boolean) {
-        this.nativeView.setChecked(value);
+        this.nativeViewProtected.setChecked(value);
     }
 
     [colorProperty.getDefault](): number {
@@ -68,9 +68,9 @@ export class Switch extends SwitchBase {
     }
     [colorProperty.setNative](value: number | Color) {
         if (value instanceof Color) {
-            this.nativeView.getThumbDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+            this.nativeViewProtected.getThumbDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
         } else {
-            this.nativeView.getThumbDrawable().clearColorFilter();
+            this.nativeViewProtected.getThumbDrawable().clearColorFilter();
         }
     }
 
@@ -79,9 +79,9 @@ export class Switch extends SwitchBase {
     }
     [backgroundColorProperty.setNative](value: number | Color) {
         if (value instanceof Color) {
-            this.nativeView.getTrackDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+            this.nativeViewProtected.getTrackDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
         } else {
-            this.nativeView.getTrackDrawable().clearColorFilter();
+            this.nativeViewProtected.getTrackDrawable().clearColorFilter();
         }
     }
 

--- a/tns-core-modules/ui/switch/switch.ios.ts
+++ b/tns-core-modules/ui/switch/switch.ios.ts
@@ -28,7 +28,7 @@ class SwitchChangeHandlerImpl extends NSObject {
 
 const zeroSize = { width: 0, height: 0 };
 export class Switch extends SwitchBase {
-    nativeView: UISwitch;
+    nativeViewProtected: UISwitch;
     private _handler: NSObject;
 
     constructor() {
@@ -36,18 +36,18 @@ export class Switch extends SwitchBase {
         const nativeView = UISwitch.new();
         this._handler = SwitchChangeHandlerImpl.initWithOwner(new WeakRef(this));
         nativeView.addTargetActionForControlEvents(this._handler, "valueChanged", UIControlEvents.ValueChanged);
-        this.nativeView = nativeView;
+        this.nativeViewProtected = nativeView;
         this.width = 51;
         this.height = 31;
     }
 
     get ios(): UISwitch {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
         // It can't be anything different from 51x31
-        let nativeSize = this.nativeView.sizeThatFits(zeroSize);
+        let nativeSize = this.nativeViewProtected.sizeThatFits(zeroSize);
         this.width = nativeSize.width;
         this.height = nativeSize.height;
 
@@ -60,21 +60,21 @@ export class Switch extends SwitchBase {
         return false;
     }
     [checkedProperty.setNative](value: boolean) {
-        this.nativeView.on = value;
+        this.nativeViewProtected.on = value;
     }
 
     [colorProperty.getDefault](): UIColor {
-        return this.nativeView.thumbTintColor;
+        return this.nativeViewProtected.thumbTintColor;
     }
     [colorProperty.setNative](value: UIColor | Color) {
-        this.nativeView.thumbTintColor = value instanceof Color ? value.ios : value;
+        this.nativeViewProtected.thumbTintColor = value instanceof Color ? value.ios : value;
     }
 
     [backgroundColorProperty.getDefault](): UIColor {
-        return this.nativeView.onTintColor;
+        return this.nativeViewProtected.onTintColor;
     }
     [backgroundColorProperty.setNative](value: UIColor | Color) {
-        this.nativeView.onTintColor = value instanceof Color ? value.ios : value;
+        this.nativeViewProtected.onTintColor = value instanceof Color ? value.ios : value;
     }
 
     [backgroundInternalProperty.getDefault](): any {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -66,13 +66,13 @@ function initializeNativeClasses() {
                 if (traceEnabled()) {
                     traceWrite("TabView.PagerAdapter.instantiateItem; restoreHierarchyState: " + item.view, traceCategory);
                 }
-                item.view.nativeView.restoreHierarchyState(this[VIEWS_STATES]);
+                item.view.nativeViewProtected.restoreHierarchyState(this[VIEWS_STATES]);
             }
 
-            if (item.view.nativeView) {
-                container.addView(item.view.nativeView);
+            if (item.view.nativeViewProtected) {
+                container.addView(item.view.nativeViewProtected);
             }
-            return item.view.nativeView;
+            return item.view.nativeViewProtected;
         }
 
         destroyItem(container: android.view.ViewGroup, index: number, nativeView: android.view.View) {
@@ -112,7 +112,7 @@ function initializeNativeClasses() {
             }
             let viewStates = this[VIEWS_STATES];
             let childCallback = function (view: View): boolean {
-                let nativeView: android.view.View = view.nativeView;
+                let nativeView: android.view.View = view.nativeViewProtected;
                 if (nativeView && nativeView.isSaveFromParentEnabled && nativeView.isSaveFromParentEnabled()) {
                     nativeView.saveHierarchyState(viewStates);
                 }
@@ -182,32 +182,32 @@ function getDefaultAccentColor(context: android.content.Context): number {
 }
 
 export class TabViewItem extends TabViewItemBase {
-    nativeView: android.widget.TextView;
+    nativeViewProtected: android.widget.TextView;
     public tabItemSpec: org.nativescript.widgets.TabItemSpec;
     public index: number;
     private _defaultTransformationMethod: android.text.method.TransformationMethod;
 
     public initNativeView(): void {
         super.initNativeView();
-        if (this.nativeView) {
-            this._defaultTransformationMethod = this.nativeView.getTransformationMethod();
+        if (this.nativeViewProtected) {
+            this._defaultTransformationMethod = this.nativeViewProtected.getTransformationMethod();
         }
     }
 
     public resetNativeView(): void {
         super.resetNativeView();
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             // We reset it here too because this could be changed by multiple properties - whiteSpace, secure, textTransform
-            this.nativeView.setTransformationMethod(this._defaultTransformationMethod);
+            this.nativeViewProtected.setTransformationMethod(this._defaultTransformationMethod);
         }
     }
 
     public createNativeView() {
-        return this.nativeView;
+        return this.nativeViewProtected;
     }
 
     public _update(): void {
-        const tv = this.nativeView;
+        const tv = this.nativeViewProtected;
         if (tv) {
             const tabLayout = <org.nativescript.widgets.TabLayout>tv.getParent();
             tabLayout.updateItemAt(this.index, this.tabItemSpec);
@@ -215,28 +215,28 @@ export class TabViewItem extends TabViewItemBase {
     }
 
     [fontSizeProperty.getDefault](): { nativeSize: number } {
-        return { nativeSize: this.nativeView.getTextSize() };
+        return { nativeSize: this.nativeViewProtected.getTextSize() };
     }
     [fontSizeProperty.setNative](value: number | { nativeSize: number }) {
         if (typeof value === "number") {
-            this.nativeView.setTextSize(value);
+            this.nativeViewProtected.setTextSize(value);
         } else {
-            this.nativeView.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
+            this.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
         }
     }
 
     [fontInternalProperty.getDefault](): android.graphics.Typeface {
-        return this.nativeView.getTypeface();
+        return this.nativeViewProtected.getTypeface();
     }
     [fontInternalProperty.setNative](value: Font | android.graphics.Typeface) {
-        this.nativeView.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
+        this.nativeViewProtected.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
     }
 
     [textTransformProperty.getDefault](): "default" {
         return "default";
     }
     [textTransformProperty.setNative](value: TextTransform | "default") {
-        const tv = this.nativeView;
+        const tv = this.nativeViewProtected;
         if (value === "default") {
             tv.setTransformationMethod(this._defaultTransformationMethod);
             tv.setText(this.title);
@@ -327,7 +327,7 @@ export class TabView extends TabViewBase {
             this._androidViewId = android.view.View.generateViewId();
         }
 
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         this._tabLayout = (<any>nativeView).tabLayout;
 
         const viewPager = (<any>nativeView).viewPager;

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -177,7 +177,7 @@ export class TabView extends TabViewBase {
         super();
 
         this._ios = UITabBarControllerImpl.initWithOwner(new WeakRef(this));
-        this.nativeView = this._ios.view;
+        this.nativeViewProtected = this._ios.view;
         this._delegate = UITabBarControllerDelegateImpl.initWithOwner(new WeakRef(this));
         this._moreNavigationControllerDelegate = UINavigationControllerDelegateImpl.initWithOwner(new WeakRef(this));
         //This delegate is set on the last line of _addTabs method.
@@ -327,7 +327,7 @@ export class TabView extends TabViewBase {
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
 
             const width = layout.getMeasureSpecSize(widthMeasureSpec);

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -126,7 +126,7 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
     }
 
     public _onFormattedTextContentsChanged(data: PropertyChangeData) {
-        if (this.nativeView) {
+        if (this.nativeViewProtected) {
             // Notifications from the FormattedString start arriving before the Android view is even created.
             this[formattedTextProperty.setNative](data.value);
         }

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -48,7 +48,7 @@ function initializeTextTransformation(): void {
 }
 
 export class TextBase extends TextBaseCommon {
-    nativeView: android.widget.TextView;
+    nativeViewProtected: android.widget.TextView;
     private _defaultTransformationMethod: android.text.method.TransformationMethod;
     private _paintFlags: number;
     private _minHeight: number;
@@ -57,7 +57,7 @@ export class TextBase extends TextBaseCommon {
     private _maxLines: number;
 
     public initNativeView(): void {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         this._defaultTransformationMethod = nativeView.getTransformationMethod();
         this._minHeight = nativeView.getMinHeight();
         this._maxHeight = nativeView.getMaxHeight();
@@ -68,7 +68,7 @@ export class TextBase extends TextBaseCommon {
 
     public resetNativeView(): void {
         super.resetNativeView();
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         // We reset it here too because this could be changed by multiple properties - whiteSpace, secure, textTransform
         nativeView.setSingleLine(this._isSingleLine);
         nativeView.setTransformationMethod(this._defaultTransformationMethod);
@@ -110,7 +110,7 @@ export class TextBase extends TextBaseCommon {
     }
 
     [formattedTextProperty.setNative](value: FormattedString) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!value) {
             if (nativeView instanceof android.widget.Button &&
                 nativeView.getTransformationMethod() instanceof TextTransformation) {
@@ -141,7 +141,7 @@ export class TextBase extends TextBaseCommon {
 
     [textTransformProperty.setNative](value: TextTransform) {
         if (value === "initial") {
-            this.nativeView.setTransformationMethod(this._defaultTransformationMethod);
+            this.nativeViewProtected.setTransformationMethod(this._defaultTransformationMethod);
             return;
         }
 
@@ -151,26 +151,26 @@ export class TextBase extends TextBaseCommon {
         }
 
         initializeTextTransformation();
-        this.nativeView.setTransformationMethod(new TextTransformation(this));
+        this.nativeViewProtected.setTransformationMethod(new TextTransformation(this));
     }
 
     [textAlignmentProperty.getDefault](): TextAlignment {
         return "initial";
     }
     [textAlignmentProperty.setNative](value: TextAlignment) {
-        let verticalGravity = this.nativeView.getGravity() & android.view.Gravity.VERTICAL_GRAVITY_MASK;
+        let verticalGravity = this.nativeViewProtected.getGravity() & android.view.Gravity.VERTICAL_GRAVITY_MASK;
         switch (value) {
             case "initial":
             case "left":
-                this.nativeView.setGravity(android.view.Gravity.START | verticalGravity);
+                this.nativeViewProtected.setGravity(android.view.Gravity.START | verticalGravity);
                 break;
 
             case "center":
-                this.nativeView.setGravity(android.view.Gravity.CENTER_HORIZONTAL | verticalGravity);
+                this.nativeViewProtected.setGravity(android.view.Gravity.CENTER_HORIZONTAL | verticalGravity);
                 break;
 
             case "right":
-                this.nativeView.setGravity(android.view.Gravity.END | verticalGravity);
+                this.nativeViewProtected.setGravity(android.view.Gravity.END | verticalGravity);
                 break;
         }
     }
@@ -178,7 +178,7 @@ export class TextBase extends TextBaseCommon {
     // Overridden in TextField because setSingleLine(false) will remove methodTransformation.
     // and we don't want to allow TextField to be multiline
     [whiteSpaceProperty.setNative](value: WhiteSpace) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         switch (value) {
             case "initial":
             case "normal":
@@ -193,109 +193,109 @@ export class TextBase extends TextBaseCommon {
     }
 
     [colorProperty.getDefault](): android.content.res.ColorStateList {
-        return this.nativeView.getTextColors();
+        return this.nativeViewProtected.getTextColors();
     }
     [colorProperty.setNative](value: Color | android.content.res.ColorStateList) {
         if (!this.formattedText || !(value instanceof Color)) {
             if (value instanceof Color) {
-                this.nativeView.setTextColor(value.android);
+                this.nativeViewProtected.setTextColor(value.android);
             } else {
-                this.nativeView.setTextColor(value);
+                this.nativeViewProtected.setTextColor(value);
             }
         }
     }
 
     [fontSizeProperty.getDefault](): { nativeSize: number } {
-        return { nativeSize: this.nativeView.getTextSize() };
+        return { nativeSize: this.nativeViewProtected.getTextSize() };
     }
     [fontSizeProperty.setNative](value: number | { nativeSize: number }) {
         if (!this.formattedText || (typeof value !== "number")) {
             if (typeof value === "number") {
-                this.nativeView.setTextSize(value);
+                this.nativeViewProtected.setTextSize(value);
             } else {
-                this.nativeView.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
+                this.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
             }
         }
     }
 
     [lineHeightProperty.getDefault](): number {
-        return this.nativeView.getLineSpacingExtra() / layout.getDisplayDensity();
+        return this.nativeViewProtected.getLineSpacingExtra() / layout.getDisplayDensity();
     }
     [lineHeightProperty.setNative](value: number) {
-        this.nativeView.setLineSpacing(value * layout.getDisplayDensity(), 1);
+        this.nativeViewProtected.setLineSpacing(value * layout.getDisplayDensity(), 1);
     }
 
     [fontInternalProperty.getDefault](): android.graphics.Typeface {
-        return this.nativeView.getTypeface();
+        return this.nativeViewProtected.getTypeface();
     }
     [fontInternalProperty.setNative](value: Font | android.graphics.Typeface) {
         if (!this.formattedText || !(value instanceof Font)) {
-            this.nativeView.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
+            this.nativeViewProtected.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
         }
     }
 
     [textDecorationProperty.getDefault](value: number) {
-        return this._paintFlags = this.nativeView.getPaintFlags();
+        return this._paintFlags = this.nativeViewProtected.getPaintFlags();
     }
 
     [textDecorationProperty.setNative](value: number | TextDecoration) {
         switch (value) {
             case "none":
-                this.nativeView.setPaintFlags(0);
+                this.nativeViewProtected.setPaintFlags(0);
                 break;
             case "underline":
-                this.nativeView.setPaintFlags(android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+                this.nativeViewProtected.setPaintFlags(android.graphics.Paint.UNDERLINE_TEXT_FLAG);
                 break;
             case "line-through":
-                this.nativeView.setPaintFlags(android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+                this.nativeViewProtected.setPaintFlags(android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
                 break;
             case "underline line-through":
-                this.nativeView.setPaintFlags(android.graphics.Paint.UNDERLINE_TEXT_FLAG | android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+                this.nativeViewProtected.setPaintFlags(android.graphics.Paint.UNDERLINE_TEXT_FLAG | android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
                 break;
             default:
-                this.nativeView.setPaintFlags(value);
+                this.nativeViewProtected.setPaintFlags(value);
                 break;
         }
     }
 
     [letterSpacingProperty.getDefault](): number {
-        return org.nativescript.widgets.ViewHelper.getLetterspacing(this.nativeView);
+        return org.nativescript.widgets.ViewHelper.getLetterspacing(this.nativeViewProtected);
     }
     [letterSpacingProperty.setNative](value: number) {
-        org.nativescript.widgets.ViewHelper.setLetterspacing(this.nativeView, value);
+        org.nativescript.widgets.ViewHelper.setLetterspacing(this.nativeViewProtected, value);
     }
 
     [paddingTopProperty.getDefault](): Length {
         return { value: this._defaultPaddingTop, unit: "px" }
     }
     [paddingTopProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
     }
 
     [paddingRightProperty.getDefault](): Length {
         return { value: this._defaultPaddingRight, unit: "px" }
     }
     [paddingRightProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
     }
 
     [paddingBottomProperty.getDefault](): Length {
         return { value: this._defaultPaddingBottom, unit: "px" }
     }
     [paddingBottomProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
     }
 
     [paddingLeftProperty.getDefault](): Length {
         return { value: this._defaultPaddingLeft, unit: "px" }
     }
     [paddingLeftProperty.setNative](value: Length) {
-        org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeView, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
+        org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
     }
 
     _setNativeText(reset: boolean = false): void {
         if (reset) {
-            this.nativeView.setText(null);
+            this.nativeViewProtected.setText(null);
             return;
         }
 
@@ -308,7 +308,7 @@ export class TextBase extends TextBaseCommon {
             transformedText = getTransformedText(stringValue, this.textTransform);
         }
 
-        this.nativeView.setText(<any>transformedText);
+        this.nativeViewProtected.setText(<any>transformedText);
     }
 }
 

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -10,7 +10,7 @@ export * from "./text-base-common";
 
 export class TextBase extends TextBaseCommon {
 
-    public nativeView: UITextField | UITextView | UILabel | UIButton;
+    public nativeViewProtected: UITextField | UITextView | UILabel | UIButton;
 
     [textProperty.getDefault](): number {
         return -1;
@@ -32,7 +32,7 @@ export class TextBase extends TextBaseCommon {
     }
 
     [colorProperty.getDefault](): UIColor {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         if (nativeView instanceof UIButton) {
             return nativeView.titleColorForState(UIControlState.Normal);
         } else {
@@ -41,7 +41,7 @@ export class TextBase extends TextBaseCommon {
     }
     [colorProperty.setNative](value: Color | UIColor) {
         const color = value instanceof Color ? value.ios : value;
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView instanceof UIButton) {
             nativeView.setTitleColorForState(color, UIControlState.Normal);
             nativeView.titleLabel.textColor = color;
@@ -51,13 +51,13 @@ export class TextBase extends TextBaseCommon {
     }
 
     [fontInternalProperty.getDefault](): UIFont {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         nativeView = nativeView instanceof UIButton ? nativeView.titleLabel : nativeView;
         return nativeView.font;
     }
     [fontInternalProperty.setNative](value: Font | UIFont) {
         if (!(value instanceof Font) || !this.formattedText) {
-            let nativeView = this.nativeView;
+            let nativeView = this.nativeViewProtected;
             nativeView = nativeView instanceof UIButton ? nativeView.titleLabel : nativeView;
             const font = value instanceof Font ? value.getUIFont(nativeView.font) : value;
             nativeView.font = font;
@@ -65,7 +65,7 @@ export class TextBase extends TextBaseCommon {
     }
 
     [textAlignmentProperty.setNative](value: TextAlignment) {
-        const nativeView = <UITextField | UITextView | UILabel>this.nativeView;
+        const nativeView = <UITextField | UITextView | UILabel>this.nativeViewProtected;
         switch (value) {
             case "initial":
             case "left":
@@ -98,7 +98,7 @@ export class TextBase extends TextBaseCommon {
 
     _setNativeText(reset: boolean = false): void {
         if (reset) {
-            const nativeView = this.nativeView;
+            const nativeView = this.nativeViewProtected;
             if (nativeView instanceof UIButton) {
                 // Clear attributedText or title won't be affected.
                 nativeView.setAttributedTitleForState(null, UIControlState.Normal);
@@ -123,7 +123,7 @@ export class TextBase extends TextBaseCommon {
         const attrText = this.createNSMutableAttributedString(this.formattedText);
         // TODO: letterSpacing should be applied per Span.
         if (this.letterSpacing !== 0) {
-            attrText.addAttributeValueRange(NSKernAttributeName, this.letterSpacing * this.nativeView.font.pointSize, { location: 0, length: attrText.length });
+            attrText.addAttributeValueRange(NSKernAttributeName, this.letterSpacing * this.nativeViewProtected.font.pointSize, { location: 0, length: attrText.length });
         }
 
         if (this.style.lineHeight) {
@@ -132,11 +132,11 @@ export class TextBase extends TextBaseCommon {
             attrText.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, { location: 0, length: attrText.length });
         }
 
-        if (this.nativeView instanceof UIButton) {
-            this.nativeView.setAttributedTitleForState(attrText, UIControlState.Normal);
+        if (this.nativeViewProtected instanceof UIButton) {
+            this.nativeViewProtected.setAttributedTitleForState(attrText, UIControlState.Normal);
         }
         else {
-            this.nativeView.attributedText = attrText;
+            this.nativeViewProtected.attributedText = attrText;
         }
     }
 
@@ -161,7 +161,7 @@ export class TextBase extends TextBaseCommon {
         }
 
         if (style.letterSpacing !== 0) {
-            dict.set(NSKernAttributeName, style.letterSpacing * this.nativeView.font.pointSize);
+            dict.set(NSKernAttributeName, style.letterSpacing * this.nativeViewProtected.font.pointSize);
         }
 
         if (style.lineHeight) {
@@ -170,7 +170,7 @@ export class TextBase extends TextBaseCommon {
             dict.set(NSParagraphStyleAttributeName, paragraphStyle);
         }
 
-        const isTextView = this.nativeView instanceof UITextView;
+        const isTextView = this.nativeViewProtected instanceof UITextView;
         if (style.color && (dict.size > 0 || isTextView)) {
             dict.set(NSForegroundColorAttributeName, style.color.ios);
         }
@@ -181,25 +181,25 @@ export class TextBase extends TextBaseCommon {
         if (dict.size > 0 || isTextView) {
             if (isTextView) {
                 // UITextView's font seems to change inside.
-                dict.set(NSFontAttributeName, this.nativeView.font);
+                dict.set(NSFontAttributeName, this.nativeViewProtected.font);
             }
             
             const result = NSMutableAttributedString.alloc().initWithString(source);
             result.setAttributesRange(<any>dict, { location: 0, length: source.length });
-            if (this.nativeView instanceof UIButton) {
-                this.nativeView.setAttributedTitleForState(result, UIControlState.Normal);
+            if (this.nativeViewProtected instanceof UIButton) {
+                this.nativeViewProtected.setAttributedTitleForState(result, UIControlState.Normal);
             } else {
-                this.nativeView.attributedText = result;
+                this.nativeViewProtected.attributedText = result;
             }
         } else {
-            if (this.nativeView instanceof UIButton) {
+            if (this.nativeViewProtected instanceof UIButton) {
                 // Clear attributedText or title won't be affected.
-                this.nativeView.setAttributedTitleForState(null, UIControlState.Normal);
-                this.nativeView.setTitleForState(source, UIControlState.Normal);
+                this.nativeViewProtected.setAttributedTitleForState(null, UIControlState.Normal);
+                this.nativeViewProtected.setTitleForState(source, UIControlState.Normal);
             } else {
                 // Clear attributedText or text won't be affected.
-                this.nativeView.attributedText = undefined;
-                this.nativeView.text = source;
+                this.nativeViewProtected.attributedText = undefined;
+                this.nativeViewProtected.text = source;
             }
         }
     }
@@ -225,7 +225,7 @@ export class TextBase extends TextBaseCommon {
     }
 
     createMutableStringForSpan(span: Span, text: string): NSMutableAttributedString {
-        const viewFont = this.nativeView.font;
+        const viewFont = this.nativeViewProtected.font;
         let attrDict = <{ key: string, value: any }>{};
         const style = span.style;
         const bold = isBold(style.fontWeight);

--- a/tns-core-modules/ui/text-field/text-field-common.ts
+++ b/tns-core-modules/ui/text-field/text-field-common.ts
@@ -8,7 +8,7 @@ export class TextFieldBase extends EditableTextBase implements TextFieldDefiniti
     public secure: boolean;
 }
 
-TextFieldBase.prototype.recycleNativeView = true;
+TextFieldBase.prototype.recycleNativeView = "auto";
 
 export const secureProperty = new Property<TextFieldBase, boolean>({ name: "secure", defaultValue: false, valueConverter: booleanConverter });
 secureProperty.register(TextFieldBase);

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -136,14 +136,14 @@ class UITextFieldImpl extends UITextField {
 export class TextField extends TextFieldBase {
     private _ios: UITextField;
     private _delegate: UITextFieldDelegateImpl;
-    nativeView: UITextField;
+    nativeViewProtected: UITextField;
 
     constructor() {
         super();
         let weakRef = new WeakRef(this);
         this._ios = UITextFieldImpl.initWithOwner(weakRef);
         this._delegate = UITextFieldDelegateImpl.initWithOwner(weakRef);
-        this.nativeView = this._ios;
+        this.nativeViewProtected = this._ios;
     }
 
     @profile
@@ -162,7 +162,7 @@ export class TextField extends TextFieldBase {
     }
 
     [hintProperty.getDefault](): string {
-        return this.nativeView.placeholder;
+        return this.nativeViewProtected.placeholder;
     }
     [hintProperty.setNative](value: string) {
         let stringValue;
@@ -171,32 +171,32 @@ export class TextField extends TextFieldBase {
         } else {
             stringValue = value + "";
         }
-        this.nativeView.placeholder = stringValue;
+        this.nativeViewProtected.placeholder = stringValue;
     }
 
     [secureProperty.getDefault](): boolean {
-        return this.nativeView.secureTextEntry;
+        return this.nativeViewProtected.secureTextEntry;
     }
     [secureProperty.setNative](value: boolean) {
-        this.nativeView.secureTextEntry = value;
+        this.nativeViewProtected.secureTextEntry = value;
     }
 
     [colorProperty.getDefault](): { textColor: UIColor, tintColor: UIColor } {
         // return this.nativeView.tintColor;
-        console.log("----> TextField: colorProperty.getDefault: " + this.nativeView.textColor)
+        console.log("----> TextField: colorProperty.getDefault: " + this.nativeViewProtected.textColor)
         return {
-            textColor: this.nativeView.textColor,
-            tintColor: this.nativeView.tintColor
+            textColor: this.nativeViewProtected.textColor,
+            tintColor: this.nativeViewProtected.tintColor
         };
     }
     [colorProperty.setNative](value: Color | { textColor: UIColor, tintColor: UIColor }) {
         if (value instanceof Color) {
             let color = value instanceof Color ? value.ios : value;
-            this.nativeView.textColor = color;
-            this.nativeView.tintColor = color;
+            this.nativeViewProtected.textColor = color;
+            this.nativeViewProtected.tintColor = color;
         } else {
-            this.nativeView.textColor = value.textColor;
-            this.nativeView.tintColor = value.tintColor;
+            this.nativeViewProtected.textColor = value.textColor;
+            this.nativeViewProtected.tintColor = value.tintColor;
         }
     }
 
@@ -204,7 +204,7 @@ export class TextField extends TextFieldBase {
         return null;
     }
     [placeholderColorProperty.setNative](value: UIColor | Color) {
-        let nativeView = this.nativeView;
+        let nativeView = this.nativeViewProtected;
         let colorAttibutes = NSMutableDictionary.new<string, any>();
         colorAttibutes.setValueForKey(value instanceof Color ? value.ios : value, NSForegroundColorAttributeName);
         let stringValue;

--- a/tns-core-modules/ui/text-view/text-view.android.ts
+++ b/tns-core-modules/ui/text-view/text-view.android.ts
@@ -12,8 +12,8 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
 
     public resetNativeView(): void {
         super.resetNativeView();
-        this.nativeView.setGravity(android.view.Gravity.TOP | android.view.Gravity.START);
+        this.nativeViewProtected.setGravity(android.view.Gravity.TOP | android.view.Gravity.START);
     }
 }
 
-TextView.prototype.recycleNativeView = true;
+TextView.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -86,7 +86,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     constructor() {
         super();
 
-        this.nativeView = this._ios = UITextView.new();
+        this.nativeViewProtected = this._ios = UITextView.new();
         if (!this._ios.font) {
             this._ios.font = UIFont.systemFontOfSize(12);
         }
@@ -123,7 +123,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
             this.showHint(hint);
         } else {
             this._isShowingHint = false;
-            this.nativeView.text = '';
+            this.nativeViewProtected.text = '';
         }
     }
 
@@ -133,28 +133,28 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
             const color = this.style.color;
 
             if (placeholderColor) {
-                this.nativeView.textColor = placeholderColor.ios;
+                this.nativeViewProtected.textColor = placeholderColor.ios;
             } else if (color) {
                 // Use semi-transparent version of color for back-compatibility 
-                this.nativeView.textColor = color.ios.colorWithAlphaComponent(0.22);
+                this.nativeViewProtected.textColor = color.ios.colorWithAlphaComponent(0.22);
             } else {
-                this.nativeView.textColor = UIColor.blackColor.colorWithAlphaComponent(0.22);
+                this.nativeViewProtected.textColor = UIColor.blackColor.colorWithAlphaComponent(0.22);
             }
         } else {
             const color = this.style.color;
 
             if (color) {
-                this.nativeView.textColor = color.ios;
-                this.nativeView.tintColor = color.ios;
+                this.nativeViewProtected.textColor = color.ios;
+                this.nativeViewProtected.tintColor = color.ios;
             } else {
-                this.nativeView.textColor = null;
-                this.nativeView.tintColor = null;
+                this.nativeViewProtected.textColor = null;
+                this.nativeViewProtected.tintColor = null;
             }
         }
     }
 
     public showHint(hint: string) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
 
         this._isShowingHint = true;
         this._refreshColor();
@@ -184,10 +184,10 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     }
 
     [editableProperty.getDefault](): boolean {
-        return this.nativeView.editable;
+        return this.nativeViewProtected.editable;
     }
     [editableProperty.setNative](value: boolean) {
-        this.nativeView.editable = value;
+        this.nativeViewProtected.editable = value;
     }
 
     [colorProperty.setNative](color: Color) {
@@ -199,98 +199,98 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
 
     [borderTopWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.top,
+            value: this.nativeViewProtected.textContainerInset.top,
             unit: "px"
         };
     }
     [borderTopWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let top = layout.toDeviceIndependentPixels(this.effectivePaddingTop + this.effectiveBorderTopWidth);
-        this.nativeView.textContainerInset = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.textContainerInset = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
     }
 
     [borderRightWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.right,
+            value: this.nativeViewProtected.textContainerInset.right,
             unit: "px"
         };
     }
     [borderRightWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let right = layout.toDeviceIndependentPixels(this.effectivePaddingRight + this.effectiveBorderRightWidth);
-        this.nativeView.textContainerInset = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
+        this.nativeViewProtected.textContainerInset = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
     }
 
     [borderBottomWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.bottom,
+            value: this.nativeViewProtected.textContainerInset.bottom,
             unit: "px"
         };
     }
     [borderBottomWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let bottom = layout.toDeviceIndependentPixels(this.effectivePaddingBottom + this.effectiveBorderBottomWidth);
-        this.nativeView.textContainerInset = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
+        this.nativeViewProtected.textContainerInset = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
     }
 
     [borderLeftWidthProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.left,
+            value: this.nativeViewProtected.textContainerInset.left,
             unit: "px"
         };
     }
     [borderLeftWidthProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let left = layout.toDeviceIndependentPixels(this.effectivePaddingLeft + this.effectiveBorderLeftWidth);
-        this.nativeView.textContainerInset = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.textContainerInset = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
     }
 
     [paddingTopProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.top,
+            value: this.nativeViewProtected.textContainerInset.top,
             unit: "px"
         };
     }
     [paddingTopProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let top = layout.toDeviceIndependentPixels(this.effectivePaddingTop + this.effectiveBorderTopWidth);
-        this.nativeView.textContainerInset = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.textContainerInset = { top: top, left: inset.left, bottom: inset.bottom, right: inset.right };
     }
 
     [paddingRightProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.right,
+            value: this.nativeViewProtected.textContainerInset.right,
             unit: "px"
         };
     }
     [paddingRightProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let right = layout.toDeviceIndependentPixels(this.effectivePaddingRight + this.effectiveBorderRightWidth);
-        this.nativeView.textContainerInset = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
+        this.nativeViewProtected.textContainerInset = { top: inset.top, left: inset.left, bottom: inset.bottom, right: right };
     }
 
     [paddingBottomProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.bottom,
+            value: this.nativeViewProtected.textContainerInset.bottom,
             unit: "px"
         };
     }
     [paddingBottomProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let bottom = layout.toDeviceIndependentPixels(this.effectivePaddingBottom + this.effectiveBorderBottomWidth);
-        this.nativeView.textContainerInset = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
+        this.nativeViewProtected.textContainerInset = { top: inset.top, left: inset.left, bottom: bottom, right: inset.right };
     }
     [paddingLeftProperty.getDefault](): Length {
         return {
-            value: this.nativeView.textContainerInset.left,
+            value: this.nativeViewProtected.textContainerInset.left,
             unit: "px"
         };
     }
     [paddingLeftProperty.setNative](value: Length) {
-        let inset = this.nativeView.textContainerInset;
+        let inset = this.nativeViewProtected.textContainerInset;
         let left = layout.toDeviceIndependentPixels(this.effectivePaddingLeft + this.effectiveBorderLeftWidth);
-        this.nativeView.textContainerInset = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
+        this.nativeViewProtected.textContainerInset = { top: inset.top, left: left, bottom: inset.bottom, right: inset.right };
     }
 }
 
-TextView.prototype.recycleNativeView = true;
+TextView.prototype.recycleNativeView = "auto";

--- a/tns-core-modules/ui/time-picker/time-picker-common.ts
+++ b/tns-core-modules/ui/time-picker/time-picker-common.ts
@@ -95,7 +95,7 @@ export abstract class TimePickerBase extends View implements TimePickerDefinitio
     public maxMinute: number;
 }
 
-TimePickerBase.prototype.recycleNativeView = true;
+TimePickerBase.prototype.recycleNativeView = "auto";
 
 export var minHourProperty = new Property<TimePickerBase, number>({
     name: "minHour", defaultValue: 0, valueChanged: (picker, oldValue, newValue) => {

--- a/tns-core-modules/ui/time-picker/time-picker.android.ts
+++ b/tns-core-modules/ui/time-picker/time-picker.android.ts
@@ -39,7 +39,7 @@ function initializeTimeChangedListener(): void {
 let apiLevel: number;
 
 export class TimePicker extends TimePickerBase {
-    nativeView: android.widget.TimePicker;
+    nativeViewProtected: android.widget.TimePicker;
     updatingNativeValue: boolean;
 
     public createNativeView() {
@@ -54,7 +54,7 @@ export class TimePicker extends TimePickerBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        const nativeView: any = this.nativeView;
+        const nativeView: any = this.nativeViewProtected;
         nativeView.listener.owner = this;
 
         const calendar = (<any>nativeView).calendar;
@@ -71,9 +71,9 @@ export class TimePicker extends TimePickerBase {
         this.updatingNativeValue = true;
         try {
             if (apiLevel >= 23) {
-                (<any>this.nativeView).setMinute(value);
+                (<any>this.nativeViewProtected).setMinute(value);
             } else {
-                this.nativeView.setCurrentMinute(new java.lang.Integer(value));
+                this.nativeViewProtected.setCurrentMinute(new java.lang.Integer(value));
             }
         } finally {
             this.updatingNativeValue = false;
@@ -84,9 +84,9 @@ export class TimePicker extends TimePickerBase {
         this.updatingNativeValue = true;
         try {
             if (apiLevel >= 23) {
-                (<any>this.nativeView).setHour(value);
+                (<any>this.nativeViewProtected).setHour(value);
             } else {
-                this.nativeView.setCurrentHour(new java.lang.Integer(value));
+                this.nativeViewProtected.setCurrentHour(new java.lang.Integer(value));
             }
         } finally {
             this.updatingNativeValue = false;

--- a/tns-core-modules/ui/time-picker/time-picker.ios.ts
+++ b/tns-core-modules/ui/time-picker/time-picker.ios.ts
@@ -23,7 +23,7 @@ function getComponents(date: Date | NSDate): NSDateComponents {
 export class TimePicker extends TimePickerBase {
     private _ios: UIDatePicker;
     private _changeHandler: NSObject;
-    public nativeView: UIDatePicker;
+    public nativeViewProtected: UIDatePicker;
 
     constructor() {
         super();
@@ -37,7 +37,7 @@ export class TimePicker extends TimePickerBase {
         let components = getComponents(NSDate.date());
         this.hour = components.hour;
         this.minute = components.minute;
-        this.nativeView = this._ios;
+        this.nativeViewProtected = this._ios;
     }
 
     get ios(): UIDatePicker {
@@ -45,67 +45,67 @@ export class TimePicker extends TimePickerBase {
     }
 
     [timeProperty.getDefault](): Date {
-        return this.nativeView.date;
+        return this.nativeViewProtected.date;
     }
     [timeProperty.setNative](value: Date) {
-        this.nativeView.date = getDate(this.hour, this.minute);
+        this.nativeViewProtected.date = getDate(this.hour, this.minute);
     }
 
     [minuteProperty.getDefault](): number {
-        return this.nativeView.date.getMinutes();
+        return this.nativeViewProtected.date.getMinutes();
     }
     [minuteProperty.setNative](value: number) {
-        this.nativeView.date = getDate(this.hour, value);
+        this.nativeViewProtected.date = getDate(this.hour, value);
     }
 
     [hourProperty.getDefault](): number {
-        return this.nativeView.date.getHours();
+        return this.nativeViewProtected.date.getHours();
     }
     [hourProperty.setNative](value: number) {
-        this.nativeView.date = getDate(value, this.minute);
+        this.nativeViewProtected.date = getDate(value, this.minute);
     }
 
     [minHourProperty.getDefault](): number {
-        return this.nativeView.minimumDate ? this.nativeView.minimumDate.getHours() : 0;
+        return this.nativeViewProtected.minimumDate ? this.nativeViewProtected.minimumDate.getHours() : 0;
     }
     [minHourProperty.setNative](value: number) {
-        this.nativeView.minimumDate = getDate(value, this.minute);
+        this.nativeViewProtected.minimumDate = getDate(value, this.minute);
     }
 
     [maxHourProperty.getDefault](): number {
-        return this.nativeView.maximumDate ? this.nativeView.maximumDate.getHours() : 24;
+        return this.nativeViewProtected.maximumDate ? this.nativeViewProtected.maximumDate.getHours() : 24;
     }
     [maxHourProperty.setNative](value: number) {
-        this.nativeView.maximumDate = getDate(value, this.minute);
+        this.nativeViewProtected.maximumDate = getDate(value, this.minute);
     }
 
     [minMinuteProperty.getDefault](): number {
-        return this.nativeView.minimumDate ? this.nativeView.minimumDate.getMinutes() : 0;
+        return this.nativeViewProtected.minimumDate ? this.nativeViewProtected.minimumDate.getMinutes() : 0;
     }
     [minMinuteProperty.setNative](value: number) {
-        this.nativeView.minimumDate = getDate(this.hour, value);
+        this.nativeViewProtected.minimumDate = getDate(this.hour, value);
     }
 
     [maxMinuteProperty.getDefault](): number {
-        return this.nativeView.maximumDate ? this.nativeView.maximumDate.getMinutes() : 60;
+        return this.nativeViewProtected.maximumDate ? this.nativeViewProtected.maximumDate.getMinutes() : 60;
     }
     [maxMinuteProperty.setNative](value: number) {
-        this.nativeView.maximumDate = getDate(this.hour, value);
+        this.nativeViewProtected.maximumDate = getDate(this.hour, value);
     }
 
     [timeProperty.getDefault](): number {
-        return this.nativeView.minuteInterval;
+        return this.nativeViewProtected.minuteInterval;
     }
     [timeProperty.setNative](value: number) {
-        this.nativeView.minuteInterval = value;
+        this.nativeViewProtected.minuteInterval = value;
     }
 
     [colorProperty.getDefault](): UIColor {
-        return this.nativeView.valueForKey("textColor");
+        return this.nativeViewProtected.valueForKey("textColor");
     }
     [colorProperty.setNative](value: Color | UIColor) {
         const color = value instanceof Color ? value.ios : value;
-        this.nativeView.setValueForKey(color, "textColor");
+        this.nativeViewProtected.setValueForKey(color, "textColor");
     }
 }
 

--- a/tns-core-modules/ui/transition/transition.android.ts
+++ b/tns-core-modules/ui/transition/transition.android.ts
@@ -422,8 +422,8 @@ function _completePageRemoval(fragment: any, isBack: boolean) {
 }
 
 export function _removePageNativeViewFromAndroidParent(page: Page): void {
-    if (page.nativeView && page.nativeView.getParent) {
-        let androidParent = page.nativeView.getParent();
+    if (page.nativeViewProtected && page.nativeViewProtected.getParent) {
+        let androidParent = page.nativeViewProtected.getParent();
         if (androidParent && androidParent.removeView) {
             if (traceEnabled()) {
                 traceWrite(`REMOVED ${page}.nativeView from its Android parent`, traceCategories.Transition);
@@ -432,7 +432,7 @@ export function _removePageNativeViewFromAndroidParent(page: Page): void {
             if (page._context) {
                 page._tearDownUI(true);
             }
-            androidParent.removeView(page.nativeView);
+            androidParent.removeView(page.nativeViewProtected);
         }
     }
 }

--- a/tns-core-modules/ui/utils.ios.ts
+++ b/tns-core-modules/ui/utils.ios.ts
@@ -31,7 +31,7 @@ export module ios {
         let width = utils.layout.toDevicePixels(size.width);
         let height = utils.layout.toDevicePixels(size.height);
 
-        var superview = (<UIView>rootView.nativeView).superview;
+        var superview = (<UIView>rootView.nativeViewProtected).superview;
         var superViewRotationRadians;
         if (superview) {
             superViewRotationRadians = atan2f(superview.transform.b, superview.transform.a);

--- a/tns-core-modules/ui/web-view/web-view.android.ts
+++ b/tns-core-modules/ui/web-view/web-view.android.ts
@@ -86,7 +86,7 @@ function initializeWebViewClient(): void {
 }
 
 export class WebView extends WebViewBase {
-    nativeView: android.webkit.WebView;
+    nativeViewProtected: android.webkit.WebView;
 
     public createNativeView() {
         initializeWebViewClient();
@@ -102,11 +102,11 @@ export class WebView extends WebViewBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        (<any>this.nativeView).client.owner = this;
+        (<any>this.nativeViewProtected).client.owner = this;
     }
 
     public disposeNativeView() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             nativeView.destroy();
         }
@@ -116,7 +116,7 @@ export class WebView extends WebViewBase {
     }
 
     public _loadUrl(src: string) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView) {
             return;
         }
@@ -125,7 +125,7 @@ export class WebView extends WebViewBase {
     }
 
     public _loadData(src: string) {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView) {
             return;
         }
@@ -135,18 +135,18 @@ export class WebView extends WebViewBase {
     }
 
     get canGoBack(): boolean {
-        return this.nativeView.canGoBack();
+        return this.nativeViewProtected.canGoBack();
     }
 
     public stopLoading() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             nativeView.stopLoading();
         }
     }
 
     get canGoForward(): boolean {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             return nativeView.canGoForward();
         }
@@ -154,21 +154,21 @@ export class WebView extends WebViewBase {
     }
 
     public goBack() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             return nativeView.goBack();
         }
     }
 
     public goForward() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             return nativeView.goForward();
         }
     }
 
     public reload() {
-        const nativeView = this.nativeView;
+        const nativeView = this.nativeViewProtected;
         if (nativeView) {
             return nativeView.reload();
         }

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -88,7 +88,7 @@ export class WebView extends WebViewBase {
     constructor() {
         super();
 
-        this.nativeView = this._ios = UIWebView.new();
+        this.nativeViewProtected = this._ios = UIWebView.new();
         this._delegate = UIWebViewDelegateImpl.initWithOwner(new WeakRef(this));
     }
 


### PR DESCRIPTION
…not accessed.

recycleNativeView filed now accepts: "always" | "never" | "auto". Always will recycle the nativeView no matter if its nativeView or android proprties are accessed. Never will disable recycling. Auto will recycle it only if nativeView and android properties are not accessed.

This is done because there are way too many places where nativeView is changed from code and we can't safely recycle these nativeViews.
