### PR TITLE
 fix(ios-layouts): switch contentInsetAdjustmentBehavior on ScrollView 

### DIFF
--- a/apps/app/ui-tests-app/scroll-view/main-page.ts
+++ b/apps/app/ui-tests-app/scroll-view/main-page.ts
@@ -12,5 +12,7 @@ export function pageLoaded(args: EventData) {
 export function loadExamples() {
     const examples = new Map<string, string>();
     examples.set("scrolling-and-sizing", "scroll-view/scrolling-and-sizing");
+    examples.set("safe-area-root-element", "scroll-view/safe-area-root-element");
+    examples.set("safe-area-sub-element", "scroll-view/safe-area-sub-element");
     return examples;
 }

--- a/apps/app/ui-tests-app/scroll-view/safe-area-root-element.xml
+++ b/apps/app/ui-tests-app/scroll-view/safe-area-root-element.xml
@@ -1,0 +1,15 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="onNavigatingTo" class="page">
+
+    <Page.actionBar>
+        <ActionBar title="My App" icon="" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+
+    <ScrollView>
+        <StackLayout>
+            <GridLayout height="30" backgroundColor="red" />
+            <GridLayout height="30" backgroundColor="yellow" />
+            <GridLayout height="30" backgroundColor="green" />
+        </StackLayout>
+    </ScrollView>
+</Page>

--- a/apps/app/ui-tests-app/scroll-view/safe-area-sub-element.xml
+++ b/apps/app/ui-tests-app/scroll-view/safe-area-sub-element.xml
@@ -1,0 +1,17 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="onNavigatingTo" class="page">
+
+    <Page.actionBar>
+        <ActionBar title="My App" icon="" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+
+    <GridLayout>
+        <ScrollView height="50" verticalAlignment="top">
+            <StackLayout>
+                <GridLayout height="30" backgroundColor="red" />
+                <GridLayout height="30" backgroundColor="yellow" />
+                <GridLayout height="30" backgroundColor="green" />
+            </StackLayout>
+        </ScrollView>
+    </GridLayout>
+</Page>

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -371,6 +371,10 @@ export abstract class ViewBase extends Observable {
     /**
      * @private
      */
+    public _automaticallyAdjustsScrollViewInsets: boolean;
+    /**
+     * @private
+     */
     _isStyleScopeHost: boolean;
 
     /**

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -178,7 +178,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     private _templateParent: ViewBase;
     private __nativeView: any;
     // private _disableNativeViewRecycling: boolean;
-    
+
     public domNode: dnm.DOMNode;
 
     public recycleNativeView: "always" | "never" | "auto";
@@ -199,6 +199,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     public _suspendedUpdates: { [propertyName: string]: Property<ViewBase, any> | CssProperty<Style, any> | CssAnimationProperty<Style, any> };
     public _suspendNativeUpdatesCount: SuspendType;
     public _isStyleScopeHost: boolean;
+    public _automaticallyAdjustsScrollViewInsets: boolean;
 
     // Dynamic properties.
     left: Length;

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -592,6 +592,8 @@ export namespace ios {
 
     export function updateAutoAdjustScrollInsets(controller: UIViewController, owner: View): void {
         const scrollable = isContentScrollable(controller, owner);
+
+        owner._automaticallyAdjustsScrollViewInsets = scrollable;
         controller.automaticallyAdjustsScrollViewInsets = scrollable;
     }
 
@@ -733,7 +735,7 @@ export namespace ios {
             if(!owner){
                 return;
             }
-        
+
             updateAutoAdjustScrollInsets(this, owner);
 
             if (!owner.parent) {


### PR DESCRIPTION
Do not auto adjust the `ScrollView` insets, by disabling [contentInsetAdjustmentBehavior](https://developer.apple.com/documentation/uikit/uiscrollviewcontentinsetadjustmentbehavior) property, when `ScrollView` is used as a root `Page` element.

_Node:_ By default UIScrollView is auto adjusting its content inset depending on the constants indicating how safe area insets are added. This 'scrolls' the `ScrollView` under the ActionBar and the safe area when it's placed as a child of the root `Page` element:

```
<Page>
   <ActionBar/>
   <GridLayout>
     <ScrollView/>
   </GridLayout>
</Page>
