### PR TITLE
Expose itemIdGenerator that can be used to generate unique ID for items on ListView

### DIFF
--- a/tns-core-modules/ui/list-view/list-view-common.ts
+++ b/tns-core-modules/ui/list-view/list-view-common.ts
@@ -23,8 +23,9 @@ export abstract class ListViewBase extends View implements ListViewDefinition {
     public static itemTapEvent = "itemTap";
     public static loadMoreItemsEvent = "loadMoreItems";
     // TODO: get rid of such hacks.
-    public static knownFunctions = ["itemTemplateSelector"]; //See component-builder.ts isKnownFunction
+    public static knownFunctions = ["itemTemplateSelector", "itemIdGenerator"]; //See component-builder.ts isKnownFunction
 
+    private _itemIdGenerator: (item: any, index: number, items: any) => number = (_item: any, index: number) => index;
     private _itemTemplateSelector: (item: any, index: number, items: any) => string;
     private _itemTemplateSelectorBindable = new Label();
     public _defaultTemplate: KeyedTemplate = {
@@ -70,6 +71,14 @@ export abstract class ListViewBase extends View implements ListViewDefinition {
         else if (typeof value === "function") {
             this._itemTemplateSelector = value;
         }
+    }
+
+    get itemIdGenerator(): (item: any, index: number, items: any) => number {
+        return this._itemIdGenerator;
+    }
+
+    set itemIdGenerator(generatorFn: (item: any, index: number, items: any) => number) {
+        this._itemIdGenerator = generatorFn;
     }
 
     public refresh() {

--- a/tns-core-modules/ui/list-view/list-view.android.ts
+++ b/tns-core-modules/ui/list-view/list-view.android.ts
@@ -216,7 +216,7 @@ function ensureListViewAdapterClass() {
         public getItem(i: number) {
             if (this.owner && this.owner.items && i < this.owner.items.length) {
                 let getItem = (<ItemsSource>this.owner.items).getItem;
-                return getItem ? getItem(i) : this.owner.items[i];
+                return getItem ? getItem.call(this.owner.items, i) : this.owner.items[i];
             }
 
             return null;

--- a/tns-core-modules/ui/list-view/list-view.android.ts
+++ b/tns-core-modules/ui/list-view/list-view.android.ts
@@ -223,7 +223,12 @@ function ensureListViewAdapterClass() {
         }
 
         public getItemId(i: number) {
-            return long(i);
+            let item = this.getItem(i);
+            let id = i;
+            if (this.owner && item && this.owner.items) {
+                id = this.owner.itemIdGenerator(item, i, this.owner.items);
+            }
+            return long(id);
         }
 
         public hasStableIds(): boolean {

--- a/tns-core-modules/ui/list-view/list-view.d.ts
+++ b/tns-core-modules/ui/list-view/list-view.d.ts
@@ -64,6 +64,11 @@ export class ListView extends View {
     itemTemplateSelector: string | ((item: any, index: number, items: any) => string);
 
     /**
+     * Item id generator
+     */
+    itemIdGenerator: (item: any, index: number, items: any) => number;
+
+    /**
      * Gets or set the items separator line color of the ListView. 
      */
     separatorColor: Color;


### PR DESCRIPTION
Following the principle of the `itemTemplateSelector`, I added an `itemIdGenerator` function that defaults to simply returning the index of the item (this is the current behaviour of the Adapter implementation for android). 

Users can set the `itemIdGenerator` to return any number as unique id for the given item (index and items). In my project I use a hash function to generate that number from a unique string property.

#4729 #4962 #4724