### PR TITLE
Fix android search-bar bug

### DIFF
--- a/apps/app/ui-tests-app/search-bar/issue-5039-view-model.ts
+++ b/apps/app/ui-tests-app/search-bar/issue-5039-view-model.ts
@@ -1,0 +1,27 @@
+import { Observable } from 'tns-core-modules/data/observable'
+import { ObservableArray } from 'tns-core-modules/data/observable-array'
+import { SearchBar } from 'tns-core-modules/ui/search-bar';
+
+export class Issue5039ViewModel extends Observable {
+
+    private _items = ['apple', 'apple cider', 'apple pie', 'orange', 'orange juice', 'strawberry', 'blueberry']
+    public items = new ObservableArray()
+
+    constructor(private _searchBar: SearchBar) {
+        super()
+        this.items.push(this._items)
+    }
+
+    onSubmit() {
+        this.filter(this._searchBar.text);
+    }
+
+    clearSearch() {
+        this.filter();
+    }
+    
+    filter(value: string = '') {
+        this.items.splice(0, this.items.length) // remove all items
+        this.items.push(this._items.filter(i => -1 !== i.indexOf(value)))
+    }
+}

--- a/apps/app/ui-tests-app/search-bar/issue-5039.ts
+++ b/apps/app/ui-tests-app/search-bar/issue-5039.ts
@@ -1,0 +1,9 @@
+import { Issue5039ViewModel } from './issue-5039-view-model'
+import { SearchBar } from "tns-core-modules/ui/search-bar";
+import { Page } from "tns-core-modules/ui/page";
+ 
+export function navigatingTo(args) {
+    const page = <Page>args.object;
+    const searchBar = <SearchBar>page.getViewById("searchBar")
+    page.bindingContext = new Issue5039ViewModel(searchBar);
+}

--- a/apps/app/ui-tests-app/search-bar/issue-5039.xml
+++ b/apps/app/ui-tests-app/search-bar/issue-5039.xml
@@ -1,0 +1,10 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo">
+    <StackLayout>
+        <SearchBar id="searchBar" hint="Search" submit="{{ onSubmit }}" clear="{{ clearSearch }}" />
+        <ListView items="{{ items }}">
+            <ListView.itemTemplate>
+                <Label text="{{ $value }}" />
+            </ListView.itemTemplate>
+        </ListView>
+    </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/search-bar/main-page.ts
+++ b/apps/app/ui-tests-app/search-bar/main-page.ts
@@ -13,5 +13,6 @@ export function loadExamples() {
     const examples = new Map<string, string>();
      examples.set("issue-4147", "search-bar/issue-4147");
      examples.set("search-bar", "search-bar/search-bar");
+     examples.set("issue-5039","search-bar/issue-5039");
     return examples;
 }

--- a/tns-core-modules/ui/search-bar/search-bar.android.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.android.ts
@@ -43,6 +43,7 @@ function initializeNativeClasses(): void {
             }
 
             this[SEARCHTEXT] = newText;
+            this[QUERY] = undefined;
             return true;
         }
 


### PR DESCRIPTION
This PR fixes https://github.com/NativeScript/NativeScript/issues/5039
Searching twice for the same item in the search bar leads to a bug where `submit` event won't be raised.
