### PR TITLE
fix-next(android-tabview): handle tab fragments attach/detach properly

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -740,7 +740,6 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
     @profile
     public onStop(fragment: android.app.Fragment, superFunc: Function): void {
         superFunc.call(fragment);
-        this.entry.resolvedPage.callUnloaded();
     }
 
     @profile


### PR DESCRIPTION
Force the android TabView pager adapter to detach tab fragments on TabView unloaded and to re-attach them on TabView loaded. Keeping the tab fragments attached after unload/navigate is problematic since they will try to recreate their native views on suspend/resume of the app.

This handles the scenario:
1. TabView is in a Frame.
2. Navigate to a new page.
3. Suspend/resume the app with "Don't keep activities".
4. Go back to the page with tabs.
Result: the tabs are empty.