### PR TITLE
fix(image): image aspect dimensions for ImageSource.fromAsset(...)

### DIFF
--- a/tests/app/image-source/image-source-tests.ts
+++ b/tests/app/image-source/image-source-tests.ts
@@ -141,8 +141,8 @@ export function testFromAssetWithScalingAndAspectRatio(done) {
     };
 
     let img = imageSource.fromAsset(asset).then((source) => {
-        TKUnit.assertEqual(source.width, scaleWidth);
-        TKUnit.assertEqual(source.height, 5);
+        TKUnit.assertEqual(source.width, 18);
+        TKUnit.assertEqual(source.height, scaleHeight);
         done();
     }, (error) => {
         done(error);

--- a/tns-core-modules/image-asset/image-asset-common.ts
+++ b/tns-core-modules/image-asset/image-asset-common.ts
@@ -33,8 +33,7 @@ export class ImageAsset  extends observable.Observable implements definition.Ima
 export function getAspectSafeDimensions(sourceWidth, sourceHeight, reqWidth, reqHeight) {
     let widthCoef = sourceWidth / reqWidth;
     let heightCoef = sourceHeight / reqHeight;
-
-    let aspectCoef = widthCoef > heightCoef ? widthCoef : heightCoef;
+    let aspectCoef = Math.min(widthCoef, heightCoef);
 
     return {
         width: Math.floor(sourceWidth / aspectCoef),


### PR DESCRIPTION
Additional fix for https://github.com/NativeScript/tns-core-modules-widgets/pull/115 to cover the scenario with ImageSource.fromAsset(...) that does not go through the widgets logic.