### PR TITLE
fix(ios-action-bar): NavigationButton cannot be hidden

### DIFF
--- a/tns-core-modules/ui/action-bar/action-bar-common.ts
+++ b/tns-core-modules/ui/action-bar/action-bar-common.ts
@@ -299,6 +299,12 @@ export class ActionItemBase extends ViewBase implements ActionItemDefinition {
         this.actionView = value;
     }
 
+    public _onVisibilityChanged(visibility: string) {
+        if (this.actionBar) {
+            this.actionBar.update();
+        }
+    }
+
     public eachChild(callback: (child: ViewBase) => boolean) {
         if (this._actionView) {
             callback(this._actionView);
@@ -323,13 +329,17 @@ function onItemChanged(item: ActionItemBase, oldValue: string, newValue: string)
     }
 }
 
+function onVisibilityChanged(item: ActionItemBase, oldValue: string, newValue: string) {
+    item._onVisibilityChanged(newValue);
+}
+
 export const textProperty = new Property<ActionItemBase, string>({ name: "text", defaultValue: "", valueChanged: onItemChanged });
 textProperty.register(ActionItemBase);
 
 export const iconProperty = new Property<ActionItemBase, string>({ name: "icon", valueChanged: onItemChanged });
 iconProperty.register(ActionItemBase);
 
-export const visibilityProperty = new Property({ name: "visibility", defaultValue: "visible", valueChanged: onItemChanged });
+export const visibilityProperty = new Property({ name: "visibility", defaultValue: "visible", valueChanged: onVisibilityChanged });
 visibilityProperty.register(ActionItemBase);
 
 export const flatProperty = new Property<ActionBarBase, boolean>({ name: "flat", defaultValue: false, valueConverter: booleanConverter });

--- a/tns-core-modules/ui/action-bar/action-bar.android.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.android.ts
@@ -103,7 +103,6 @@ export class AndroidActionBarSettings implements AndroidActionBarSettingsDefinit
 }
 
 export class NavigationButton extends ActionItem {
-    //
 }
 
 export class ActionBar extends ActionBarBase {

--- a/tns-core-modules/ui/action-bar/action-bar.d.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.d.ts
@@ -239,7 +239,12 @@ export interface AndroidActionBarSettings {
  * Represents the navigation (a.k.a. "back") button.
  */
 export class NavigationButton extends ActionItem {
-
+    //@private
+    /**
+     * @private
+     */
+    _navigationItem?: any
+    //@endprivate
 }
 
 /** @internal */

--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -44,7 +44,14 @@ export class ActionItem extends ActionItemBase {
 }
 
 export class NavigationButton extends ActionItem {
+    _navigationItem: UINavigationItem;
 
+    public _onVisibilityChanged(visibility: string): void {
+        if (this._navigationItem) {
+            const visible: boolean = visibility === "visible";
+            this._navigationItem.setHidesBackButtonAnimated(!visible, true);
+        }
+    }
 }
 
 export class ActionBar extends ActionBarBase {
@@ -82,7 +89,7 @@ export class ActionBar extends ActionBarBase {
         if (!navBar) {
             return { width: 0, height: 0 };
         }
-        
+
         const frame = navBar.frame;
         const size = frame.size;
         const width = layout.toDevicePixels(size.width);
@@ -158,7 +165,8 @@ export class ActionBar extends ActionBarBase {
 
         // Set back button visibility
         if (this.navigationButton) {
-            navigationItem.setHidesBackButtonAnimated(!isVisible(this.navigationButton), true);
+            this.navigationButton._navigationItem = navigationItem;
+            navigationItem.setHidesBackButtonAnimated(!isVisible(this.navigationButton), false);
         }
 
         // Populate action items


### PR DESCRIPTION
**The problem**: Cannot hide back button when navigating between pages with transition. The problem occurs because of the native fade-in/fade-out animation of the back button.

**The solution**: Disable back button animation when transitioning between pages. Animation should occurs only on manual `NavigationButton` visibility change

Fix https://github.com/NativeScript/NativeScript/issues/5406
Fix https://github.com/NativeScript/nativescript-angular/issues/1194