### PR TITLE
fix: crash at application launch on Android P

### DIFF
--- a/tns-core-modules/ui/frame/fragment.transitions.android.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.android.ts
@@ -55,6 +55,10 @@ export const completedEntries = new Map<number, ExpandedEntry>();
 
 let TransitionListener: TransitionListener;
 let AnimationListener: android.animation.Animator.AnimatorListener;
+let loadAnimatorMethod: java.lang.reflect.Method;
+let reflectionDone: boolean;
+let defaultEnterAnimatorStatic: android.animation.Animator;
+let defaultExitAnimatorStatic: android.animation.Animator;
 
 export function _setAndroidFragmentTransitions(
     animated: boolean,
@@ -70,6 +74,12 @@ export function _setAndroidFragmentTransitions(
     const entries = waitingQueue.get(frameId);
     if (entries && entries.size > 0) {
         throw new Error("Calling navigation before previous navigation finish.");
+    }
+
+    // NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
+    // TODO: Update condition when Android P SDK version returns 28
+    if (sdkVersion() < 27) {
+        initDefaultAnimations(manager);
     }
 
     if (sdkVersion() >= 21) {
@@ -110,7 +120,13 @@ export function _setAndroidFragmentTransitions(
     if (name === "none") {
         transition = new NoTransition(0, null);
     } else if (name === "default") {
-        transition = new FadeTransition(0, null);
+        // NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
+        // TODO: Update condition when Android P SDK version returns 28
+        if (sdkVersion() < 27) {
+            transition = new DefaultTransition(0, null);
+        } else {
+            transition = new FadeTransition(150, null);
+        }
     } else if (useLollipopTransition) {
         // setEnterTransition: Enter
         // setExitTransition: Exit
@@ -164,7 +180,13 @@ export function _setAndroidFragmentTransitions(
         }
     }
 
-    setupDefaultAnimations(newEntry, new FadeTransition(0, null));
+    // NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
+    // TODO: Update condition when Android P SDK version returns 28
+    if (sdkVersion() < 27) {
+        setupDefaultAnimations(newEntry, new DefaultTransition(0, null));
+    } else {
+        setupDefaultAnimations(newEntry, new FadeTransition(150, null));
+    }
 
     printTransitions(currentEntry);
     printTransitions(newEntry);
@@ -729,6 +751,40 @@ function javaObjectArray(...params: java.lang.Object[]) {
     return nativeArray;
 }
 
+function javaClassArray(...params: java.lang.Class<any>[]) {
+    const nativeArray = Array.create(java.lang.Class, params.length);
+    params.forEach((value, i) => nativeArray[i] = value);
+    return nativeArray;
+}
+
+function initDefaultAnimations(manager: android.app.FragmentManager): void {
+    if (reflectionDone) {
+        return;
+    }
+
+    reflectionDone = true;
+
+    loadAnimatorMethod = manager.getClass().getDeclaredMethod("loadAnimator", javaClassArray(android.app.Fragment.class, java.lang.Integer.TYPE, java.lang.Boolean.TYPE, java.lang.Integer.TYPE));
+    if (loadAnimatorMethod != null) {
+        loadAnimatorMethod.setAccessible(true);
+
+        const fragment_open = java.lang.Integer.valueOf(android.app.FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
+        const zero = java.lang.Integer.valueOf(0);
+        const fragment = new android.app.Fragment();
+
+        // Get default enter transition.
+        defaultEnterAnimatorStatic = loadAnimatorMethod.invoke(manager, javaObjectArray(fragment, fragment_open, java.lang.Boolean.TRUE, zero));
+
+        // Get default exit transition.
+        defaultExitAnimatorStatic = loadAnimatorMethod.invoke(manager, javaObjectArray(fragment, fragment_open, java.lang.Boolean.FALSE, zero));
+    }
+}
+
+function getDefaultAnimation(enter: boolean): android.animation.Animator {
+    const defaultAnimator = enter ? defaultEnterAnimatorStatic : defaultExitAnimatorStatic;
+    return defaultAnimator ? defaultAnimator.clone() : null;
+}
+
 function createDummyZeroDurationAnimator(): android.animation.Animator {
     const animator = android.animation.ValueAnimator.ofObject(intEvaluator(), javaObjectArray(java.lang.Integer.valueOf(0), java.lang.Integer.valueOf(1)));
     animator.setDuration(0);
@@ -762,5 +818,19 @@ function printTransitions(entry: ExpandedEntry) {
 class NoTransition extends Transition {
     public createAndroidAnimator(transitionType: string): android.animation.Animator {
         return createDummyZeroDurationAnimator();
+    }
+}
+
+class DefaultTransition extends Transition {
+    public createAndroidAnimator(transitionType: string): android.animation.Animator {
+        switch (transitionType) {
+            case AndroidTransitionType.enter:
+            case AndroidTransitionType.popEnter:
+                return getDefaultAnimation(true);
+
+            case AndroidTransitionType.popExit:
+            case AndroidTransitionType.exit:
+                return getDefaultAnimation(false);
+        }
     }
 }

--- a/tns-core-modules/ui/frame/fragment.transitions.android.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.android.ts
@@ -50,6 +50,10 @@ const sdkVersion = lazy(() => parseInt(device.sdkVersion));
 const intEvaluator = lazy(() => new android.animation.IntEvaluator());
 const defaultInterpolator = lazy(() => new android.view.animation.AccelerateDecelerateInterpolator());
 
+// NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
+// TODO: Update condition when Android P SDK version returns 28
+const isAndroidP = lazy(() => sdkVersion() >= 27);
+
 export const waitingQueue = new Map<number, Set<ExpandedEntry>>();
 export const completedEntries = new Map<number, ExpandedEntry>();
 
@@ -76,9 +80,7 @@ export function _setAndroidFragmentTransitions(
         throw new Error("Calling navigation before previous navigation finish.");
     }
 
-    // NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
-    // TODO: Update condition when Android P SDK version returns 28
-    if (sdkVersion() < 27) {
+    if (!isAndroidP()) {
         initDefaultAnimations(manager);
     }
 
@@ -120,12 +122,10 @@ export function _setAndroidFragmentTransitions(
     if (name === "none") {
         transition = new NoTransition(0, null);
     } else if (name === "default") {
-        // NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
-        // TODO: Update condition when Android P SDK version returns 28
-        if (sdkVersion() < 27) {
-            transition = new DefaultTransition(0, null);
-        } else {
+        if (isAndroidP()) {
             transition = new FadeTransition(150, null);
+        } else {
+            transition = new DefaultTransition(0, null);
         }
     } else if (useLollipopTransition) {
         // setEnterTransition: Enter
@@ -180,12 +180,10 @@ export function _setAndroidFragmentTransitions(
         }
     }
 
-    // NOTE: Android P Beta SDK version returns 27, which is API level for Android 8.1
-    // TODO: Update condition when Android P SDK version returns 28
-    if (sdkVersion() < 27) {
-        setupDefaultAnimations(newEntry, new DefaultTransition(0, null));
-    } else {
+    if (isAndroidP()) {
         setupDefaultAnimations(newEntry, new FadeTransition(150, null));
+    } else {
+        setupDefaultAnimations(newEntry, new DefaultTransition(0, null));
     }
 
     printTransitions(currentEntry);


### PR DESCRIPTION
Reference: https://developer.android.com/preview/restrictions-non-sdk-interfaces

Android P introduces new restrictions on the use of non-SDK interfaces, whether directly, via reflection, or via JNI. These restrictions are applied whenever an app references a non-SDK interface or attempts to obtain its handle using reflection or JNI.

In particular, fallback default transition to fade transition.

## What is the current behavior?
We use reflection to obtain a non-SDK interface and initialize default transition.

## What is the new behavior?
Fallback default transition to fade transition.

Fixes https://github.com/NativeScript/NativeScript/issues/5798.
