### PR TITLE
Wrong definition of canEvaluatePolicyError

### DIFF
--- a/tns-platform-declarations/ios/objc-i386/objc!LocalAuthentication.d.ts
+++ b/tns-platform-declarations/ios/objc-i386/objc!LocalAuthentication.d.ts
@@ -45,7 +45,7 @@ declare class LAContext extends NSObject {
 
 	touchIDAuthenticationAllowableReuseDuration: number;
 
-	canEvaluatePolicyError(policy: LAPolicy, error : NSError): boolean;
+	canEvaluatePolicyError(policy: LAPolicy, error: NSError): boolean;
 
 	evaluateAccessControlOperationLocalizedReasonReply(accessControl: any, operation: LAAccessControlOperation, localizedReason: string, reply: (p1: boolean, p2: NSError) => void): void;
 

--- a/tns-platform-declarations/ios/objc-i386/objc!LocalAuthentication.d.ts
+++ b/tns-platform-declarations/ios/objc-i386/objc!LocalAuthentication.d.ts
@@ -45,7 +45,7 @@ declare class LAContext extends NSObject {
 
 	touchIDAuthenticationAllowableReuseDuration: number;
 
-	canEvaluatePolicyError(policy: LAPolicy): boolean;
+	canEvaluatePolicyError(policy: LAPolicy, error : NSError): boolean;
 
 	evaluateAccessControlOperationLocalizedReasonReply(accessControl: any, operation: LAAccessControlOperation, localizedReason: string, reply: (p1: boolean, p2: NSError) => void): void;
 


### PR DESCRIPTION
IOS LAContext's canEvaluatePolicyError method always throw an error
 because of the wrong definition. (missing parameter)

this pr will fix the problem.
