### PR TITLE
fix(webview): remove log and set scale on start

### DIFF
--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -56,9 +56,6 @@ class WKNavigationDelegateImpl extends NSObject
         }
         const owner = this._owner.get();
         if (owner) {
-           webView.evaluateJavaScriptCompletionHandler("document.body.height",(val,err)=>{
-               console.log(val);
-           });
             let src = owner.src;
             if (webView.URL) {
                 src = webView.URL.absoluteString;
@@ -92,7 +89,7 @@ export class WebView extends WebViewBase {
         const configuration = WKWebViewConfiguration.new();
         this._delegate = WKNavigationDelegateImpl.initWithOwner(new WeakRef(this));
         const jScript = "var meta = document.createElement('meta'); meta.setAttribute('name', 'viewport'); meta.setAttribute('content', 'initial-scale=1.0'); document.getElementsByTagName('head')[0].appendChild(meta);";
-        const wkUScript = WKUserScript.alloc().initWithSourceInjectionTimeForMainFrameOnly(jScript,WKUserScriptInjectionTime.AtDocumentEnd,true);
+        const wkUScript = WKUserScript.alloc().initWithSourceInjectionTimeForMainFrameOnly(jScript,WKUserScriptInjectionTime.AtDocumentStart,true);
         const wkUController = WKUserContentController.new();
         wkUController.addUserScript(wkUScript);
         configuration.userContentController = wkUController;


### PR DESCRIPTION
NOTE: Cherry-picked from https://github.com/NativeScript/NativeScript/pull/5200 due to CI infrastructure issues with the original PR.

Remove unwanted logging & Sets the content scaling before the document finishes loading

### You have unit tests
Yes
