### PR TITLE
Avoid applying CSS multiple times

### DIFF
--- a/apps/app/ui-tests-app/main-page.xml
+++ b/apps/app/ui-tests-app/main-page.xml
@@ -15,4 +15,4 @@
       </ListView.itemTemplate>
     </ListView>
   </GridLayout>
-</Page> 
+</Page>

--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -359,7 +359,7 @@ function showReportPage(finalMessage: string) {
         setTimeout(() => {
             messageContainer.dismissSoftInput();
             (<android.view.View>messageContainer.nativeViewProtected).scrollTo(0, 0);
-        });
+        }, 10);
     }
 }
 

--- a/tests/app/ui/lifecycle/pages/button-counter.ts
+++ b/tests/app/ui/lifecycle/pages/button-counter.ts
@@ -5,6 +5,13 @@ export class Button extends button.Button {
     nativeBackgroundRedraws = 0;
     backgroundInternalSetNativeCount = 0;
     fontInternalSetNativeCount = 0;
+    colorSetNativeCount = 0;
+    colorPropertyChangeCount = 0;
+
+    constructor() {
+        super();
+        this.style.on("colorChange", () => this.colorPropertyChangeCount++);
+    }
 
     [view.backgroundInternalProperty.setNative](value) {
         this.backgroundInternalSetNativeCount++;
@@ -17,6 +24,10 @@ export class Button extends button.Button {
     _redrawNativeBackground(value: any): void {
         this.nativeBackgroundRedraws++;
         super._redrawNativeBackground(value);
+    }
+    [view.colorProperty.setNative](value) {
+        this.colorSetNativeCount++;
+        return super[view.colorProperty.setNative](value);
     }
 }
 Button.prototype.recycleNativeView = "never";

--- a/tests/app/ui/lifecycle/pages/page-two.css
+++ b/tests/app/ui/lifecycle/pages/page-two.css
@@ -1,0 +1,15 @@
+Button {
+    color: orange;
+}
+
+.red {
+    color: red;
+}
+
+.blue {
+    color: blue;
+}
+
+.nocolor {
+    background: red;
+}

--- a/tests/app/ui/lifecycle/pages/page-two.xml
+++ b/tests/app/ui/lifecycle/pages/page-two.xml
@@ -1,0 +1,8 @@
+<Page xmlns:btnCount="ui/lifecycle/pages/button-counter">
+    <StackLayout id="stack">
+        <btnCount:Button id="btn1" text="one" class="nocolor" />
+        <btnCount:Button id="btn2" text="two" class="red" />
+        <btnCount:Button id="btn3" text="three" class="blue" />
+        <btnCount:Button id="btn4" text="four" class="red blue" />
+    </StackLayout>
+</Page>

--- a/tests/app/ui/segmented-bar/segmented-bar-tests-native.ios.ts
+++ b/tests/app/ui/segmented-bar/segmented-bar-tests-native.ios.ts
@@ -5,12 +5,10 @@ export function getNativeItemsCount(bar: segmentedBarModule.SegmentedBar): numbe
 }
 
 export function checkNativeItemsTextColor(bar: segmentedBarModule.SegmentedBar): boolean {
-    var isValid = true;
-
     var attrs = (<UISegmentedControl>bar.nativeViewProtected).titleTextAttributesForState(UIControlState.Normal);
-    isValid = bar.color && attrs && attrs.valueForKey(NSForegroundColorAttributeName) === bar.color.ios;
-
-    return isValid;
+    var nativeViewColor = bar.color && attrs && attrs.valueForKey(NSForegroundColorAttributeName);
+    var barColor = bar.color.ios;
+    return barColor.isEqual(nativeViewColor);
 }
 
 export function setNativeSelectedIndex(bar: segmentedBarModule.SegmentedBar, index: number): void {

--- a/tests/app/ui/styling/style-tests.ts
+++ b/tests/app/ui/styling/style-tests.ts
@@ -67,6 +67,7 @@ export function test_applies_css_changes_to_application_rules_after_page_load() 
     helper.buildUIAndRunTest(label1, function (views: Array<viewModule.View>) {
         application.addCss(".applicationChangedLabelAfter { color: blue; }");
         label1.className = "applicationChangedLabelAfter";
+        console.log("IsLoaded: " + label1.isLoaded);
         helper.assertViewColor(label1, "#0000FF");
     });
 }
@@ -615,7 +616,7 @@ export function test_setInlineStyle_setsLocalValues() {
     stack.addChild(testButton);
 
     helper.buildUIAndRunTest(stack, function (views: Array<viewModule.View>) {
-        (<any>testButton)._applyInlineStyle("color: red;");
+        (<any>testButton).style = "color: red;";
         helper.assertViewColor(testButton, "#FF0000");
     });
 }
@@ -624,7 +625,7 @@ export function test_setStyle_throws() {
     const testButton = new buttonModule.Button();
 
     TKUnit.assertThrows(function () {
-        (<any>testButton).style = "background-color: red;";
+        (<any>testButton).style = {};
     }, "View.style property is read-only.");
 }
 

--- a/tests/app/ui/styling/value-source-tests.ts
+++ b/tests/app/ui/styling/value-source-tests.ts
@@ -5,6 +5,19 @@ import * as helper from "../helper";
 import * as TKUnit from "../../TKUnit";
 import { unsetValue } from "tns-core-modules/ui/core/view";
 
+export var test_value_Inherited_after_unset = function () {
+    let page = helper.getCurrentPage();
+    page.css = "StackLayout { color: #FF0000; } .blue { color: #0000FF; }";
+    let btn = new button.Button();
+    let testStack = new stack.StackLayout();
+    page.content = testStack;
+    testStack.addChild(btn);
+    btn.className = "blue";
+    helper.assertViewColor(btn, "#0000FF");
+    btn.className = "";
+    helper.assertViewColor(btn, "#FF0000");
+}
+
 export var test_value_Inherited_stronger_than_Default = function () {
     let page = helper.getCurrentPage();
     let btn = new button.Button();

--- a/tns-core-modules/ui/builder/component-builder/component-builder.ts
+++ b/tns-core-modules/ui/builder/component-builder/component-builder.ts
@@ -125,12 +125,6 @@ const applyComponentCss = profile("applyComponentCss", (instance: View, moduleNa
                 cssApplied = true;
             }
         }
-
-        if (!cssApplied) {
-            // Called only to apply application css.
-            // If we have page css (through file or cssAttribute) we have appCss applied.
-            (<any>instance)._refreshCss();
-        }
     }
 });
 
