### PR TITLE
fix(frame): add generic frame cleanup logic after modal dialog close

### DIFF
--- a/tests/app/ui/page/modal-tab-page.ts
+++ b/tests/app/ui/page/modal-tab-page.ts
@@ -1,0 +1,13 @@
+import { NavigatedData } from "tns-core-modules/ui/page";
+import { View } from "tns-core-modules/ui/core/view";
+import * as TKUnit from "../../TKUnit";
+import { stack } from "tns-core-modules/ui/frame";
+import { isAndroid } from "tns-core-modules/platform";
+
+export function onNavigatedTo(args: NavigatedData) {
+    TKUnit.assertEqual(stack().length, 2, "Host and tab modal frame should be instantiated at this point!");
+    // shownModally raised after page.NavigatedTo on iOS so we close modal there
+    if (isAndroid) {
+        (args.object as View).closeModal();
+    }
+}

--- a/tests/app/ui/page/modal-tab-page.xml
+++ b/tests/app/ui/page/modal-tab-page.xml
@@ -1,0 +1,8 @@
+<Page backgroundColor="green" navigatedTo="onNavigatedTo">
+
+    <ActionBar class="action-bar">
+        <Label class="action-bar-title" text="Modal"></Label>
+    </ActionBar>
+
+    <Label text="Text" />
+</Page>

--- a/tests/app/ui/page/modal-tab-root.ts
+++ b/tests/app/ui/page/modal-tab-root.ts
@@ -1,0 +1,22 @@
+import { ShownModallyData } from "tns-core-modules/ui/core/view";
+import { TabView } from "tns-core-modules/ui/tab-view/tab-view";
+import * as TKUnit from "../../TKUnit";
+import { stack } from "tns-core-modules/ui/frame";
+import { isIOS } from "tns-core-modules/platform"
+
+export function onShownModally(args: ShownModallyData) {
+    const tabView = <TabView>args.object;
+    TKUnit.assertNotNull(tabView);
+    if (args.context) {
+        args.context.shownModally = true;
+    }
+
+    const hostFrame = stack()[0];
+    TKUnit.assertNotNull(hostFrame, "Host frame should not be null");
+    TKUnit.assertEqual(hostFrame.currentPage.modal, tabView, "hostFrame.currentPage.modal should be equal to the tabView instance on tabView.shownModally event handler.");
+
+    // shownModally raised after page.NavigatedTo on iOS
+    if (isIOS) {
+        args.closeCallback("return value");
+    }
+}

--- a/tests/app/ui/page/modal-tab-root.xml
+++ b/tests/app/ui/page/modal-tab-root.xml
@@ -1,0 +1,11 @@
+<TabView androidTabsPosition="bottom" shownModally="onShownModally">
+    <TabViewItem title="Modal First">
+        <Frame defaultPage="ui/page/modal-tab-page" />
+    </TabViewItem>
+    <TabViewItem>
+        <Frame />
+    </TabViewItem>
+    <TabViewItem title="Modal Second">
+        <Label text="tab 2" />
+    </TabViewItem>
+</TabView>

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -959,7 +959,10 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     }
 
     public _dialogClosed(): void {
-        return;
+        eachDescendant(this, (child: ViewBase) => {
+            child._dialogClosed();
+            return true;
+        });
     }
 
     public _onRootViewReset(): void {

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -435,7 +435,8 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
     }
 
     public _dialogClosed(): void {
-        this._popFromFrameStack();
+        // No super call as we do not support nested frames to clean up
+        this._removeFromFrameStack();
     }
 
     public _onRootViewReset(): void {


### PR DESCRIPTION
- Revises and generalizes fix for https://github.com/NativeScript/NativeScript/issues/5340
- Add test for the more general modal tab with frame scenario