### PR TITLE
Fix crash on iOS 

### DIFF
--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -38,9 +38,9 @@ class NotificationObserver2 extends NSObject {
     };
 }
 
-export observer = NotificationObserver2.initWithCallback(handleNotification);
+export const __observer = NotificationObserver2.initWithCallback(handleNotification);
 const notificationCenter = utils.ios.getter(NSNotificationCenter, NSNotificationCenter.defaultCenter);
-notificationCenter.addObserverSelectorNameObject(observer, "onReceive", UIApplicationDidChangeStatusBarFrameNotification, null);
+notificationCenter.addObserverSelectorNameObject(__observer, "onReceive", UIApplicationDidChangeStatusBarFrameNotification, null);
 
 function handleNotification(notification: NSNotification): void {
     // When there is a 40px high "in-call" status bar, nobody moves the navigationBar top from 20 to 40 and it remains underneath the status bar.

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -38,7 +38,7 @@ class NotificationObserver2 extends NSObject {
     };
 }
 
-const observer = NotificationObserver2.initWithCallback(handleNotification);
+export observer = NotificationObserver2.initWithCallback(handleNotification);
 const notificationCenter = utils.ios.getter(NSNotificationCenter, NSNotificationCenter.defaultCenter);
 notificationCenter.addObserverSelectorNameObject(observer, "onReceive", UIApplicationDidChangeStatusBarFrameNotification, null);
 


### PR DESCRIPTION
JS object that extend NSObject was not held into memory and was collected by gc.
Here is the stacktrace:
```
Successfully synced application org.nativescript.apps on device 5521452A-8299-42CF-83D5-E569BFCA1583.
CONSOLE LOG file:///app/ui-tests-app/app.ts:1:12: ####### ------ APP MODULES START
Class PLBuildVersion is implemented in both /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 10.3.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AssetsLibraryServices.framework/AssetsLibraryServices (0x11d5a9cc0) and /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 10.3.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PhotoLibraryServices.framework/PhotoLibraryServices (0x11d3c06f0). One of the two will be used. Which one is undefined.
CONSOLE LOG file:///app/ui-tests-app/app.ts:79:20: ### NativeScriptError: TypeError: this._onReceiveCallback is not a function. (In 'this._onReceiveCallback(notification)', 'this._onReceiveCallback' is undefined)
CONSOLE LOG file:///app/ui-tests-app/app.ts:80:20: ### nativeException: undefined
CONSOLE LOG file:///app/ui-tests-app/app.ts:81:20: ### stackTace: undefined
CONSOLE LOG file:///app/ui-tests-app/app.ts:82:20: ### stack: onReceive@file:///app/tns_modules/tns-core-modules/ui/frame/frame.js:34:32
CONSOLE WARN file:///app/ui-tests-app/app.ts:22:17: this._onReceiveCallback is not a function. (In 'this._onReceiveCallback(notification)', 'this._onReceiveCallback' is undefined)
1   0x1084dad4b NativeScript::FFICallback<NativeScript::ObjCMethodCallback>::ffiClosureCallback(ffi_cif*, void*, void**, void*)
2   0x108b7e28e ffi_closure_unix64_inner
3   0x108b7ebd2 ffi_closure_unix64
4   0x10c6b1b29 _CFXRegistrationPost
5   0x10c6b1892 ___CFXNotificationPost_block_invoke
6   0x10c675102 -[_CFXNotificationRegistrar find:object:observer:enumerator:]
7   0x10c674261 _CFXNotificationPost
8   0x10952fca4 -[NSNotificationCenter postNotificationName:object:userInfo:]
9   0x109a87e9d -[UIApplication _notifyDidChangeStatusBarFrame:]
10  0x109a95fce -[UIApplication statusBar:didAnimateFromHeight:toHeight:animation:]
11  0x10a123d40 -[UIStatusBar _finishedSettingStyleWithOldHeight:newHeight:animation:]
12  0x10a12221a __66-[UIStatusBar _requestStyleAttributes:animationParameters:forced:]_block_invoke.247
13  0x109b3c08e +[UIView(Animation) performWithoutAnimation:]
14  0x10a19fa94 +[UIStatusBarAnimationParameters animateWithParameters:fromCurrentState:frameInterval:animations:completion:]
15  0x10a122070 -[UIStatusBar _requestStyleAttributes:animationParameters:forced:]
16  0x10a121890 -[UIStatusBar requestStyle:animationParameters:forced:]
17  0x10a1215ca -[UIStatusBar requestStyle:animated:forced:]
18  0x109a85f6c -[UIApplication _createStatusBarWithRequestedStyle:orientation:hidden:]
19  0x109a8230b -[UIApplication _runWithMainScene:transitionContext:completion:]
20  0x109a7f7f3 -[UIApplication workspaceDidEndTransaction:]
21  0x10d0dd5f6 __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__
22  0x10d0dd46d -[FBSSerialQueue _performNext]
23  0x10d0dd7f6 -[FBSSerialQueue _performNextFromRunLoopSource]
24  0x10c6b8c01 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
25  0x10c69e0cf __CFRunLoopDoSources0
26  0x10c69d5ff __CFRunLoopRun
27  0x10c69d016 CFRunLoopRunSpecific
28  0x109a7e08f -[UIApplication _run]
29  0x109a84134 UIApplicationMain
30  0x108b7ea2d ffi_call_unix64
31  0x12525b800
file:///app/tns_modules/tns-core-modules/ui/frame/frame.js:34:32: JS ERROR TypeError: this._onReceiveCallback is not a function. (In 'this._onReceiveCallback(notification)', 'this._onReceiveCallback' is undefined)
```