### PR TITLE
Add a 'focus' event to text input fields

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -5,6 +5,7 @@ export * from "../text-base";
 
 export abstract class EditableTextBase extends TextBase implements EditableTextBaseDefinition {
     public static blurEvent = "blur";
+    public static focusEvent = "focus";
 
     public keyboardType: KeyboardType;
     public returnKeyType: ReturnKeyType;

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -77,6 +77,7 @@ function initializeEditTextListeners(): void {
                     clearTimeout(dismissKeyboardTimeoutId);
                     dismissKeyboardTimeoutId = undefined;
                 }
+                owner.notify({ eventName: EditableTextBase.focusEvent, object: owner });
             }
             else {
                 if (owner._dirtyTextAccumulator || owner._dirtyTextAccumulator === "") {

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
@@ -9,6 +9,7 @@ import { TextBase, Property, CssProperty, Style, Color, FormattedString } from "
  */
 export class EditableTextBase extends TextBase {
     public static blurEvent: string;
+    public static focusEvent: string;
 
     /**
      * Gets or sets the soft keyboard type.

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -33,6 +33,13 @@ class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
         return true;
     }
 
+    public textFieldDidBeginEditing(textField: UITextField): void {
+        const owner = this._owner.get();
+        if (owner) {
+          owner.notify({ eventName: TextField.focusEvent, object: owner });
+        }
+    }
+
     public textFieldDidEndEditing(textField: UITextField) {
         const owner = this._owner.get();
         if (owner) {

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -29,10 +29,11 @@ class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
         return true;
     }
 
-    public textViewDidBeginEditing(textView: UITextView) {
-        var owner = this._owner.get();
+    public textViewDidBeginEditing(textView: UITextView): void {
+      const owner = this._owner.get();
         if (owner) {
             owner._isEditing = true;
+            owner.notify({ eventName: TextView.focusEvent, object: owner });
         }
     }
 


### PR DESCRIPTION
Implements #2181 

Locally tested with a {N} 3.0 starter app with this added to the XML:

```xml
      <TextField focus="{{ onFocusTextField }}"
                 blur="{{ onBlurTextField }}"
                 tap="{{ onTapTextField }}"
                 text="textField"/>

      <TextView focus="{{ onFocusTextView }}"
                blur="{{ onBlurTextView }}"
                tap="{{ onTapTextView }}"
                text="textView"/>
```

And this added to `main-view-model.js`:

```js
    viewModel.onTapTextField = function(arg) {
      console.log(">> onTapTextField: " + arg);
    };

    viewModel.onTapTextView = function(arg) {
      console.log(">> onTapTextView: " + arg);
    };

    viewModel.onBlurTextField = function(arg) {
      console.log(">> onBlurTextField: " + arg);
    };

    viewModel.onFocusTextField = function(arg) {
      console.log(">> onFocusTextField: " + arg);
    };

    viewModel.onBlurTextView = function(arg) {
      console.log(">> onBlurTextView: " + arg);
    };

    viewModel.onFocusTextView = function(arg) {
      console.log(">> onFocusTextView: " + arg);
    };
```