### PR TITLE
fix(inspector): Fix --debug-brk issue with Inspector

### DIFF
--- a/tns-core-modules/debugger/devtools-elements.common.ts
+++ b/tns-core-modules/debugger/devtools-elements.common.ts
@@ -27,6 +27,10 @@ function getViewById(nodeId: number): ViewBase {
 
 export function getDocument() {
     const topMostFrame = frameTopmost();
+    if (!topMostFrame) {
+        return undefined;
+    }
+    
     try {
         topMostFrame.ensureDomNode();
         


### PR DESCRIPTION
## What is the current behavior?
The devtools module polutes the log when debugging a iOS app with: tns debug ios --inspector --debug-brk. See issue: https://github.com/NativeScript/ios-runtime/issues/887, https://github.com/NativeScript/ios-runtime/issues/886

## What is the new behavior?
The devtools module does not log each attempt to resolve the topmost frame anymore. The polling is silent up until the frame is resolved.
