### PR TITLE
Add a globals.registerWebpackModules that can register dynamic require webpack context

### DIFF
--- a/tns-core-modules/module.d.ts
+++ b/tns-core-modules/module.d.ts
@@ -15,6 +15,20 @@ declare namespace NodeJS {
         require(id: string): any;
         registerModule(name: string, loader: ((name: string) => any)): void;
         /**
+         * Register all modules from a webpack context.
+         * The context is one created using the following webpack utility:
+         * https://webpack.github.io/docs/context.html
+         * 
+         * The extension map is optional, modules in the webpack context will have their original file extension (e.g. may be ".ts" or ".scss" etc.),
+         * while the built-in module builders in {N} will look for ".js", ".css" or ".xml" files. Adding a map such as:
+         * ```
+         * { ".ts": ".js" }
+         * ```
+         * Will resolve lookups for .js to the .ts file.
+         * By default scss, and ts files are mapped.
+         */
+        registerWebpackModules(context: { keys(): string[], (key: string): any }, extensionMap?: { [originalFileExtension: string]: string });
+        /**
          * The NativeScript XML builder, style-scope, application modules use various resources such as:
          * app.css, page.xml files and modules during the application life-cycle.
          * The moduleResolvers can be used to provide additional mechanisms to locate such resources.

--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -82,13 +82,13 @@ function loadCustomComponent(componentPath: string, componentName?: string, attr
 
     if (xmlFilePath) {
         // Custom components with XML
-        var jsFilePath = resolveFileName(fullComponentPathFilePathWithoutExt, "js");
 
         var subExports = context;
         if (global.moduleExists(moduleName)) {
             // Component has registered code module.
             subExports = global.loadModule(moduleName);
         } else {
+            var jsFilePath = resolveFileName(fullComponentPathFilePathWithoutExt, "js");
             if (jsFilePath) {
                 // Component has code file.
                 subExports = global.loadModule(jsFilePath)

--- a/tns-core-modules/ui/builder/component-builder/component-builder.ts
+++ b/tns-core-modules/ui/builder/component-builder/component-builder.ts
@@ -11,6 +11,8 @@ import { profile } from "../../../profiling";
 import * as debugModule from "../../../utils/debug";
 import * as platform from "../../../platform";
 
+import * as filesystem from "../../../file-system";
+
 const UI_PATH = "ui/";
 const MODULES = {
     "TabViewItem": "ui/tab-view",
@@ -119,6 +121,13 @@ const applyComponentCss = profile("applyComponentCss", (instance: View, moduleNa
 
     if (typeof (<any>instance).addCssFile === "function") {//instance instanceof Page) {
         if (moduleNamePath && !cssApplied) {
+
+            const appPath = filesystem.knownFolders.currentApp().path;
+            const cssPathRelativeToApp = (moduleNamePath.startsWith(appPath) ? "./" + moduleNamePath.substr(appPath.length + 1) : moduleNamePath) + ".css";
+            if (global.moduleExists(cssPathRelativeToApp)) {
+                (<any>instance).addCssFile(cssPathRelativeToApp);
+            }
+
             let cssFilePath = resolveFileName(moduleNamePath, "css");
             if (cssFilePath) {
                 (<any>instance).addCssFile(cssFilePath);

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -508,7 +508,7 @@ export class StyleScope {
         }
 
         this._reset();
-        let parsedCssSelectors = cssString ? CSSSource.fromSource(cssString, this._keyframes, cssFileName) : CSSSource.fromFile(cssFileName, this._keyframes);
+        let parsedCssSelectors = cssString ? CSSSource.fromSource(cssString, this._keyframes, cssFileName) : CSSSource.fromURI(cssFileName, this._keyframes);
         this._css = this._css + parsedCssSelectors.source;
         this._localCssSelectors.push.apply(this._localCssSelectors, parsedCssSelectors.selectors); 
         this._localCssSelectorVersion++;


### PR DESCRIPTION
The web pack require can now create a dynamic require context, and that context can be fed into the modules so the .js and .css files can be loaded through web pack loaders.

Consider the following `bundle.config.js`:
```JavaScript
if (global.TNS_WEBPACK) {
    // registers tns-core-modules UI framework modules
    require("bundle-entry-points");

    // register application modules
    // This will register each xml, css, js, ts, scss etc. in the app/ folder
    const context = require.context("~/", true, /page\.(xml|css|js|ts|scss)$/);
    global.registerWebpackModules(context);
}
```
This will make a context for the entire app (`~/` is the `app/`) folder and recursively require all files that end in `...page.xml`, `...page.css`, `...page.ts` etc. Webpack will create a map such as:
```
var map = {
	"./main-page.js": 151,
	"./main-page.scss": 153,
	"./main-page.xml": 154,
	"./views/second-page.css": 155,
	"./views/second-page.js": 156,
	"./views/second-page.xml": 157
};
```
for the bundle.js, (note they can be added to the vendor.js and get into the snapshot for android too)  and then when the {N} builder resolves a page, it will load the css and js files from that map.

The last argument of `require.context` is a regex so it allows great flexibility.
Developers will no longer need to `global.registerModule` for each of their JavaScript files as long as they can figure out a convention (like placing all views in a `views` folder, or postfixing each page with `page.*`, or if they are happy listing each .js file from `app/`.

This utility is designed to work with the nativescript-dev-webpack's `PlatformFSPlugin` or `NativeScriptAngularCompilerPlugin` that would virtually map file.android.* and file.ios.* to file.*.