### PR TITLE
fix-next(modal) fix crash when closing modal dialog with root tabview Fixes #5391

### DIFF
--- a/tests/app/ui/tab-view/tab-view-tests.ts
+++ b/tests/app/ui/tab-view/tab-view-tests.ts
@@ -2,9 +2,9 @@ import { UITest } from "../../ui-test";
 import { Label } from "tns-core-modules/ui/label";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
 import { unsetValue } from "tns-core-modules/ui/core/view";
-import TKUnit = require("../../TKUnit");
-import helper = require("../helper");
-import tabViewTestsNative = require("./tab-view-tests-native");
+import * as TKUnit from "../../TKUnit";
+import * as helper from "../helper";
+import * as tabViewTestsNative from "./tab-view-tests-native";
 
 // Using a TabView requires the "ui/tab-view" module.
 // >> article-require-tabview-module

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -175,21 +175,18 @@ function initializeDialogFragment() {
 
             this._shownCallback();
         }
-
-        public onStop(): void {
-            super.onStop();
-            const owner = this.owner;
-            if (owner.isLoaded) {
-                owner.callUnloaded();
-            }
-        }
-
+        
         public onDismiss(dialog: android.content.IDialogInterface): void {
             super.onDismiss(dialog);
             const manager = this.getFragmentManager();
             if (manager) {
                 removeModal(this.owner._domId);
                 this._dismissCallback();
+            }
+
+            const owner = this.owner;
+            if (owner.isLoaded) {
+                owner.callUnloaded();
             }
         }
 

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -461,6 +461,10 @@ export class TabView extends TabViewBase {
     }
 
     private shouldUpdateAdapter(items: Array<TabViewItemDefinition>) {
+        if (!this._pagerAdapter) {
+            return false;
+        }
+        
         const currentPagerAdapterItems = (<any>this._pagerAdapter).items;
 
         // if both values are null, should not update


### PR DESCRIPTION
Fixes #5391 

Alternative solutions that were considered but ultimately couldn't be used as they exhibited different problems on different API levels and/or in the test harness app:

- Do not force the tabview pager adapter transaction:
``` ts
class FragmentPagerAdapter extends android.support.v4.view.PagerAdapter {

        // ...

        finishUpdate(container: android.view.ViewGroup): void {
            /*if (this.mCurTransaction != null) {
                if (android.os.Build.VERSION.SDK_INT >= 24) {
                    (<any>this.mCurTransaction).commitNowAllowingStateLoss();
                } else {
                    this.mCurTransaction.commitAllowingStateLoss();
                    this.owner._getFragmentManager().executePendingTransactions();
                }

                this.mCurTransaction = null;
            }*/
           if (this.mCurTransaction != null) {
               (<any>this.mCurTransaction).commitAllowingStateLoss();
               this.mCurTransaction = null;
           }
        }
}
```

- Force dialog fragment dismissal transaction:
``` ts
export class View extends ViewCommon {

    // ...

    protected _hideNativeModalView(parent: View) {
        const manager = this._dialogFragment.getFragmentManager();
        if (manager) {
            this._dialogFragment.dismissAllowingStateLoss();
            manager.executePendingTransactions();
        }

        this._dialogFragment = null;
        super._hideNativeModalView(parent);
    }
```

- Bypass DialogFragment.dismissAllowingStateLoss() altogether and implement the fragment removal manually (drawback is that we would change DialogFragment lifecycle a bit e.g. onDismiss() would be called a little bit later -- this does not have noticeable side effects but still):
``` ts
    // in View (view.android.ts)

    protected _hideNativeModalView(parent: View) {
        const manager = this._dialogFragment.getFragmentManager();
        if (manager) {
            const transaction = manager.beginTransaction();
            transaction.remove(this._dialogFragment);
            if (android.os.Build.VERSION.SDK_INT >= 24) {
                transaction.commitNowAllowingStateLoss();
            } else {
                transaction.commitAllowingStateLoss();
                manager.executePendingTransactions();
            }
        }

        this._dialogFragment = null;
        super._hideNativeModalView(parent);
    }
```