### PR TITLE
Commas should be semicolons in TS definition

### DIFF
--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -282,17 +282,17 @@ export interface AndroidActivityRequestPermissionsEventData extends AndroidActiv
     /**
      * The request code.
      */
-    requestCode: number,
+    requestCode: number;
 
     /**
      * The Permissions
      */
-    permissions: Array<string>,
+    permissions: Array<string>;
 
     /**
      * The Granted.
      */
-    grantResults: Array<number>
+    grantResults: Array<number>;
 }
 
 /**


### PR DESCRIPTION
.. at least, that's what my IDE was screaming at me. So I created this PR to shut it up 🤐