### PR TITLE
refactor(ios): clean up iOS8 or lower specific checks in codebase

### DIFF
--- a/tests/app/ui/list-view/list-view-tests.ts
+++ b/tests/app/ui/list-view/list-view-tests.ts
@@ -188,9 +188,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
             completed = args.index === (listView.items.length - 1);
         });
 
-        // iOS7 needs to know the size of the cell before it is generated so we first measure them using fake cell
-        // then we generate the real cells. This cause itemLoading to be called twice per index.
-        let expected = (platform.device.os === platform.platformNames.ios && utils.ios.MajorVersion === 7) ? 2 : 1;
+        let expected = 1;
         TKUnit.waitUntilReady(() => completed);
         TKUnit.assertEqual(indexes[0], expected, "itemLoading called more than once");
         TKUnit.assertEqual(indexes[1], expected, "itemLoading called more than once");
@@ -557,12 +555,7 @@ export class ListViewTest extends testModule.UITest<listViewModule.ListView> {
 
         this.waitUntilListViewReady();
 
-        if (utils.ios && utils.ios.MajorVersion < 8) {
-            TKUnit.assertEqual(converterCalledCounter, listViewModel.get("items").length * 2, "Converter should be called once for every item.");
-        }
-        else {
-            TKUnit.assertEqual(converterCalledCounter, listViewModel.get("items").length, "Converter should be called once for every item.");
-        }
+        TKUnit.assertEqual(converterCalledCounter, listViewModel.get("items").length, "Converter should be called once for every item.");
     }
 
     public test_RemovingChildViewsBeforeListView() {

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -578,8 +578,6 @@ export class CustomLayoutView extends View {
     }
 }
 
