### PR TITLE
fix: Stabilise scroll-view tests for ios 9 and 10

### DIFF
--- a/tests/app/ui/scroll-view/scroll-view-tests.ts
+++ b/tests/app/ui/scroll-view/scroll-view-tests.ts
@@ -25,6 +25,8 @@ class ScrollLayoutTest extends UITest<ScrollView> {
         btn.height = { value: 500, unit: "px" };
         scrollView.content = btn;
 
+        // Use page with scrollableContent disabled for scroll-view tests
+        (<any>this.testPage).scrollableContent = false;
         return scrollView;
     }
 


### PR DESCRIPTION
Execute all ScrollView tests inside a page with `scrollableContent = false`.  IOS 9 and 10 are setting wrong scrollable insets during navigation in pages.