### PR TITLE
fix(webpack): register wrap layout

### DIFF
--- a/tns-core-modules/bundle-entry-points.ts
+++ b/tns-core-modules/bundle-entry-points.ts
@@ -21,6 +21,7 @@ if (global.TNS_WEBPACK) {
     global.registerModule("ui/layouts/grid-layout", () => require("ui/layouts/grid-layout"))
     global.registerModule("ui/layouts/stack-layout", () => require("ui/layouts/stack-layout"))
     global.registerModule("ui/layouts/flexbox-layout", () => require("ui/layouts/flexbox-layout"))
+    global.registerModule("ui/layouts/wrap-layout", () => require("ui/layouts/wrap-layout"))
     global.registerModule("ui/list-picker", () => require("ui/list-picker"))
     global.registerModule("ui/page", () => require("ui/page"))
     global.registerModule("ui/placeholder", () => require("ui/placeholder"))


### PR DESCRIPTION
Currently webpack fails if app is using wrap layout since it is not registered here. Registering it manually in the app works as a workaround, but still I think it would be nice to have it here by default.