-const majorVersion = iosUtils.MajorVersion;
-
 export namespace ios {
     export function isContentScrollable(controller: UIViewController, owner: View): boolean {
         let scrollableContent = (<any>owner).scrollableContent;

--- a/tns-core-modules/ui/dialogs/dialogs.ios.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.ios.ts
@@ -2,100 +2,16 @@
  * iOS specific dialogs functions implementation.
  */
 
-import { DialogOptions, ConfirmOptions, PromptOptions, PromptResult, LoginOptions, LoginResult, ActionOptions } from ".";
+import { ConfirmOptions, PromptOptions, PromptResult, LoginOptions, LoginResult, ActionOptions } from ".";
 import { getCurrentPage, getLabelColor, getButtonColor, getTextFieldColor, isDialogOptions, inputType, ALERT, OK, CONFIRM, CANCEL, PROMPT, LOGIN } from "./dialogs-common";
 import { isString, isDefined, isFunction } from "../../utils/types";
-import * as utils from "../../utils/utils";
-import getter = utils.ios.getter;
 
 export * from "./dialogs-common";
-
-class UIAlertViewDelegateImpl extends NSObject implements UIAlertViewDelegate {
-    public static ObjCProtocols = [UIAlertViewDelegate];
-
-    private _callback: (view: any, index: number) => void;
-
-    public static initWithCallback(callback: (view: any, index: number) => void): UIAlertViewDelegateImpl {
-        let delegate = <UIAlertViewDelegateImpl>UIAlertViewDelegateImpl.new();
-        delegate._callback = callback;
-        return delegate;
-    }
-
-    public alertViewClickedButtonAtIndex(view, index) {
-        this._callback(view, index);
-    }
-}
-
-class UIActionSheetDelegateImpl extends NSObject implements UIActionSheetDelegate {
-    public static ObjCProtocols = [UIActionSheetDelegate];
-
-    private _callback: (actionSheet: UIActionSheet, index: number) => void;
-
-    public static initWithCallback(callback: (actionSheet: UIActionSheet, index: number) => void): UIActionSheetDelegateImpl {
-        let delegate = <UIActionSheetDelegateImpl>UIActionSheetDelegateImpl.new();
-        delegate._callback = callback;
-        return delegate;
-    }
-
-    public actionSheetClickedButtonAtIndex(actionSheet, index) {
-        this._callback(actionSheet, index);
-    }
-}
-
-function createUIAlertView(options: DialogOptions): UIAlertView {
-    let alert = UIAlertView.new();
-    alert.title = options && options.title ? options.title : "";
-    alert.message = options && options.message ? options.message : "";
-    return alert;
-}
 
 enum allertButtons {
     cancel = 1 << 0,
     neutral = 1 << 1,
     ok = 1 << 2,
-}
-
-function addButtonsToAlertDialog(alert: UIAlertView, options: ConfirmOptions): void {
-    if (!options) {
-        return;
-    }
-
-    if (options.cancelButtonText) {
-        alert.tag = allertButtons.cancel;
-        alert.addButtonWithTitle(options.cancelButtonText);
-    }
-
-    if (options.neutralButtonText) {
-        alert.tag = alert.tag | allertButtons.neutral;
-        alert.addButtonWithTitle(options.neutralButtonText);
-    }
-
-    if (options.okButtonText) {
-        alert.tag = alert.tag | allertButtons.ok;
-        alert.addButtonWithTitle(options.okButtonText);
-    }
-}
-
-function getDialogResult(buttons: allertButtons, index: number) {
-    let hasCancel = buttons & allertButtons.cancel;
-    let hasNeutral = buttons & allertButtons.neutral;
-    let hasOk = buttons & allertButtons.ok;
-
-    if (hasCancel && hasNeutral && hasOk) {
-        return index === 0 ? false : index === 2 ? true : undefined;
-    } else if (buttons & hasNeutral && hasOk) {
-        return index === 0 ? undefined : true;
-    } else if (hasCancel && hasOk) {
-        return index !== 0;
-    } else if (hasCancel && hasNeutral) {
-        return index === 0 ? false : undefined;
-    } else if (hasCancel) {
-        return false;
-    } else if (hasOk) {
-        return true;
-    }
-
-    return undefined;
 }
 
 function addButtonsToAlertController(alertController: UIAlertController, options: ConfirmOptions, callback?: Function): void {
@@ -131,31 +47,11 @@ export function alert(arg: any): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         try {
             let options = !isDialogOptions(arg) ? { title: ALERT, okButtonText: OK, message: arg + "" } : arg;
+            let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
+            
+            addButtonsToAlertController(alertController, options, () => { resolve(); });
 
-            if (utils.ios.MajorVersion < 8) {
-                let alert = createUIAlertView(options);
-
-                if (options.okButtonText) {
-                    alert.addButtonWithTitle(options.okButtonText);
-                }
-
-                // Assign first to local letiable, otherwise it will be garbage collected since delegate is weak reference.
-                let delegate = UIAlertViewDelegateImpl.initWithCallback(function (view, index) {
-                    resolve();
-                    // Remove the local letiable for the delegate.
-                    delegate = undefined;
-                });
-
-                alert.delegate = delegate;
-
-                alert.show();
-            } else {
-                let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
-
-                addButtonsToAlertController(alertController, options, () => { resolve(); });
-
-                showUIAlertController(alertController);
-            }
+            showUIAlertController(alertController);
         } catch (ex) {
             reject(ex);
         }
@@ -166,31 +62,11 @@ export function confirm(arg: any): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
         try {
             let options = !isDialogOptions(arg) ? { title: CONFIRM, okButtonText: OK, cancelButtonText: CANCEL, message: arg + "" } : arg;
+            let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
 
-            if (utils.ios.MajorVersion < 8) {
-                let alert = createUIAlertView(options);
+            addButtonsToAlertController(alertController, options, (r) => { resolve(r); });
 
-                addButtonsToAlertDialog(alert, options);
-
-                // Assign first to local letiable, otherwise it will be garbage collected since delegate is weak reference.
-                let delegate = UIAlertViewDelegateImpl.initWithCallback(function (view, index) {
-                    resolve(getDialogResult(alert.tag, index));
-
-                    // Remove the local letiable for the delegate.
-                    delegate = undefined;
-                });
-
-                alert.delegate = delegate;
-
-                alert.show();
-            } else {
-                let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
-
-                addButtonsToAlertController(alertController, options, (r) => { resolve(r); });
-
-                showUIAlertController(alertController);
-            }
-
+            showUIAlertController(alertController);
         } catch (ex) {
             reject(ex);
         }
@@ -225,60 +101,28 @@ export function prompt(arg: any): Promise<PromptResult> {
     return new Promise<PromptResult>((resolve, reject) => {
         try {
             let textField: UITextField;
+            let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
 
-            if (utils.ios.MajorVersion < 8) {
-                let alert = createUIAlertView(options);
+            alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
+                arg.text = isString(options.defaultText) ? options.defaultText : "";
+                arg.secureTextEntry = options && options.inputType === inputType.password;
 
-                if (options.inputType === inputType.password) {
-                    alert.alertViewStyle = UIAlertViewStyle.SecureTextInput;
-                } else {
-                    alert.alertViewStyle = UIAlertViewStyle.PlainTextInput;
+                if (options && options.inputType === inputType.email) {
+                    arg.keyboardType = UIKeyboardType.EmailAddress;
                 }
 
-                addButtonsToAlertDialog(alert, options);
-
-                textField = alert.textFieldAtIndex(0);
-                textField.text = isString(options.defaultText) ? options.defaultText : "";
-
-                if (options.inputType === inputType.email) {
-                    textField.keyboardType = UIKeyboardType.EmailAddress;
+                let color = getTextFieldColor();
+                if (color) {
+                    arg.textColor = arg.tintColor = color.ios;
                 }
+            });
 
-                // Assign first to local letiable, otherwise it will be garbage collected since delegate is weak reference.
-                let delegate = UIAlertViewDelegateImpl.initWithCallback(function (view, index) {
-                    resolve({ result: getDialogResult(alert.tag, index), text: textField.text });
-                    // Remove the local letiable for the delegate.
-                    delegate = undefined;
-                });
+            textField = alertController.textFields.firstObject;
 
-                alert.delegate = delegate;
+            addButtonsToAlertController(alertController, options,
+                (r) => { resolve({ result: r, text: textField.text }); });
 
-                alert.show();
-            } else {
-                let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
-
-                alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
-                    arg.text = isString(options.defaultText) ? options.defaultText : "";
-                    arg.secureTextEntry = options && options.inputType === inputType.password;
-
-                    if (options && options.inputType === inputType.email) {
-                        arg.keyboardType = UIKeyboardType.EmailAddress;
-                    }
-
-                    let color = getTextFieldColor();
-                    if (color) {
-                        arg.textColor = arg.tintColor = color.ios;
-                    }
-                });
-
-                textField = alertController.textFields.firstObject;
-
-                addButtonsToAlertController(alertController, options,
-                    (r) => { resolve({ result: r, text: textField.text }); });
-
-                showUIAlertController(alertController);
-            }
-
+            showUIAlertController(alertController);
         } catch (ex) {
             reject(ex);
         }
@@ -316,72 +160,43 @@ export function login(arg: any): Promise<LoginResult> {
         try {
             let userNameTextField: UITextField;
             let passwordTextField: UITextField;
+            let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
 
-            if (utils.ios.MajorVersion < 8) {
-                let alert = createUIAlertView(options);
+            alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
+                arg.placeholder = "Login";
+                arg.text = isString(options.userName) ? options.userName : "";
 
-                alert.alertViewStyle = UIAlertViewStyle.LoginAndPasswordInput;
+                let color = getTextFieldColor();
+                if (color) {
+                    arg.textColor = arg.tintColor = color.ios;
+                }
+            });
 
-                addButtonsToAlertDialog(alert, options);
+            alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
+                arg.placeholder = "Password";
+                arg.secureTextEntry = true;
+                arg.text = isString(options.password) ? options.password : "";
 
-                userNameTextField = alert.textFieldAtIndex(0);
-                userNameTextField.text = isString(options.userName) ? options.userName : "";
+                let color = getTextFieldColor();
+                if (color) {
+                    arg.textColor = arg.tintColor = color.ios;
+                }
+            });
 
-                passwordTextField = alert.textFieldAtIndex(1);
-                passwordTextField.text = isString(options.password) ? options.password : "";
+            userNameTextField = alertController.textFields.firstObject;
+            passwordTextField = alertController.textFields.lastObject;
 
-                // Assign first to local letiable, otherwise it will be garbage collected since delegate is weak reference.
-                let delegate = UIAlertViewDelegateImpl.initWithCallback(function (view, index) {
-                    resolve({ result: getDialogResult(alert.tag, index), userName: userNameTextField.text, password: passwordTextField.text });
-                    // Remove the local letiable for the delegate.
-                    delegate = undefined;
-                });
-
-                alert.delegate = delegate;
-
-                alert.show();
-            } else {
-                let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
-
-                alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
-                    arg.placeholder = "Login";
-                    arg.text = isString(options.userName) ? options.userName : "";
-
-                    let color = getTextFieldColor();
-                    if (color) {
-                        arg.textColor = arg.tintColor = color.ios;
-                    }
-                });
-
-                alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
-                    arg.placeholder = "Password";
-                    arg.secureTextEntry = true;
-                    arg.text = isString(options.password) ? options.password : "";
-
-                    let color = getTextFieldColor();
-                    if (color) {
-                        arg.textColor = arg.tintColor = color.ios;
-                    }
-                });
-
-                userNameTextField = alertController.textFields.firstObject;
-                passwordTextField = alertController.textFields.lastObject;
-
-                addButtonsToAlertController(alertController, options,
-                    (r) => {
-
-                        resolve({
-                            result: r,
-                            userName:
-                            userNameTextField.text,
-                            password: passwordTextField.text
-                        });
-
+            addButtonsToAlertController(alertController, options,
+                (r) => {
+                    resolve({
+                        result: r,
+                        userName:
+                        userNameTextField.text,
+                        password: passwordTextField.text
                     });
+                });
 
-                showUIAlertController(alertController);
-            }
-
+            showUIAlertController(alertController);
         } catch (ex) {
             reject(ex);
         }