@@ -211,13 +205,7 @@ export function setPropertyValue(instance: View, instanceModule: Object, exports
         instance[propertyName] = exports[propertyValue];
     }
     else {
-        let attrHandled = false;
-        if (!attrHandled && instance._applyXmlAttribute) {
-            attrHandled = instance._applyXmlAttribute(propertyName, propertyValue);
-        }
-        if (!attrHandled) {
-            instance[propertyName] = propertyValue;
-        }
+        instance[propertyName] = propertyValue;
     }
 }
 

--- a/tns-core-modules/ui/core/properties/properties.d.ts
+++ b/tns-core-modules/ui/core/properties/properties.d.ts
@@ -77,6 +77,7 @@ export class CssProperty<T extends Style, U> {
     public readonly setNative: symbol;
     public readonly name: string;
     public readonly cssName: string;
+    public readonly cssLocalName: string;
     public readonly defaultValue: U;
     public register(cls: { prototype: T }): void;
     public isSet(instance: T): boolean;
@@ -92,7 +93,7 @@ export class ShorthandProperty<T extends Style, P> {
     public readonly name: string;
     public readonly cssName: string;
 
-    public register(cls: { prototype: T }): void;
+    public register(cls: typeof Style): void;
 }
 
 export class CssAnimationProperty<T extends Style, U> {
@@ -100,11 +101,10 @@ export class CssAnimationProperty<T extends Style, U> {
 
     public readonly getDefault: symbol;
     public readonly setNative: symbol;
-    public readonly key: symbol;
 
     public readonly name: string;
     public readonly cssName: string;
-    public readonly native: symbol;
+    public readonly cssLocalName: string;
 
     readonly keyframe: string;
 

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -221,6 +221,7 @@ export abstract class ViewBase extends Observable {
 
     _cssState: any /* "ui/styling/style-scope" */;
     _setCssState(next: any /* "ui/styling/style-scope" */);
+    _resetStyles();
     _registerAnimation(animation: KeyframeAnimation);
     _unregisterAnimation(animation: KeyframeAnimation);
     _cancelAllAnimations();

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -168,11 +168,6 @@ export abstract class ViewBase extends Observable {
     public className: string;
 
     /**
-     * Gets or sets inline style selectors for this view.   
-     */
-    public inlineStyleSelector: SelectorCore;
-
-    /**
      * Gets owner page. This is a read-only property.
      */
     public readonly page: Page;
@@ -220,16 +215,22 @@ export abstract class ViewBase extends Observable {
     _domId: number;
 
     _cssState: any /* "ui/styling/style-scope" */;
-    _setCssState(next: any /* "ui/styling/style-scope" */);
-    _resetStyles();
-    _registerAnimation(animation: KeyframeAnimation);
-    _unregisterAnimation(animation: KeyframeAnimation);
-    _cancelAllAnimations();
+    /**
+     * @private
+     * Notifies each child's css state for change, recursively.
+     * Either the style scope, className or id properties were changed. 
+     */
+    _onCssStateChange(): void;
 
     public cssClasses: Set<string>;
     public cssPseudoClasses: Set<string>;
 
     public _goToVisualState(state: string): void;
+    /**
+     * This used to be the way to set attribute values in early {N} versions.
+     * Now attributes are expected to be set as plain properties on the view instances.
+     * @deprecated
+     */
     public _applyXmlAttribute(attribute, value): boolean;
     public setInlineStyle(style: string): void;
 
@@ -294,7 +295,7 @@ export abstract class ViewBase extends Observable {
     /**
      * @protected
      * @unstable
-     * A widget can call this method to discard mathing css pseudo class.
+     * A widget can call this method to discard matching css pseudo class.
      */
     public deletePseudoClass(name: string): void;
 
@@ -332,6 +333,11 @@ export abstract class ViewBase extends Observable {
      * @private
      */
     _setupAsRootView(context: any): void;
+
+    /**
+     * @private
+     */
+    _inheritStyleScope(styleScope: any /* StyleScope */): void;
     //@endprivate
 }
 

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -138,10 +138,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     private _androidView: Object;
     private _style: Style;
     private _isLoaded: boolean;
-    private _registeredAnimations: Array<KeyframeAnimation>;
     private _visualState: string;
-    private _inlineStyleSelector: SelectorCore;
-    private _invalidStyles: boolean;
     private __nativeView: any;
     // private _disableNativeViewRecycling: boolean;
     public domNode: DOMNode;
@@ -158,7 +155,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     public _domId: number;
     public _context: any;
     public _isAddedToNativeVisualTree: boolean;
-    public _cssState: ssm.CssState;
+    public _cssState: ssm.CssState = new ssm.CssState(this);
     public _styleScope: ssm.StyleScope;
     public _suspendedUpdates: { [propertyName: string]: Property<ViewBase, any> | CssProperty<Style, any> | CssAnimationProperty<Style, any> };
     public _suspendNativeUpdatesCount: number;
@@ -230,8 +227,12 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     get style(): Style {
         return this._style;
     }
-    set style(value) {
-        throw new Error("View.style property is read-only.");
+    set style(inlineStyle: Style /* | string */) {
+        if (typeof inlineStyle === "string") {
+            this.setInlineStyle(inlineStyle);
+        } else {
+            throw new Error("View.style property is read-only.");
+        }
     }
 
     get android(): any {
@@ -253,13 +254,6 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     }
     set class(v: string) {
         this.className = v;
-    }
-
-    get inlineStyleSelector(): SelectorCore {
-        return this._inlineStyleSelector;
-    }
-    set inlineStyleSelector(value: SelectorCore) {
-        this._inlineStyleSelector = value;
     }
 
     getViewById<T extends ViewBaseDefinition>(id: string): T {
@@ -289,8 +283,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     @profile
     public onLoaded() {
         this._isLoaded = true;
-        this._updateStylesIfInvalid();
-
+        this._cssState.onLoaded();
         this._resumeNativeUpdates();
         this._loadEachChild();
         this._emit("loaded");
@@ -308,6 +301,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         this._suspendNativeUpdates();
         this._unloadEachChild();
         this._isLoaded = false;
+        this._cssState.onUnloaded();
         this._emit("unloaded");
     }
 
@@ -339,99 +333,8 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         });
     }
 
-    @profile
-    public _applyStyles() {
-        const scope = this._styleScope;
-        if (scope) {
-            scope.matchSelectors(this);
-        } else {
-            this._setCssState(null);
-        }
-    }
-
-    // TODO: Make sure the state is set to null and this is called on unloaded to clean up change listeners...
-    @profile
-    _setCssState(next: ssm.CssState): void {
-        const previous = this._cssState;
-        this._cssState = next;
-
-        if (!this._invalidateCssHandler) {
-            this._invalidateCssHandler = () => {
-                if (this._invalidateCssHandlerSuspended) {
-                    return;
-                }
-                this.applyCssState();
-            };
-        }
-
-        try {
-            this._invalidateCssHandlerSuspended = true;
-
-            if (next) {
-                next.changeMap.forEach((changes, view) => {
-                    if (changes.attributes) {
-                        changes.attributes.forEach(attribute => {
-                            view.addEventListener(attribute + "Change", this._invalidateCssHandler);
-                        });
-                    }
-                    if (changes.pseudoClasses) {
-                        changes.pseudoClasses.forEach(pseudoClass => {
-                            let eventName = ":" + pseudoClass;
-                            view.addEventListener(":" + pseudoClass, this._invalidateCssHandler);
-                            if (view[eventName]) {
-                                view[eventName](+1);
-                            }
-                        });
-                    }
-                });
-            }
-
-            if (previous) {
-                previous.changeMap.forEach((changes, view) => {
-                    if (changes.attributes) {
-                        changes.attributes.forEach(attribute => {
-                            view.removeEventListener("onPropertyChanged:" + attribute, this._invalidateCssHandler);
-                        });
-                    }
-                    if (changes.pseudoClasses) {
-                        changes.pseudoClasses.forEach(pseudoClass => {
-                            let eventName = ":" + pseudoClass;
-                            view.removeEventListener(eventName, this._invalidateCssHandler);
-                            if (view[eventName]) {
-                                view[eventName](-1);
-                            }
-                        });
-                    }
-                });
-            }
-
-        } finally {
-            this._invalidateCssHandlerSuspended = false;
-        }
-
-        this.applyCssState();
-    }
-
     private notifyPseudoClassChanged(pseudoClass: string): void {
         this.notify({ eventName: ":" + pseudoClass, object: this });
-    }
-
-    /**
-     * Notify that some attributes or pseudo classes that may affect the current CssState had changed.
-     */
-    private _invalidateCssHandler;
-    private _invalidateCssHandlerSuspended: boolean;
-
-    @profile
-    private applyCssState(): void {
-        this._batchUpdate(() => {
-            if (!this._cssState) {
-                this._cancelAllAnimations();
-                resetCSSProperties(this.style);
-                return;
-            }
-            this._cssState.apply();
-        });
     }
 
     private pseudoClassAliases = {
@@ -473,19 +376,6 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
             if (this.cssPseudoClasses.has(allStates[i])) {
                 this.cssPseudoClasses.delete(allStates[i]);
                 this.notifyPseudoClassChanged(allStates[i]);
-            }
-        }
-    }
-
-    @profile
-    private _applyInlineStyle(inlineStyle) {
-        if (typeof inlineStyle === "string") {
-            try {
-                // this.style._beginUpdate();
-                ensureStyleScopeModule();
-                styleScopeModule.applyInlineStyle(this, inlineStyle);
-            } finally {
-                // this.style._endUpdate();
             }
         }
     }
@@ -587,22 +477,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         }
     }
 
-    @profile
-    _setStyleScope(scope: ssm.StyleScope): void {
-        if (this._styleScope !== scope) {
-            this._styleScope = scope;
-            this._resetStyles();
-        }
-    }
-
     public _addViewCore(view: ViewBase, atIndex?: number) {
         propagateInheritableProperties(this, view);
-
-        const styleScope = this._styleScope;
-        if (styleScope) {
-            view._setStyleScope(styleScope);
-        }
-
+        view._inheritStyleScope(this._styleScope);
         propagateInheritableCssProperties(this.style, view.style);
 
         if (this._context) {
@@ -615,8 +492,8 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     }
 
     /**
-    * Core logic for removing a child view from this instance. Used by the framework to handle lifecycle events more centralized. Do not use outside the UI Stack implementation.
-    */
+     * Core logic for removing a child view from this instance. Used by the framework to handle lifecycle events more centralized. Do not use outside the UI Stack implementation.
+     */
     public _removeView(view: ViewBase) {
         if (traceEnabled()) {
             traceWrite(`${this}._removeView(${view})`, traceCategories.ViewHierarchy);
@@ -639,16 +516,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
      * Method is intended to be overridden by inheritors and used as "protected"
      */
     public _removeViewCore(view: ViewBase) {
-        // TODO: Discuss this.
-        if (this._styleScope === view._styleScope) {
-            view._setStyleScope(null);
-        }
-
         if (view.isLoaded) {
             view.onUnloaded();
         }
-
-        // view.unsetInheritedProperties();
 
         if (view._context) {
             view._tearDownUI();
@@ -664,10 +534,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     }
 
     public initNativeView(): void {
-        // No initNativeView(this)?
-        if (this._cssState) {
-            this._cssState.playPendingKeyframeAnimations();
-        }
+        //
     }
 
     public resetNativeView(): void {
@@ -689,9 +556,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         //     }
         // }
 
-        if (this._cssState) {
-            this._cancelAllAnimations();
-        }
+        // if (this._cssState) {
+        //     this._cancelAllAnimations();
+        // }
     }
 
     _setupAsRootView(context: any): void {
@@ -896,12 +763,12 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         this.addPseudoClass(state);
     }
 
-    public _applyXmlAttribute(attribute, value): boolean {
-        if (attribute === "style") {
-            this._applyInlineStyle(value);
-            return true;
-        }
-
+    /**
+     * This used to be the way to set attribute values in early {N} versions.
+     * Now attributes are expected to be set as plain properties on the view instances.
+     * @deprecated
+     */
+    public _applyXmlAttribute(): boolean {
         return false;
     }
 
@@ -910,7 +777,8 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
             throw new Error("Parameter should be valid CSS string!");
         }
 
-        this._applyInlineStyle(style);
+        ensureStyleScopeModule();
+        styleScopeModule.applyInlineStyle(this, style);
     }
 
     public _parentChanged(oldParent: ViewBase): void {
@@ -933,30 +801,6 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         initNativeView(this);
     }
 
-    public _registerAnimation(animation: KeyframeAnimation) {
-        if (this._registeredAnimations === undefined) {
-            this._registeredAnimations = new Array<KeyframeAnimation>();
-        }
-        this._registeredAnimations.push(animation);
-    }
-
-    public _unregisterAnimation(animation: KeyframeAnimation) {
-        if (this._registeredAnimations) {
-            let index = this._registeredAnimations.indexOf(animation);
-            if (index >= 0) {
-                this._registeredAnimations.splice(index, 1);
-            }
-        }
-    }
-
-    public _cancelAllAnimations() {
-        if (this._registeredAnimations) {
-            for (let animation of this._registeredAnimations) {
-                animation.cancel();
-            }
-        }
-    }
-
     public toString(): string {
         let str = this.typeName;
         if (this.id) {
@@ -972,21 +816,21 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         return str;
     }
 
-    _resetStyles(): void {
-        this._invalidStyles = true;
-        if (this.isLoaded) {
-            this._updateStylesIfInvalid();
-        }
+    _onCssStateChange(): void {
+        this._cssState.onChange();
+        eachDescendant(this, (child: ViewBase) => {
+            child._cssState.onChange();
+            return true;
+        });
     }
 
-    _updateStylesIfInvalid(): void {
-        if (this._invalidStyles && this.isLoaded) {
-            this._applyStyles();
-            this._invalidStyles = false;
-            this.eachChild((child: ViewBase) => {
-                child._setStyleScope(this._styleScope)
-                child._resetStyles();
-                return true;
+    _inheritStyleScope(styleScope: ssm.StyleScope): void {
+        if (this._styleScope !== styleScope) {
+            this._styleScope = styleScope;
+            this._onCssStateChange();
+            this.eachChild(child => {
+                child._inheritStyleScope(styleScope);
+                return true
             });
         }
     }
@@ -1039,12 +883,12 @@ export const classNameProperty = new Property<ViewBase, string>({
         if (typeof newValue === "string") {
             newValue.split(" ").forEach(c => classes.add(c));
         }
-        view._resetStyles();
+        view._onCssStateChange();
     }
 });
 classNameProperty.register(ViewBase);
 
-export const idProperty = new Property<ViewBase, string>({ name: "id", valueChanged: (view, oldValue, newValue) => view._resetStyles });
+export const idProperty = new Property<ViewBase, string>({ name: "id", valueChanged: (view, oldValue, newValue) => view._onCssStateChange() });
 idProperty.register(ViewBase);
 
 export function booleanConverter(v: string): boolean {

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -100,7 +100,6 @@ export class View extends ViewCommon {
             this.nativeViewProtected.setClickable(this._isClickable);
         }
 
-        this._cancelAllAnimations();
         super.onUnloaded();
     }
 

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -67,7 +67,7 @@ export interface Size {
  * This class is the base class for all UI components. 
  * A View occupies a rectangular area on the screen and is responsible for drawing and layouting of all UI components within. 
  */
-export abstract class View extends ViewBase implements ApplyXmlAttributes {
+export abstract class View extends ViewBase {
     /**
      * Gets the android-specific native instance that lies behind this proxy. Will be available if running on an Android platform.
      */
@@ -82,8 +82,6 @@ export abstract class View extends ViewBase implements ApplyXmlAttributes {
      * Gets or sets the binding context of this instance. This object is used as a source for each Binding that does not have a source object specified.
      */
     bindingContext: any;
-
-    //----------Style property shortcuts----------
 
     /**
      * Gets or sets the border color of the view.
@@ -413,12 +411,6 @@ export abstract class View extends ViewBase implements ApplyXmlAttributes {
      */
     public focus(): boolean;
 
-    /**
-     * Sets in-line CSS string as style.
-     * @param style - In-line CSS string. 
-     */
-    public setInlineStyle(style: string): void;
-
     public getGestureObservers(type: GestureTypes): Array<GesturesObserver>;
 
     /**
@@ -490,7 +482,6 @@ export abstract class View extends ViewBase implements ApplyXmlAttributes {
 
     _eachLayoutView(callback: (View) => void): void;
 
-    public _applyXmlAttribute(attribute: string, value: any): boolean;
     public eachChildView(callback: (view: View) => boolean): void;
 
     //@private
@@ -645,19 +636,6 @@ export interface AddChildFromBuilder {
      * @param value - Value of the element.
      */
     _addChildFromBuilder(name: string, value: any): void;
-}
-
-/**
- * Defines an interface used to create a member of a class from string representation (used in xml declaration).
- */
-export interface ApplyXmlAttributes {
-    /**
-     * Called for every attribute in xml declaration. <... fontWeight="bold" ../>
-     * @param attributeName - the name of the attribute (fontAttributes)
-     * @param attrValue - the value of the attribute (bold)
-     * Should return true if this attribute is handled and there is no need default handler to process it.
-     */
-    _applyXmlAttribute(attributeName: string, attrValue: any): boolean;
 }
 
 export const automationTextProperty: Property<View, string>;

--- a/tns-core-modules/ui/dialogs/dialogs-common.ts
+++ b/tns-core-modules/ui/dialogs/dialogs-common.ts
@@ -51,7 +51,7 @@ function applySelectors(view: View) {
     if (currentPage) {
         let styleScope = currentPage._getStyleScope();
         if (styleScope) {
-            styleScope.applySelectors(view);
+            styleScope.matchSelectors(view);
         }
     }
 }

--- a/tns-core-modules/ui/dialogs/dialogs-common.ts
+++ b/tns-core-modules/ui/dialogs/dialogs-common.ts
@@ -49,7 +49,7 @@ export function getCurrentPage(): Page {
 function applySelectors(view: View) {
     let currentPage = getCurrentPage();
     if (currentPage) {
-        let styleScope = currentPage._getStyleScope();
+        let styleScope = currentPage._styleScope;
         if (styleScope) {
             styleScope.matchSelectors(view);
         }

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -89,7 +89,6 @@ const entryCreatePage = profile("entry.create", (entry: NavigationEntry): Page =
         throw new Error("Failed to create Page with entry.create() function.");
     }
 
-    page._refreshCss();
     return page;
 });
 

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
@@ -281,27 +281,14 @@ export class GridLayoutBase extends LayoutBase implements GridLayoutDefinition {
         this.requestLayout();
     }
 
-    _applyXmlAttribute(attributeName: string, attributeValue: any): boolean {
-        if (attributeName === "columns") {
-            this._setColumns(attributeValue);
-            return true;
-        }
-        else if (attributeName === "rows") {
-            this._setRows(attributeValue);
-            return true;
-        }
-
-        return super._applyXmlAttribute(attributeName, attributeValue);
-    }
-
-    private _setColumns(value: string) {
-        this.removeColumns();
-        parseAndAddItemSpecs(value, (spec: ItemSpec) => this.addColumn(spec));
-    }
-
-    private _setRows(value: string) {
+    set rows(value: string) {
         this.removeRows();
         parseAndAddItemSpecs(value, (spec: ItemSpec) => this.addRow(spec));
+    }
+
+    set columns(value: string) {
+        this.removeColumns();
+        parseAndAddItemSpecs(value, (spec: ItemSpec) => this.addColumn(spec));
     }
 }
 

--- a/tns-core-modules/ui/page/page-common.ts
+++ b/tns-core-modules/ui/page/page-common.ts
@@ -133,18 +133,11 @@ export class PageBase extends ContentView implements PageDefinition {
     }
 
     // Used in component-builder.ts
+    @profile
     public _refreshCss(): void {
         const scopeVersion = this._styleScope.ensureSelectors();
         if (scopeVersion !== this._cssAppliedVersion) {
-            const styleScope = this._styleScope;
-            this._resetCssValues();
-            const checkSelectors = (view: View): boolean => {
-                styleScope.applySelectors(view);
-                return true;
-            };
-
-            checkSelectors(this);
-            eachDescendant(this, checkSelectors);
+            this._resetStyles();
             this._cssAppliedVersion = scopeVersion;
         }
     }

--- a/tns-core-modules/ui/page/page.d.ts
+++ b/tns-core-modules/ui/page/page.d.ts
@@ -254,15 +254,6 @@ export class Page extends ContentView {
      * @param isBackNavigation - True if the Page is being navigated from using the Frame.goBack() method, false otherwise.
      */
     public onNavigatedFrom(isBackNavigation: boolean): void;
-
-    /**
-     * @private
-     */
-    _refreshCss(): void;
-    /**
-     * @private
-     */ 
-    _getStyleScope(): styleScope.StyleScope;
     //@endprivate
 }
 

--- a/tns-core-modules/ui/styling/style/style.d.ts
+++ b/tns-core-modules/ui/styling/style/style.d.ts
@@ -48,7 +48,6 @@ export interface CommonLayoutParams {
 }
 
 export class Style extends Observable {
-
     public fontInternal: Font;
     public backgroundInternal: Background;
 
@@ -149,4 +148,20 @@ export class Style extends Observable {
     public flexShrink: FlexShrink;
     public flexWrapBefore: FlexWrapBefore;
     public alignSelf: AlignSelf;
+
+    /**
+     * The property bag is a simple class that is paired with the Style class.
+     * Setting regular css properties on the PropertyBag should simply preserve their values.
+     * Setting shorthand css properties on the PropertyBag should decompose the provided value, and set each of the shorthand composite properties.
+     * The shorthand properties are defined as non-enumerable so it should be safe to for-in the keys that are set in the bag.
+     */
+    public readonly PropertyBag: PropertyBagClass;
+}
+
+interface PropertyBagClass {
+    new(): PropertyBag;
+    prototype: PropertyBag;
+}
+interface PropertyBag {
+    [property: string]: string;
 }

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -118,4 +118,7 @@ export class Style extends Observable implements StyleDefinition {
     public flexShrink: FlexShrink;
     public flexWrapBefore: FlexWrapBefore;
     public alignSelf: AlignSelf;
+
+    public PropertyBag: { new(): { [property: string]: string }, prototype: { [property: string]: string } };
 }
+Style.prototype.PropertyBag = class { [property: string]: string; }

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -10,7 +10,7 @@
         "removeComments": true,
         "experimentalDecorators": true,
         "diagnostics": true,
-        "sourceMap": true,
+        "inlineSourceMap": true,
         "jsx": "react",
         "reactNamespace": "UIBuilder",
         "lib": [


### PR DESCRIPTION
The branch have to achieve the following objectives:
 - CSS should be applied just once when a visual tree is instantiated during navigation
 - Setting id or className should not trigger excessive property change notifications nor native setter calls

In the `nativescript-sdk-examples-ng`, navigation to `Color/Creating Colors` times:

|              | PageRouterOutlet.activateWith | ViewBase._addView | Total       |
| ------- | ------------------------------- | -------------------- | -------- |
| before  | 172 ms.                                        | 123 ms.                      | 295 ms. |
| after     | 127 ms.                                        | 132 ms.                      | 259 ms. |

CSS-es are now querried a little bit before onLoaded is raised, and so the CSS application is removed from activateWith and moved to the _addView of the root page view. Setting id and className will not re-select and re-apply CSS so there is some 10%-ish improvement during navigation.

Startup-time doesn't seem to be affected much in that case.

_applyXMLAttribute is now deprecated, the style property is now settable with string. The logic in the builder have been simplified, we can probably simplify the angular renderer too.

 - Related https://github.com/NativeScript/NativeScript/issues/4715
 - Related https://github.com/NativeScript/NativeScript/issues/4721
 - Related https://github.com/NativeScript/NativeScript/issues/4767
 - Related https://github.com/NativeScript/NativeScript/issues/4740