### PR TITLE
fix: throw if global css file is not found in webpack context

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -73,7 +73,12 @@ export function getCssFileName(): string {
 }
 
 export function loadAppCss(): void {
-    events.notify(<LoadAppCSSEventData>{ eventName: "loadAppCss", object: app, cssFile: getCssFileName() });
+    try {
+        events.notify(<LoadAppCSSEventData>{ eventName: "loadAppCss", object: app, cssFile: getCssFileName() });
+    } catch (e) {
+        throw new Error(`The file ${getCssFileName()} couldn't be loaded! ` +
+           `You may need to register it inside ./app/vendor.ts.`);
+    }
 }
 
 export function addCss(cssText: string): void {


### PR DESCRIPTION
Catching the error will prevent bundling with snapshot to fail with:

```
com is not defined
```