### PR TITLE
fix(android-frame): recreate frame if no cached one found on app resume

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -945,7 +945,7 @@ function setActivityContent(activity: android.app.Activity, savedInstanceState: 
             if (!rootView) {
                 // If we have frameId from extras - we are starting a new activity from navigation (e.g. new Frame().navigate()))
                 // Then we check if we have frameId from savedInstanceState - this happens when Activity is destroyed but app was not (e.g. suspend)
-                rootView = frameId >= 0 ? getFrameById(frameId) : new Frame();
+                rootView = getFrameById(frameId) || new Frame();
             }
 
             if (rootView instanceof Frame) {


### PR DESCRIPTION
Fix https://github.com/NativeScript/NativeScript/issues/5318