### PR TITLE
refactor: set parentNode property to ViewBase

### DIFF
--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -158,6 +158,11 @@ export abstract class ViewBase extends Observable {
     public readonly parent: ViewBase;
 
     /**
+     * Gets the template parent or the native parent. Sets the template parent.
+     */
+    public parentNode: ViewBase;
+
+    /**
      * Gets or sets the id for this view.
      */
     public id: string;

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -149,6 +149,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     private _style: Style;
     private _isLoaded: boolean;
     private _visualState: string;
+    private _templateParent: ViewBase;
     private __nativeView: any;
     // private _disableNativeViewRecycling: boolean;
     public domNode: dnm.DOMNode;
@@ -219,6 +220,14 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         super();
         this._domId = viewIdCounter++;
         this._style = new Style(this);
+    }
+
+    get parentNode() {
+        return this._templateParent || this.parent;
+    }
+
+    set parentNode(node: ViewBase) {
+        this._templateParent = node;
     }
 
     get nativeView(): any {


### PR DESCRIPTION
Setter:
You can set a '_templateParent' by setting node.parentNode. This won't
affect the native parent of the node.
Getter:
Returns '_templateParent', if set, or the native parent otherwise.
Reason:
This will help us remove that abstraction from nativescript-angular as
it matches the DOM Nodes API name.