### PR TITLE
fix-next(css): CSS not applied to "drawerContent" when RadSideDrawer is used as root

### DIFF
--- a/tests/app/testRunner.ts
+++ b/tests/app/testRunner.ts
@@ -225,20 +225,23 @@ allTests["ANIMATION"] = animationTests;
 import * as lifecycle from "./ui/lifecycle/lifecycle-tests";
 allTests["LIFECYCLE"] = lifecycle;
 
-
 import * as cssAnimationTests from "./ui/animation/css-animation-tests";
 allTests["CSS-ANIMATION"] = cssAnimationTests;
 
 import * as transitionTests from "./navigation/transition-tests";
 allTests["TRANSITIONS"] = transitionTests;
+
 import * as searchBarTests from "./ui/search-bar/search-bar-tests";
 allTests["SEARCH-BAR"] = searchBarTests;
 
 import * as navigationTests from "./navigation/navigation-tests";
 allTests["NAVIGATION"] = navigationTests;
 
-import * as resetRootViewTests from "./navigation/reset-root-view-tests";
+import * as resetRootViewTests from "./ui/root-view/reset-root-view-tests";
 allTests["RESET-ROOT-VIEW"] = resetRootViewTests;
+
+import * as rootViewTests from "./ui/root-view/root-view-tests";
+allTests["ROOT-VIEW"] = rootViewTests;
 
 const testsSuitesWithLongDelay = {
     HTTP: 15 * 1000,

--- a/tests/app/ui/helper.ts
+++ b/tests/app/ui/helper.ts
@@ -215,6 +215,11 @@ export function assertViewBackgroundColor(testView: ViewBase, hexColor: string) 
     TKUnit.assertEqual(testView.style.backgroundColor.hex, hexColor, "backgroundColor property");
 }
 
