### PR TITLE
fix(image-source.ios): case statement, allow jpg and jpeg

### DIFF
--- a/tns-core-modules/image-source/image-source.ios.ts
+++ b/tns-core-modules/image-source/image-source.ios.ts
@@ -185,10 +185,11 @@ function getFileName(path: string): string {
 function getImageData(instance: UIImage, format: "png" | "jpeg" | "jpg", quality = 1.0): NSData {
     var data = null;
     switch (format) {
-        case "png": // PNG
+        case "png":
             data = UIImagePNGRepresentation(instance);
             break;
-        case "jpeg" || "jpg": // JPEG
+        case "jpeg":
+        case "jpg":
             data = UIImageJPEGRepresentation(instance, quality);
             break;
     }


### PR DESCRIPTION
the current implementation does not work if one specifies "jpg", it works only with "jpeg" due to the || syntax used before. 
fixes #4873

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Using "jpg" as image format spectification does not work as expected on ios.

## What is the new behavior?
"jpg" can be used the same as "jpeg".

Fixes/Implements/Closes #4873.

