### PR TITLE
Add required inspector fields for Elements and Network

### DIFF
--- a/tns-core-modules/debugger/debugger.ts
+++ b/tns-core-modules/debugger/debugger.ts
@@ -70,6 +70,8 @@ export namespace NetworkAgent {
         url: string;
         method: string;
         headers: any;
+        initialPriority: string;
+        referrerPolicy: string;
         postData?: string;
     }
 
@@ -79,6 +81,7 @@ export namespace NetworkAgent {
         request: Request;
         timestamp: number;
         type: string;
+        wallTime: number;
     }
 
     export interface Response {
@@ -88,6 +91,10 @@ export namespace NetworkAgent {
         headers: any;
         headersText?: string;
         mimeType: string;
+        connectionReused: boolean;
+        connectionId: number;
+        encodedDataLength: number;
+        securityState: string;
         fromDiskCache?: boolean;
     }
 
@@ -113,13 +120,23 @@ export namespace NetworkAgent {
         const requestIdStr = requestId.toString();
         // Content-Type and content-type are both common in headers spelling
         const mimeType: string = <string>headers["Content-Type"] || <string>headers["content-type"] || "application/octet-stream";
+        const contentLengthHeader: string = <string>headers["Content-Length"] || <string>headers["content-length"];
+        var contentLength = parseInt(contentLengthHeader, 10);
+        if (isNaN(contentLength)) {
+            contentLength = 0;
+        }
+
         const response: NetworkAgent.Response = {
             url: result.url || "",
             status: result.statusCode,
             statusText: result.statusText || "",
             headers: headers,
             mimeType: mimeType,
-            fromDiskCache: false
+            fromDiskCache: false,
+            connectionReused: true,
+            connectionId: 0,
+            encodedDataLength: contentLength,
+            securityState: "info"
         }
 
         const responseData: NetworkAgent.ResponseData = {
@@ -130,7 +147,11 @@ export namespace NetworkAgent {
         }
 
         global.__inspector.responseReceived(responseData);
-        global.__inspector.loadingFinished({ requestId: requestIdStr, timestamp: getTimeStamp() });
+        global.__inspector.loadingFinished({
+            requestId: requestIdStr,
+            timestamp: getTimeStamp(),
+            encodedDataLength: contentLength
+        });
 
         const hasTextContent = responseData.type === "Document" || responseData.type === "Script";
         let data;
@@ -164,7 +185,9 @@ export namespace NetworkAgent {
             url: options.url,
             method: options.method,
             headers: options.headers || {},
-            postData: options.content ? options.content.toString() : ""
+            postData: options.content ? options.content.toString() : "",
+            initialPriority: "Medium",
+            referrerPolicy: "no-referrer-when-downgrade"
         }
 
         const requestData: NetworkAgent.RequestData = {
@@ -172,7 +195,8 @@ export namespace NetworkAgent {
             url: request.url,
             request: request,
             timestamp: getTimeStamp(),
-            type: "Document"
+            type: "Document",
+            wallTime: 0
         }
 
         global.__inspector.requestWillBeSent(requestData);

--- a/tns-core-modules/debugger/dom-node.ts
+++ b/tns-core-modules/debugger/dom-node.ts
@@ -210,7 +210,8 @@ export class DOMNode {
             localName: this.localName,
             nodeValue: this.nodeValue,
             children: this.children.map(c => c.toObject()),
-            attributes: this.attributes
+            attributes: this.attributes,
+            backendNodeId: 0
         };
     }
 }


### PR DESCRIPTION
In the upcoming release of the android-runtime the V8 engine will be upgraded to the latest stable version _6.6.346.23_. In this version some changes have been introduced to the inspector protocol and more specifically a couple of new fields have been made required.

The runtime sets default values to those fields if not provided but it would be more appropriate if the modules could pass them.