### PR TITLE
chore(modal): update d.ts for showModal(...) parameters

### DIFF
--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -116,9 +116,11 @@ export abstract class ViewBase extends Observable {
      * This same context will be available in the arguments of the shownModally event handler.
      * @param closeCallback - A function that will be called when the view is closed.
      * Any arguments provided when calling ShownModallyData.closeCallback will be available here.
-     * @param fullscreen - An optional parameter specifying whether to show the modal page in full-screen mode.
+     * @param fullscreen - An optional parameter specifying whether to show the modal view in full-screen mode.
+     * @param animated - An optional parameter specifying whether to show the modal view with animation.
+     * @param stretched - An optional parameter specifying whether to stretch the modal view when not in full-screen mode.
      */
-    showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean, animated?: boolean): ViewBase;
+    showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean, animated?: boolean, stretched?: boolean): ViewBase;
 
     /**
      * Shows the view passed as parameter as a modal view.
@@ -126,8 +128,10 @@ export abstract class ViewBase extends Observable {
      * @param context - Any context you want to pass to the modally shown view. This same context will be available in the arguments of the shownModally event handler.
      * @param closeCallback - A function that will be called when the view is closed. Any arguments provided when calling ShownModallyData.closeCallback will be available here.
      * @param fullscreen - An optional parameter specifying whether to show the modal view in full-screen mode.
+     * @param animated - An optional parameter specifying whether to show the modal view with animation.
+     * @param stretched - An optional parameter specifying whether to stretch the modal view when not in full-screen mode.
      */
-    showModal(view: ViewBase, context: any, closeCallback: Function, fullscreen?: boolean, animated?: boolean): ViewBase;
+    showModal(view: ViewBase, context: any, closeCallback: Function, fullscreen?: boolean, animated?: boolean, stretched?: boolean): ViewBase;
 
     /**
      * Deprecated. Showing view as modal is deprecated.

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -507,39 +507,6 @@ export abstract class View extends ViewBase {
     on(event: "shownModally", callback: (args: ShownModallyData) => void, thisArg?: any);
 
     /**
-    * Shows the View contained in moduleName as a modal view.
-    * @param moduleName - The name of the module to load starting from the application root.
-    * @param context - Any context you want to pass to the modally shown view.
-    * This same context will be available in the arguments of the shownModally event handler.
-    * @param closeCallback - A function that will be called when the view is closed.
-    * Any arguments provided when calling ShownModallyData.closeCallback will be available here.
-    * @param fullscreen - An optional parameter specifying whether to show the modal page in full-screen mode.
-    * @param stretched - An optional parameter specifying whether to stretch the modal page when not in full-screen mode.
-    */
-    showModal(moduleName: string, context: any, closeCallback: Function, fullscreen?: boolean, animated?: boolean, stretched?: boolean): View;
-
-    /**
-     * Shows the view passed as parameter as a modal view.
-     * @param view - View instance to be shown modally.
-     * @param context - Any context you want to pass to the modally shown view. This same context will be available in the arguments of the shownModally event handler.
-     * @param closeCallback - A function that will be called when the view is closed. Any arguments provided when calling ShownModallyData.closeCallback will be available here.
-     * @param fullscreen - An optional parameter specifying whether to show the modal view in full-screen mode.
-     * @param stretched - An optional parameter specifying whether to stretch the modal page when not in full-screen mode.
-     */
-    showModal(view: View, context: any, closeCallback: Function, fullscreen?: boolean, animated?: boolean, stretched?: boolean): View;
-
-    /**
-     * Deprecated. Showing view as modal is deprecated.
-     * Use showModal method with arguments.
-     */
-    showModal(): View;
-
-    /**
-     * Closes the current modal view that this page is showing.
-     */
-    closeModal(): void;
-
-    /**
      * Returns the current modal view that this page is showing (is parent of), if any.
      */
     modal: View;


### PR DESCRIPTION
It seems we released the new `showModal(...)` API with incomplete d.ts metadata. This causes a problem in the following scenario where at the moment an additional type checking is needed: https://github.com/NativeScript/nativescript-angular/pull/1293