### PR TITLE
feat(view): expose method for android back override

### DIFF
--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -203,7 +203,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
         return false;
     }
 
-    public _onBackPressed(): boolean {
+    public onBackPressed(): boolean {
         return false;
     }
 

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -115,7 +115,7 @@ function initializeDialogFragment() {
             };
             view.notify(args);
 
-            if (!args.cancel && !view._onBackPressed()) {
+            if (!args.cancel && !view.onBackPressed()) {
                 super.onBackPressed();
             }
         }

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -678,10 +678,11 @@ export abstract class View extends ViewBase {
      * @private
      */
     _onLivesync(): boolean;
+
     /**
-     * @private
+     * Derived classes can override this method to handle Android back button press. 
      */
-    _onBackPressed(): boolean;
+    onBackPressed(): boolean;
     /**
      * @private
      */

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -249,7 +249,7 @@ export class Frame extends FrameBase {
         }
     }
 
-    public _onBackPressed(): boolean {
+    public onBackPressed(): boolean {
         if (this.canGoBack()) {
             this.goBack();
             return true;
@@ -884,7 +884,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
             };
             view.notify(viewArgs);
 
-            if (!viewArgs.cancel && !view._onBackPressed()) {
+            if (!viewArgs.cancel && !view.onBackPressed()) {
                 callSuper = true;
             }
         }

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -510,10 +510,10 @@ export class TabView extends TabViewBase {
         super.disposeNativeView();
     }
 
-    public _onBackPressed(): boolean {
+    public onBackPressed(): boolean {
         const currentView = this._selectedView;
         if (currentView) {
-            return currentView._onBackPressed();
+            return currentView.onBackPressed();
         }
 
         return false;


### PR DESCRIPTION
Expose method on View class onBackPressed(). Third party controls
like RadSideDrawer can use this method to override the default Android
back button handling. By default the app closes.