@@ -452,57 +267,26 @@ export function action(arg: any): Promise<string> {
         try {
             let i: number;
             let action: string;
+            let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.ActionSheet);
 
-            if (utils.ios.MajorVersion < 8) {
-                let actionSheet = UIActionSheet.new();
-
-                if (isString(options.message)) {
-                    actionSheet.title = options.message;
-                }
-
-                if (options.actions) {
-                    for (i = 0; i < options.actions.length; i++) {
-                        action = options.actions[i];
-                        if (isString(action)) {
-                            actionSheet.addButtonWithTitle(action);
-                        }
+            if (options.actions) {
+                for (i = 0; i < options.actions.length; i++) {
+                    action = options.actions[i];
+                    if (isString(action)) {
+                        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(action, UIAlertActionStyle.Default, (arg: UIAlertAction) => {
+                            resolve(arg.title);
+                        }));
                     }
                 }
-
-                if (isString(options.cancelButtonText)) {
-                    actionSheet.addButtonWithTitle(options.cancelButtonText);
-                    actionSheet.cancelButtonIndex = actionSheet.numberOfButtons - 1;
-                }
-
-                let delegate = UIActionSheetDelegateImpl.initWithCallback(function (sender: UIActionSheet, index: number) {
-                    resolve(sender.buttonTitleAtIndex(index));
-                    delegate = undefined;
-                });
-
-                actionSheet.delegate = delegate;
-                actionSheet.showInView(getter(UIApplication, UIApplication.sharedApplication).keyWindow);
-            } else {
-                let alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.ActionSheet);
-
-                if (options.actions) {
-                    for (i = 0; i < options.actions.length; i++) {
-                        action = options.actions[i];
-                        if (isString(action)) {
-                            alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(action, UIAlertActionStyle.Default, (arg: UIAlertAction) => {
-                                resolve(arg.title);
-                            }));
-                        }
-                    }
-                }
-
-                if (isString(options.cancelButtonText)) {
-                    alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.cancelButtonText, UIAlertActionStyle.Cancel, (arg: UIAlertAction) => {
-                        resolve(arg.title);
-                    }));
-                }
-
-                showUIAlertController(alertController);
             }
