### PR TITLE
Fix android navigation when there is default/initial transition on API 21+

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -140,7 +140,11 @@ export class Frame extends FrameBase {
         const fragmentTransaction = manager.beginTransaction();
 
         const animated = this._getIsAnimatedNavigation(backstackEntry.entry);
-        const navigationTransition = this._getNavigationTransition(backstackEntry.entry);
+        // NOTE: Don't use transition for the initial nagivation (same as on iOS)
+        //. On API 21+ transition won't be triggered unless there was at least one
+        // layout pass so we will wait forever for transitionCompleted handler...
+        // https://github.com/NativeScript/NativeScript/issues/4895
+        const navigationTransition = this._currentEntry ? this._getNavigationTransition(backstackEntry.entry) : null;
 
         _setAndroidFragmentTransitions(animated, navigationTransition, currentFragment, newFragment, fragmentTransaction, manager);
         if (currentFragment) {


### PR DESCRIPTION
Initial transitions are ingored on android (as they are on ios) because on API 21+ Transition class requires at least one layout pass before transitions are executed. If we don't ignore it our transition handlers won't execute and frame navigation won't execute because it thinks there is a pending navigation.

Fix https://github.com/NativeScript/NativeScript/issues/4895