### PR TITLE
Add Enterkey-Processing for some IMEs to editable-text-base.android

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -103,13 +103,10 @@ function initializeEditTextListeners(): void {
             }
 
             // https://github.com/NativeScript/NativeScript/issues/5121 
-            // default or preinstalled IME is not raise onEditorAction, but Google's input method(e.g. Google Japanese Input,Google Korean Input.) raises this.
+            // default or preinstalled IME is not raise onEditorAction, but Google's input method(e.g. Google Japanese Input,Google Korean Input.)
+            // and hardware keyboard raise this.
             // so we have to treat this as returning false .If not so, we cannot make new-lines.
             if (actionId === android.view.inputmethod.EditorInfo.IME_NULL && (event && event.getKeyCode() === android.view.KeyEvent.KEYCODE_ENTER)) {
-                if (textView.getMaxLines() === 1) {
-                    owner.dismissSoftInput();
-                    return true;
-                }
                 owner._onReturnPress();
                 return false;
             }

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -102,6 +102,17 @@ function initializeEditTextListeners(): void {
                 return;
             }
 
+            // https://github.com/NativeScript/NativeScript/issues/5121 
+            // default or preinstalled IME is not raise onEditorAction, but Google's input method(e.g. Google Japanese Input,Google Korean Input.) raises this.
+            // so we have to treat this as returning false .If not so, we cannot make new-lines.
+            if (actionId === 0 && (event && event.getKeyCode() === android.view.KeyEvent.KEYCODE_ENTER)) {
+                if (textView.getMaxLines() === 1) {
+                    owner.dismissSoftInput();
+                }
+                owner._onReturnPress();
+                return false;
+            }
+            
             if (actionId === android.view.inputmethod.EditorInfo.IME_ACTION_DONE ||
                 actionId === android.view.inputmethod.EditorInfo.IME_ACTION_GO ||
                 actionId === android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH ||

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -105,9 +105,10 @@ function initializeEditTextListeners(): void {
             // https://github.com/NativeScript/NativeScript/issues/5121 
             // default or preinstalled IME is not raise onEditorAction, but Google's input method(e.g. Google Japanese Input,Google Korean Input.) raises this.
             // so we have to treat this as returning false .If not so, we cannot make new-lines.
-            if (actionId === 0 && (event && event.getKeyCode() === android.view.KeyEvent.KEYCODE_ENTER)) {
+            if (actionId === android.view.inputmethod.EditorInfo.IME_NULL && (event && event.getKeyCode() === android.view.KeyEvent.KEYCODE_ENTER)) {
                 if (textView.getMaxLines() === 1) {
                     owner.dismissSoftInput();
+                    return true;
                 }
                 owner._onReturnPress();
                 return false;


### PR DESCRIPTION
default or preinstalled IME is not raise onEditorAction, but Google's input method(e.g. Google Japanese Input,Google Korean Input.) raises this.
so we have to treat this as returning false .If not so, we cannot make new-lines.

Fixes #5121 

linted,compiled