### PR TITLE
fix-next(frame): remove current entry fragment on reset root view

### DIFF
--- a/e2e/modal-navigation/e2e/e2e-spec-tab-root/tab-root-modal-frame.e2e-spec.ts
+++ b/e2e/modal-navigation/e2e/e2e-spec-tab-root/tab-root-modal-frame.e2e-spec.ts
@@ -6,7 +6,7 @@ import { modalFrameBackground,
     testNestedModalPageBackground
 } from "../shared.e2e-spec"
 
-describe.skip("tab root modal frame background scenarios", () => {
+describe("tab root modal frame background scenarios", () => {
 
     let driver: AppiumDriver;
     let screen: Screen;

--- a/e2e/modal-navigation/e2e/e2e-spec-tab-root/tab-root-modal-page.e2e-spec.ts
+++ b/e2e/modal-navigation/e2e/e2e-spec-tab-root/tab-root-modal-page.e2e-spec.ts
@@ -6,7 +6,7 @@ import { modalPageBackground,
     testNestedModalPageBackground
 } from "../shared.e2e-spec"
 
-describe.skip("tab root modal page background scenarios", () => {
+describe("tab root modal page background scenarios", () => {
 
     let driver: AppiumDriver;
     let screen: Screen;

--- a/e2e/modal-navigation/e2e/e2e-spec-tab-root/tab-root-modal-tab.e2e-spec.ts
+++ b/e2e/modal-navigation/e2e/e2e-spec-tab-root/tab-root-modal-tab.e2e-spec.ts
@@ -8,7 +8,7 @@ import { modalFrameBackground,
     testSecondItemBackground
 } from "../shared.e2e-spec"
 
-describe.skip("tab root modal tab view background scenarios", () => {
+describe("tab root modal tab view background scenarios", () => {
 
     let driver: AppiumDriver;
     let screen: Screen;

--- a/e2e/modal-navigation/package.json
+++ b/e2e/modal-navigation/package.json
@@ -35,7 +35,10 @@
     "uglifyjs-webpack-plugin": "~1.1.6",
     "webpack": "~3.10.0",
     "webpack-bundle-analyzer": "^2.9.1",
-    "webpack-sources": "~1.1.0"
+    "webpack-sources": "~1.1.0",
+    "@types/chai": "^4.0.2",
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^7.0.5"
   },
   "scripts": {
     "e2e": "tsc -p e2e && mocha --opts ./e2e/config/mocha.opts",

--- a/e2e/modal-navigation/tsconfig.json
+++ b/e2e/modal-navigation/tsconfig.json
@@ -24,6 +24,6 @@
     "exclude": [
         "node_modules",
         "platforms",
-	    "e2e"
+        "e2e"
     ]
 }

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -177,27 +177,22 @@ export class Frame extends FrameBase {
     }
 
     _onRootViewReset(): void {
-        if (this._currentEntry && this._currentEntry.fragment) {
-            const manager: android.app.FragmentManager = this._getFragmentManager();
-
-            const transaction = manager.beginTransaction();
-            transaction.remove(this._currentEntry.fragment);
-            transaction.commitAllowingStateLoss();
-        }
-
+        this.disposeCurrentFragment();
         super._onRootViewReset();
     }
 
     onUnloaded() {
+        this.disposeCurrentFragment();
+        super.onUnloaded();
+    }
+
+    private disposeCurrentFragment(){
         if (this._currentEntry && this._currentEntry.fragment) {
             const manager: android.app.FragmentManager = this._getFragmentManager();
-
             const transaction = manager.beginTransaction();
             transaction.remove(this._currentEntry.fragment);
             transaction.commitAllowingStateLoss();
         }
-
-        super.onUnloaded();
     }
 
     private createFragment(backstackEntry: BackstackEntry, fragmentTag: string): android.app.Fragment {

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -176,6 +176,18 @@ export class Frame extends FrameBase {
         }
     }
 
+    _onRootViewReset(): void {
+        if (this._currentEntry && this._currentEntry.fragment) {
+            const manager: android.app.FragmentManager = this._getFragmentManager();
+
+            const transaction = manager.beginTransaction();
+            transaction.remove(this._currentEntry.fragment);
+            transaction.commitAllowingStateLoss();
+        }
+
+        super._onRootViewReset();
+    }
+
     onUnloaded() {
         if (this._currentEntry && this._currentEntry.fragment) {
             const manager: android.app.FragmentManager = this._getFragmentManager();


### PR DESCRIPTION
Problem:

When we reset root view and minimize/restore application with "Don't keep activities" turned ON, we try to restore the latest fragment. However, it is not available anymore, so could not be restored. In this case, remove it when changing root view in order to create a new one.

Steps to reproduce:

- run the [modal-navigation](https://github.com/NativeScript/NativeScript/tree/vchimev/reset-root-view/e2e/modal-navigation) app
- turn on  the "Don't keep activities" setting in the Developer options for Android
- tap on "Change root view" to set `TabView` as the application root
- minimize and restore application

Stack trace:

```
System.err: Error: Cannot find Frame for NO ENTRY, FragmentClass{f14f72e #0 id=0x1 fragment0[0]}
System.err: File: "file:///data/data/org.nativescript.modalnavigation/files/app/tns_modules/tns-core-modules/ui/frame/frame.js, line: 651, column: 18
System.err: StackTrace:
System.err: 	Frame: function:'FragmentCallbacksImplementation.onCreate', file:'file:///data/data/org.nativescript.modalnavigation/files/app/tns_modules/tns-core-modules/ui/frame/frame.js', line: 547, column: 23
System.err: 	Frame: function:'FragmentClass.onCreate', file:'file:///data/data/org.nativescript.modalnavigation/files/app/tns_modules/tns-core-modules/ui/frame/fragment.js', line: 24, column: 25
System.err: 	Frame: function:'ActivityCallbacksImplementation.onCreate', file:'file:///data/data/org.nativescript.modalnavigation/files/app/tns_modules/tns-core-modules/ui/frame/frame.js', line: 651, column: 19
System.err: 	Frame: function:'NativeScriptActivity.onCreate', file:'file:///data/data/org.nativescript.modalnavigation/files/app/tns_modules/tns-core-modules/ui/frame/activity.js', line: 20, column: 25
```