### PR TITLE
chore(layout-changed): update layoutChanged event tests delay

### DIFF
--- a/apps/app/ui-tests-app/events/layout-changed-event.ts
+++ b/apps/app/ui-tests-app/events/layout-changed-event.ts
@@ -1,0 +1,26 @@
+import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
+import { Button } from "tns-core-modules/ui/button";
+import { TextView } from "tns-core-modules/ui/text-view";
+import { View } from "tns-core-modules/ui/core/view";
+import { EventData } from "tns-core-modules/data/observable";
+let buttonsCount = 1;
+
+export function onLayoutChanged(args) {
+    let msg = "StackLayout layout changed - width:" + args.object.getActualSize().width;
+    (<TextView>args.object.page.getViewById("output")).text += msg + "\n";
+}
+
+export function addChild(args) {
+    let button = new Button();
+    button.text = "Button" + buttonsCount;
+    button.margin = 10;
+    button.backgroundColor = "lightgreen";
+    
+    (<StackLayout>args.object.page.getViewById("target")).addChild(button);
+    buttonsCount++;
+}
+
+export function clear(args) {
+    (<StackLayout>args.object.page.getViewById("target")).removeChildren();
+    args.object.page.getViewById("output").text = "";
+}

--- a/apps/app/ui-tests-app/events/layout-changed-event.xml
+++ b/apps/app/ui-tests-app/events/layout-changed-event.xml
@@ -1,0 +1,11 @@
+<Page>
+  <GridLayout rows="*, *, *" >
+    <StackLayout horizontalAlignment="left" orientation="horizontal" backgroundColor="yellow" id="target" margin="20" layoutChanged="onLayoutChanged"/>
+    
+    <StackLayout row="1">
+        <Button text="clear" tap="clear"/>
+        <Button text="add child" tap="addChild"/>
+    </StackLayout>
+    <TextView row="2" id="output" automationText="output" style="font-size: 10, font-family: monospace;"/>
+  </GridLayout>
+</Page>

--- a/apps/app/ui-tests-app/events/main-page.ts
+++ b/apps/app/ui-tests-app/events/main-page.ts
@@ -19,6 +19,7 @@ export function loadExamples() {
     examples.set("i61", "events/i61");
     examples.set("i73", "events/i73");
     examples.set("i86", "events/i86");
+    examples.set("layout changed", "events/layout-changed-event");
 
     return examples;
 }

--- a/tests/app/ui/helper.ts
+++ b/tests/app/ui/helper.ts
@@ -163,7 +163,7 @@ export function waitUntilNavigatedTo(page: Page, action: Function) {
 
     page.on("navigatedTo", navigatedTo);
     action();
-    TKUnit.waitUntilReady(() => completed, 100);
+    TKUnit.waitUntilReady(() => completed, 5);
 }
 
 export function waitUntilNavigatedFrom(action: Function) {

--- a/tests/app/ui/tab-view/tab-view-root-tests.ts
+++ b/tests/app/ui/tab-view/tab-view-root-tests.ts
@@ -15,7 +15,7 @@ function waitUntilNavigatedTo(pages: Page[], action: Function) {
 
     pages.forEach(page => page.on("navigatedTo", navigatedTo));
     action();
-    TKUnit.waitUntilReady(() => completed === pages.length, 100);
+    TKUnit.waitUntilReady(() => completed === pages.length, 5);
 }
 
 function createPage(i: number) {

--- a/tests/app/ui/view/view-tests-layout-event.ts
+++ b/tests/app/ui/view/view-tests-layout-event.ts
@@ -15,7 +15,7 @@ export function test_event_LayoutChanged_GetActualSize() {
             buttonLayoutChanged = true;
         });
 
-        TKUnit.waitUntilReady(() => buttonLayoutChanged);
+        TKUnit.waitUntilReady(() => buttonLayoutChanged, 5);
         TKUnit.assert(views[1].getActualSize().height > 0);
         TKUnit.assert(views[1].getActualSize().width > 0);
     };
@@ -32,7 +32,7 @@ export function test_event_LayoutChanged_Listeners() {
             buttonLayoutChanged = true;
         });
 
