### PR TITLE
keep some variable from early GC to speed up start time

### DIFF
--- a/tns-core-modules/application/application.android.ts
+++ b/tns-core-modules/application/application.android.ts
@@ -45,6 +45,8 @@ export class AndroidApplication extends Observable implements AndroidApplication
     public foregroundActivity: android.app.Activity;
     public startActivity: android.app.Activity;
     public packageName: string;
+    // we are using these property to store the callbacks to avoid early GC collection which would trigger MarkReachableObjects
+    private callbacks: any = {};
 
     public get currentContext(): android.content.Context {
         return this.foregroundActivity;
@@ -63,10 +65,11 @@ export class AndroidApplication extends Observable implements AndroidApplication
         this.packageName = nativeApp.getPackageName();
         this.context = nativeApp.getApplicationContext();
 
-        let lifecycleCallbacks = initLifecycleCallbacks();
-        let componentCallbacks = initComponentCallbacks();
-        this.nativeApp.registerActivityLifecycleCallbacks(lifecycleCallbacks);
-        this.nativeApp.registerComponentCallbacks(componentCallbacks);
+        // we store those callbacks and add a function for clearing them later so that the objects will be eligable for GC
+        this.callbacks.lifecycleCallbacks = initLifecycleCallbacks(() => this.callbacks = {});
+        this.callbacks.componentCallbacks = initComponentCallbacks();
+        this.nativeApp.registerActivityLifecycleCallbacks(this.callbacks.lifecycleCallbacks);
+        this.nativeApp.registerComponentCallbacks(this.callbacks.componentCallbacks);
 
         this._registerPendingReceivers();
     }
@@ -190,7 +193,7 @@ export function getNativeApplication(): android.app.Application {
 
         // the getInstance might return null if com.tns.NativeScriptApplication exists but is  not the starting app type
         if (!nativeApp) {
-            // TODO: Should we handle the case when a custom application type is provided and the user has not explicitly initialized the application module? 
+            // TODO: Should we handle the case when a custom application type is provided and the user has not explicitly initialized the application module?
             const clazz = java.lang.Class.forName("android.app.ActivityThread");
             if (clazz) {
                 const method = clazz.getMethod("currentApplication", null);
@@ -217,7 +220,7 @@ global.__onLiveSync = function () {
     livesync();
 };
 
-function initLifecycleCallbacks() {
+function initLifecycleCallbacks(clearCallbacks: () => void) {
     const setThemeOnLaunch = profile("setThemeOnLaunch", (activity: android.app.Activity) => {
         // Set app theme after launch screen was used during startup
         const activityInfo = activity.getPackageManager().getActivityInfo(activity.getComponentName(), android.content.pm.PackageManager.GET_META_DATA);
@@ -235,14 +238,16 @@ function initLifecycleCallbacks() {
 
     const subscribeForGlobalLayout = profile("subscribeForGlobalLayout", function (activity: android.app.Activity) {
         const rootView = activity.getWindow().getDecorView().getRootView();
-        let onGlobalLayoutListener = new android.view.ViewTreeObserver.OnGlobalLayoutListener({
+        // store the listener not to trigger GC collection before collecting the method
+        this.onGlobalLayoutListener = new android.view.ViewTreeObserver.OnGlobalLayoutListener({
             onGlobalLayout() {
                 notify({ eventName: displayedEvent, object: androidApp, activity });
                 let viewTreeObserver = rootView.getViewTreeObserver();
-                viewTreeObserver.removeOnGlobalLayoutListener(onGlobalLayoutListener);
+                viewTreeObserver.removeOnGlobalLayoutListener(this.onGlobalLayoutListener);
+                clearCallbacks();
             }
         });
-        rootView.getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
+        rootView.getViewTreeObserver().addOnGlobalLayoutListener(this.onGlobalLayoutListener);
     });
 
     const lifecycleCallbacks = new android.app.Application.ActivityLifecycleCallbacks({

--- a/tns-core-modules/application/application.android.ts
+++ b/tns-core-modules/application/application.android.ts
@@ -66,7 +66,7 @@ export class AndroidApplication extends Observable implements AndroidApplication
         this.context = nativeApp.getApplicationContext();
 
         // we store those callbacks and add a function for clearing them later so that the objects will be eligable for GC
-        this.callbacks.lifecycleCallbacks = initLifecycleCallbacks(() => this.callbacks = {});
+        this.callbacks.lifecycleCallbacks = initLifecycleCallbacks();
         this.callbacks.componentCallbacks = initComponentCallbacks();
         this.nativeApp.registerActivityLifecycleCallbacks(this.callbacks.lifecycleCallbacks);
         this.nativeApp.registerComponentCallbacks(this.callbacks.componentCallbacks);
@@ -220,7 +220,7 @@ global.__onLiveSync = function () {
     livesync();
 };
 
-function initLifecycleCallbacks(clearCallbacks: () => void) {
+function initLifecycleCallbacks() {
     const setThemeOnLaunch = profile("setThemeOnLaunch", (activity: android.app.Activity) => {
         // Set app theme after launch screen was used during startup
         const activityInfo = activity.getPackageManager().getActivityInfo(activity.getComponentName(), android.content.pm.PackageManager.GET_META_DATA);
@@ -244,7 +244,6 @@ function initLifecycleCallbacks(clearCallbacks: () => void) {
                 notify({ eventName: displayedEvent, object: androidApp, activity });
                 let viewTreeObserver = rootView.getViewTreeObserver();
                 viewTreeObserver.removeOnGlobalLayoutListener(this.onGlobalLayoutListener);
-                clearCallbacks();
             }
         });
         rootView.getViewTreeObserver().addOnGlobalLayoutListener(this.onGlobalLayoutListener);


### PR DESCRIPTION
To avoid early GC which will trigger MarkReachableObjects on startup I'm storing some callback locally which are cleared once they are not needed anymore.