### PR TITLE
fix: update UUID implementation to new api introduced on IOS6

### DIFF
--- a/tns-core-modules/platform/platform.ios.ts
+++ b/tns-core-modules/platform/platform.ios.ts
@@ -67,8 +67,7 @@ class Device implements DeviceDefinition {
         var app_uuid = userDefaults.stringForKey(uuid_key);
 
         if (!app_uuid) {
-            var uuidRef = CFUUIDCreate(kCFAllocatorDefault);
-            app_uuid = CFUUIDCreateString(kCFAllocatorDefault, uuidRef);
+            app_uuid = NSUUID.UUID().UUIDString;
             userDefaults.setObjectForKey(app_uuid, uuid_key);
             userDefaults.synchronize();
         }


### PR DESCRIPTION
This pr changes the way UUID is created on iOS because of api changes on iOS 6 version.
[iOS Documentation about this](https://developer.apple.com/documentation/foundation/nsuuid?language=objc)

Fixes #4603 .