+export function assertTabSelectedTabTextColor(testView: ViewBase, hexColor: string) {
+    TKUnit.assert(testView.style.selectedTabTextColor, "selectedTabTextColor property not applied correctly. Style value is not defined.");
+    TKUnit.assertEqual(testView.style.selectedTabTextColor.hex, hexColor, "selectedTabTextColor property not applied correctly");
+}
+
 export function forceGC() {
     if (isIOS) {
         /* tslint:disable:no-unused-expression */

--- a/tests/app/ui/root-view/mymodule/MyControl.css
+++ b/tests/app/ui/root-view/mymodule/MyControl.css
@@ -1,0 +1,3 @@
+﻿.MyStackLayout {
+    background-color: red;
+}

--- a/tests/app/ui/root-view/mymodule/MyControl.ts
+++ b/tests/app/ui/root-view/mymodule/MyControl.ts
@@ -1,0 +1,24 @@
+﻿import * as observable from "tns-core-modules/data/observable";
+import * as stackLayoutModule from "tns-core-modules/ui/layouts/stack-layout";
+import * as label from "tns-core-modules/ui/label";
+import * as button from "tns-core-modules/ui/button";
+
+export class MyControl extends stackLayoutModule.StackLayout {
+    constructor() {
+        super();
+
+        var counter: number = 0;
+
+        var lbl = new label.Label();
+        var btn = new button.Button();
+        btn.text = "Tap me!";
+        btn.on(button.Button.tapEvent, (args: observable.EventData) => {
+            lbl.text = "Tap " + counter++;
+        });
+
+        this.addChild(lbl);
+        this.addChild(btn);
+
+        this.className = "MyStackLayout";
+    }
+}

--- a/tests/app/ui/root-view/mymodule/package.json
+++ b/tests/app/ui/root-view/mymodule/package.json
@@ -1,0 +1,2 @@
+{ "name" : "MyControl",
+  "main" : "MyControl.js" }

--- a/tests/app/ui/root-view/reset-root-view-tests.ts
+++ b/tests/app/ui/root-view/reset-root-view-tests.ts
@@ -1,5 +1,5 @@
-﻿import * as TKUnit from "../TKUnit";
-import * as helper from "../ui/helper";
+﻿import * as TKUnit from "../../TKUnit";
+import * as helper from "../helper";
 import { Page } from "tns-core-modules/ui/page";
 import { Frame, NavigationEntry, stack } from "tns-core-modules/ui/frame";
 import { _resetRootView, getRootView } from "tns-core-modules/application";

--- a/tests/app/ui/root-view/root-modules/custom-component-root.css
+++ b/tests/app/ui/root-view/root-modules/custom-component-root.css
@@ -1,0 +1,3 @@
+.MyStackLayoutRoot {
+    background-color: blue;
+}

--- a/tests/app/ui/root-view/root-modules/custom-component-root.xml
+++ b/tests/app/ui/root-view/root-modules/custom-component-root.xml
@@ -1,0 +1,2 @@
+<customControls:MyControl xmlns:customControls="ui/root-view/mymodule" class="MyStackLayoutRoot">
+</customControls:MyControl>

--- a/tests/app/ui/root-view/root-modules/gridlayout-root.css
+++ b/tests/app/ui/root-view/root-modules/gridlayout-root.css
@@ -1,0 +1,3 @@
+.MyStackLayoutRoot {
+    background-color: blue;
+}

--- a/tests/app/ui/root-view/root-modules/gridlayout-root.xml
+++ b/tests/app/ui/root-view/root-modules/gridlayout-root.xml
@@ -1,0 +1,2 @@
+<GridLayout class="MyStackLayoutRoot">
+</GridLayout>

--- a/tests/app/ui/root-view/root-modules/tabview-root.css
+++ b/tests/app/ui/root-view/root-modules/tabview-root.css
@@ -1,0 +1,3 @@
+TabView {
+    selected-tab-text-color: blue;
+}

--- a/tests/app/ui/root-view/root-modules/tabview-root.xml
+++ b/tests/app/ui/root-view/root-modules/tabview-root.xml
@@ -1,0 +1,17 @@
+<TabView>
+    <TabView.items>
+
+    <TabViewItem title="Tab">
+        <TabViewItem.view>
+            <Label text="Tab" />
+        </TabViewItem.view>
+    </TabViewItem>
+
+    <TabViewItem title="Tab">
+        <TabViewItem.view>
+            <Label text="Tab" />
+        </TabViewItem.view>
+    </TabViewItem>
+
+    </TabView.items>
+</TabView>

--- a/tests/app/ui/root-view/root-view-tests.ts
+++ b/tests/app/ui/root-view/root-view-tests.ts
@@ -1,0 +1,74 @@
+import * as TKUnit from "../../TKUnit";
+import { Page } from "tns-core-modules/ui/page";
+import { Frame, NavigationEntry, stack } from "tns-core-modules/ui/frame";
+import { _resetRootView, getRootView } from "tns-core-modules/application";
+import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view";
+import { GridLayout } from "tns-core-modules/ui/layouts/grid-layout";
+import * as myCustomControlWithoutXml from "./mymodule/MyControl";
+import * as helper from "../helper";
+
+function createTestFrameRootEntry() {
+    const page = new Page();
+    const frameRoot = new Frame();
+    frameRoot.navigate(() => page);
+
+    const entry: NavigationEntry = {
+        create: () => frameRoot
+    };
+
+    return {
+        entry: entry,
+        root: frameRoot,
+        page: page
+    };
+}
+
+export function test_custom_component_rootview_css_applied() {
+    var entry = {
+        moduleName: "ui/root-view/root-modules/custom-component-root"
+    };
+
+    _resetRootView(entry);
+
+    var rootView = getRootView();
+    TKUnit.waitUntilReady(() => rootView.isLoaded);
+
+    TKUnit.assert(rootView instanceof myCustomControlWithoutXml.MyControl);
+    helper.assertViewBackgroundColor(rootView, "#0000FF");
+};
+
+export function test_tabview_rootview_css_applied() {
+    var entry = {
+        moduleName: "ui/root-view/root-modules/tabview-root"
+    };
+
+    _resetRootView(entry);
+
+    var rootView = getRootView();
+    TKUnit.waitUntilReady(() => rootView.isLoaded);
+
+    TKUnit.assert(rootView instanceof TabView);
+    helper.assertTabSelectedTabTextColor(rootView, "#0000FF");
+};
+
+export function test_gridlayout_rootview_css_applied() {
+    var entry = {
+        moduleName: "ui/root-view/root-modules/gridlayout-root"
+    };
+
+    _resetRootView(entry);
+
+    var rootView = getRootView();
+    TKUnit.waitUntilReady(() => rootView.isLoaded);
+
+    TKUnit.assert(rootView instanceof GridLayout);
+    helper.assertViewBackgroundColor(rootView, "#0000FF");
+};
+
+export function tearDownModule() {
+    // reset the root to frame for other tests
+    const resetFrameRoot = createTestFrameRootEntry();
+
+    _resetRootView(resetFrameRoot.entry);
+    TKUnit.waitUntilReady(() => resetFrameRoot.page.isLoaded);
+}

--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -158,7 +158,7 @@ function loadInternal(fileName: string, context?: any, moduleNamePath?: string):
     return componentModule;
 }
 
-function loadCustomComponent(componentPath: string, componentName?: string, attributes?: Object, context?: Object, parentPage?: View, isRootComponent: boolean = true): ComponentModule {
+function loadCustomComponent(componentPath: string, componentName?: string, attributes?: Object, context?: Object, parentPage?: View, isRootComponent: boolean = true, moduleNamePath?: string): ComponentModule {
     if (!parentPage && context) {
         // Read the parent page that was passed down below
         // https://github.com/NativeScript/NativeScript/issues/1639
@@ -211,7 +211,7 @@ function loadCustomComponent(componentPath: string, componentName?: string, attr
         }
     } else {
         // Custom components without XML
-        result = getComponentModule(componentName, componentPath, attributes, context, undefined, isRootComponent);
+        result = getComponentModule(componentName, componentPath, attributes, context, moduleNamePath, isRootComponent);
     }
 
     // webpack modules require paths to be relative to /app folder.
@@ -607,7 +607,7 @@ namespace xml2ui {
         private buildComponent(args: xml.ParserEvent): ComponentModule {
             if (args.prefix && args.namespace) {
                 // Custom components
-                return loadCustomComponent(args.namespace, args.elementName, args.attributes, this.context, this.currentRootView, !this.currentRootView);
+                return loadCustomComponent(args.namespace, args.elementName, args.attributes, this.context, this.currentRootView, !this.currentRootView, this.moduleNamePath);
             } else {
                 // Default components
                 let namespace = args.namespace;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When RadSideDrawer from the Pro UI suite is used as a root of the app and there is an .css file for that module, it is not applied for the drawer's `.drawerContent`.

## What is the new behavior?
The .css file is applied to the RadSideDrawer's `.drawerContent` content when the component is used as a root element.

Fixes/Implements/Closes #[Issue Number].
https://github.com/telerik/nativescript-ui-feedback/issues/507

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

