### PR TITLE
Increase timeout for HTTP tests

### DIFF
--- a/tests/app/TKUnit.ts
+++ b/tests/app/TKUnit.ts
@@ -118,13 +118,13 @@ function runAsync(testInfo: TestInfoEntry, recursiveIndex: number, testTimeout?:
             testInfo.isPassed = true;
             runTests(testsQueue, recursiveIndex + 1);
         } else if (error) {
-            write(`--- ["${testInfo.testName}"] FAILED: ${error.message}, duration: ${duration}`, trace.messageType.error);
+            write(`--- [${testInfo.testName}] FAILED: ${error.message}, duration: ${duration}`, trace.messageType.error);
            testInfo.errorMessage = error.message;
             runTests(testsQueue, recursiveIndex + 1);
         } else {
             const testEndTime = time();
             if (testEndTime - testStartTime > timeout) {
-                write(`--- ["${testInfo.testName}"] TIMEOUT, duration: ${duration}`, trace.messageType.error);
+                write(`--- [${testInfo.testName}] TIMEOUT, duration: ${duration}`, trace.messageType.error);
                 testInfo.errorMessage = "Test timeout.";
                 runTests(testsQueue, recursiveIndex + 1);
             } else {

--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -238,6 +238,10 @@ allTests["SEARCH-BAR"] = searchBarTests;
 import * as navigationTests from "./navigation/navigation-tests";
 allTests["NAVIGATION"] = navigationTests;
 
+const testsSuitesWithLongDelay = {
+    HTTP: 15 * 1000,
+}
+
 const testsWithLongDelay = {
     testLocation: 10000,
     testLocationOnce: 10000,
@@ -433,7 +437,7 @@ export function runAll(testSelector?: string) {
                 if (test.setUp) {
                     testsQueue.push(new TestInfo(test.setUp, test));
                 }
-                const testTimeout = testsWithLongDelay[testName];
+                const testTimeout = testsWithLongDelay[testName] || testsSuitesWithLongDelay[name];
                 testsQueue.push(new TestInfo(testFunction, test, true, name + "." + testName, false, null, testTimeout));
                 if (test.tearDown) {
                     testsQueue.push(new TestInfo(test.tearDown, test));


### PR DESCRIPTION
This is needed for more stable CI builds. _Fresh_ emulators sometimes take too much time on initial http requests which cause tests to fail.
