### PR TITLE
chore: set keepAspectRatio to true as default in image-asset

### DIFF
--- a/tests/app/image-source/image-source-tests.ts
+++ b/tests/app/image-source/image-source-tests.ts
@@ -15,7 +15,7 @@ export function testFromResource() {
     // >> imagesource-resname
     const img = imageSource.fromResource("icon");
     // << imagesource-resname
-    
+
     TKUnit.assert(img.height > 0, "image.fromResource failed");
 }
 
@@ -139,6 +139,22 @@ export function testFromAssetWithScalingAndAspectRatio(done) {
         height: scaleHeight,
         keepAspectRatio: true
     };
+
+    let img = imageSource.fromAsset(asset).then((source) => {
+        TKUnit.assertEqual(source.width, 18);
+        TKUnit.assertEqual(source.height, scaleHeight);
+        done();
+    }, (error) => {
+        done(error);
+    });
+}
+
+export function testFromAssetWithScalingAndDefaultAspectRatio(done) {
+    let asset = new imageAssetModule.ImageAsset(splashscreenPath);
+    let scaleWidth = 10;
+    let scaleHeight = 11;
+    asset.options.width = scaleWidth;
+    asset.options.height = scaleHeight;
 
     let img = imageSource.fromAsset(asset).then((source) => {
         TKUnit.assertEqual(source.width, 18);

--- a/tns-core-modules/image-asset/image-asset-common.ts
+++ b/tns-core-modules/image-asset/image-asset-common.ts
@@ -9,6 +9,11 @@ export class ImageAsset  extends observable.Observable implements definition.Ima
     ios: PHAsset;
     android: string;
 
+    constructor () {
+        super();
+        this._options = { keepAspectRatio: true };
+    }
+
     get options(): definition.ImageAssetOptions {
         return this._options;
     }
@@ -24,6 +29,8 @@ export class ImageAsset  extends observable.Observable implements definition.Ima
     set nativeImage(value: any) {
         this._nativeImage = value;
     }
+
+    
 
     public getImageAsync(callback: (image: any, error: Error) => void) {
         //


### PR DESCRIPTION
Currently, ImageAsset instances are created with options.keepAspectRatio = false as default. This PR makes the default true as this is the more expected value.