### PR TITLE
Implemented cookie sync between wkwebview & sharedHTTPCookieStorage

### DIFF
--- a/tns-core-modules/ui/web-view/web-view-common.ts
+++ b/tns-core-modules/ui/web-view/web-view-common.ts
@@ -1,11 +1,13 @@
 import { WebView as WebViewDefinition, LoadEventData, NavigationType } from ".";
-import { ContainerView, Property, EventData, CSSType } from "../core/view";
+import { booleanConverter, ContainerView, CSSType, EventData, Property } from "../core/view";
 import { File, knownFolders, path } from "../../file-system";
 
 export { File, knownFolders, path, NavigationType };
 export * from "../core/view";
 
 export const srcProperty = new Property<WebViewBase, string>({ name: "src" });
+export const syncCookiesProperty = new Property<WebViewBase, boolean>({ name: "syncCookies", defaultValue: false, valueConverter: booleanConverter });
+export const cookieExpiresInProperty = new Property<WebViewBase, boolean>({ name: "cookieExpiresIn" });
 
 @CSSType("WebView")
 export abstract class WebViewBase extends ContainerView implements WebViewDefinition {
@@ -13,6 +15,8 @@ export abstract class WebViewBase extends ContainerView implements WebViewDefini
     public static loadFinishedEvent = "loadFinished";
 
     public src: string;
+    public syncCookies: boolean;
+    public cookieExpiresIn: string;
 
     public _onLoadFinished(url: string, error?: string) {
         let args = <LoadEventData>{
@@ -100,3 +104,5 @@ export interface WebViewBase {
 }
 
 srcProperty.register(WebViewBase);
+syncCookiesProperty.register(WebViewBase);
+cookieExpiresInProperty.register(WebViewBase);

--- a/tns-core-modules/ui/web-view/web-view-common.ts
+++ b/tns-core-modules/ui/web-view/web-view-common.ts
@@ -7,7 +7,7 @@ export * from "../core/view";
 
 export const srcProperty = new Property<WebViewBase, string>({ name: "src" });
 export const syncCookiesProperty = new Property<WebViewBase, boolean>({ name: "syncCookies", defaultValue: false, valueConverter: booleanConverter });
-export const cookieExpiresInProperty = new Property<WebViewBase, boolean>({ name: "cookieExpiresIn" });
+export const cookieExpiresInProperty = new Property<WebViewBase, number>({ name: "cookieExpiresIn", valueConverter: parseInt });
 
 @CSSType("WebView")
 export abstract class WebViewBase extends ContainerView implements WebViewDefinition {
@@ -16,7 +16,7 @@ export abstract class WebViewBase extends ContainerView implements WebViewDefini
 
     public src: string;
     public syncCookies: boolean;
-    public cookieExpiresIn: string;
+    public cookieExpiresIn: number;
 
     public _onLoadFinished(url: string, error?: string) {
         let args = <LoadEventData>{

--- a/tns-core-modules/ui/web-view/web-view.android.ts
+++ b/tns-core-modules/ui/web-view/web-view.android.ts
@@ -3,7 +3,7 @@ import { WebViewBase, knownFolders, traceEnabled, traceWrite, traceCategories } 
 export * from "./web-view-common";
 
 interface WebViewClient {
-    new (owner: WebView): android.webkit.WebViewClient;
+    new(owner: WebView): android.webkit.WebViewClient;
 }
 
 let WebViewClient: WebViewClient;

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -39,10 +39,10 @@ class WKNavigationDelegateImpl extends NSObject
             if (traceEnabled()) {
                 traceWrite("WKNavigationDelegateClass.webViewDecidePolicyForNavigationActionDecisionHandler(" + navigationAction.request.URL.absoluteString + ", " + navigationAction.navigationType + ")", traceCategories.Debug);
             }
-            
-            if ( owner.syncCookies ) {
+
+            if (owner.syncCookies) {
                 // Following handle will get invoked for subsequent page navigation and updates the sharedHTTPCookieStorage
-                webView.evaluateJavaScriptCompletionHandler("window.webkit.messageHandlers.updateCookies.postMessage(document.cookie);", null);            
+                webView.evaluateJavaScriptCompletionHandler("window.webkit.messageHandlers.updateCookies.postMessage(document.cookie);", null);
             }
             owner._onLoadStarted(navigationAction.request.URL.absoluteString, navType);
         }
@@ -108,7 +108,7 @@ class WKScriptMessageHandlerImpl extends NSObject
                 }
 
                 // we need NSHTTPCookieOriginURL for NSHTTPCookie to be created
-                let cookieWithURL = cookies[i] + "; ORIGINURL=" + owner.ios.URL ;
+                let cookieWithURL = cookies[i] + "; ORIGINURL=" + owner.ios.URL;
                 let httpCookie = this.getCookie(cookieWithURL);
 
                 if (httpCookie) {
@@ -134,38 +134,38 @@ class WKScriptMessageHandlerImpl extends NSObject
             let value = cookieMap[key];
             let uppercaseKey = key.toUpperCase();
 
-            if ( uppercaseKey === "DOMAIN" ) {
+            if (uppercaseKey === "DOMAIN") {
                 if (!value.startsWith(".") && !value.startsWith("www")) {
                     value = "." + value;
                 }
 
                 cookieProperties.setObjectForKey(value, NSHTTPCookieDomain);
-            } else if ( uppercaseKey === "VERSION" ) {
+            } else if (uppercaseKey === "VERSION") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieVersion);
-            } else if ( uppercaseKey === "MAX-AGE" || uppercaseKey === "MAXAGE" ) {
+            } else if (uppercaseKey === "MAX-AGE" || uppercaseKey === "MAXAGE") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieMaximumAge);
-            } else if ( uppercaseKey === "PATH" ) {
+            } else if (uppercaseKey === "PATH") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookiePath);
-            } else if ( uppercaseKey === "ORIGINURL" ) {
+            } else if (uppercaseKey === "ORIGINURL") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieOriginURL);
-            } else if ( uppercaseKey === "PORT" ) {
+            } else if (uppercaseKey === "PORT") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookiePort);
-            } else if ( uppercaseKey === "SECURE" || uppercaseKey === "ISSECURE" ) {
+            } else if (uppercaseKey === "SECURE" || uppercaseKey === "ISSECURE") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieSecure);
-            } else if ( uppercaseKey === "COMMENT" ) {
+            } else if (uppercaseKey === "COMMENT") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieComment);
-            } else if ( uppercaseKey === "COMMENTURL" ) {
+            } else if (uppercaseKey === "COMMENTURL") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieCommentURL);
-            } else if ( uppercaseKey === "EXPIRES" ) {
+            } else if (uppercaseKey === "EXPIRES") {
                 let dateFormatter: NSDateFormatter = NSDateFormatter.new();
                 dateFormatter.locale = NSLocale.alloc().initWithLocaleIdentifier("en_US");
                 dateFormatter.dateFormat = "EEE, dd-MMM-yyyy HH:mm:ss zzz";
                 cookieProperties.setObjectForKey(dateFormatter.dateFromString(value), NSHTTPCookieExpires);
-            } else if ( uppercaseKey === "DISCART" ) {
+            } else if (uppercaseKey === "DISCART") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieDiscard);
-            } else if ( uppercaseKey === "NAME" ) {
+            } else if (uppercaseKey === "NAME") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieName);
-            } else if ( uppercaseKey === "VALUE" ) {
+            } else if (uppercaseKey === "VALUE") {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieValue);
             } else {
                 cookieProperties.setObjectForKey(key, NSHTTPCookieName);
@@ -174,13 +174,13 @@ class WKScriptMessageHandlerImpl extends NSObject
         }
 
         // document.cookie doesn't return cookie expiration date, so added cookieExpiresIn property for overriding