-        TKUnit.waitUntilReady(() => buttonLayoutChanged);
+        TKUnit.waitUntilReady(() => buttonLayoutChanged, 5);
         TKUnit.assertFalse(views[0].hasListeners(View.layoutChangedEvent));
         TKUnit.assert(views[1].hasListeners(View.layoutChangedEvent));
     };
@@ -61,50 +61,9 @@ export function test_event_LayoutChanged_IsRaised() {
     stackLayout.addChild(button);
     newPage.content = stackLayout;
 
-    TKUnit.waitUntilReady(() => stackLayoutChanged && buttonLayoutChanged);
+    TKUnit.waitUntilReady(() => stackLayoutChanged && buttonLayoutChanged, 5);
     TKUnit.assert(stackLayoutChanged);
     TKUnit.assert(buttonLayoutChanged);
-
-    newPage.content = null;
-};
-
-export function test_event_LayoutChanged_IsRaised_StackLayout_ChildAdded() {
-    helper.clearPage();
-    let newPage = helper.getCurrentPage();
-
-    let stackLayoutChangedCount = 0;
-    let button1LayoutChangedCount = 0;
-    let button2LayoutChanged = false;
-
-    let stackLayout = new StackLayout();
-
-    // StackLayout should not be stretched in order to layout again when new button added.
-    stackLayout.verticalAlignment = "top";
-    let button1 = new Button();
-    let button2 = new Button();
-
-    stackLayout.on(View.layoutChangedEvent, (data) => {
-        stackLayoutChangedCount++;
-    });
-
-    button1.on(View.layoutChangedEvent, (data) => {
-        button1LayoutChangedCount++;
-    });
-
-    button2.on(View.layoutChangedEvent, (data) => {
-        button2LayoutChanged = true;
-    });
-
-    stackLayout.addChild(button1);
-    newPage.content = stackLayout;
-
-    TKUnit.waitUntilReady(() => stackLayout.isLoaded);
-    stackLayout.addChild(button2);
-    
-    TKUnit.waitUntilReady(() => button2LayoutChanged);
-    TKUnit.assertEqual(stackLayoutChangedCount, 2);
-    TKUnit.assertEqual(button1LayoutChangedCount, 1);
-    TKUnit.assert(button2LayoutChanged);
 
     newPage.content = null;
 };
@@ -124,7 +83,7 @@ export function test_event_LayoutChanged_IsRaised_ChildMarginChanged() {
 
         (<Button>views[2]).marginTop = 50;
 
-        TKUnit.waitUntilReady(() => buttonLayoutChanged);
+        TKUnit.waitUntilReady(() => buttonLayoutChanged, 5);
 
         TKUnit.assert(stackLayoutChanged);
         TKUnit.assert(buttonLayoutChanged);
@@ -148,7 +107,7 @@ export function test_event_LayoutChanged_IsRaised_ParentMarginChanged() {
 
         (<Button>views[2]).marginTop = 50;
 
-        TKUnit.waitUntilReady(() => buttonLayoutChanged);
+        TKUnit.waitUntilReady(() => buttonLayoutChanged, 5);
 
         TKUnit.assert(stackLayoutChanged);
         TKUnit.assert(buttonLayoutChanged);
@@ -176,7 +135,7 @@ export function test_event_LayoutChanged_IsNotRaised_TransformChanged() {
         button.rotate += 50;
         button.height = 200;
 
-        TKUnit.waitUntilReady(() => button.height === 200);
+        TKUnit.waitUntilReady(() => button.height === 200, 5);
 
         TKUnit.assertEqual(stackLayoutChangedCount, 1);
         TKUnit.assertEqual(buttonLayoutChangedCount, 1);
@@ -200,7 +159,7 @@ export function test_event_LayoutChanged_IsRaised_StackLayout_SizeChanged() {
 
         (<StackLayout>views[1]).height = 100;
 
-        TKUnit.waitUntilReady(() => buttonLayoutChanged);
+        TKUnit.waitUntilReady(() => buttonLayoutChanged, 5);
 
         TKUnit.assert(stackLayoutChanged);
         TKUnit.assert(buttonLayoutChanged);


### PR DESCRIPTION
Extending time for layoutChanged event tests, since it could be fired later compared to other events