### PR TITLE
Added check for owner in button listener

### DIFF
--- a/tns-core-modules/ui/button/button.android.ts
+++ b/tns-core-modules/ui/button/button.android.ts
@@ -9,7 +9,7 @@ import { TouchGestureEventData, GestureTypes, TouchAction } from "../gestures";
 export * from "./button-common";
 
 interface ClickListener {
-    new (owner: Button): android.view.View.OnClickListener;
+    new(owner: Button): android.view.View.OnClickListener;
 }
 
 let ClickListener: ClickListener;
@@ -29,7 +29,10 @@ function initializeClickListener(): void {
         }
 
         public onClick(v: android.view.View): void {
-            this.owner._emit(ButtonBase.tapEvent);
+            const owner = this.owner;
+            if (owner) {
+                owner._emit(ButtonBase.tapEvent);
+            }
         }
     }
 


### PR DESCRIPTION
If you set tap gesture on a button parent (e.g. some layout for example) and set tap handler on the button and click the button there is a chance to execute navigation with clear history. This will remove current fragment and will clear the button listener owner. Still android will fire the click handler and we will throw an exception.

Fix https://github.com/NativeScript/NativeScript/issues/4897