### PR TITLE
feat(ios-list-view): introduce iosEstimatedRowHeight property.

### DIFF
--- a/apps/app/ui-tests-app/list-view/scrolling-and-sizing.xml
+++ b/apps/app/ui-tests-app/list-view/scrolling-and-sizing.xml
@@ -51,5 +51,15 @@
             </ListView>
         </StackLayout>
  
+         <StackLayout class="p-10" row="3">
+            <Label text="ios-estimated-row-height" class="body m-b-10" />
+            <ListView items="{{ $value }}" iosEstimatedRowHeight="0">
+                <ListView.itemTemplate>
+                    <Label text="{{ $value }}" />
+                </ListView.itemTemplate>
+            </ListView>
+            <Label text="after-auto-estimated-height" class="body m-b-10" />
+        </StackLayout>
+
     </StackLayout>
 </Page>

--- a/tns-core-modules/ui/list-view/list-view-common.ts
+++ b/tns-core-modules/ui/list-view/list-view-common.ts
@@ -41,6 +41,7 @@ export abstract class ListViewBase extends View implements ListViewDefinition {
     public _itemTemplatesInternal = new Array<KeyedTemplate>(this._defaultTemplate);
     public _effectiveRowHeight: number = autoEffectiveRowHeight;
     public rowHeight: Length;
+    public iosEstimatedRowHeight: Length;
     public items: any[] | ItemsSource;
     public itemTemplate: string | Template;
     public itemTemplates: string | Array<KeyedTemplate>;
@@ -205,6 +206,11 @@ export const rowHeightProperty = new CoercibleProperty<ListViewBase, Length>({
     }, valueConverter: Length.parse
 });
 rowHeightProperty.register(ListViewBase);
+
+export const iosEstimatedRowHeightProperty = new Property<ListViewBase, Length>({
+    name: "iosEstimatedRowHeight", valueConverter: (v) => Length.parse(v)
+});
+iosEstimatedRowHeightProperty.register(ListViewBase);
 
 export const separatorColorProperty = new CssProperty<Style, Color>({ name: "separatorColor", cssName: "separator-color", equalityComparer: Color.equals, valueConverter: (v) => new Color(v) });
 separatorColorProperty.register(Style);

--- a/tns-core-modules/ui/list-view/list-view.d.ts
+++ b/tns-core-modules/ui/list-view/list-view.d.ts
@@ -79,6 +79,12 @@ export class ListView extends View {
     rowHeight: Length;
 
     /**
+     * Gets or set the estimated height of rows in the ListView.
+     * The default value is 44px.
+     */
+    iosEstimatedRowHeight: Length;
+
+    /**
      * Forces the ListView to reload all its items.
      */
     refresh();
@@ -172,6 +178,11 @@ export const separatorColor: Property<ListView, Color>;
  * Represents the observable property backing the rowHeight property of each ListView instance.
  */
 export const rowHeightProperty: Property<ListView, Length>;
+
+/**
+ * Represents the observable property backing the iosEstimatedRowHeight property of each ListView instance.
+ */
+export const iosEstimatedRowHeightProperty: Property<ListView, Length>;
 
 /**
  * Backing property for separator color property.

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -340,7 +340,7 @@ export class ListView extends ListViewBase {
             return height;
         }
 
-        return this.ios.estimatedRowHeight;
+        return this._ios.estimatedRowHeight;
     }
 
     public _prepareCell(cell: ListViewCell, indexPath: NSIndexPath): number {

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -2,7 +2,7 @@
 import { ItemEventData } from ".";
 import {
     ListViewBase, View, KeyedTemplate, Length, Observable, Color,
-    separatorColorProperty, itemTemplatesProperty, layout, EventData
+    separatorColorProperty, itemTemplatesProperty, iosEstimatedRowHeightProperty, layout, EventData
 } from "./list-view-common";
 import { StackLayout } from "../layouts/stack-layout";
 import { ProxyViewContainer } from "../proxy-view-container";
@@ -138,7 +138,7 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
     public tableViewHeightForRowAtIndexPath(tableView: UITableView, indexPath: NSIndexPath): number {
         const owner = this._owner.get();
         if (!owner) {
-            return DEFAULT_HEIGHT;
+            return tableView.estimatedRowHeight;
         }
 
         let height: number;
@@ -188,7 +188,7 @@ class UITableViewRowHeightDelegateImpl extends NSObject implements UITableViewDe
         }
         return indexPath;
     }
-    
+
     public tableViewDidSelectRowAtIndexPath(tableView: UITableView, indexPath: NSIndexPath): NSIndexPath {
         tableView.deselectRowAtIndexPathAnimated(indexPath, true);
 
@@ -198,7 +198,7 @@ class UITableViewRowHeightDelegateImpl extends NSObject implements UITableViewDe
     public tableViewHeightForRowAtIndexPath(tableView: UITableView, indexPath: NSIndexPath): number {
         let owner = this._owner.get();
         if (!owner) {
-            return DEFAULT_HEIGHT;
+            return tableView.estimatedRowHeight;
         }
 
         return owner._effectiveRowHeight;
@@ -340,7 +340,7 @@ export class ListView extends ListViewBase {
             return height;
         }
 
-        return DEFAULT_HEIGHT;
+        return this.ios.estimatedRowHeight;
     }
 
     public _prepareCell(cell: ListViewCell, indexPath: NSIndexPath): number {
@@ -422,5 +422,14 @@ export class ListView extends ListViewBase {
         }
 
         this.refresh();
+    }
+
+    [iosEstimatedRowHeightProperty.getDefault](): Length {
+        return DEFAULT_HEIGHT;
+    }
+    [iosEstimatedRowHeightProperty.setNative](value: Length) {
+        const nativeView = this._ios;
+        const estimatedHeight = Length.toDevicePixels(value, 0);
+        nativeView.estimatedRowHeight = estimatedHeight < 0 ? DEFAULT_HEIGHT : estimatedHeight;
     }
 }


### PR DESCRIPTION
`iosEstimatedRowHeight` property sets [estimatedRowHeight](https://developer.apple.com/documentation/uikit/uitableview/1614925-estimatedrowheight) of the UITableView which forces the ListView to auto-measure its items.

Setting `iosEstimatedRowHeight="0"` can easily resolve [issue](https://github.com/NativeScript/NativeScript/issues/3818)