### PR TITLE
feat(tab-view-android): enable tabs repositioning

### DIFF
--- a/apps/app/ui-tests-app/tab-view/main-page.ts
+++ b/apps/app/ui-tests-app/tab-view/main-page.ts
@@ -21,5 +21,6 @@ export function loadExamples() {
     examples.set("tab-view-icons", "tab-view/tab-view-icon");
     examples.set("tab-view-icon-change", "tab-view/tab-view-icon-change");
     examples.set("text-transform", "tab-view/text-transform");
+    examples.set("tab-view-bottom-position","tab-view/tab-view-bottom-position");
     return examples;
 }

--- a/apps/app/ui-tests-app/tab-view/tab-view-bottom-position.xml
+++ b/apps/app/ui-tests-app/tab-view/tab-view-bottom-position.xml
@@ -1,0 +1,20 @@
+<Page>
+  <TabView androidTabsPosition="bottom">
+    <TabView.items>
+      <TabViewItem title="First">
+        <TabViewItem.view>
+          <GridLayout>
+            <Label text="First View" verticalAlignment="center" horizontalAlignment="center"/>
+          </GridLayout>
+        </TabViewItem.view>
+      </TabViewItem>
+      <TabViewItem title="Second">
+        <TabViewItem.view>
+          <GridLayout>
+            <Label text="Second View" verticalAlignment="center" horizontalAlignment="center"/>
+          </GridLayout>
+        </TabViewItem.view>
+      </TabViewItem>
+    </TabView.items>
+  </TabView>
+</Page>

--- a/tns-core-modules/ui/tab-view/tab-view-common.ts
+++ b/tns-core-modules/ui/tab-view/tab-view-common.ts
@@ -92,6 +92,7 @@ export class TabViewBase extends View implements TabViewDefinition, AddChildFrom
     public items: TabViewItemDefinition[];
     public selectedIndex: number;
     public androidOffscreenTabLimit: number;
+    public androidTabsPosition: "top" | "bottom";
     public iosIconRenderingMode: "automatic" | "alwaysOriginal" | "alwaysTemplate";
 
     get androidSelectedTabHighlightColor(): Color {
@@ -177,7 +178,7 @@ export class TabViewBase extends View implements TabViewDefinition, AddChildFrom
                 if (!item.view) {
                     throw new Error(`TabViewItem must have a view.`);
                 }
-                
+
                 this._addView(item);
             });
         }
@@ -248,6 +249,9 @@ export const androidOffscreenTabLimitProperty = new Property<TabViewBase, number
     valueConverter: (v) => parseInt(v)
 });
 androidOffscreenTabLimitProperty.register(TabViewBase);
