### PR TITLE
Fix for iOS 11 ListView top offset 

### DIFF
--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -8,6 +8,7 @@ import { StackLayout } from "../layouts/stack-layout";
 import { ProxyViewContainer } from "../proxy-view-container";
 import { ios } from "../../utils/utils";
 import { profile } from "../../profiling";
+import { device } from "../../platform";
 
 export * from "./list-view-common";
 
@@ -222,6 +223,10 @@ export class ListView extends ListViewBase {
         this._ios.estimatedRowHeight = DEFAULT_HEIGHT;
         this._ios.rowHeight = UITableViewAutomaticDimension;
         this._ios.dataSource = this._dataSource = DataSource.initWithOwner(new WeakRef(this));
+        if (parseInt(device.sdkVersion) >= 11) {
+            this._ios.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+        }
+        
         this._delegate = UITableViewDelegateImpl.initWithOwner(new WeakRef(this));
         this._heights = new Array<number>();
         this._map = new Map<ListViewCell, View>();

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -205,6 +205,17 @@ class UITableViewRowHeightDelegateImpl extends NSObject implements UITableViewDe
     }
 }
 
+// TODO: Remove this declaration when 'tns-platform-declarations' is update with iOS 11 declarations
+declare const enum UIScrollViewContentInsetAdjustmentBehavior {
+	Automatic = 0,
+
+	ScrollableAxes = 1,
+
+	Never = 2,
+
+	Always = 3
+}
+
 export class ListView extends ListViewBase {
     public _ios: UITableView;
     private _dataSource;
@@ -224,7 +235,8 @@ export class ListView extends ListViewBase {
         this._ios.rowHeight = UITableViewAutomaticDimension;
         this._ios.dataSource = this._dataSource = DataSource.initWithOwner(new WeakRef(this));
         if (parseInt(device.sdkVersion) >= 11) {
-            this._ios.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+            // TODO: Remove the cast to 'any' when 'tns-platform-declarations' is update with iOS 11 declarations
+            (<any>this._ios).contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
         }
         
         this._delegate = UITableViewDelegateImpl.initWithOwner(new WeakRef(this));


### PR DESCRIPTION
This PR addresses this issue https://github.com/NativeScript/NativeScript/issues/4916. In iOS 11 there is a new [contentInsetAdjustmentBehavior](https://developer.apple.com/documentation/uikit/uiscrollview/2902261-contentinsetadjustmentbehavior) behavior of the UIScrollView which is inherited by the ListView's UITableView. The default value of this new behavior is [automatic](https://developer.apple.com/documentation/uikit/uiscrollviewcontentinsetadjustmentbehavior/2902258-automatic) which adjusts the top offset as described by the API description: 

> Content is always adjusted vertically when the scroll view is the content view of a view controller that is currently displayed by a navigation or tab bar controller. If the scroll view is horizontally scrollable, the horizontal content offset is also adjusted when there are nonzero safe area insets. 

After this PR it may be a good feature to actually support the new different value of this new behavior, at the moment the animations provided by this behavior are not working inside the {N} layouts (GridLayout, StackLayout etc.)