### PR TITLE
fix(android-images): set decodeHeight/decodeWidth default values to dip

### DIFF
--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -1,5 +1,5 @@
 ﻿import { Image as ImageDefinition, Stretch } from ".";
-import { View, Property, InheritedCssProperty, Style, Color, isIOS, booleanConverter } from "../core/view";
+import { View, Property, InheritedCssProperty, Length, Style, Color, isIOS, booleanConverter } from "../core/view";
 import { ImageAsset } from "../../image-asset";
 import { ImageSource, fromAsset, fromNativeSource, fromUrl } from "../../image-source";
 import { isDataURI, isFileOrResourcePath, RESOURCE_PREFIX } from "../../utils/utils";
@@ -13,6 +13,8 @@ export abstract class ImageBase extends View implements ImageDefinition {
     public isLoading: boolean;
     public stretch: Stretch;
     public loadMode: "sync" | "async";
+    public decodeWidth: Length;
+    public decodeHeight: Length;
 
     get tintColor(): Color {
         return this.style.tintColor;
@@ -119,3 +121,9 @@ stretchProperty.register(ImageBase);
 
 export const tintColorProperty = new InheritedCssProperty<Style, Color>({ name: "tintColor", cssName: "tint-color", equalityComparer: Color.equals, valueConverter: (value) => new Color(value) });
 tintColorProperty.register(Style);
+
+export const decodeHeightProperty = new Property<ImageBase, Length>({ name: "decodeHeight", defaultValue: { value: 0, unit: "dip" }, valueConverter: Length.parse });
+decodeHeightProperty.register(ImageBase);
+
+export const decodeWidthProperty = new Property<ImageBase, Length>({ name: "decodeWidth", defaultValue: { value: 0, unit: "dip" }, valueConverter: Length.parse });
+decodeWidthProperty.register(ImageBase);

--- a/tns-core-modules/ui/image/image.android.ts
+++ b/tns-core-modules/ui/image/image.android.ts
@@ -1,6 +1,6 @@
 ﻿import {
     ImageSource, ImageAsset, ImageBase, stretchProperty, imageSourceProperty, srcProperty, tintColorProperty, Color,
-    isDataURI, isFileOrResourcePath, RESOURCE_PREFIX
+    isDataURI, isFileOrResourcePath, RESOURCE_PREFIX, Length
 } from "./image-common";
 import { knownFolders } from "../../file-system";
 
@@ -43,8 +43,6 @@ function initializeImageLoadedListener() {
 export class Image extends ImageBase {
     nativeViewProtected: org.nativescript.widgets.ImageView;
 
-    public decodeWidth = 0;
-    public decodeHeight = 0;
     public useCache = true;
 
     public createNativeView() {
@@ -52,7 +50,7 @@ export class Image extends ImageBase {
             AndroidImageView = org.nativescript.widgets.ImageView;
         }
         initializeImageLoadedListener();
-        
+
         const imageView = new AndroidImageView(this._context);
         const listener = new ImageLoadedListener(this);
         imageView.setImageLoadedListener(listener);
@@ -73,7 +71,7 @@ export class Image extends ImageBase {
 
     public resetNativeView(): void {
         super.resetNativeView();
-        this.nativeViewProtected.setImageMatrix(new android.graphics.Matrix());        
+        this.nativeViewProtected.setImageMatrix(new android.graphics.Matrix());
     }
 
     public _createImageSourceFromSrc(value: string | ImageSource | ImageAsset) {
@@ -89,8 +87,8 @@ export class Image extends ImageBase {
 
         let screen = platform.screen.mainScreen;
 
-        let decodeWidth = Math.min(this.decodeWidth, screen.widthPixels);
-        let decodeHeight = Math.min(this.decodeHeight, screen.heightPixels);
+        let decodeWidth = Math.min(Length.toDevicePixels(this.decodeWidth, 0), screen.widthPixels);
+        let decodeHeight = Math.min(Length.toDevicePixels(this.decodeHeight, 0), screen.heightPixels);
         let keepAspectRatio = this._calculateKeepAspectRatio();
         if (value instanceof ImageAsset) {
             if (value.options) {


### PR DESCRIPTION
Currently `decodeWidth` and `decodeHeight` properties accept values as pixels which can lead to confusion and poor picture quality in some scenarios. 

From now on `decodeWidth` and `decodeHeight` can be used in the following way:
- `decodeHeight="200"` - will be converted to DIP
- `decodeHeight="200dip"` - will be converted to DIP
- `decodeHeight="200px"` - used as exact pixels with no convertion.

BREAKING CHANGE: change decodeHeight/decodeWidth properties from accepting exact pixels to device independent pixels (DIP) by default.