### PR TITLE
fix(uilabel): line height setter should not break line break mode

### DIFF
--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -131,6 +131,10 @@ export class TextBase extends TextBaseCommon {
             paragraphStyle.lineSpacing = this.lineHeight;
             // make sure a possible previously set text alignment setting is not lost when line height is specified
             paragraphStyle.alignment = (<UITextField | UITextView | UILabel>this.nativeViewProtected).textAlignment;
+            if (this.nativeViewProtected instanceof  UILabel) {
+                // make sure a possible previously set line break mode is not lost when line height is specified
+                paragraphStyle.lineBreakMode = this.nativeViewProtected.lineBreakMode;
+            }
             attrText.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, { location: 0, length: attrText.length });
         }
 
@@ -171,6 +175,10 @@ export class TextBase extends TextBaseCommon {
             paragraphStyle.lineSpacing = style.lineHeight;
             // make sure a possible previously set text alignment setting is not lost when line height is specified
             paragraphStyle.alignment = (<UITextField | UITextView | UILabel>this.nativeViewProtected).textAlignment;
+            if (this.nativeViewProtected instanceof  UILabel) {
+                // make sure a possible previously set line break mode is not lost when line height is specified
+                paragraphStyle.lineBreakMode = this.nativeViewProtected.lineBreakMode;
+            }
             dict.set(NSParagraphStyleAttributeName, paragraphStyle);
         }
 


### PR DESCRIPTION
NOTE: Cherry-picked from https://github.com/NativeScript/NativeScript/pull/5251 due to CI infrastructure issues with the original PR.

When setting line-height using a stylesheet, line break mode will stop working.

__Working line break mode:__
https://play.nativescript.org/?template=play-ng&id=3HPeu8

__Now adding a style to home.component.css:__

```css
Label {
    line-height: 1;
}
```

__Results in broken line break mode:__
https://play.nativescript.org/?template=play-ng&id=3HPeu8&v=5


My Pull Request fixes this behavior.