### PR TITLE
fix(Image): catch Response content may not be converted to an Image

### DIFF
--- a/tns-core-modules/http/http.ts
+++ b/tns-core-modules/http/http.ts
@@ -33,7 +33,7 @@ export function getJSON<T>(arg: any): Promise<T> {
 export function getImage(arg: any): Promise<ImageSource> {
     return httpRequest
         .request(typeof arg === "string" ? { url: arg, method: "GET" } : arg)
-        .then(responce => responce.content.toImage());
+        .then(response => response.content.toImage());
 }
 
 export function getFile(arg: any, destinationFilePath?: string): Promise<any> {

--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -1,9 +1,8 @@
 ﻿import { Image as ImageDefinition, Stretch } from ".";
-import { View, Property, InheritedCssProperty, Length, Style, Color, isIOS, booleanConverter, CSSType } from "../core/view";
+import { View, Property, InheritedCssProperty, Length, Style, Color, isIOS, booleanConverter, CSSType, traceEnabled, traceWrite, traceCategories } from "../core/view";
 import { ImageAsset } from "../../image-asset";
 import { ImageSource, fromAsset, fromNativeSource, fromUrl } from "../../image-source";
 import { isDataURI, isFileOrResourcePath, RESOURCE_PREFIX } from "../../utils/utils";
-
 export * from "../core/view";
 export { ImageSource, ImageAsset, fromAsset, fromNativeSource, fromUrl, isDataURI, isFileOrResourcePath, RESOURCE_PREFIX };
 
@@ -82,6 +81,15 @@ export abstract class ImageBase extends View implements ImageDefinition {
                     if (this["_url"] === value) {
                         this.imageSource = r;
                         this.isLoading = false;
+                    }
+                }, err => {
+                    // catch: Response content may not be converted to an Image 
+                    this.isLoading = false;
+                    if (traceEnabled()) {
+                        if (typeof err === "object" && err.message) {
+                            err = err.message;
+                        }
+                        traceWrite(err, traceCategories.Debug);
                     }
                 });
             }


### PR DESCRIPTION
closes https://github.com/NativeScript/nativescript-angular/issues/851
addresses part of https://github.com/NativeScript/NativeScript/issues/3381

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

Apps fail when this error occurs.

## What is the new behavior?

Developers can now have a meaningful and productive debugging session to make great apps. Error is now properly caught and with tracing enabled with `Debug` category developers may now easily pick up these types of issues.

closes https://github.com/NativeScript/nativescript-angular/issues/851
addresses part of https://github.com/NativeScript/NativeScript/issues/3381