### PR TITLE
Application-Settings: Non-blocking changes

### DIFF
--- a/tests/app/application-settings/application-settings-tests.ts
+++ b/tests/app/application-settings/application-settings-tests.ts
@@ -102,6 +102,16 @@ export var testClear = function () {
     TKUnit.assert(!appSettings.hasKey(numberKey), "Failed to remove key: " + numberKey);
 };
 
+export var testFlush = function () {
+    appSettings.setString(stringKey, "String value");
+    // >> application-settings-flush
+    var flushed = appSettings.flush();
+    // will return boolean indicating whether flush to disk was successful
+    // << application-settings-flush
+    TKUnit.assert(flushed, "Flush failed: "+ flushed);
+    TKUnit.assert(appSettings.hasKey(stringKey), "There is no key: " + stringKey);
+};
+
 export var testInvalidKey = function () {
     try {
         appSettings.hasKey(undefined);

--- a/tns-core-modules/application-settings/application-settings.android.ts
+++ b/tns-core-modules/application-settings/application-settings.android.ts
@@ -1,7 +1,7 @@
 ﻿import * as common from "./application-settings-common";
 import { getNativeApplication } from "../application";
 
-var sharedPreferences;
+var sharedPreferences: android.content.ISharedPreferences;
 function ensureSharedPreferences() {
     if (!sharedPreferences) {
         sharedPreferences = (<android.app.Application>getNativeApplication()).getApplicationContext().getSharedPreferences("prefs.db", 0);
@@ -80,6 +80,6 @@ export function clear(): void {
     sharedPreferences.edit().clear().apply();
 }
 
-export var flush = function (): void {
-    sharedPreferences.edit().commit();
+export var flush = function (): boolean {
+    return sharedPreferences.edit().commit();
 }

--- a/tns-core-modules/application-settings/application-settings.android.ts
+++ b/tns-core-modules/application-settings/application-settings.android.ts
@@ -49,7 +49,7 @@ export function setBoolean(key: string, value: boolean): void {
     common.ensureValidValue(value, "boolean");
     var editor = sharedPreferences.edit();
     editor.putBoolean(key, value);
-    editor.commit();
+    editor.apply();
 }
 
 export function setString(key: string, value: string): void {
@@ -57,7 +57,7 @@ export function setString(key: string, value: string): void {
     common.ensureValidValue(value, "string");
     var editor = sharedPreferences.edit();
     editor.putString(key, value);
-    editor.commit();
+    editor.apply();
 }
 
 export function setNumber(key: string, value: number): void {
@@ -65,17 +65,21 @@ export function setNumber(key: string, value: number): void {
     common.ensureValidValue(value, "number");
     var editor = sharedPreferences.edit();
     editor.putFloat(key, float(value));
-    editor.commit();
+    editor.apply();
 }
 
 export function remove(key: string): void {
     verify(key);
     var editor = sharedPreferences.edit();
     editor.remove(key);
-    editor.commit();
+    editor.apply();
 }
 
 export function clear(): void {
     ensureSharedPreferences();
-    sharedPreferences.edit().clear().commit();
+    sharedPreferences.edit().clear().apply();
+}
+
+export var flush = function (): void {
+    sharedPreferences.edit().commit();
 }

--- a/tns-core-modules/application-settings/application-settings.d.ts
+++ b/tns-core-modules/application-settings/application-settings.d.ts
@@ -64,5 +64,6 @@ export function clear(): void;
 
 /**
  * Flush all changes to disk synchronously.
+ * @return {boolean} flag indicating if changes were saved successfully to disk.
  */
-export function flush(): void;
+export function flush(): boolean;

--- a/tns-core-modules/application-settings/application-settings.d.ts
+++ b/tns-core-modules/application-settings/application-settings.d.ts
@@ -61,3 +61,8 @@ export function remove(key: string): void;
  * Removes all values.
  */
 export function clear(): void;
+
+/**
+ * Flush all changes to disk synchronously.
+ */
+export function flush(): void;

--- a/tns-core-modules/application-settings/application-settings.ios.ts
+++ b/tns-core-modules/application-settings/application-settings.ios.ts
@@ -62,6 +62,6 @@ export var clear = function (): void {
     userDefaults.removePersistentDomainForName(utils.ios.getter(NSBundle, NSBundle.mainBundle).bundleIdentifier);
 }
 
-export var flush = function (): void {
-    userDefaults.synchronize();
+export var flush = function (): boolean {
+    return userDefaults.synchronize();
 }

--- a/tns-core-modules/application-settings/application-settings.ios.ts
+++ b/tns-core-modules/application-settings/application-settings.ios.ts
@@ -39,29 +39,29 @@ export var setBoolean = function (key: string, value: boolean): void {
     Common.checkKey(key);
     Common.ensureValidValue(value, "boolean");
     userDefaults.setBoolForKey(value, key);
-    userDefaults.synchronize();
 }
 
 export var setString = function (key: string, value: string): void {
     Common.checkKey(key);
     Common.ensureValidValue(value, "string");
     userDefaults.setObjectForKey(value, key);
-    userDefaults.synchronize();
 }
 
 export var setNumber = function (key: string, value: number): void {
     Common.checkKey(key);
     Common.ensureValidValue(value, "number");
     userDefaults.setDoubleForKey(value, key);
-    userDefaults.synchronize();
 }
 
 export var remove = function (key: string): void {
     Common.checkKey(key);
     userDefaults.removeObjectForKey(key);
-    userDefaults.synchronize();
 }
 
 export var clear = function (): void {
     userDefaults.removePersistentDomainForName(utils.ios.getter(NSBundle, NSBundle.mainBundle).bundleIdentifier);
+}
+
+export var flush = function (): void {
+    userDefaults.synchronize();
 }


### PR DESCRIPTION
Fixes #4871

Changes to Application-Settings were blocking, meaning that changes would completely block the main (UI) thread until they were written to disk. This had some pretty nasty stuttering effects when saving large strings or stringified objects with Application-Settings.

## Android - SharedPreferences
On Android, calling `apply` instead of `commit`, saves changes to the in-memory cache, and starts an async save to disk. `commit` blocks and is only relevant when you actually need the return value indicating whether the disk write succeeded, which Nativescript does not care about. [source](https://developer.android.com/reference/android/content/SharedPreferences.Editor.html#apply())

> Unlike commit(), which writes its preferences out to persistent storage synchronously, apply() commits its changes to the in-memory SharedPreferences immediately but starts an asynchronous commit to disk and you won't be notified of any failures. If another editor on this SharedPreferences does a regular commit() while a apply() is still outstanding, the commit() will block until all async commits are completed as well as the commit itself.

> You don't need to worry about Android component lifecycles and their interaction with apply() writing to disk. The framework makes sure in-flight disk writes from apply() complete before switching states.

## iOS - NSUserDefaults

On iOS, any changes affects the in-memory version of UserDefaults and explicitly calling `synchronize` writes the in-memory UserDefaults to disk before returning. According to Apple documentation this call is now unnecessary and should not be used. [source](https://developer.apple.com/documentation/foundation/userdefaults/1414005-synchronize)

> At runtime, you use UserDefaults objects to read the defaults that your app uses from a user’s defaults database. UserDefaults caches the information to avoid having to open the user’s defaults database each time you need a default value. When you set a default value, it’s changed synchronously within your process, and asynchronously to persistent storage and other processes.

## Explicit disk sync

I've added an explicit `flush` call which has the old behaviour of blocking the thread until changes has been sync'ed to disk, if for some reason it should be needed by anyone.

These changes should be covered by existing unit tests.