### PR TITLE
feat: Register ./app.css instead of app.css so it can be provided by webpack context

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -30,7 +30,7 @@ export const lowMemoryEvent = "lowMemory";
 export const uncaughtErrorEvent = "uncaughtError";
 export const orientationChangedEvent = "orientationChanged";
 
-let cssFile: string = "app.css";
+let cssFile: string = "./app.css";
 
 let resources: any = {};
 


### PR DESCRIPTION
This will let us register the app.css in webpack from a context, and potentially
have a configuration such as:
```
const appCssContext = require.context("~/", false, /^\.\/app\.(css|scss|less|sass)$/);
global.registerWebpackModules(appCssContext);
```
That will work with all of the app.css, app.scss, app.less etc. without further manual reconfiguration.
