### PR TITLE
Create a deep copy of fontFamily before passing to UIFontDescriptor

### DIFF
--- a/tns-core-modules/ui/styling/font.ios.ts
+++ b/tns-core-modules/ui/styling/font.ios.ts
@@ -142,7 +142,7 @@ function createUIFont(font: Font, defaultFont: UIFont): UIFont {
             break;
         } else {
             const fontAttributes = {
-                [UIFontDescriptorFamilyAttribute]: fontFamily,
+                [UIFontDescriptorFamilyAttribute]: NSString.stringWithString(fontFamily).mutableCopy(),
                 [UIFontDescriptorTraitsAttribute]: fontDescriptorTraits
             };
 


### PR DESCRIPTION
This fixes #5019, see the discussion there.