### PR TITLE
[Do not merge - WIP] feat(android): Add a 'profiling: lifecycle' to track startup times

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -59,14 +59,14 @@ function getAttachListener(): android.view.View.OnAttachStateChangeListener {
             }
 
             onViewAttachedToWindow(view: android.view.View): void {
-                const owner: View = view[ownerSymbol];
-                if (owner) {
+                const owner: Frame = view[ownerSymbol];
+                if (owner && !owner._attachedToWindow) {
                     owner._onAttachedToWindow();
                 }
             }
 
             onViewDetachedFromWindow(view: android.view.View): void {
-                const owner: View = view[ownerSymbol];
+                const owner: Frame = view[ownerSymbol];
                 if (owner) {
                     owner._onDetachedFromWindow();
                 }
@@ -97,7 +97,7 @@ export class Frame extends FrameBase {
     private _delayedNavigationEntry: BackstackEntry;
     private _containerViewId: number = -1;
     private _tearDownPending = false;
-    private _attachedToWindow = false;
+    _attachedToWindow = false;
     public _isBack: boolean = true;
 
     constructor() {
@@ -1053,6 +1053,10 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
         }
 
         activity.setContentView(rootView.nativeViewProtected, new org.nativescript.widgets.CommonLayoutParams());
+
+        if (rootView instanceof Frame && !rootView._attachedToWindow) {
+            rootView._onAttachedToWindow();
+        }
     }
 }
 


### PR DESCRIPTION
Consider this a very light-weight mode of 'profiling: timline'.
By adding in the `app/package.json` a:
```
{
  "profiling": "lifecycle"
}
```
The app will print out the time it takes to launch the app.
In future, we can add times for navigation, time to respond user interaction, etc.
