### PR TITLE
iOS: setting borderRadius on Image with http/s source fails to render

### DIFF
--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -78,6 +78,8 @@ export abstract class ImageBase extends View implements ImageDefinition {
                 fromUrl(value).then((r) => {
                     if (this["_url"] === value) {
                         this.imageSource = r;
+                        // Clone the backgroundStyle to correct (now invalid?) background state.
+                        this.style.backgroundInternal = this.style.backgroundInternal.clone();
                         this.isLoading = false;
                     }
                 });

--- a/tns-core-modules/ui/styling/background-common.ts
+++ b/tns-core-modules/ui/styling/background-common.ts
@@ -27,7 +27,7 @@ export class Background implements BackgroundDefinition {
     public borderBottomRightRadius: number = 0;
     public clipPath: string;
 
-    private clone(): Background {
+    clone(): Background {
         const clone = new Background();
 
         clone.color = this.color;

--- a/tns-core-modules/ui/styling/background.d.ts
+++ b/tns-core-modules/ui/styling/background.d.ts
@@ -46,6 +46,7 @@ export class Background {
     public withClipPath(value: string): Background;
 
     public isEmpty(): boolean;
+    public clone(): Background;
 
     public static equals(value1: Background, value2: Background): boolean;
 


### PR DESCRIPTION
When loading an image from a remote resource, all the background properties are applied before the imageSource. When assigning borderRadius to an image, then later setting its imageSource would cause the image to be in a bad render state and completely disappear from the UI.

This patch clones the backgroundInternal property after async assignment of the imageSource, which causes the render state to be corrected.

Fixes #4804 

I'm not sure this is the very best fix and am open to suggestions.