### PR TITLE
chore(tsc): enable noUnusedLocals compiler option for tns-core-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "unit-test": "tsc -p tsconfig.unit-tests.json && mocha --opts unit-tests/mocha.opts",
     "unit-test-watch": "mocha-typescript-watch -p tsconfig.unit-tests.json --opts unit-tests/mocha.opts",
     "compile-all": "npm run tsc -- -p tsconfig.json --outDir bin/dist",
-    "compile-modules": "npm run tsc -- -p tsconfig-modules.json --outDir bin/dist",
+    "compile-modules": "npm run tsc -- -p tsconfig.modules.json --outDir bin/dist",
     "compile-check-base-dts": "npm run tsc -- -p tsconfig.base-dts.json",
     "compile-unit-tests": "npm run tsc -- -p tsconfig.unit-tests.json --outDir bin/dist/unit-tests",
     "compile-check-combined-dts": "npm run tsc -- -p tsconfig.combined-dts.json",

--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -18,7 +18,6 @@ export * from "./application-common";
 import { createViewFromEntry } from "../ui/builder";
 import { ios as iosView, View } from "../ui/core/view";
 import { Frame, NavigationEntry } from "../ui/frame";
-import { ios } from "../ui/utils";
 import * as utils from "../utils/utils";
 import { profile, level as profilingLevel, Level } from "../profiling";
 

--- a/tns-core-modules/css/parser.ts
+++ b/tns-core-modules/css/parser.ts
@@ -1,7 +1,5 @@
 export type Parsed<V> = { start: number, end: number, value: V };
 
-import * as reworkcss from "./reworkcss";
-
 // Values
 export type ARGB = number;
 export type URL = string;
@@ -833,7 +831,7 @@ const doubleQuoteStringRegEx = /"((?:[^\n\r\f\"]|\\(?:\$|\n|[0-9a-fA-F]{1,6}\s?)
 const commentRegEx = /(\/\*(?:[^\*]|\*[^\/])*\*\/)/gym;
 const numberRegEx = /[\+\-]?(?:\d+\.\d+|\d+|\.\d+)(?:[eE][\+\-]?\d+)?/gym;
 const nameRegEx = /-?(?:(?:[a-zA-Z_]|[^\x00-\x7F]|\\(?:\$|\n|[0-9a-fA-F]{1,6}\s?))(?:[a-zA-Z_0-9\-]*|\\(?:\$|\n|[0-9a-fA-F]{1,6}\s?))*)/gym;
