### PR TITLE
fix-next(ios-modal): fix empty modal view when using common layout as root

### DIFF
--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -317,7 +317,13 @@ export class View extends ViewCommon {
         super._showNativeModalView(parentWithController, context, closeCallback, fullscreen, stretched);
         let controller = this.viewController;
         if (!controller) {
+            const nativeView = this.ios || this.nativeViewProtected;
             controller = ios.UILayoutViewController.initWithOwner(new WeakRef(this));
+
+            if (nativeView instanceof UIView) {
+                controller.view.addSubview(nativeView);
+            }
+
             this.viewController = controller;
         }
 
@@ -733,7 +739,7 @@ export namespace ios {
         public viewWillAppear(animated: boolean): void {
             super.viewWillAppear(animated);
             const owner = this.owner.get();
-            if(!owner){
+            if (!owner) {
                 return;
             }
 


### PR DESCRIPTION
__The problem__: Empty modal view when using common layout (`GridLayout/StackLayout` e.g.) as a root element.

__The solution__: The `UIView` was not added as a child of the `UIViewController`

_e2e/modal-navigation tests already available for this scenario_