### PR TITLE
fix: layoutParent crash with ProxyViewContainer

### DIFF
--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -694,7 +694,7 @@ export namespace ios {
             return;
         }
 
-        if (view instanceof View) {
+        if (view instanceof View && view.nativeViewProtected) {
             const frame = view.nativeViewProtected.frame;
             const origin = frame.origin;
             const size = frame.size;


### PR DESCRIPTION
`layoutParent` method crashes with `ProxyViewContainer` as it does not have a native view.