+
+            if (isString(options.cancelButtonText)) {
+                alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.cancelButtonText, UIAlertActionStyle.Cancel, (arg: UIAlertAction) => {
+                    resolve(arg.title);
+                }));
+            }
+
+            showUIAlertController(alertController);
 
         } catch (ex) {
             reject(ex);

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -141,13 +141,9 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
             return tableView.estimatedRowHeight;
         }
 
-        let height: number;
-        if (ios.MajorVersion >= 8) {
-            height = owner.getHeight(indexPath.row);
-        }
-
-        if (ios.MajorVersion < 8 || height === undefined) {
-            // in iOS 7.1 (or iOS8+ after call to scrollToRowAtIndexPath:atScrollPosition:animated:) this method is called before tableViewCellForRowAtIndexPath so we need fake cell to measure its content.
+        let height = owner.getHeight(indexPath.row);
+        if (height === undefined) {
+            // in iOS8+ after call to scrollToRowAtIndexPath:atScrollPosition:animated: this method is called before tableViewCellForRowAtIndexPath so we need fake cell to measure its content.
             const template = owner._getItemTemplate(indexPath.row);
             let cell = this._measureCellMap.get(template.key);
             if (!cell) {


### PR DESCRIPTION
tns-core-modules@4.0 require iOS9 or later due to the UILayoutGuide usage so we no longer need the iOS8 (and lower) checks in the codebase.