### PR TITLE
FIX: Checking webView.request.URL is not null before getting properties

### DIFF
--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -58,8 +58,13 @@ class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
             traceWrite("UIWebViewDelegateClass.webViewDidFinishLoad(" + webView.request.URL + ")", traceCategories.Debug);
         }
         let owner = this._owner.get();
+        
         if (owner) {
-            owner._onLoadFinished(webView.request.URL.absoluteString);
+            let src = owner.src;
+            if (webView.request && webView.request.URL) {
+                src = webView.request.URL.absoluteString;
+            }
+            owner._onLoadFinished(src);
         }
     }
 


### PR DESCRIPTION
- The symptom is the app would crash when web view tries to load
certain (valid) requests.

Fixes https://github.com/NativeScript/NativeScript/issues/3328
