### PR TITLE
Fixes TabView icons changes.

### DIFF
--- a/apps/app/ui-tests-app/tab-view/main-page.ts
+++ b/apps/app/ui-tests-app/tab-view/main-page.ts
@@ -19,6 +19,7 @@ export function loadExamples() {
     examples.set("tabmore", "tab-view/tab-view-more");
     examples.set("tabViewCss", "tab-view/tab-view-css");
     examples.set("tab-view-icons", "tab-view/tab-view-icon");
+    examples.set("tab-view-icon-change", "tab-view/tab-view-icon-change");
     examples.set("text-transform", "tab-view/text-transform");
     return examples;
 }

--- a/apps/app/ui-tests-app/tab-view/tab-view-icon-change.ts
+++ b/apps/app/ui-tests-app/tab-view/tab-view-icon-change.ts
@@ -1,0 +1,17 @@
+import { EventData } from "tns-core-modules/data/observable";
+import { Button } from "tns-core-modules/ui/button";
+import { TabView, SelectedIndexChangedEventData } from "tns-core-modules/ui/tab-view";
+
+export function onSelectedIndexChanged(args: SelectedIndexChangedEventData) {
+    const tabView = args.object as TabView;
+    
+    const newItem = tabView.items[args.newIndex];
+    if (newItem) {
+        newItem.iconSource = "res://icon";
+    }
+
+    const oldItem = tabView.items[args.oldIndex];
+    if (oldItem) {
+        oldItem.iconSource = "res://testlogo";
+    }
+}

--- a/apps/app/ui-tests-app/tab-view/tab-view-icon-change.xml
+++ b/apps/app/ui-tests-app/tab-view/tab-view-icon-change.xml
@@ -1,0 +1,16 @@
+ <Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="onNavigatingTo">
+    <TabView id="tab-view" selectedIndexChanged="onSelectedIndexChanged" iosIconRenderingMode="alwaysOriginal">
+        <TabView.items>
+            <TabViewItem iconSource="res://icon">
+                <TabViewItem.view>
+                    <Label text="first tab"/>
+                </TabViewItem.view>
+            </TabViewItem>
+            <TabViewItem iconSource="res://testlogo"> 
+                <TabViewItem.view>
+                    <Label text="second tab"/>
+                </TabViewItem.view>
+            </TabViewItem>
+        </TabView.items>
+    </TabView>
+</Page> 

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -19,11 +19,11 @@ const PRIMARY_COLOR = "colorPrimary";
 const DEFAULT_ELEVATION = 4;
 
 interface PagerAdapter {
-    new (owner: TabView, items: Array<TabViewItem>): android.support.v4.view.PagerAdapter;
+    new(owner: TabView, items: Array<TabViewItem>): android.support.v4.view.PagerAdapter;
 }
 
 interface PageChangedListener {
-    new (owner: TabView): android.support.v4.view.ViewPager.SimpleOnPageChangeListener;
+    new(owner: TabView): android.support.v4.view.ViewPager.SimpleOnPageChangeListener;
 }
 
 let PagerAdapter: PagerAdapter;
@@ -208,11 +208,10 @@ export class TabViewItem extends TabViewItemBase {
 
     public _update(): void {
         const tv = this.nativeViewProtected;
-        if (tv) {
-            const tabLayout = <org.nativescript.widgets.TabLayout>tv.getParent().getParent().getParent();
+        const tabView = this.parent as TabView;
+        if (tv && tabView) {
             this.tabItemSpec = createTabItemSpec(this);
-
-            tabLayout.updateItemAt(this.index, this.tabItemSpec);
+            tabView.updateAndroidItemAt(this.index, this.tabItemSpec);
         }
     }
 
@@ -382,6 +381,10 @@ export class TabView extends TabViewBase {
         });
 
         this._pagerAdapter.notifyDataSetChanged();
+    }
+
+    public updateAndroidItemAt(index: number, spec: org.nativescript.widgets.TabItemSpec) {
+        this._tabLayout.updateItemAt(index, spec);
     }
 
     [androidOffscreenTabLimitProperty.getDefault](): number {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -87,7 +87,7 @@ function initializeNativeClasses() {
             container.removeView(nativeView);
 
             // Note: this.owner._removeView will clear item.view.nativeView.
-            // So call this after the native instance is removed form the container. 
+            // So call this after the native instance is removed form the container.
             // if (item.view.parent === this.owner) {
             //     this.owner._removeView(item.view);
             // }
@@ -209,7 +209,9 @@ export class TabViewItem extends TabViewItemBase {
     public _update(): void {
         const tv = this.nativeViewProtected;
         if (tv) {
-            const tabLayout = <org.nativescript.widgets.TabLayout>tv.getParent();
+            const tabLayout = <org.nativescript.widgets.TabLayout>tv.getParent().getParent().getParent();
+            this.tabItemSpec = createTabItemSpec(this);
+
             tabLayout.updateItemAt(this.index, this.tabItemSpec);
         }
     }
@@ -313,7 +315,7 @@ export class TabView extends TabViewBase {
         const listener = new PageChangedListener(this);
         (<any>viewPager).addOnPageChangeListener(listener);
         (<any>viewPager).listener = listener;
-        
+
         const adapter = new PagerAdapter(this, null);
         viewPager.setAdapter(adapter);
         (<any>viewPager).adapter = adapter;


### PR DESCRIPTION
This is an extended version of #4606 by @NathanaelA 
 
Original description:
> This Fixes/Implements #4138 .
> 
> This issue has two fixes; the first is that the item is now a couple levels deeper in the hierarchy; so we have to go up a couple parents to get to the actual TabView root controller in NS 3.  
>  
> The second issue; is even though we change the itemSource value, the item assigned to this tab view was never refreshed; so we call the function that recreates the tabview item with the new values.
