### PR TITLE
chore(view): expose onBackPressed in d.ts

### DIFF
--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -575,6 +575,11 @@ export abstract class View extends ViewBase {
     public getActualSize(): Size;
 
     /**
+     * Derived classes can override this method to handle Android back button press. 
+     */
+    onBackPressed(): boolean;
+
+    /**
      * @private
      * A valid css string which will be applied for all nested UI components (based on css rules).
      */
@@ -678,11 +683,6 @@ export abstract class View extends ViewBase {
      * @private
      */
     _onLivesync(): boolean;
-
-    /**
-     * Derived classes can override this method to handle Android back button press. 
-     */
-    onBackPressed(): boolean;
     /**
      * @private
      */


### PR DESCRIPTION
Move the onBackPressed() definition out of the `//@private` -- `//@endprivate` scope, so that it is not trimmed on build.