### PR TITLE
Fix crash where some android Drawables doesn't implement getConstantState

### DIFF
--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -459,7 +459,16 @@ export class View extends ViewCommon {
     [backgroundInternalProperty.getDefault](): android.graphics.drawable.Drawable {
         const nativeView = this.nativeViewProtected;
         const drawable = nativeView.getBackground();
-        return drawable ? drawable.getConstantState().newDrawable(nativeView.getResources()) : null;
+        if (drawable) {
+            const constantState = drawable.getConstantState();
+            if (constantState) {
+                return constantState.newDrawable(nativeView.getResources());
+            } else {
+                return drawable;
+            }
+        }
+        
+        return null;
     }
     [backgroundInternalProperty.setNative](value: android.graphics.drawable.Drawable | Background) {
         this._redrawNativeBackground(value);

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -412,14 +412,14 @@ export class TabView extends TabViewBase {
         selectedIndexProperty.coerce(this);
     }
 
-    [tabBackgroundColorProperty.getDefault](): android.graphics.drawable.Drawable.ConstantState {
-        return this._tabLayout.getBackground().getConstantState();
+    [tabBackgroundColorProperty.getDefault](): android.graphics.drawable.Drawable {
+        return this._tabLayout.getBackground();
     }
-    [tabBackgroundColorProperty.setNative](value: android.graphics.drawable.Drawable.ConstantState | Color) {
+    [tabBackgroundColorProperty.setNative](value: android.graphics.drawable.Drawable | Color) {
         if (value instanceof Color) {
             this._tabLayout.setBackgroundColor(value.android);
         } else {
-            this._tabLayout.setBackground(value ? value.newDrawable() : null);
+            this._tabLayout.setBackground(tryCloneDrawable(value, this.nativeViewProtected.getResources));
         }
     }
 
@@ -447,4 +447,15 @@ export class TabView extends TabViewBase {
         const color = value instanceof Color ? value.android : value;
         tabLayout.setSelectedIndicatorColors([color]);
     }
+}
+
+function tryCloneDrawable(value: android.graphics.drawable.Drawable, resources: android.content.res.Resources): android.graphics.drawable.Drawable {
+    if (value) {
+        const constantState = value.getConstantState();
+        if (constantState) {
+            return constantState.newDrawable(resources);
+        }
+    }
+
+    return value;
 }


### PR DESCRIPTION
Changed all controls that were using getConstantState.