### PR TITLE
fix-next(tabview): fix tab title layout in modal root tabview Fixes #5392

### DIFF
--- a/apps/app/ui-tests-app/modal-view/login-page.xml
+++ b/apps/app/ui-tests-app/modal-view/login-page.xml
@@ -1,4 +1,6 @@
-﻿<Page xmlns="http://schemas.nativescript.org/tns.xsd" shownModally="onShownModally" loaded="onLoaded" unloaded="onUnloaded" backgroundColor="Red">
+﻿<Page xmlns="http://schemas.nativescript.org/tns.xsd" shownModally="onShownModally" 
+  loaded="onLoaded" unloaded="onUnloaded" backgroundColor="Red"
+  horizontalAlignment="center" verticalAlignment="middle">
   <StackLayout backgroundColor="PaleGreen" margin="10">
     <TextField hint="username" id="username" text="username"/>
     <TextField hint="password" id="password" text="password" secure="true"/>

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -366,7 +366,19 @@ export class TabView extends TabViewBase {
         }
 
         const context: android.content.Context = this._context;
-        const nativeView = new org.nativescript.widgets.GridLayout(context);
+
+        // In a modal dialog scenario with root tabview inside the DialogFragment 
+        // content at some point is set via PhoneWindow.setContentView(view) call
+        // where "view" is the gridLayout root element of the tabview; 
+        // this results in setContentView(view, new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)) call
+        // that unconditionally overwrites the default instance of CommonLayoutParams attached to the gridLayout by us.
+        // As the default setter essentially created new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.FILL)
+        // we lose the Gravity.FILL setting and that prevents the gridLayout from stretching horizontally 
+        // so tab item titles do not distribute the excess whitespace among themselves.
+        // We need an outer native wrapper element to be laid out by the DialogFragment so
+        // we can perform the layout of the inner gridLayout element as expected.
+        const nativeViewWrapper = new org.nativescript.widgets.GridLayout(context);
+        const gridLayout = new org.nativescript.widgets.GridLayout(context);
         const viewPager = new org.nativescript.widgets.TabViewPager(context);
         const tabLayout = new org.nativescript.widgets.TabLayout(context);
         const lp = new org.nativescript.widgets.CommonLayoutParams();
