### PR TITLE
feat(ios-image-source): standardize quality scale in image-source 

### DIFF
--- a/tests/app/image-source/image-source-tests.ts
+++ b/tests/app/image-source/image-source-tests.ts
@@ -54,6 +54,17 @@ export function testSaveToFile() {
     TKUnit.assert(fs.File.exists(path), "Image not saved to file");
 }
 
+export function testSaveToFile_WithQuality() {
+    // >> imagesource-save-to
+    const img = imageSource.fromFile(imagePath);
+    const folder = fs.knownFolders.documents();
+    const path = fs.path.join(folder.path, "test.png");
+    const saved = img.saveToFile(path, "png", 70);
+    // << imagesource-save-to
+    TKUnit.assert(saved, "Image not saved to file");
+    TKUnit.assert(fs.File.exists(path), "Image not saved to file");
+}
+
 export function testFromFile() {
     // >> imagesource-load-local
     const folder = fs.knownFolders.documents();
@@ -187,10 +198,35 @@ export function testBase64Encode_PNG() {
         "Base 64 encoded PNG");
 }
 
+export function testBase64Encode_PNG_WithQuality() {
+    // >> imagesource-to-base-string
+    const img = imageSource.fromFile(smallImagePath);
+    let base64String = img.toBase64String("png", 80);
+    // << imagesource-to-base-string
+
+    base64String = base64String.substr(0, expectedPngStart.length);
+    TKUnit.assertEqual(
+        base64String,
+        expectedPngStart,
+        "Base 64 encoded PNG");
+}
+
 export function testBase64Encode_JPEG() {
     const img = imageSource.fromFile(smallImagePath);
 
     let base64String = img.toBase64String("jpeg");
+    base64String = base64String.substr(0, expectedJpegStart.length);
+
+    TKUnit.assertEqual(
+        base64String,
+        expectedJpegStart,
+        "Base 64 encoded JPEG");
+}
+
+export function testBase64Encode_JPEG_With_Quality() {
+    const img = imageSource.fromFile(smallImagePath);
+
+    let base64String = img.toBase64String("jpeg", 80);
     base64String = base64String.substr(0, expectedJpegStart.length);
 
     TKUnit.assertEqual(

--- a/tests/app/image-source/image-source-tests.ts
+++ b/tests/app/image-source/image-source-tests.ts
@@ -55,12 +55,10 @@ export function testSaveToFile() {
 }
 
 export function testSaveToFile_WithQuality() {
-    // >> imagesource-save-to
     const img = imageSource.fromFile(imagePath);
     const folder = fs.knownFolders.documents();
     const path = fs.path.join(folder.path, "test.png");
     const saved = img.saveToFile(path, "png", 70);
-    // << imagesource-save-to
     TKUnit.assert(saved, "Image not saved to file");
     TKUnit.assert(fs.File.exists(path), "Image not saved to file");
 }
@@ -199,11 +197,8 @@ export function testBase64Encode_PNG() {
 }
 
 export function testBase64Encode_PNG_WithQuality() {
-    // >> imagesource-to-base-string
     const img = imageSource.fromFile(smallImagePath);
     let base64String = img.toBase64String("png", 80);
-    // << imagesource-to-base-string
-
     base64String = base64String.substr(0, expectedPngStart.length);
     TKUnit.assertEqual(
         base64String,

--- a/tns-core-modules/image-source/image-source.d.ts
+++ b/tns-core-modules/image-source/image-source.d.ts
@@ -98,14 +98,14 @@ export class ImageSource {
     * Saves this instance to the specified file, using the provided image format and quality.
     * @param path The path of the file on the file system to save to.
     * @param format The format (encoding) of the image.
-    * @param quality Optional parameter, specifying the quality of the encoding. Defaults to the maximum available quality.
+    * @param quality Optional parameter, specifying the quality of the encoding. Defaults to the maximum available quality. Quality varies on a scale of 0 to 100.
     */
     saveToFile(path: string, format: "png" | "jpeg" | "jpg", quality?: number): boolean;
 
     /**
      * Converts the image to base64 encoded string, using the provided image format and quality.
      * @param format The format (encoding) of the image.
-     * @param quality Optional parameter, specifying the quality of the encoding. Defaults to the maximum available quality.
+     * @param quality Optional parameter, specifying the quality of the encoding. Defaults to the maximum available quality. Quality varies on a scale of 0 to 100.
      */
     toBase64String(format: "png" | "jpeg" | "jpg", quality?: number): string;
 }

--- a/tns-core-modules/image-source/image-source.ios.ts
+++ b/tns-core-modules/image-source/image-source.ios.ts
@@ -130,6 +130,10 @@ export class ImageSource implements ImageSourceDefinition {
             return false;
         }
 
+        if (quality != null && quality > 1) {
+            quality = quality - 0 / (100 - 0);  // Normalize quality on a scale of 0 to 1
+        }
+
         const data = getImageData(this.ios, format, quality);
         if (data) {
             return NSFileManager.defaultManager.createFileAtPathContentsAttributes(path, data, null);
@@ -142,6 +146,10 @@ export class ImageSource implements ImageSourceDefinition {
         let res = null;
         if (!this.ios) {
             return res;
+        }
+
+        if (quality != null && quality > 1) {
+            quality = quality - 0 / (100 - 0);  // Normalize quality on a scale of 0 to 1
         }
 
         const data = getImageData(this.ios, format, quality);

--- a/tns-core-modules/image-source/image-source.ios.ts
+++ b/tns-core-modules/image-source/image-source.ios.ts
@@ -130,7 +130,7 @@ export class ImageSource implements ImageSourceDefinition {
             return false;
         }
 
-        if (quality != null && quality > 1) {
+        if (quality) {
             quality = quality - 0 / (100 - 0);  // Normalize quality on a scale of 0 to 1
         }
 
@@ -148,7 +148,7 @@ export class ImageSource implements ImageSourceDefinition {
             return res;
         }
 
-        if (quality != null && quality > 1) {
+        if (quality) {
             quality = quality - 0 / (100 - 0);  // Normalize quality on a scale of 0 to 1
         }
 


### PR DESCRIPTION

Normalize quality in saveToFile and toBase64String to follow 0-100 scale - standardize implementation on both platforms

closes #5474

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
quality parameter in image-source follows different scales for both the platforms. On iOS it goes from 0.0-1.0 and on Android it goes from 0-100. Developer needs to manually check for platform when using quality.

## What is the new behavior?
<!-- Describe the changes. -->
iOS implementation of image-source toBase64String and saveToFile now normalizes the quality scale so that both the platforms follow the same scale from 0-100. For iOS the values of 0-100 are converted to a scale of 0.0-1.0.

Fixes/Implements/Closes #[5474].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

