### PR TITLE
fix(android-connectivity): Add ethernet connection type

### DIFF
--- a/tns-core-modules/connectivity/connectivity.android.ts
+++ b/tns-core-modules/connectivity/connectivity.android.ts
@@ -4,10 +4,12 @@ export enum connectionType {
     none = 0,
     wifi = 1,
     mobile = 2,
+    ethernet = 3
 }
 
 const wifi = "wifi";
 const mobile = "mobile";
+const ethernet = "ethernet";
 
 // Get Connection Type
 function getConnectivityManager(): android.net.ConnectivityManager {
@@ -36,6 +38,10 @@ export function getConnectionType(): number {
     
     if (type.indexOf(mobile) !== -1){
         return connectionType.mobile;
+    }
+
+    if (type.indexOf(ethernet) !== -1){
+        return connectionType.ethernet;
     }
         
     return connectionType.none;

--- a/tns-core-modules/connectivity/connectivity.d.ts
+++ b/tns-core-modules/connectivity/connectivity.d.ts
@@ -27,7 +27,12 @@ export enum connectionType {
     /**
      * Denotes a mobile connection, i.e. cellular network or WAN.
      */
-    mobile = 2
+    mobile = 2,
+
+    /**
+     * Denotes an ethernet connection
+     */
+    ethernet = 3
 }
 
 /**


### PR DESCRIPTION
When calling getConnectionType on an emulator, the connection type can be returned as "ethernet", which causes getConnectionType to return none when there is a connection.

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
2 failed on emulator un-releated to the connectivity code being changed here
- [X] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.
To the extent to match the existing connectivity test

## What is the current behavior?
If the connection type is "ethernet" getConnectionType will return none.

## What is the new behavior?
If the connection type is "ethernet" getConnectionType will properly return the "ethernet" connection type

Fixes/Implements/Closes #5669.