@@ -376,13 +388,13 @@ export class TabView extends TabViewBase {
         lp.row = 1;
 
         if (this.androidTabsPosition === "top") {
-            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
-            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
 
             viewPager.setLayoutParams(lp);
         } else {
-            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
-            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
 
             tabLayout.setLayoutParams(lp);
             viewPager.setSwipePageEnabled(false);
@@ -390,17 +402,20 @@ export class TabView extends TabViewBase {
             accentColor = 0x00FFFFFF;
         }
 
-        nativeView.addView(viewPager);
-        (<any>nativeView).viewPager = viewPager;
+        nativeViewWrapper.addView(gridLayout);
+        (<any>nativeViewWrapper).gridLayout = gridLayout;
+
+        gridLayout.addView(viewPager);
+        (<any>gridLayout).viewPager = viewPager;
 
         const adapter = new PagerAdapter(this);
         viewPager.setAdapter(adapter);
         (<any>viewPager).adapter = adapter;
 
-        nativeView.addView(tabLayout);
-        (<any>nativeView).tabLayout = tabLayout;
+        gridLayout.addView(tabLayout);
+        (<any>gridLayout).tabLayout = tabLayout;
 
-        setElevation(nativeView, tabLayout);
+        setElevation(gridLayout, tabLayout);
 
         if (accentColor) {
             tabLayout.setSelectedIndicatorColors([accentColor]);
@@ -410,7 +425,7 @@ export class TabView extends TabViewBase {
             tabLayout.setBackgroundColor(primaryColor);
         }
 
-        return nativeView;
+        return nativeViewWrapper;
     }
 
     public initNativeView(): void {
@@ -420,9 +435,9 @@ export class TabView extends TabViewBase {
         }
 
         const nativeView: any = this.nativeViewProtected;
-        this._tabLayout = (<any>nativeView).tabLayout;
+        this._tabLayout = (<any>nativeView).gridLayout.tabLayout;
 
-        const viewPager = (<any>nativeView).viewPager;
+        const viewPager = (<any>nativeView).gridLayout.viewPager;
         viewPager.setId(this._androidViewId);
         this._viewPager = viewPager;
         this._pagerAdapter = (<any>viewPager).adapter;

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -366,19 +366,7 @@ export class TabView extends TabViewBase {
         }
 
         const context: android.content.Context = this._context;
-
-        // In a modal dialog scenario with root tabview inside the DialogFragment 
-        // content at some point is set via PhoneWindow.setContentView(view) call
-        // where "view" is the gridLayout root element of the tabview; 
-        // this results in setContentView(view, new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)) call
-        // that unconditionally overwrites the default instance of CommonLayoutParams attached to the gridLayout by us.
-        // As the default setter essentially created new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.FILL)
-        // we lose the Gravity.FILL setting and that prevents the gridLayout from stretching horizontally 
-        // so tab item titles do not distribute the excess whitespace among themselves.
-        // We need an outer native wrapper element to be laid out by the DialogFragment so
-        // we can perform the layout of the inner gridLayout element as expected.
-        const nativeViewWrapper = new org.nativescript.widgets.GridLayout(context);
-        const gridLayout = new org.nativescript.widgets.GridLayout(context);
+        const nativeView = new org.nativescript.widgets.GridLayout(context);
         const viewPager = new org.nativescript.widgets.TabViewPager(context);
         const tabLayout = new org.nativescript.widgets.TabLayout(context);
         const lp = new org.nativescript.widgets.CommonLayoutParams();
@@ -388,13 +376,13 @@ export class TabView extends TabViewBase {
         lp.row = 1;
 
         if (this.androidTabsPosition === "top") {
-            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
-            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
 
             viewPager.setLayoutParams(lp);
         } else {
-            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
-            gridLayout.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.star));
+            nativeView.addRow(new org.nativescript.widgets.ItemSpec(1, org.nativescript.widgets.GridUnitType.auto));
 
             tabLayout.setLayoutParams(lp);
             viewPager.setSwipePageEnabled(false);
@@ -402,20 +390,17 @@ export class TabView extends TabViewBase {
             accentColor = 0x00FFFFFF;
         }
 
-        nativeViewWrapper.addView(gridLayout);
-        (<any>nativeViewWrapper).gridLayout = gridLayout;
-
-        gridLayout.addView(viewPager);
-        (<any>gridLayout).viewPager = viewPager;
+        nativeView.addView(viewPager);
+        (<any>nativeView).viewPager = viewPager;
 
         const adapter = new PagerAdapter(this);
         viewPager.setAdapter(adapter);
         (<any>viewPager).adapter = adapter;
 
-        gridLayout.addView(tabLayout);
-        (<any>gridLayout).tabLayout = tabLayout;
+        nativeView.addView(tabLayout);
+        (<any>nativeView).tabLayout = tabLayout;
 
-        setElevation(gridLayout, tabLayout);
+        setElevation(nativeView, tabLayout);
 
         if (accentColor) {
             tabLayout.setSelectedIndicatorColors([accentColor]);
@@ -425,7 +410,7 @@ export class TabView extends TabViewBase {
             tabLayout.setBackgroundColor(primaryColor);
         }
 
-        return nativeViewWrapper;
+        return nativeView;
     }
 
     public initNativeView(): void {
@@ -435,9 +420,9 @@ export class TabView extends TabViewBase {
         }
 
         const nativeView: any = this.nativeViewProtected;
-        this._tabLayout = (<any>nativeView).gridLayout.tabLayout;
+        this._tabLayout = (<any>nativeView).tabLayout;
 
-        const viewPager = (<any>nativeView).gridLayout.viewPager;
+        const viewPager = (<any>nativeView).viewPager;
         viewPager.setId(this._androidViewId);
         this._viewPager = viewPager;
         this._pagerAdapter = (<any>viewPager).adapter;


### PR DESCRIPTION
Fixes https://github.com/NativeScript/NativeScript/issues/5392

See comments below.

~~In a modal dialog scenario with root tabview inside, the DialogFragment content at some point is set via PhoneWindow.setContentView(view) call where `view` is the gridLayout root element of the tabview. This results in `setContentView(view, new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))` call that unconditionally overwrites the default instance of CommonLayoutParams attached to the gridLayout by us. As the default setter essentially created `new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.FILL)` we lose the Gravity.FILL setting and that prevents the gridLayout from stretching horizontally so tab item titles do not distribute the excess whitespace among themselves.~~

~~The proposed solution is to add a no-op outer native wrapper element to be laid out by the DialogFragment so we can perform the layout of the inner `gridLayout` element as expected.~~

~~Alternatively (as this problem is related only to modal dialog scenarios and I do not like the solution very much) we can make no changes to the tabview codebase and instruct those devs that hit the problem to add the additional GridLayout wrapper element by themselves in their own application code (the drawback is that it looks "broken" out-of-the-box).~~

Also, @MartoYankov pointed out something else that we might consider at some point -- generally the problem here is triggered by https://github.com/NativeScript/tns-core-modules-widgets/blob/a9ac20da20422ae57aa4cfa76bc03dc27d6bc885/android/widgets/src/main/java/org/nativescript/widgets/GridLayout.java#L259 in the GridLayout codebase that decides how the grid layout should behave based on a setting of its own LayoutParams while Android documentation states that "LayoutParams are used by views to tell their parents how they want to be laid out".  


BREAKING CHANGE: [Android] NativeScript no longer overwrites the horizontal/vertical alignment on the user-defined root visual element when opening it in modal dialog window (i.e. not fullscreen).

If your application logic relied on the previous behavior you need to manually set `horizontalAlignment="center"` and `verticalAlignment="middle"` on the root visual element you are showing modally.