-const nonQuoteURLRegEx = /(:?[^\)\s\t\n\r\f\'\"\(]|\\(?:\$|\n|[0-9a-fA-F]{1,6}\s?))*/gym; // TODO: non-printable code points omitted
+// const nonQuoteURLRegEx = /(:?[^\)\s\t\n\r\f\'\"\(]|\\(?:\$|\n|[0-9a-fA-F]{1,6}\s?))*/gym; // TODO: non-printable code points omitted
 
 type InputToken = "(" | ")" | "{" | "}" | "[" | "]" | ":" | ";" | "," | " " | "^=" | "|=" | "$=" | "*=" | "~=" | "<!--" | "-->" | undefined /* <EOF-token> */ | InputTokenObject | FunctionInputToken | FunctionToken | SimpleBlock | AtKeywordToken;
 
@@ -1025,7 +1023,7 @@ export class CSS3Parser {
 
     private consumeAWhitespace(): InputToken {
         whitespaceRegEx.lastIndex = this.nextInputCodePointIndex;
-        const result = whitespaceRegEx.exec(this.text);
+        whitespaceRegEx.exec(this.text);
         this.nextInputCodePointIndex = whitespaceRegEx.lastIndex;
         return " ";
     }

--- a/tns-core-modules/debugger/webinspector-css.ios.ts
+++ b/tns-core-modules/debugger/webinspector-css.ios.ts
@@ -2,9 +2,6 @@ import * as inspectorCommandTypes from "./InspectorBackendCommands.ios";
 var inspectorCommands: typeof inspectorCommandTypes = require("./InspectorBackendCommands");
 
 import * as debuggerDomains from "./debugger";
-import * as devToolsElements from "./devtools-elements";
-
-declare var __inspectorSendEvent;
 
 import { attachCSSInspectorCommandCallbacks } from "./devtools-elements";
 

--- a/tns-core-modules/debugger/webinspector-dom.ios.ts
+++ b/tns-core-modules/debugger/webinspector-dom.ios.ts
@@ -3,9 +3,6 @@ var inspectorCommands: typeof inspectorCommandTypes = require("./InspectorBacken
 // var inspectorCommandTypes: any = inspectorCommands;
 
 import * as debuggerDomains from "./debugger";
-import * as devToolsElements from "./devtools-elements";
-
-declare var __inspectorSendEvent;
 
 import { attachDOMInspectorEventCallbacks, attachDOMInspectorCommandCallbacks } from "./devtools-elements";
 

--- a/tns-core-modules/file-system/file-system.ts
+++ b/tns-core-modules/file-system/file-system.ts
@@ -137,9 +137,7 @@ export class FileSystemEntity {
         var path = parentFolder.path;
         var newPath = fileAccess.joinPath(path, newName);
 
-        var hasError = false;
         var localError = function (error) {
-            hasError = true;
             if (onError) {
                 onError(error);
             }

--- a/tns-core-modules/globals/globals.ts
+++ b/tns-core-modules/globals/globals.ts
@@ -126,8 +126,6 @@ global.registerModule("fetch", () => require("fetch"));
     }
 }
 
-const __tnsGlobalMergedModules = new Map<string, boolean>();
-
 function registerOnGlobalContext(name: string, module: string): void {
 
     Object.defineProperty(global, name, {

--- a/tns-core-modules/image-asset/image-asset.android.ts
+++ b/tns-core-modules/image-asset/image-asset.android.ts
@@ -1,4 +1,3 @@
-import * as platform from "../platform";
 import * as common from "./image-asset-common";
 import { path as fsPath, knownFolders } from "../file-system";
 
@@ -88,31 +87,4 @@ var calculateAngleFromFile = function (filename: string) {
     }
 
     return rotationAngle;
-}
-
-var calculateInSampleSize = function (imageWidth, imageHeight, reqWidth, reqHeight) {
-    let sampleSize = 1;
-    let displayWidth = platform.screen.mainScreen.widthDIPs;
-    let displayHeigth = platform.screen.mainScreen.heightDIPs;
-    reqWidth = (reqWidth > 0 && reqWidth < displayWidth) ? reqWidth : displayWidth;
-    reqHeight = (reqHeight > 0 && reqHeight < displayHeigth) ? reqHeight : displayHeigth;
-    if (imageWidth > reqWidth && imageHeight > reqHeight) {
-        let halfWidth = imageWidth / 2;
-        let halfHeight = imageHeight / 2;
-        while ((halfWidth / sampleSize) > reqWidth && (halfHeight / sampleSize) > reqHeight) {
-            sampleSize *= 2;
-        }
-    }
-
-    var totalPixels = (imageWidth / sampleSize) * (imageHeight / sampleSize);
-
-    // Anything more than 2x the requested pixels we'll sample down further
-    var totalReqPixelsCap = reqWidth * reqHeight * 2;
-
-    while (totalPixels > totalReqPixelsCap) {
-        sampleSize *= 2;
-        totalPixels = (imageWidth / sampleSize) * (imageHeight / sampleSize);
-    }
-
-    return sampleSize;
 }

--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -282,9 +282,7 @@ export class ActionBar extends ActionBarBase {
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number) {
         const width = layout.getMeasureSpecSize(widthMeasureSpec);
-        const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);
         const height = layout.getMeasureSpecSize(heightMeasureSpec);
-        const heightMode = layout.getMeasureSpecMode(heightMeasureSpec);
 
         if (this.titleView) {
             View.measureChild(this, this.titleView, UNSPECIFIED, UNSPECIFIED);

--- a/tns-core-modules/ui/animation/animation.ios.ts
+++ b/tns-core-modules/ui/animation/animation.ios.ts
@@ -18,8 +18,6 @@ let _skip = "_skip";
 
 let FLT_MAX = 340282346638528859811704183484516925440.000000;
 
-declare var CASpringAnimation: any;
-
 class AnimationInfo {
     public propertyNameToAnimate: string;
     public fromValue: any;

--- a/tns-core-modules/ui/animation/keyframe-animation.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.ts
@@ -12,7 +12,7 @@ import { View, Color } from "../core/view";
 
 import { AnimationCurve } from "../enums";
 
-import { isEnabled as traceEnabled, write as traceWrite, categories as traceCategories, messageType as traceType } from "../../trace";
+import { write as traceWrite, categories as traceCategories, messageType as traceType } from "../../trace";
 
 // Types.
 import { unsetValue } from "../core/properties";

--- a/tns-core-modules/ui/core/bindable/bindable.ts
+++ b/tns-core-modules/ui/core/bindable/bindable.ts
@@ -91,8 +91,6 @@ export class Binding {
     private sourceOptions: { instance: WeakRef<any>; property: string };
     private targetOptions: { instance: WeakRef<Object>; property: string };
 
-    private sourcesAndProperties: Array<{ instance: Object; property: string }>;
-
     private sourceProperties: Array<string>;
     private propertyChangeListeners: Map<string, Observable> = new Map<string, Observable>();
 
@@ -140,7 +138,6 @@ export class Binding {
         });
 
         this.propertyChangeListeners.clear();
-        this.sourcesAndProperties = null;
 
         if (this.source) {
             this.source.clear();

--- a/tns-core-modules/ui/core/control-state-change/control-state-change.ios.ts
+++ b/tns-core-modules/ui/core/control-state-change/control-state-change.ios.ts
@@ -3,7 +3,7 @@ import { ControlStateChangeListener as ControlStateChangeListenerDefinition } fr
 
 class ObserverClass extends NSObject {
     // NOTE: Refactor this - use Typescript property instead of strings....
-    observeValueForKeyPathOfObjectChangeContext(path: string, obj: Object, change: NSDictionary<any, any>, context: any) {
+    observeValueForKeyPathOfObjectChangeContext(path: string) {
         if (path === "selected") {
             this["_owner"]._onSelectedChanged();
         } else if (path === "enabled") {
@@ -16,7 +16,6 @@ class ObserverClass extends NSObject {
 
 export class ControlStateChangeListener implements ControlStateChangeListenerDefinition {
     private _observer: NSObject;
-    private _states: string[];
     private _control: UIControl;
     private _observing: boolean = false;
 
@@ -44,14 +43,17 @@ export class ControlStateChangeListener implements ControlStateChangeListenerDef
         }
     }
 
+    //@ts-ignore
     private _onEnabledChanged() {
         this._updateState();
     }
 
+    //@ts-ignore
     private _onSelectedChanged() {
         this._updateState();
     }
 
+    //@ts-ignore
     private _onHighlightedChanged() {
         this._updateState();
     }

--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -670,7 +670,7 @@ export class CssAnimationProperty<T extends Style, U> implements definitions.Css
 
     public _valueConverter?: (value: string) => any;
 
-    constructor(private options: definitions.CssAnimationPropertyOptions<T, U>) {
+    constructor(options: definitions.CssAnimationPropertyOptions<T, U>) {
         const { valueConverter, equalityComparer, valueChanged, defaultValue } = options;
         const propertyName = options.name;
         this.name = propertyName;

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -1,14 +1,12 @@
 // Definitions.
 import { ViewBase as ViewBaseDefinition } from ".";
 import { Page } from "../../page";
-import { SelectorCore } from "../../styling/css-selector";
 import { Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf } from "../../layouts/flexbox-layout";
-import { KeyframeAnimation } from "../../animation/keyframe-animation";
 
 // Types.
-import { Property, CssProperty, CssAnimationProperty, InheritedProperty, Style, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, resetCSSProperties, initNativeView, resetNativeView } from "../properties";
+import { Property, CssProperty, CssAnimationProperty, InheritedProperty, Style, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView } from "../properties";
 import { Source } from "../../../utils/debug";
-import { Binding, BindingOptions, Observable, WrappedValue, PropertyChangeData, traceEnabled, traceWrite, traceCategories, traceNotifyEvent } from "../bindable";
+import { Binding, BindingOptions, Observable, WrappedValue, PropertyChangeData, traceEnabled, traceWrite, traceCategories } from "../bindable";
 import { isIOS, isAndroid } from "../../../platform";
 import { layout } from "../../../utils/utils";
 import { Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../../styling/style-properties";

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -1,5 +1,4 @@
 // Definitions.
-import { ViewBase } from "../view-base";
 import { Point, CustomLayoutView as CustomLayoutViewDefinition, dip } from ".";
 import { GestureTypes, GestureEventData } from "../../gestures";
 import { AndroidActivityBackPressedEventData } from "../../../application";
@@ -34,7 +33,6 @@ const modalMap = new Map<number, DialogOptions>();
 let TouchListener: TouchListener;
 let disableUserInteractionListener: org.nativescript.widgets.DisableUserInteractionListener;
 let DialogFragment: DialogFragment;
-let Dialog: android.app.Dialog;
 
 interface DialogOptions {
     owner: View;

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -8,9 +8,6 @@ import {
 } from "./view-common";
 
 import { ios as iosBackground, Background } from "../../styling/background";
-// HACK: Webpack. Use a fully-qualified import to allow resolve.extensions(.ios.js) to
-// kick in. `../utils` doesn't seem to trigger the webpack extensions mechanism.
-import * as uiUtils from "tns-core-modules/ui/utils";
 import { ios as iosUtils } from "../../../utils/utils";
 import {
     Visibility,
@@ -650,9 +647,6 @@ export namespace ios {
         const navBarHidden = navController ? navController.navigationBarHidden : true;
         const scrollable = isContentScrollable(controller, owner);
         const hasChildControllers = controller.childViewControllers.count > 0;
-
-        const safeAreaTopLength = safeOrigin.y - fullscreenOrigin.y;
-        const safeAreaBottomLength = fullscreenSize.height - safeAreaSize.height - safeAreaTopLength;
 
         if (!(controller.edgesForExtendedLayout & UIRectEdge.Top)) {
             const statusBarHeight = getStatusBarHeight(controller);

--- a/tns-core-modules/ui/dialogs/dialogs.ios.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.ios.ts
@@ -8,31 +8,25 @@ import { isString, isDefined, isFunction } from "../../utils/types";
 
 export * from "./dialogs-common";
 
-enum allertButtons {
-    cancel = 1 << 0,
-    neutral = 1 << 1,
-    ok = 1 << 2,
-}
-
 function addButtonsToAlertController(alertController: UIAlertController, options: ConfirmOptions, callback?: Function): void {
     if (!options) {
         return;
     }
 
     if (isString(options.cancelButtonText)) {
-        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.cancelButtonText, UIAlertActionStyle.Default, (arg: UIAlertAction) => {
+        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.cancelButtonText, UIAlertActionStyle.Default, () => {
             raiseCallback(callback, false);
         }));
     }
 
     if (isString(options.neutralButtonText)) {
-        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.neutralButtonText, UIAlertActionStyle.Default, (arg: UIAlertAction) => {
+        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.neutralButtonText, UIAlertActionStyle.Default, () => {
             raiseCallback(callback, undefined);
         }));
     }
 
     if (isString(options.okButtonText)) {
-        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.okButtonText, UIAlertActionStyle.Default, (arg: UIAlertAction) => {
+        alertController.addAction(UIAlertAction.actionWithTitleStyleHandler(options.okButtonText, UIAlertActionStyle.Default, () => {
             raiseCallback(callback, true);
         }));
     }
@@ -129,7 +123,7 @@ export function prompt(arg: any): Promise<PromptResult> {
     });
 }
 
-export function login(arg: any): Promise<LoginResult> {
+export function login(): Promise<LoginResult> {
     let options: LoginOptions;
 
     let defaultOptions = { title: LOGIN, okButtonText: OK, cancelButtonText: CANCEL };
@@ -236,7 +230,7 @@ function showUIAlertController(alertController: UIAlertController) {
     }
 }
 
-export function action(arg: any): Promise<string> {
+export function action(): Promise<string> {
     let options: ActionOptions;
 
     let defaultOptions = { title: null, cancelButtonText: CANCEL };

--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -1,5 +1,5 @@
 ﻿import { EditableTextBase as EditableTextBaseDefinition, KeyboardType, ReturnKeyType, UpdateTextTrigger, AutocapitalizationType } from ".";
-import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser, resetSymbol } from "../text-base";
+import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser } from "../text-base";
 
 export * from "../text-base";
 

--- a/tns-core-modules/ui/frame/activity.android.ts
+++ b/tns-core-modules/ui/frame/activity.android.ts
@@ -6,6 +6,7 @@ if ((<any>global).__snapshot || (<any>global).__snapshotEnabled) {
     globals.install();
 }
 
+//@ts-ignore
 @JavaProxy("com.tns.NativeScriptActivity")
 class NativeScriptActivity extends android.app.Activity {
     private _callbacks: AndroidActivityCallbacks;

--- a/tns-core-modules/ui/frame/fragment.transitions.android.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.android.ts
@@ -1,5 +1,5 @@
 // Definitions.
-import { NavigationTransition, BackstackEntry, Frame } from "../frame";
+import { NavigationTransition, BackstackEntry } from "../frame";
 import { AnimationType } from "./fragment.transitions";
 
 // Types.
@@ -44,11 +44,6 @@ interface ExpandedEntry extends BackstackEntry {
     transition: Transition;
     transitionName: string;
     frameId: number
-}
-
-interface FragmentCallbacks {
-    frame: Frame;
-    entry: ExpandedEntry;
 }
 
 const sdkVersion = lazy(() => parseInt(device.sdkVersion));

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -3,10 +3,8 @@ import { Frame as FrameDefinition, NavigationEntry, BackstackEntry, NavigationTr
 import { Page } from "../page";
 
 // Types.
-import { View, CustomLayoutView, isIOS, isAndroid, traceEnabled, traceWrite, traceCategories, EventData, Property, CSSType } from "../core/view";
-import { resolveFileName } from "../../file-system/file-name-resolver";
-import { knownFolders, path } from "../../file-system";
-import { parse, createViewFromEntry } from "../builder";
+import { View, CustomLayoutView, isIOS, isAndroid, traceEnabled, traceWrite, traceCategories, Property, CSSType } from "../core/view";
+import { createViewFromEntry } from "../builder";
 import { profile } from "../../profiling";
 
 import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack } from "./frame-stack";

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -1,6 +1,6 @@
 ﻿// Definitions.
 import {
-    AndroidFrame as AndroidFrameDefinition, BackstackEntry, NavigationEntry,
+    AndroidFrame as AndroidFrameDefinition, BackstackEntry,
     NavigationTransition, AndroidFragmentCallbacks, AndroidActivityCallbacks
 } from ".";
 import { Page } from "../page";
@@ -8,7 +8,7 @@ import { Page } from "../page";
 // Types.
 import * as application from "../../application";
 import {
-    FrameBase, NavigationContext, stack, goBack, View, Observable, topmost,
+    FrameBase, stack, goBack, View, Observable,
     traceEnabled, traceWrite, traceCategories
 } from "./frame-common";
 
@@ -94,7 +94,6 @@ export function reloadPage(): void {
 
 export class Frame extends FrameBase {
     private _android: AndroidFrame;
-    private _delayedNavigationEntry: BackstackEntry;
     private _containerViewId: number = -1;
     private _tearDownPending = false;
     private _attachedToWindow = false;
@@ -311,7 +310,6 @@ export class Frame extends FrameBase {
                 startActivity(currentActivity, this._android.frameId);
             }
 
-            this._delayedNavigationEntry = newEntry;
             return;
         }
 

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -1,14 +1,12 @@
 ﻿// Definitions.
-import { iOSFrame as iOSFrameDefinition, BackstackEntry, NavigationTransition, NavigationEntry } from ".";
+import { iOSFrame as iOSFrameDefinition, BackstackEntry, NavigationTransition } from ".";
 import { Page } from "../page";
 import { profile } from "../../profiling";
 
 //Types.
-import { FrameBase, View, topmost, layout, traceEnabled, traceWrite, traceCategories, isCategorySet } from "./frame-common";
+import { FrameBase, View, layout, traceEnabled, traceWrite, traceCategories, isCategorySet } from "./frame-common";
 import { _createIOSAnimatedTransitioning } from "./fragment.transitions";
-// HACK: Webpack. Use a fully-qualified import to allow resolve.extensions(.ios.js) to
-// kick in. `../utils` doesn't seem to trigger the webpack extensions mechanism.
-import * as uiUtils from "../../ui/utils";
+
 import * as utils from "../../utils/utils";
 
 export * from "./frame-common";
@@ -569,14 +567,12 @@ class iOSFrame implements iOSFrameDefinition {
     private _controller: UINavigationControllerImpl;
     private _showNavigationBar: boolean;
     private _navBarVisibility: "auto" | "never" | "always" = "auto";
-    private _frame: Frame;
 
     // TabView uses this flag to disable animation while showing/hiding the navigation bar because of the "< More" bar.
     // See the TabView._handleTwoNavigationBars method for more details.
     public _disableNavBarAnimation: boolean;
 
     constructor(frame: Frame) {
-        this._frame = frame;
         this._controller = UINavigationControllerImpl.initWithOwner(new WeakRef(frame));
     }
 
@@ -589,14 +585,7 @@ class iOSFrame implements iOSFrameDefinition {
     }
     public set showNavigationBar(value: boolean) {
         this._showNavigationBar = value;
-
-        const viewController = this._controller.viewControllers;
-        const length = viewController ? viewController.count : 0;
-        const animated = length > 0 && !this._disableNavBarAnimation;
-
         this._controller.setNavigationBarHiddenAnimated(!value, true);
-        // this._controller.view.setNeedsLayout();
-        // this._controller.view.layoutIfNeeded();
     }
 
     public get navBarVisibility(): "auto" | "never" | "always" {

--- a/tns-core-modules/ui/gestures/gestures.android.ts
+++ b/tns-core-modules/ui/gestures/gestures.android.ts
@@ -81,14 +81,12 @@ function initializePinchGestureListener() {
         private _observer: GesturesObserver;
         private _target: View;
         private _scale: number;
-        private _density: number;
 
         constructor(observer: GesturesObserver, target: View) {
             super();
 
             this._observer = observer;
             this._target = target;
-            this._density = layout.getDisplayDensity();
 
             return global.__native(this);
         }

--- a/tns-core-modules/ui/image-cache/image-cache.ios.ts
+++ b/tns-core-modules/ui/image-cache/image-cache.ios.ts
@@ -66,6 +66,7 @@ class MemmoryWarningHandler extends NSObject {
 export class Cache extends common.Cache {
     private _cache: NSCache<any, any>;
     //private _delegate: NSCacheDelegate;
+    //@ts-ignore
     private _memoryWarningHandler: MemmoryWarningHandler;
 
     constructor() {

--- a/tns-core-modules/ui/list-view/list-view.android.ts
+++ b/tns-core-modules/ui/list-view/list-view.android.ts
@@ -7,7 +7,6 @@ import { StackLayout } from "../layouts/stack-layout";
 import { ProxyViewContainer } from "../proxy-view-container";
 import { LayoutBase } from "../layouts/layout-base";
 import { profile } from "../../profiling";
-import { onScroll } from "../../../apps/app/ui-tests-app/list-view/list-view";
 
 export * from "./list-view-common";
 

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -1,14 +1,11 @@
-﻿import { ScrollEventData } from "../scroll-view";
-import { ItemEventData } from ".";
+﻿import { ItemEventData } from ".";
 import {
     ListViewBase, View, KeyedTemplate, Length, Observable, Color,
     separatorColorProperty, itemTemplatesProperty, iosEstimatedRowHeightProperty, layout, EventData
 } from "./list-view-common";
 import { StackLayout } from "../layouts/stack-layout";
 import { ProxyViewContainer } from "../proxy-view-container";
-import { ios } from "../../utils/utils";
 import { profile } from "../../profiling";
-import { device } from "../../platform";
 
 export * from "./list-view-common";
 

--- a/tns-core-modules/ui/page/page-common.ts
+++ b/tns-core-modules/ui/page/page-common.ts
@@ -1,12 +1,11 @@
 ﻿import { Page as PageDefinition, NavigatedData, ShownModallyData } from ".";
 import {
-    ContentView, View, eachDescendant, Property, CssProperty, Color, isIOS,
-    booleanConverter, resetCSSProperties, Style, EventData, CSSType
+    ContentView, View, Property, CssProperty, Color, isIOS,
+    booleanConverter, Style, EventData, CSSType
 } from "../content-view";
-import { Frame, topmost as topmostFrame } from "../frame";
+import { Frame } from "../frame";
 import { ActionBar } from "../action-bar";
 import { KeyframeAnimationInfo } from "../animation/keyframe-animation";
-import { File, path, knownFolders } from "../../file-system";
 import { profile } from "../../profiling";
 
 export * from "../content-view";

--- a/tns-core-modules/ui/page/page.android.ts
+++ b/tns-core-modules/ui/page/page.android.ts
@@ -1,4 +1,4 @@
-﻿import { View, PageBase, Color, actionBarHiddenProperty, statusBarStyleProperty, androidStatusBarBackgroundProperty, EventData } from "./page-common";
+﻿import { View, PageBase, Color, actionBarHiddenProperty, statusBarStyleProperty, androidStatusBarBackgroundProperty } from "./page-common";
 import { ActionBar } from "../action-bar";
 import { GridLayout } from "../layouts/grid-layout";
 import { device } from "../../platform";

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -4,21 +4,13 @@ import { Frame } from "../frame";
 // Types.
 import { ios as iosView } from "../core/view";
 import {
-    PageBase, View, ViewBase, layout,
-    actionBarHiddenProperty, statusBarStyleProperty,
-    traceEnabled, traceWrite, traceCategories, PercentLength, Color
+    PageBase, View, layout,
+    actionBarHiddenProperty, statusBarStyleProperty, Color
 } from "./page-common";
-import { ios as iosApp } from "../../application";
-import { device } from "../../platform";
-// HACK: Webpack. Use a fully-qualified import to allow resolve.extensions(.ios.js) to
-// kick in. `../utils` doesn't seem to trigger the webpack extensions mechanism.
-import * as uiUtils from "../../ui/utils";
+
 import { profile } from "../../profiling";
 
 export * from "./page-common";
-
-import { ios } from "../../utils/utils";
-import getter = ios.getter;
 
 const ENTRY = "_entry";
 const DELEGATE = "_delegate";
@@ -82,7 +74,6 @@ class UIViewControllerImpl extends UIViewController {
 
         const frame = this.navigationController ? (<any>this.navigationController).owner : null;
         const newEntry = this[ENTRY];
-        const modalParent = owner._modalParent;
 
         // Don't raise event if currentPage was showing modal page.
         if (!owner._presentedViewController && newEntry && (!frame || frame.currentPage !== owner)) {

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -73,7 +73,6 @@ const pattern: RegExp = /('|")(.*?)\1/;
 
 class CSSSource {
     private _selectors: RuleSet[] = [];
-    private static cssFilesCache: { [path: string]: CSSSource } = {};
 
     private constructor(private _ast: SyntaxTree, private _url: string, private _file: string, private _keyframes: KeyframesMap, private _source: string) {
         this.parse();
@@ -480,13 +479,7 @@ CssState.prototype._matchInvalid = true;
 export class StyleScope {
 
     private _selectors: SelectorsMap;
-
-    // caches all the visual states by the key of the visual state selectors
-    private _statesByKey = {};
-    private _viewIdToKey = {};
-
     private _css: string = "";
-    private _cssFileName: string;
     private _mergedCssSelectors: RuleSet[];
     private _localCssSelectors: RuleSet[] = [];
     private _localCssSelectorVersion: number = 0;
@@ -499,7 +492,6 @@ export class StyleScope {
     }
 
     set css(value: string) {
-        this._cssFileName = undefined;
         this.setCss(value);
     }
 
@@ -514,7 +506,6 @@ export class StyleScope {
     @profile
     private setCss(cssString: string, cssFileName?): void {
         this._css = cssString;
-        this._reset();
 
         const cssFile = CSSSource.fromSource(cssString, this._keyframes, cssFileName);
         this._localCssSelectors = cssFile.selectors;
@@ -528,7 +519,6 @@ export class StyleScope {
             return;
         }
 
-        this._reset();
         let parsedCssSelectors = cssString ? CSSSource.fromSource(cssString, this._keyframes, cssFileName) : CSSSource.fromURI(cssFileName, this._keyframes);
         this._css = this._css + parsedCssSelectors.source;
         this._localCssSelectors.push.apply(this._localCssSelectors, parsedCssSelectors.selectors); 
@@ -589,11 +579,6 @@ export class StyleScope {
     public query(node: Node): SelectorCore[] {
         this.ensureSelectors();
         return this._selectors.query(node).selectors;
-    }
-
-    private _reset() {
-        this._statesByKey = {};
-        this._viewIdToKey = {};
     }
 
     private _getSelectorsVersion() {
@@ -676,14 +661,14 @@ function isKeyframe(node: CssNode): node is KeyframesDefinition {
     return node.type === "keyframes";
 }
 
-class InlineSelector implements SelectorCore {
-    constructor(ruleSet: RuleSet) {
-        this.ruleset = ruleSet;
-    }
+// class InlineSelector implements SelectorCore {
+//     constructor(ruleSet: RuleSet) {
+//         this.ruleset = ruleSet;
+//     }
 
-    public specificity = 0x01000000;
-    public rarity = 0;
-    public dynamic: boolean = false;
-    public ruleset: RuleSet;
-    public match(node: Node): boolean { return true; }
-}
+//     public specificity = 0x01000000;
+//     public rarity = 0;
+//     public dynamic: boolean = false;
+//     public ruleset: RuleSet;
+//     public match(node: Node): boolean { return true; }
+// }

--- a/tns-core-modules/ui/tab-view/tab-view-common.ts
+++ b/tns-core-modules/ui/tab-view/tab-view-common.ts
@@ -1,4 +1,4 @@
-﻿import { TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition, SelectedIndexChangedEventData, TabViewItem } from ".";
+﻿import { TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition, SelectedIndexChangedEventData } from ".";
 import {
     View, ViewBase, Style, Property, CssProperty, CoercibleProperty,
     Color, isIOS, AddArrayFromBuilder, AddChildFromBuilder, EventData, CSSType

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -5,7 +5,7 @@ import {
     TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty,
     tabTextColorProperty, tabBackgroundColorProperty, selectedTabTextColorProperty,
     androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty,
-    fontSizeProperty, fontInternalProperty, View, layout, traceCategory, traceEnabled,
+    fontSizeProperty, fontInternalProperty, layout, traceCategory, traceEnabled,
     traceWrite, Color
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
@@ -15,7 +15,6 @@ import { Frame } from "../frame";
 
 export * from "./tab-view-common";
 
-const VIEWS_STATES = "_viewStates";
 const ACCENT_COLOR = "colorAccent";
 const PRIMARY_COLOR = "colorPrimary";
 const DEFAULT_ELEVATION = 4;

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -9,15 +9,10 @@ import {
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
 import { fromFileOrResource } from "../../image-source";
-import { Page } from "../page";
 import { profile } from "../../profiling";
-import * as uiUtils from "../utils";
-import * as utils from "../../utils/utils";
 import { Frame } from "../frame";
 
 export * from "./tab-view-common";
-
-const getter = utils.ios.getter;
 
 class UITabBarControllerImpl extends UITabBarController {
 
@@ -203,8 +198,6 @@ export class TabView extends TabViewBase {
     public _ios: UITabBarControllerImpl;
     private _delegate: UITabBarControllerDelegateImpl;
     private _moreNavigationControllerDelegate: UINavigationControllerDelegateImpl;
-    private _tabBarHeight: number = 0;
-    private _navBarHeight: number = 0;
     private _iconsCache = {};
 
     constructor() {

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -8,7 +8,6 @@ import {
     CSSType
 } from "../editable-text-base";
 
-import { ios } from "../../utils/utils";
 import { profile } from "../../profiling";
 
 export * from "../editable-text-base";

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -1,6 +1,5 @@
 import { WebViewBase, knownFolders, traceWrite, traceEnabled, traceCategories, NavigationType } from "./web-view-common";
 import { profile } from "../../profiling";
-import { layout } from "../core/view";
 export * from "./web-view-common";
 
 class WKNavigationDelegateImpl extends NSObject

--- a/tns-core-modules/utils/utils.ios.ts
+++ b/tns-core-modules/utils/utils.ios.ts
@@ -1,5 +1,4 @@
-﻿import * as fsModule from "../file-system";
-import {
+﻿import {
     write as traceWrite, categories as traceCategories, messageType as traceMessageType
 } from "../trace";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "extends": "./tsconfig.shared",
     "exclude": [
-        "tns-core-modules/docs-shims.d.ts",
-        "tns-platform-declarations/node_modules/",
-        "tns-platform-declarations/package/",
         "tns-core-modules/node_modules/",
         "tns-core-modules/package/",
+        "tns-core-modules/references.d.ts",
+        "tns-platform-declarations/ios/objc-x86_64/",
+        "tns-platform-declarations/node_modules/",
+        "tns-platform-declarations/package/",
+        "tns-platform-declarations/references.d.ts",
         "tests/node_modules",
         "tests/package/",
         "tests/platforms",
@@ -19,10 +21,7 @@
         "build",
         "Deploy",
         "out",
-        "obj",
-        "tns-platform-declarations/references.d.ts",
-        "tns-core-modules/references.d.ts",
-        "tns-platform-declarations/ios/objc-x86_64/",
+        "obj",       
         "unit-tests/common-types.d.ts"
     ]
 }

--- a/tsconfig.modules.json
+++ b/tsconfig.modules.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.shared",
+    "compilerOptions": {
+        "noUnusedLocals": true
+    },
+    "include": [
+        "tns-core-modules/**/*.ts"
+    ],
+    "exclude": [
+        "tns-core-modules/node_modules/",
+        "tns-core-modules/package/"
+    ]
+}


### PR DESCRIPTION
Removing some dead code.

NOTE: noUnusedLocals is enabled for the specific tsconfig.modules.json that is only used by `npm run compile-modules` at the moment.
