### PR TITLE
fix(ios-frame): do not update backstack when navigating the same page

### DIFF
--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -37,6 +37,14 @@ export class Frame extends FrameBase {
         return this._ios;
     }
 
+    public setCurrent(entry: BackstackEntry, isBack: boolean): void {
+        if (entry !== this._currentEntry) {
+            this._updateBackstack(entry, isBack);
+        }
+
+        super.setCurrent(entry, isBack);
+    }
+
     @profile
     public _navigateCore(backstackEntry: BackstackEntry) {
         super._navigateCore(backstackEntry);
@@ -352,7 +360,7 @@ class UINavigationControllerImpl extends UINavigationController {
 
     @profile
     public viewDidDisappear(animated: boolean): void {
-        super.viewDidDisappear(animated);    
+        super.viewDidDisappear(animated);
         const owner = this._owner.get();
         if (owner && owner.isLoaded && !owner.parent && !this.presentedViewController) {
             owner.callUnloaded();

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -138,7 +138,6 @@ class UIViewControllerImpl extends UIViewController {
                 isBack = isBackNavigationTo(owner, newEntry);
             }
 
-            frame._updateBackstack(newEntry, isBack);
             frame.setCurrent(newEntry, isBack);
 
             // If page was shown with custom animation - we need to set the navigationController.delegate to the animatedDelegate.


### PR DESCRIPTION
The problem:
Currently the entries backstack is updated on every page navigation (even if the entry is the same as the current one) which leads to unnecessary unload events.

The Solution: Prevent backstack update when navigating to the same entry ([already done for Android](https://github.com/NativeScript/NativeScript/blob/b8e0beccddbc538860ba72991e3c225fa470836f/tns-core-modules/ui/frame/frame.android.ts#L202))
