### PR TITLE
fix-next(modal): navigation events' workflow in modal dialog scenarios Fixes #5323 #5340

### DIFF
--- a/tests/app/app/app.ts
+++ b/tests/app/app/app.ts
@@ -141,4 +141,4 @@ else {
 
 console.log(`TIME TO LOAD APP: ${time} ms`);
 
-application.start({ moduleName: "app/mainPage" });
+application.run({ moduleName: "app/appRoot" });

--- a/tests/app/app/appRoot.xml
+++ b/tests/app/app/appRoot.xml
@@ -1,0 +1,1 @@
+<Frame defaultPage="app/mainPage" />

--- a/tests/app/app/mainPage.ts
+++ b/tests/app/app/mainPage.ts
@@ -1,9 +1,6 @@
 ﻿import { Page } from "tns-core-modules/ui/page";
 import * as trace from "tns-core-modules/trace";
 import * as tests from "../testRunner";
-import { Label } from "tns-core-modules/ui/label";
-import * as application from "tns-core-modules/application";
-import * as platform from "tns-core-modules/platform";
 
 trace.enable();
 trace.addCategories(trace.categories.Test + "," + trace.categories.Error);
@@ -18,46 +15,12 @@ trace.addCategories(trace.categories.Test + "," + trace.categories.Error);
 //    trace.categories.VisualTreeEvents
 // ));
 
-let page = new Page();
-page.id = "mainPage";
-
-page.on(Page.navigatedToEvent, onNavigatedTo);
-
 function runTests() {
     setTimeout(() => tests.runAll(''), 10);
 }
 
-function onNavigatedTo(args) {
-    let label = new Label();
-    label.text = "Running non-UI tests...";
-    page.content = label;
-    args.object.off(Page.navigatedToEvent, onNavigatedTo);
-
-    // Request permission to write test-results.xml file for API >= 23
-    // if (platform.isAndroid && parseInt(platform.device.sdkVersion) >= 23) {
-    //     let handler = (args: application.AndroidActivityRequestPermissionsEventData) => {
-    //         application.android.off(application.AndroidApplication.activityRequestPermissionsEvent, handler);
-    //         if (args.requestCode === 1234 && args.grantResults.length > 0 && args.grantResults[0] === android.content.pm.PackageManager.PERMISSION_GRANTED) {
-    //             runTests();
-    //         } else {
-    //             trace.write("Permission for write to external storage not granted!", trace.categories.Error, trace.messageType.error);
-    //         }
-    //     };
-
-    //     application.android.on(application.AndroidApplication.activityRequestPermissionsEvent, handler);
-
-    //     if ((<any>android.support.v4.content.ContextCompat).checkSelfPermission(application.android.currentContext, (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE) !== android.content.pm.PackageManager.PERMISSION_GRANTED) {
-    //         (<any>android.support.v4.app.ActivityCompat).requestPermissions(application.android.currentContext, [(<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE], 1234);
-    //     } else {
-    //         runTests();
-    //     }
-    // } else {
-    //     runTests();
-    // }
+export function onNavigatedTo(args) {
+    args.object.off(Page.loadedEvent, onNavigatedTo);
 
     runTests();
-}
-
-export function createPage() {
-    return page;
 }

--- a/tests/app/app/mainPage.xml
+++ b/tests/app/app/mainPage.xml
@@ -1,0 +1,3 @@
+<Page navigatedTo="onNavigatedTo">
+    <Label text="Running non-UI tests..." />
+</Page>

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,10 +6,10 @@
   "nativescript": {
     "id": "org.nativescript.UnitTestApp",
     "tns-ios": {
-      "version": "3.2.0"
+      "version": "3.4.1"
     },
     "tns-android": {
-      "version": "3.2.0"
+      "version": "3.4.1"
     }
   },
   "dependencies": {

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -40,7 +40,10 @@
   "snapshot": {
     "android": {
       "tns-java-classes": {
-        "modules": ["ui/frame/activity", "ui/frame/fragment"]
+        "modules": [
+          "ui/frame/activity",
+          "ui/frame/fragment"
+        ]
       }
     }
   }

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -86,6 +86,16 @@ export interface ShownModallyData extends EventData {
  */
 export abstract class View extends ViewBase {
     /**
+     * String value used when hooking to showingModally event.
+     */
+    public static showingModallyEvent: string;
+
+    /**
+     * String value used when hooking to shownModally event.
+     */
+    public static shownModallyEvent: string;
+    
+    /**
      * Gets the android-specific native instance that lies behind this proxy. Will be available if running on an Android platform.
      */
     public android: any;

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -58,7 +58,16 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
     @profile
     public onLoaded() {
         super.onLoaded();
+
+        this._pushInFrameStack();
         this._processNextNavigationEntry();
+    }
+
+    @profile
+    public onUnloaded() {
+        super.onUnloaded();
+
+        this._popFromFrameStack();
     }
 
     public canGoBack(): boolean {
@@ -182,8 +191,6 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
         //     }
         //     app.on(app.orientationChangedEvent, (data) => this._onOrientationChanged());
         // }
-
-        this._pushInFrameStack();
 
         const backstackEntry: BackstackEntry = {
             entry: entry,

--- a/tns-core-modules/ui/page/page.d.ts
+++ b/tns-core-modules/ui/page/page.d.ts
@@ -40,16 +40,6 @@ export module knownCollections {
  */
 export class Page extends ContentView {
     /**
-     * String value used when hooking to showingModally event.
-     */
-    public static showingModallyEvent: string;
-
-    /**
-     * String value used when hooking to shownModally event.
-     */
-    public static shownModallyEvent: string;
-
-    /**
      * String value used when hooking to navigatingTo event.
      */
     public static navigatingToEvent: string;

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -180,10 +180,11 @@ class UIViewControllerImpl extends UIViewController {
         }
 
         const frame = owner.frame;
-        // Skip navigation events if we are hiding because we are about to show modal page
+        // Skip navigation events if we are hiding because we are about to show a modal page,
+        // or because we are closing a modal page, 
         // or because we are in tab and another controller is selected.
         const tab = this.tabBarController;
-        if (!owner._presentedViewController && frame && frame.currentPage === owner) {
+        if (!owner._presentedViewController && !this.presentingViewController && frame && frame.currentPage === owner) {
             const willSelectViewController = tab && (<any>tab)._willSelectViewController;
             if (!willSelectViewController
                 || willSelectViewController === tab.selectedViewController) {

--- a/tns-platform-declarations/package.json
+++ b/tns-platform-declarations/package.json
@@ -1,13 +1,11 @@
 {
   "name": "tns-platform-declarations",
   "version": "4.0.0",
-  "description":
-    "Platform-specific TypeScript declarations for NativeScript for accessing native objects",
+  "description": "Platform-specific TypeScript declarations for NativeScript for accessing native objects",
   "main": "",
   "scripts": {
     "test": "tsc",
-    "package-tag":
-      "npm version $npm_package_version-$PACKAGE_VERSION --no-git-tag-version"
+    "package-tag": "npm version $npm_package_version-$PACKAGE_VERSION --no-git-tag-version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fixes https://github.com/NativeScript/NativeScript/issues/5323
- Fixes https://github.com/NativeScript/NativeScript/issues/5340
- Updates unit tests project for application.run(...)
- Moves showingModallyEvent/shownModallyEvent static strings from Page to View.d.ts


~~TODO: _Error: Cannot pop a Frame which is not at the top of the navigation stack._ in a scenario with root tabview when switching tabs whose tabitems contain Frames.~~