### PR TITLE
Fix background scale quality

### DIFF
--- a/tns-core-modules/ui/styling/background.ios.ts
+++ b/tns-core-modules/ui/styling/background.ios.ts
@@ -338,7 +338,7 @@ function uiColorFromImage(img: UIImage, view: View, callback: (uiColor: UIColor)
 
     if (params.sizeX > 0 && params.sizeY > 0) {
         const resizeRect = CGRectMake(0, 0, params.sizeX, params.sizeY);
-        UIGraphicsBeginImageContext(resizeRect.size);
+        UIGraphicsBeginImageContextWithOptions(resizeRect.size, false, 0.0);
         img.drawInRect(resizeRect);
         img = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();


### PR DESCRIPTION
UIGraphicsBeginImageContextWithOptions with scale factor 0 makes sure the device scale factor is used automatically and not 1.0


Fixes/Implements #5112.

