### PR TITLE
Fix missing borderRadius on Image in iOS

### DIFF
--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -227,19 +227,21 @@ export class View extends ViewCommon {
     }
 
     private _onSizeChanged(): void {
-        let nativeView = this.nativeViewProtected;
+        const nativeView = this.nativeViewProtected;
         if (!nativeView) {
             return;
         }
 
-        let background = this.style.backgroundInternal;
-        const backgroundDependsOnSize = background.image || !background.hasUniformBorder();
+        const background = this.style.backgroundInternal;
+        const backgroundDependsOnSize = background.image 
+            || !background.hasUniformBorder()
+            || background.hasBorderRadius();
 
         if (this._nativeBackgroundState === "invalid" || (this._nativeBackgroundState === "drawn" && backgroundDependsOnSize)) {
             this._redrawNativeBackground(background);
         }
 
-        let clipPath = this.style.clipPath;
+        const clipPath = this.style.clipPath;
         if (clipPath !== "" && this[clipPathProperty.setNative]) {
             this[clipPathProperty.setNative](clipPath);
         }


### PR DESCRIPTION
https://github.com/NativeScript/NativeScript/issues/4804 is fixed in 3.2 but there is another bug which doesn't render borderRadius on Image element.