### PR TITLE
fix(ios-action-bar): NavigationButton text change on first navigation

### DIFF
--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -13,6 +13,8 @@ import * as utils from "../../utils/utils";
 
 export * from "./frame-common";
 
+const majorVersion = utils.ios.MajorVersion;
+
 const ENTRY = "_entry";
 const NAV_DEPTH = "_navDepth";
 const TRANSITION = "_transition";
@@ -85,6 +87,13 @@ export class Frame extends FrameBase {
 
         backstackEntry[NAV_DEPTH] = navDepth;
         viewController[ENTRY] = backstackEntry;
+
+        if (!animated && majorVersion > 10) {
+            // Reset back button title before pushing view controller to prevent
+            // displaying default 'back' title (when NavigaitonButton custom title is set).
+            let barButtonItem = UIBarButtonItem.alloc().initWithTitleStyleTargetAction("", UIBarButtonItemStyle.Plain, null, null);
+            viewController.navigationItem.backBarButtonItem = barButtonItem;
+        }
 
         // First navigation.
         if (!this._currentEntry) {


### PR DESCRIPTION
**The problem**: NavigationButton (a.k.a back button) won't change its title on first navigation when there 
is no transition animation - iOS 11+ only.

**The solution**: Set empty back button title on the parent view controller when navigating

For reference: [stackoverflow1](https://stackoverflow.com/questions/44815042/uinavigationcontroller-back-button-doesnt-hide-title-on-ios-11)  and  [stackoverflow2](https://stackoverflow.com/questions/1449339/how-do-i-change-the-title-of-the-back-button-on-a-navigation-bar) 

Fix https://github.com/NativeScript/NativeScript/issues/5169