### PR TITLE
docs: Change up-for-grabs filter with `help wanted`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,4 +75,4 @@ It's our turn from there on! We will review the PR and discuss changes you might
 
 ### Where to Start
 
-If you want to contribute, but you are not sure where to start - look for [issues marked with up-for-grabs tag](https://github.com/NativeScript/NativeScript/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs).
+If you want to contribute, but you are not sure where to start - look for [issues labeled `help wanted`](https://github.com/NativeScript/NativeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).


### PR DESCRIPTION
Since `up-for-grabs` label is outdated, the starting point for contributions is changed to filter by `help wanted` label.