+
+export const androidTabsPositionProperty = new Property<TabViewBase, "top" | "bottom">({ name: "androidTabsPosition", defaultValue: "top" });
+androidTabsPositionProperty.register(TabViewBase);
 
 export const tabTextColorProperty = new CssProperty<Style, Color>({ name: "tabTextColor", cssName: "tab-text-color", equalityComparer: Color.equals, valueConverter: (v) => new Color(v) });
 tabTextColorProperty.register(Style);

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -5,8 +5,8 @@ import {
     TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty,
     tabTextColorProperty, tabBackgroundColorProperty, selectedTabTextColorProperty,
     androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty,
-    androidTabsPositionProperty, fontSizeProperty, fontInternalProperty, View, layout,
-    traceCategory, traceEnabled, traceWrite, Color
+    fontSizeProperty, fontInternalProperty, View, layout, traceCategory, traceEnabled, 
+    traceWrite, Color
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
 import { fromFileOrResource } from "../../image-source";
@@ -585,21 +585,6 @@ export class TabView extends TabViewBase {
         const color = value instanceof Color ? value.android : value;
         tabLayout.setSelectedIndicatorColors([color]);
     }
-
-    // [androidTabsPositionProperty.getDefault](): "top" | "bottom" {
-    //     return "top";
-    // }
-    // [androidTabsPositionProperty.setNative](value: "top" | "bottom") {
-    //     let items = this.items;
-    //     if (items && items.length) {
-    //         for (let i = 0, length = items.length; i < length; i++) {
-    //             const item = items[i];
-    //             if (item.iconSource) {
-    //                 (<TabViewItem>item)._update();
-    //             }
-    //         }
-    //     }
-    // }
 }
 
 function tryCloneDrawable(value: android.graphics.drawable.Drawable, resources: android.content.res.Resources): android.graphics.drawable.Drawable {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -5,7 +5,7 @@ import {
     TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty,
     tabTextColorProperty, tabBackgroundColorProperty, selectedTabTextColorProperty,
     androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty,
-    fontSizeProperty, fontInternalProperty, View, layout,
+    androidTabsPositionProperty, fontSizeProperty, fontInternalProperty, View, layout,
     traceCategory, traceEnabled, traceWrite, Color
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
@@ -367,29 +367,28 @@ export class TabView extends TabViewBase {
 
         const context: android.content.Context = this._context;
         const nativeView = new org.nativescript.widgets.GridLayout(context);
-        nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
-        nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
-
-        const tabLayout = new org.nativescript.widgets.TabLayout(context);
-        nativeView.addView(tabLayout);
-        (<any>nativeView).tabLayout = tabLayout;
-
-        setElevation(nativeView, tabLayout);
-
-        const accentColor = getDefaultAccentColor(context);
-        if (accentColor) {
-            tabLayout.setSelectedIndicatorColors([accentColor]);
-        }
-
-        const primaryColor = ad.resources.getPaletteColor(PRIMARY_COLOR, context);
-        if (primaryColor) {
-            tabLayout.setBackgroundColor(primaryColor);
-        }
-
         const viewPager = new android.support.v4.view.ViewPager(context);
+        const tabLayout = new org.nativescript.widgets.TabLayout(context);
         const lp = new org.nativescript.widgets.CommonLayoutParams();
+        const primaryColor = ad.resources.getPaletteColor(PRIMARY_COLOR, context);
+        let accentColor = getDefaultAccentColor(context);
+
         lp.row = 1;
-        viewPager.setLayoutParams(lp);
+
+        if (this.androidTabsPosition === "top") {
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+
+            viewPager.setLayoutParams(lp);
+        } else {
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+
+            tabLayout.setLayoutParams(lp);
+            // set completely transparent accent color for tab selected indicator.
+            accentColor = 0x00FFFFFF;
+        }
+
         nativeView.addView(viewPager);
         (<any>nativeView).viewPager = viewPager;
 
@@ -397,7 +396,55 @@ export class TabView extends TabViewBase {
         viewPager.setAdapter(adapter);
         (<any>viewPager).adapter = adapter;
 
+        nativeView.addView(tabLayout);
+        (<any>nativeView).tabLayout = tabLayout;
+
+        setElevation(nativeView, tabLayout);
+
+        if (accentColor) {
+            tabLayout.setSelectedIndicatorColors([accentColor]);
+        }
+
+        if (primaryColor) {
+            tabLayout.setBackgroundColor(primaryColor);
+        }
+
+        console.log(this.androidTabsPosition);
         return nativeView;
+
+        // const context: android.content.Context = this._context;
+        // const nativeView = new org.nativescript.widgets.GridLayout(context);
+        // nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+        // nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+
+        // const tabLayout = new org.nativescript.widgets.TabLayout(context);
+        // nativeView.addView(tabLayout);
+        // (<any>nativeView).tabLayout = tabLayout;
+
+        // setElevation(nativeView, tabLayout);
+
+        // const accentColor = getDefaultAccentColor(context);
+        // if (accentColor) {
+        //     tabLayout.setSelectedIndicatorColors([accentColor]);
+        // }
+
+        // const primaryColor = ad.resources.getPaletteColor(PRIMARY_COLOR, context);
+        // if (primaryColor) {
+        //     tabLayout.setBackgroundColor(primaryColor);
+        // }
+
+        // const viewPager = new android.support.v4.view.ViewPager(context);
+        // const lp = new org.nativescript.widgets.CommonLayoutParams();
+        // lp.row = 1;
+        // viewPager.setLayoutParams(lp);
+        // nativeView.addView(viewPager);
+        // (<any>nativeView).viewPager = viewPager;
+
+        // const adapter = new PagerAdapter(this);
+        // viewPager.setAdapter(adapter);
+        // (<any>viewPager).adapter = adapter;
+
+        // return nativeView;
     }
 
     public initNativeView(): void {
@@ -572,6 +619,21 @@ export class TabView extends TabViewBase {
         const color = value instanceof Color ? value.android : value;
         tabLayout.setSelectedIndicatorColors([color]);
     }
+
+    // [androidTabsPositionProperty.getDefault](): "top" | "bottom" {
+    //     return "top";
+    // }
+    // [androidTabsPositionProperty.setNative](value: "top" | "bottom") {
+    //     let items = this.items;
+    //     if (items && items.length) {
+    //         for (let i = 0, length = items.length; i < length; i++) {
+    //             const item = items[i];
+    //             if (item.iconSource) {
+    //                 (<TabViewItem>item)._update();
+    //             }
+    //         }
+    //     }
+    // }
 }
 
 function tryCloneDrawable(value: android.graphics.drawable.Drawable, resources: android.content.res.Resources): android.graphics.drawable.Drawable {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -367,7 +367,7 @@ export class TabView extends TabViewBase {
 
         const context: android.content.Context = this._context;
         const nativeView = new org.nativescript.widgets.GridLayout(context);
-        const viewPager = new android.support.v4.view.ViewPager(context);
+        const viewPager = new org.nativescript.widgets.TabViewPager(context);
         const tabLayout = new org.nativescript.widgets.TabLayout(context);
         const lp = new org.nativescript.widgets.CommonLayoutParams();
         const primaryColor = ad.resources.getPaletteColor(PRIMARY_COLOR, context);
@@ -385,6 +385,7 @@ export class TabView extends TabViewBase {
             nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
 
             tabLayout.setLayoutParams(lp);
+            viewPager.setSwipePageEnabled(false);
             // set completely transparent accent color for tab selected indicator.
             accentColor = 0x00FFFFFF;
         }
@@ -409,42 +410,7 @@ export class TabView extends TabViewBase {
             tabLayout.setBackgroundColor(primaryColor);
         }
 
-        console.log(this.androidTabsPosition);
         return nativeView;
-
-        // const context: android.content.Context = this._context;
-        // const nativeView = new org.nativescript.widgets.GridLayout(context);
-        // nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
-        // nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
-
-        // const tabLayout = new org.nativescript.widgets.TabLayout(context);
-        // nativeView.addView(tabLayout);
-        // (<any>nativeView).tabLayout = tabLayout;
-
-        // setElevation(nativeView, tabLayout);
-
-        // const accentColor = getDefaultAccentColor(context);
-        // if (accentColor) {
-        //     tabLayout.setSelectedIndicatorColors([accentColor]);
-        // }
-
-        // const primaryColor = ad.resources.getPaletteColor(PRIMARY_COLOR, context);
-        // if (primaryColor) {
-        //     tabLayout.setBackgroundColor(primaryColor);
-        // }
-
-        // const viewPager = new android.support.v4.view.ViewPager(context);
-        // const lp = new org.nativescript.widgets.CommonLayoutParams();
-        // lp.row = 1;
-        // viewPager.setLayoutParams(lp);
-        // nativeView.addView(viewPager);
-        // (<any>nativeView).viewPager = viewPager;
-
-        // const adapter = new PagerAdapter(this);
-        // viewPager.setAdapter(adapter);
-        // (<any>viewPager).adapter = adapter;
-
-        // return nativeView;
     }
 
     public initNativeView(): void {

--- a/tns-core-modules/ui/tab-view/tab-view.d.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.d.ts
@@ -110,6 +110,14 @@ export class TabView extends View {
     androidOffscreenTabLimit: number;
 
     /**
+     * Gets or set the tabs vertical position.
+     * Valid values are:
+     *  - top
+     *  - bottom
+     */
+    androidTabsPosition: "top" | "bottom";
+
+    /**
      * String value used when hooking to the selectedIndexChanged event.
      */
     public static selectedIndexChangedEvent: string;

--- a/tns-platform-declarations/android/org.nativescript.widgets.d.ts
+++ b/tns-platform-declarations/android/org.nativescript.widgets.d.ts
@@ -371,6 +371,13 @@
                 getItemCount(): number;
             }
 
+            export class TabViewPager extends android.support.v4.view.ViewPager {
+                constructor(context: android.content.Context);
+                constructor(context: android.content.Context, attrs: android.util.IAttributeSet);
+
+                setSwipePageEnabled(enabled: boolean): void;
+            }
+
             export class TabItemSpec {
                 title: string;
                 iconId: number;


### PR DESCRIPTION
Changes:
1. Add `androidTabsPosition` property that enables positioning the tab view items `top` or `bottom`. 
2. Switch to the new [`TabViewPager`](https://github.com/NativeScript/tns-core-modules-widgets/pull/112) in order to disable swipe gestures over the content area (when  `androidTabsPosition="bottom"`.