-        if ( !cookieProperties[NSHTTPCookieExpires] && cookieExpiresIn ) {
+        if (!cookieProperties[NSHTTPCookieExpires] && cookieExpiresIn) {
             let currentDate = NSDate.date();
             let expireDate = currentDate.dateByAddingTimeInterval(cookieExpiresIn);
             cookieProperties.setObjectForKey(expireDate, NSHTTPCookieExpires);
         }
 
-        if ( !cookieProperties.objectForKey(NSHTTPCookiePath) ) {
+        if (!cookieProperties.objectForKey(NSHTTPCookiePath)) {
             cookieProperties.setObjectForKey("/", NSHTTPCookiePath);
         }
 
@@ -192,11 +192,11 @@ class WKScriptMessageHandlerImpl extends NSObject
         let cookieMap = [];
         let cookieKeyValueStrings = cookieWithURL.split(";");
 
-        for ( let i = 0; i < cookieKeyValueStrings.length; i++ ) {
+        for (let i = 0; i < cookieKeyValueStrings.length; i++) {
             let cookieKeyValueString = cookieKeyValueStrings[i];
 
             let separator = cookieKeyValueString.indexOf("=");
-            if ( separator !== -1 && separator > 0 && separator < cookieKeyValueString.length ) {
+            if (separator !== -1 && separator > 0 && separator < cookieKeyValueString.length) {
                 let key = cookieKeyValueString.substring(0, separator).trim();
                 let value = cookieKeyValueString.substring(separator + 1).trim()
                 cookieMap[key] = value;
@@ -241,7 +241,7 @@ export class WebView extends WebViewBase {
     }
 
     private javascriptStringWithCookie(cookie: NSHTTPCookie) {
-        let cookieString = cookie.name + "=" + cookie.value + ";domain=" + cookie.domain + ";path=" + (cookie.path?cookie.path:"/");
+        let cookieString = cookie.name + "=" + cookie.value + ";domain=" + cookie.domain + ";path=" + (cookie.path ? cookie.path : "/");
 
         if (cookie.secure) {
             cookieString += ";secure=true";
@@ -313,18 +313,18 @@ export class WebView extends WebViewBase {
                 for (let i = 0; i < NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies.count; i++) {
                     let cookie: NSHTTPCookie = NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies[i];
                     if (cookie.name.includes("'")) {
-                        traceWrite("Skipping " + cookie.properties + " because it contains a '", traceCategories.Debug);                
+                        traceWrite("Skipping " + cookie.properties + " because it contains a '", traceCategories.Debug);
                         continue;
                     }
 
                     if (!cookie.domain.endsWith(validDomain)) {
-                        traceWrite("Skipping " + cookie.properties + " (because not " + validDomain + ")", traceCategories.Debug);     
+                        traceWrite("Skipping " + cookie.properties + " (because not " + validDomain + ")", traceCategories.Debug);
                         continue;
                     }
 
                     // Are we secure only?
                     if (cookie.secure && !requestIsSecure) {
-                        traceWrite("Skipping " + cookie.properties + " (because " + url.absoluteString + " not secure)", traceCategories.Debug);                             
+                        traceWrite("Skipping " + cookie.properties + " (because " + url.absoluteString + " not secure)", traceCategories.Debug);
                         continue;
                     }
 
@@ -332,7 +332,7 @@ export class WebView extends WebViewBase {
                 }
 
                 let header = cookieArray.join(";");
-                traceWrite("cookie header = " + header, traceCategories.Debug);        
+                traceWrite("cookie header = " + header, traceCategories.Debug);
                 request.setValueForHTTPHeaderField(header, "Cookie");
             }
             this.ios.loadRequest(request);

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -42,7 +42,7 @@ class WKNavigationDelegateImpl extends NSObject
             
             if ( owner.syncCookies ) {
                 // Following handle will get invoked for subsequent page navigation and updates the sharedHTTPCookieStorage
-                webView.evaluateJavaScriptCompletionHandler("window.webkit.messageHandlers.updateCookies.postMessage(document.cookie);",(val,err)=>{});            
+                webView.evaluateJavaScriptCompletionHandler("window.webkit.messageHandlers.updateCookies.postMessage(document.cookie);", null);            
             }
             owner._onLoadStarted(navigationAction.request.URL.absoluteString, navType);
         }
@@ -134,38 +134,38 @@ class WKScriptMessageHandlerImpl extends NSObject
             let value = cookieMap[key];
             let uppercaseKey = key.toUpperCase();
 
-            if ( uppercaseKey == "DOMAIN" ) {
+            if ( uppercaseKey === "DOMAIN" ) {
                 if (!value.startsWith('.') && !value.startsWith('www')) {
                     value = "." + value;
                 }
 
                 cookieProperties.setObjectForKey(value, NSHTTPCookieDomain);
-            } else if ( uppercaseKey == "VERSION" ) {
+            } else if ( uppercaseKey === "VERSION" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieVersion);
-            } else if ( uppercaseKey == "MAX-AGE" || uppercaseKey == "MAXAGE" ) {
+            } else if ( uppercaseKey === "MAX-AGE" || uppercaseKey === "MAXAGE" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieMaximumAge);
-            } else if ( uppercaseKey == "PATH" ) {
+            } else if ( uppercaseKey === "PATH" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookiePath);
-            } else if ( uppercaseKey == "ORIGINURL" ) {
+            } else if ( uppercaseKey === "ORIGINURL" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieOriginURL);
-            } else if ( uppercaseKey == "PORT" ) {
+            } else if ( uppercaseKey === "PORT" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookiePort);
-            } else if ( uppercaseKey == "SECURE" || uppercaseKey == "ISSECURE" ) {
+            } else if ( uppercaseKey === "SECURE" || uppercaseKey === "ISSECURE" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieSecure);
-            } else if ( uppercaseKey == "COMMENT" ) {
+            } else if ( uppercaseKey === "COMMENT" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieComment);
-            } else if ( uppercaseKey == "COMMENTURL" ) {
+            } else if ( uppercaseKey === "COMMENTURL" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieCommentURL);
-            } else if ( uppercaseKey == "EXPIRES" ) {
+            } else if ( uppercaseKey === "EXPIRES" ) {
                 let dateFormatter: NSDateFormatter = NSDateFormatter.new();
                 dateFormatter.locale = NSLocale.alloc().initWithLocaleIdentifier("en_US");
                 dateFormatter.dateFormat = "EEE, dd-MMM-yyyy HH:mm:ss zzz";
                 cookieProperties.setObjectForKey(dateFormatter.dateFromString(value), NSHTTPCookieExpires);
-            } else if ( uppercaseKey == "DISCART" ) {
+            } else if ( uppercaseKey === "DISCART" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieDiscard);
-            } else if ( uppercaseKey == "NAME" ) {
+            } else if ( uppercaseKey === "NAME" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieName);
-            } else if ( uppercaseKey == "VALUE" ) {
+            } else if ( uppercaseKey === "VALUE" ) {
                 cookieProperties.setObjectForKey(value, NSHTTPCookieValue);
             } else {
                 cookieProperties.setObjectForKey(key, NSHTTPCookieName);
@@ -196,7 +196,7 @@ class WKScriptMessageHandlerImpl extends NSObject
             let cookieKeyValueString = cookieKeyValueStrings[i];
 
             let separator = cookieKeyValueString.indexOf('=');
-            if ( separator != -1 && separator > 0 && separator < cookieKeyValueString.length ) {
+            if ( separator !== -1 && separator > 0 && separator < cookieKeyValueString.length ) {
                 let key = cookieKeyValueString.substring(0, separator).trim();
                 let value = cookieKeyValueString.substring(separator + 1).trim()
                 cookieMap[key] = value;
@@ -307,7 +307,7 @@ export class WebView extends WebViewBase {
 
             if (this.syncCookies) {
                 let validDomain = url.host;
-                let requestIsSecure = (url.scheme == 'https');
+                let requestIsSecure = (url.scheme === 'https');
 
                 let cookieArray = [];
                 for (let i = 0; i < NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies.count; i++) {
@@ -321,7 +321,6 @@ export class WebView extends WebViewBase {
                         traceWrite("Skipping " + cookie.properties + " (because not " + validDomain + ")", traceCategories.Debug);     
                         continue;
                     }
-
 
                     // Are we secure only?
                     if (cookie.secure && !requestIsSecure) {

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -39,6 +39,9 @@ class WKNavigationDelegateImpl extends NSObject
             if (traceEnabled()) {
                 traceWrite("WKNavigationDelegateClass.webViewDecidePolicyForNavigationActionDecisionHandler(" + navigationAction.request.URL.absoluteString + ", " + navigationAction.navigationType + ")", traceCategories.Debug);
             }
+
+            // Following handle will get invoke for subsequent page navigation and updates the sharedHTTPCookieStorage
+            webView.evaluateJavaScriptCompletionHandler("window.webkit.messageHandlers.updateCookies.postMessage(document.cookie);",(val,err)=>{});            
             owner._onLoadStarted(navigationAction.request.URL.absoluteString, navType);
         }
     }
@@ -79,9 +82,134 @@ class WKNavigationDelegateImpl extends NSObject
 
 }
 
+// WKScriptMessageHandlerImpl javascript handler will updates the document.cookie to sharedHTTPCookieStorage
+class WKScriptMessageHandlerImpl extends NSObject
+    implements WKScriptMessageHandler {
+    public static ObjCProtocols = [WKScriptMessageHandler];
+    public static initWithOwner(owner: WeakRef<WebView>): WKScriptMessageHandlerImpl {
+        const handler = <WKScriptMessageHandlerImpl>WKScriptMessageHandlerImpl.new();
+        handler._owner = owner;
+        return handler;
+    }
+    private _owner: WeakRef<WebView>;
+
+    public userContentControllerDidReceiveScriptMessage(userContentController: WKUserContentController, message: WKScriptMessage): void {
+        const owner = this._owner.get();
+        if (owner) {
+            let body: string = message.body;
+            let cookies = body.split("; ");
+            for (let i = 0; i < cookies.length; i++) {
+                let comps = cookies[i].split('=');
+
+                if (comps.length < 2) {
+                    continue;
+                }
+
+                // we need NSHTTPCookieOriginURL for NSHTTPCookie to be created
+                let cookieWithURL = cookies[i] + "; ORIGINURL=" + owner.ios.URL ;
+                let httpCookie = this.getCookie(cookieWithURL);
+
+                if (httpCookie) {
+                    traceWrite("Adding cookie to sharedHTTPCookieStorage = " + httpCookie, traceCategories.Debug);
+                    NSHTTPCookieStorage.sharedHTTPCookieStorage.setCookie(httpCookie);
+                }
+            }
+        }
+    }
+
+    private getCookie(cookieWithURL): NSHTTPCookie {
+        let cookieExpiresIn = null;
+        const owner = this._owner.get();
+        if (owner) {
+            cookieExpiresIn = owner.cookieExpiresIn;
+        }
+
+        let cookieMap = this.cookieMap(cookieWithURL);
+        let cookieProperties = NSMutableDictionary.new();
+
+        for (let key in cookieMap) {
+
+            let value = cookieMap[key];
+            let uppercaseKey = key.toUpperCase();
+
+            if ( uppercaseKey == "DOMAIN" ) {
+                if (!value.startsWith('.') && !value.startsWith('www')) {
+                    value = "." + value;
+                }
+
+                cookieProperties.setObjectForKey(value, NSHTTPCookieDomain);
+            } else if ( uppercaseKey == "VERSION" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieVersion);
+            } else if ( uppercaseKey == "MAX-AGE" || uppercaseKey == "MAXAGE" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieMaximumAge);
+            } else if ( uppercaseKey == "PATH" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookiePath);
+            } else if ( uppercaseKey == "ORIGINURL" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieOriginURL);
+            } else if ( uppercaseKey == "PORT" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookiePort);
+            } else if ( uppercaseKey == "SECURE" || uppercaseKey == "ISSECURE" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieSecure);
+            } else if ( uppercaseKey == "COMMENT" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieComment);
+            } else if ( uppercaseKey == "COMMENTURL" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieCommentURL);
+            } else if ( uppercaseKey == "EXPIRES" ) {
+                let dateFormatter: NSDateFormatter = NSDateFormatter.new();
+                dateFormatter.locale = NSLocale.alloc().initWithLocaleIdentifier("en_US");
+                dateFormatter.dateFormat = "EEE, dd-MMM-yyyy HH:mm:ss zzz";
+                cookieProperties.setObjectForKey(dateFormatter.dateFromString(value), NSHTTPCookieExpires);
+            } else if ( uppercaseKey == "DISCART" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieDiscard);
+            } else if ( uppercaseKey == "NAME" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieName);
+            } else if ( uppercaseKey == "VALUE" ) {
+                cookieProperties.setObjectForKey(value, NSHTTPCookieValue);
+            } else {
+                cookieProperties.setObjectForKey(key, NSHTTPCookieName);
+                cookieProperties.setObjectForKey(value, NSHTTPCookieValue);
+            }
+        }
+
+        // document.cookie doesn't return cookie expiration date, so added cookieExpiresIn property for overriding
+        if ( !cookieProperties[NSHTTPCookieExpires] && cookieExpiresIn ) {
+            let currentDate = NSDate.date();
+            let expireDate = currentDate.dateByAddingTimeInterval(cookieExpiresIn);
+            cookieProperties.setObjectForKey(expireDate, NSHTTPCookieExpires);
+        }
+
+        if ( !cookieProperties.objectForKey(NSHTTPCookiePath) ) {
+            cookieProperties.setObjectForKey("/", NSHTTPCookiePath);
+        }
+
+        let cookie: NSHTTPCookie = NSHTTPCookie.cookieWithProperties(cookieProperties.copy());
+        return cookie;
+    }
+
+    private cookieMap(cookieWithURL): any {
+        let cookieMap = [];
+        let cookieKeyValueStrings = cookieWithURL.split(';');
+
+        for ( let i = 0; i < cookieKeyValueStrings.length; i++ ) {
+            let cookieKeyValueString = cookieKeyValueStrings[i];
+
+            let separator = cookieKeyValueString.indexOf('=');
+            if ( separator != -1 && separator > 0 && separator < cookieKeyValueString.length ) {
+                let key = cookieKeyValueString.substring(0, separator).trim();
+                let value = cookieKeyValueString.substring(separator + 1).trim()
+                cookieMap[key] = value;
+            }
+        }
+
+        return cookieMap;
+    }
+}
+
 export class WebView extends WebViewBase {
     nativeViewProtected: WKWebView;
     private _delegate: any;
+    private _wkUController: any;
+    private _isCookieHandlerAttached: boolean = false;
 
     createNativeView() {
         const jScript = "var meta = document.createElement('meta'); meta.setAttribute('name', 'viewport'); meta.setAttribute('content', 'initial-scale=1.0'); document.getElementsByTagName('head')[0].appendChild(meta);";
@@ -110,6 +238,16 @@ export class WebView extends WebViewBase {
         super.disposeNativeView();
     }
 
+    private javascriptStringWithCookie(cookie: NSHTTPCookie) {
+        let cookieString = cookie.name + "=" + cookie.value + ";domain=" + cookie.domain + ";path=" + (cookie.path?cookie.path:'/');
+
+        if (cookie.secure) {
+            cookieString += ";secure=true";
+        }
+
+        return cookieString;
+    }
+
     @profile
     public onLoaded() {
         super.onLoaded();
@@ -129,11 +267,73 @@ export class WebView extends WebViewBase {
         this.ios.stopLoading();
     }
 
+    setupCookieHandlers() {
+        if (this.syncCookies && !this._isCookieHandlerAttached) {
+            this._isCookieHandlerAttached = true;
+            const jScriptOutCookie = "window.webkit.messageHandlers.updateCookies.postMessage(document.cookie);";
+            const wkUScriptOutCookie = WKUserScript.alloc().initWithSourceInjectionTimeForMainFrameOnly(jScriptOutCookie, WKUserScriptInjectionTime.AtDocumentStart, true);
+            this._wkUController.addUserScript(wkUScriptOutCookie);
+            let cookieScriptHandler = WKScriptMessageHandlerImpl.initWithOwner(new WeakRef(this));
+            this._wkUController.addScriptMessageHandlerName(cookieScriptHandler, "updateCookies");
+
+
+            let jScriptInCookie = "var cookieNames = document.cookie.split('; ').map(function(cookie) { return cookie.split('=')[0] } );";
+            for (let i = 0; i < NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies.count; i++) {
+                let cookie: NSHTTPCookie = NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies[i];
+                if (cookie.name.includes("'")) {
+                    console.log("Skipping " + cookie.properties + " because it contains a '");
+                    continue;
+                }
+
+                jScriptInCookie += "if (cookieNames.indexOf('" + cookie.name + "') == -1) { document.cookie='" + this.javascriptStringWithCookie(cookie) + "'; };";
+            }
+
+            traceWrite("jScriptInCookie = " + jScriptInCookie, traceCategories.Debug);
+            const wkUScriptInCookie = WKUserScript.alloc().initWithSourceInjectionTimeForMainFrameOnly(jScriptInCookie, WKUserScriptInjectionTime.AtDocumentStart, true);
+            this._wkUController.addUserScript(wkUScriptInCookie);
+        }
+    }
+
     public _loadUrl(src: string) {
-        if (src.startsWith("file:///")) {
+        if (src.startsWith('file:///')) {
             this.ios.loadFileURLAllowingReadAccessToURL(NSURL.URLWithString(src), NSURL.URLWithString(src));
         } else {
-            this.ios.loadRequest(NSURLRequest.requestWithURL(NSURL.URLWithString(src)));
+            this.setupCookieHandlers();
+            let url: NSURL = NSURL.URLWithString(src);
+            let request: NSMutableURLRequest = NSMutableURLRequest.requestWithURL(url);
+
+            if (this.syncCookies) {
+                let validDomain = url.host;
+                let requestIsSecure = (url.scheme == 'https');
+
+                let cookieArray = [];
+                for (let i = 0; i < NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies.count; i++) {
+                    let cookie: NSHTTPCookie = NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies[i];
+                    if (cookie.name.includes("'")) {
+                        traceWrite("Skipping " + cookie.properties + " because it contains a '", traceCategories.Debug);                
+                        continue;
+                    }
+
+                    if (!cookie.domain.endsWith(validDomain)) {
+                        traceWrite("Skipping " + cookie.properties + " (because not " + validDomain + ")", traceCategories.Debug);     
+                        continue;
+                    }
+
+
+                    // Are we secure only?
+                    if (cookie.secure && !requestIsSecure) {
+                        traceWrite("Skipping " + cookie.properties + " (because " + url.absoluteString + " not secure)", traceCategories.Debug);                             
+                        continue;
+                    }
+
+                    cookieArray.push(cookie.name + "=" + cookie.value);
+                }
+
+                let header = cookieArray.join(';');
+                traceWrite("cookie header = " + header, traceCategories.Debug);        
+                request.setValueForHTTPHeaderField(header, 'Cookie');
+            }
+            this.ios.loadRequest(request);
         }
     }
 

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -101,7 +101,7 @@ class WKScriptMessageHandlerImpl extends NSObject
             let body: string = message.body;
             let cookies = body.split("; ");
             for (let i = 0; i < cookies.length; i++) {
-                let comps = cookies[i].split('=');
+                let comps = cookies[i].split("=");
 
                 if (comps.length < 2) {
                     continue;
@@ -135,7 +135,7 @@ class WKScriptMessageHandlerImpl extends NSObject
             let uppercaseKey = key.toUpperCase();
 
             if ( uppercaseKey === "DOMAIN" ) {
-                if (!value.startsWith('.') && !value.startsWith('www')) {
+                if (!value.startsWith(".") && !value.startsWith("www")) {
                     value = "." + value;
                 }
 
@@ -190,12 +190,12 @@ class WKScriptMessageHandlerImpl extends NSObject
 
     private cookieMap(cookieWithURL): any {
         let cookieMap = [];
-        let cookieKeyValueStrings = cookieWithURL.split(';');
+        let cookieKeyValueStrings = cookieWithURL.split(";");
 
         for ( let i = 0; i < cookieKeyValueStrings.length; i++ ) {
             let cookieKeyValueString = cookieKeyValueStrings[i];
 
-            let separator = cookieKeyValueString.indexOf('=');
+            let separator = cookieKeyValueString.indexOf("=");
             if ( separator !== -1 && separator > 0 && separator < cookieKeyValueString.length ) {
                 let key = cookieKeyValueString.substring(0, separator).trim();
                 let value = cookieKeyValueString.substring(separator + 1).trim()
@@ -241,7 +241,7 @@ export class WebView extends WebViewBase {
     }
 
     private javascriptStringWithCookie(cookie: NSHTTPCookie) {
-        let cookieString = cookie.name + "=" + cookie.value + ";domain=" + cookie.domain + ";path=" + (cookie.path?cookie.path:'/');
+        let cookieString = cookie.name + "=" + cookie.value + ";domain=" + cookie.domain + ";path=" + (cookie.path?cookie.path:"/");
 
         if (cookie.secure) {
             cookieString += ";secure=true";
@@ -298,7 +298,7 @@ export class WebView extends WebViewBase {
     }
 
     public _loadUrl(src: string) {
-        if (src.startsWith('file:///')) {
+        if (src.startsWith("file:///")) {
             this.ios.loadFileURLAllowingReadAccessToURL(NSURL.URLWithString(src), NSURL.URLWithString(src));
         } else {
             this.setupCookieHandlers();
@@ -307,7 +307,7 @@ export class WebView extends WebViewBase {
 
             if (this.syncCookies) {
                 let validDomain = url.host;
-                let requestIsSecure = (url.scheme === 'https');
+                let requestIsSecure = (url.scheme === "https");
 
                 let cookieArray = [];
                 for (let i = 0; i < NSHTTPCookieStorage.sharedHTTPCookieStorage.cookies.count; i++) {
@@ -331,9 +331,9 @@ export class WebView extends WebViewBase {
                     cookieArray.push(cookie.name + "=" + cookie.value);
                 }
 
-                let header = cookieArray.join(';');
+                let header = cookieArray.join(";");
                 traceWrite("cookie header = " + header, traceCategories.Debug);        
-                request.setValueForHTTPHeaderField(header, 'Cookie');
+                request.setValueForHTTPHeaderField(header, "Cookie");
             }
             this.ios.loadRequest(request);
         }


### PR DESCRIPTION
Fixes https://github.com/NativeScript/NativeScript/issues/5327

The solution is discussed in the following link

https://stackoverflow.com/questions/26573137/can-i-set-the-cookies-to-be-used-by-a-wkwebview

Example usage: 

```xml
 <WebView [src]="url" syncCookies="true" cookieExpiresIn="1209600"></WebView>
```
    
The below two attributes are only implemented for iOS 

- syncCookies - Values accepted true or false. Default value is false.
- cookieExpiresIn - Values specified in seconds. For eg. 1209600 seconds is equal to 14 days


To help the rest of the community review your change, please ensure:

### PR has a meaningful title
A good title is less than 50 characters and starts with a capital
letter, similar to a good [Git Commit Message] (http://chris.beams.io/posts/git-commit/).

### The commit message references a specific issue in this repo
Fixes #5327.

### You have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)
if appropriate.

