### PR TITLE
fix(android/text ios/text): allow -1 to be a valid binding value

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -1,5 +1,5 @@
 ﻿import { EditableTextBase as EditableTextBaseDefinition, KeyboardType, ReturnKeyType, UpdateTextTrigger, AutocapitalizationType } from ".";
-import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser } from "../text-base";
+import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser, resetSymbol } from "../text-base";
 
 export * from "../text-base";
 

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -1,7 +1,7 @@
 ﻿import {
     EditableTextBase as EditableTextBaseCommon, keyboardTypeProperty,
     returnKeyTypeProperty, editableProperty,
-    autocapitalizationTypeProperty, autocorrectProperty, hintProperty,
+    autocapitalizationTypeProperty, autocorrectProperty, hintProperty, resetSymbol,
     textProperty, placeholderColorProperty, Color, textTransformProperty, maxLengthProperty
 } from "./editable-text-base-common";
 
@@ -241,13 +241,13 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         }
     }
 
-    [textProperty.getDefault](): number {
-        return -1;
+    [textProperty.getDefault](): number | symbol {
+        return resetSymbol;
     }
-    [textProperty.setNative](value: string | number) {
+    [textProperty.setNative](value: string | number | symbol) {
         try {
             this._changeFromCode = true;
-            this._setNativeText(value === -1);
+            this._setNativeText(value === resetSymbol);
         } finally {
             this._changeFromCode = false;
         }

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -213,3 +213,5 @@ letterSpacingProperty.register(Style);
 
 export const lineHeightProperty = new CssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 lineHeightProperty.register(Style);
+
+export const resetSymbol = Symbol(-1);

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -214,4 +214,4 @@ letterSpacingProperty.register(Style);
 export const lineHeightProperty = new CssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 lineHeightProperty.register(Style);
 
-export const resetSymbol = Symbol(-1);
+export const resetSymbol = Symbol("textPropertyDefault");

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -5,7 +5,7 @@ import {
     TextBaseCommon, formattedTextProperty, textAlignmentProperty, textDecorationProperty, fontSizeProperty,
     textProperty, textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty,
     paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length,
-    whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold
+    whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold, resetSymbol
 } from "./text-base-common";
 
 export * from "./text-base-common";
@@ -97,12 +97,12 @@ export class TextBase extends TextBaseCommon {
         this._maxHeight = this._maxLines = undefined;
     }
 
-    [textProperty.getDefault](): number {
-        return -1;
+    [textProperty.getDefault](): symbol | number {
+        return resetSymbol;
     }
 
-    [textProperty.setNative](value: string | number) {
-        const reset = value === -1;
+    [textProperty.setNative](value: string | number | symbol) {
+        const reset = value === resetSymbol;
         if (!reset && this.formattedText) {
             return;
         }

--- a/tns-core-modules/ui/text-base/text-base.d.ts
+++ b/tns-core-modules/ui/text-base/text-base.d.ts
@@ -123,3 +123,5 @@ export const letterSpacingProperty: CssProperty<Style, number>;
 
 //Used by tab view
 export function getTransformedText(text: string, textTransform: TextTransform): string;
+
+export const resetSymbol: symbol;

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -3,7 +3,7 @@ import { Font } from "../styling/font";
 import {
     TextBaseCommon, textProperty, formattedTextProperty, textAlignmentProperty, textDecorationProperty,
     textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty, lineHeightProperty,
-    FormattedString, Span, Color, isBold
+    FormattedString, Span, Color, isBold, resetSymbol
 } from "./text-base-common";
 
 export * from "./text-base-common";
@@ -12,11 +12,11 @@ export class TextBase extends TextBaseCommon {
 
     public nativeViewProtected: UITextField | UITextView | UILabel | UIButton;
 
-    [textProperty.getDefault](): number {
-        return -1;
+    [textProperty.getDefault](): number | symbol {
+        return resetSymbol;
     }
-    [textProperty.setNative](value: string | number) {
-        const reset = value === -1;
+    [textProperty.setNative](value: string | number | symbol) {
+        const reset = value === resetSymbol;
         if (!reset && this.formattedText) {
             return;
         }


### PR DESCRIPTION
Instead of using -1 as a special value, use Symbol(-1)
so that it can't be reset accidentally

Closes issue #5559

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
https://github.com/NativeScript/NativeScript/issues/5559

## What is the new behavior?
Replaced -1 with Symbol(-1) so that it reset can't be set accidentally

Fixes/Implements/Closes #[Issue Number].

#5556 
