### PR TITLE
fix(minor): reword missing-xml-error to be clearer

### DIFF
--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -173,7 +173,7 @@ export const resolvePageFromEntry = profile("resolvePageFromEntry", (entry: Navi
         }
 
         if (!page) {
-            throw new Error("Failed to load Page from entry.moduleName: " + entry.moduleName);
+            throw new Error("Failed to load page XML file for module: " + entry.moduleName);
         }
     }
 


### PR DESCRIPTION
The PR aims to make troubleshooting of missing XML views easier. I personally find the current error very vague, and it took peeking inside the device's files to realize that the `xml` files are being referred to as `page`. The mention of `entry.moduleName`, when I have nothing of the sorts in my code made it harder even.
