### PR TITLE
feat: support intent replacement in the android activity

### DIFF
--- a/tns-core-modules/ui/frame/activity.android.ts
+++ b/tns-core-modules/ui/frame/activity.android.ts
@@ -28,6 +28,11 @@ class NativeScriptActivity extends android.app.Activity {
         this._callbacks.onCreate(this, savedInstanceState, super.onCreate);
     }
 
+    protected onNewIntent(intent: android.content.Intent): void {
+        super.onNewIntent(intent);
+        super.setIntent(intent);
+    }
+
     protected onSaveInstanceState(outState: android.os.Bundle): void {
         this._callbacks.onSaveInstanceState(this, outState, super.onSaveInstanceState);
     }


### PR DESCRIPTION
Avoid getting a wrong intent from the main activity when the [android:launchMode](https://developer.android.com/guide/topics/manifest/activity-element.html)  is set to `singleTop` or `singleTask`.

fix issues: 
* https://github.com/NativeScript/push-plugin/issues/188
* https://github.com/NativeScript/push-plugin/issues/193

