### PR TITLE
Fix crash on API 23

### DIFF
--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -460,7 +460,11 @@ export class View extends ViewCommon {
         if (drawable) {
             const constantState = drawable.getConstantState();
             if (constantState) {
-                return constantState.newDrawable(nativeView.getResources());
+                try {
+                    return constantState.newDrawable(nativeView.getResources());
+                } catch (e) {
+                    return drawable;
+                }
             } else {
                 return drawable;
             }


### PR DESCRIPTION
constantState.newDrawable(nativeView.getResources()); throws exception in Java.

Fix https://github.com/bradmartin/nativescript-floatingactionbutton/issues/57
Addition to https://github.com/NativeScript/NativeScript/issues/4728
