### PR TITLE
fix(image): apply tintColor correctly on iOS

### DIFF
--- a/tns-core-modules/ui/image/image.ios.ts
+++ b/tns-core-modules/ui/image/image.ios.ts
@@ -25,7 +25,7 @@ export class Image extends ImageBase {
         if (value && this.nativeViewProtected.image && !this._templateImageWasCreated) {
             this.nativeViewProtected.image = this.nativeViewProtected.image.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
             this._templateImageWasCreated = true;
-        } else if (this.nativeViewProtected.image && this._templateImageWasCreated) {
+        } else if (!value && this.nativeViewProtected.image && this._templateImageWasCreated) {
             this._templateImageWasCreated = false;
             this.nativeViewProtected.image = this.nativeViewProtected.image.imageWithRenderingMode(UIImageRenderingMode.Automatic);
         }
@@ -48,7 +48,7 @@ export class Image extends ImageBase {
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        // We don't call super because we measure native view with specific size.     
+        // We don't call super because we measure native view with specific size.
         const width = layout.getMeasureSpecSize(widthMeasureSpec);
         const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);
 


### PR DESCRIPTION
NOTE: Cherry-picked from https://github.com/NativeScript/NativeScript/pull/5266 due to CI infrastructure issues with the original PR.

Fixes #4778 

Previously image was reset on every second call to setTintColor, which led to some weird behavior on iOS. Especially since setTintColor could be called many times, when set through property or style.

It now only resets image to non-template when tintColor is changed to a non-color value (e.g. removed).

NOTE: Fix for Android Image.tintColor here: https://github.com/NativeScript/tns-core-modules-widgets/pull/110
