### PR TITLE
Remove _onNavigatingTo in frame.ios.ts

### DIFF
--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -349,10 +349,6 @@ export class Frame extends FrameBase {
         }
     }
 
-    public _onNavigatingTo(backstackEntry: BackstackEntry, isBack: boolean) {
-        //
-    }
-
     _handleHigherInCallStatusBarIfNeeded() {
         let statusBarHeight = uiUtils.ios.getStatusBarHeight();
         if (!this._ios ||


### PR DESCRIPTION
Remove the empty _onNavigatingTo method which was overriding the same method in the FrameBase class and preventing the "navigatedTo" method from firing. Fixes #4398
Edit: never mind, it's called elsewhere, which is why the function was overriden 😄
  
  