### PR TITLE
fix(ios-searchbar): fix crash with auto-sized searchbar in iOS11 Fixes #5655

### DIFF
--- a/apps/app/ui-tests-app/search-bar/issue-5655.xml
+++ b/apps/app/ui-tests-app/search-bar/issue-5655.xml
@@ -1,0 +1,28 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd">
+    <StackLayout>
+        <GridLayout height="60" rows="auto" columns="auto, *">
+            <SearchBar id="searchBar1" hint="Search" text="auto(sb), * col, no width" />   
+        </GridLayout>
+        <GridLayout height="60" rows="auto" columns="auto, *">
+            <SearchBar id="searchBar2" width="100%" hint="Search" text="auto(sb), * col, width 100%" />   
+        </GridLayout>
+        <GridLayout height="60" rows="auto" columns="auto, *">
+            <SearchBar id="searchBar3" width="300" hint="Search" text="auto(sb), * col, width 300dip" />   
+        </GridLayout>
+        <GridLayout height="60" rows="auto" columns="*, auto">
+            <SearchBar col="1" id="searchBar4" width="300" hint="Search" text="*, auto(sb) col, width 300dip" />   
+        </GridLayout>
+        <GridLayout height="60" rows="auto" columns="auto, 200">
+            <SearchBar id="searchBar5" hint="Search" text="auto(sb), 200 cols, no width" />   
+        </GridLayout>
+        <GridLayout height="60" rows="auto" columns="200, auto">
+            <SearchBar col="1" id="searchBar6" hint="Search" text="200, auto(sb) cols, no width" />   
+        </GridLayout>
+        <StackLayout height="60">
+            <SearchBar id="searchBar7" hint="Search" text="stack, no width" />
+        </StackLayout>
+        <StackLayout height="60">
+            <SearchBar id="searchBar8" width="300" hint="Search" text="stack, width 300dip" />
+        </StackLayout>
+    </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/search-bar/main-page.ts
+++ b/apps/app/ui-tests-app/search-bar/main-page.ts
@@ -11,8 +11,10 @@ export function pageLoaded(args: EventData) {
 
 export function loadExamples() {
     const examples = new Map<string, string>();
-     examples.set("issue-4147", "search-bar/issue-4147");
-     examples.set("search-bar", "search-bar/search-bar");
-     examples.set("issue-5039","search-bar/issue-5039");
+    examples.set("issue-4147", "search-bar/issue-4147");
+    examples.set("search-bar", "search-bar/search-bar");
+    examples.set("issue-5039", "search-bar/issue-5039");
+    examples.set("issue-5655", "search-bar/issue-5655");
+    
     return examples;
 }

--- a/tns-core-modules/ui/search-bar/search-bar.ios.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.ios.ts
@@ -3,8 +3,11 @@ import {
     SearchBarBase, Color, colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty,
     textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty
 } from "./search-bar-common";
+import { ios as iosUtils } from "../../utils/utils";
 
 export * from "./search-bar-common";
+
+const majorVersion = iosUtils.MajorVersion;
 
 class UISearchBarDelegateImpl extends NSObject implements UISearchBarDelegate {
     public static ObjCProtocols = [UISearchBarDelegate];
@@ -52,6 +55,20 @@ class UISearchBarDelegateImpl extends NSObject implements UISearchBarDelegate {
     }
 }
 
+class UISearchBarImpl extends UISearchBar {
+    sizeThatFits(size: CGSize): CGSize {
+        // iOS11 SDK does not support passing sizeThatFits(...) non-finite width value;
+        // iOS layout system will take care to size the element properly when passed 0
+        if (majorVersion >= 11) {
+            if (!!size.width) {
+                size.width = 0;
+            }
+        }
+
+        return super.sizeThatFits(size);
+    }
+}
+
 export class SearchBar extends SearchBarBase {
     private _ios: UISearchBar;
     private _delegate;
@@ -61,7 +78,7 @@ export class SearchBar extends SearchBarBase {
     constructor() {
         super();
 
-        this.nativeViewProtected = this._ios = UISearchBar.new();
+        this.nativeViewProtected = this._ios = UISearchBarImpl.new();
         this._delegate = UISearchBarDelegateImpl.initWithOwner(new WeakRef(this));
     }
 


### PR DESCRIPTION
Apparently iOS11 SDK does not support passing sizeThatFits(...) non-finite width value any more.
In a scenario where searchbar should be auto-sized(grid with auto column) our [measure logic](https://github.com/NativeScript/NativeScript/blob/9717bbf8477052a6306fd09c55efc58399141d82/tns-core-modules/ui/core/view/view.ios.ts#L125) always [passes infinity values](https://github.com/NativeScript/NativeScript/blob/9717bbf8477052a6306fd09c55efc58399141d82/tns-core-modules/utils/utils.ios.ts#L38) in case layout mode is unspecified so we extend the UISearchBar widget and add the fix there.

- Fixes https://github.com/NativeScript/NativeScript/issues/5655
- Added test page in UI tests app (/search-bar/issue-5655.xml) with the following output:
![simulator screen shot - iphone 6 - 2018-04-11 at 19 06 48](https://user-images.githubusercontent.com/2650247/38629052-9d645d7c-3dbb-11e8-9732-2d5c1dab51e4.png)
