### PR TITLE
fix(android): prevent error during tear down

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -261,7 +261,10 @@ export class Frame extends FrameBase {
                 }
 
                 entry.recreated = false;
-                current.recreated = false;
+
+                if (current) {
+                    current.recreated = false;
+                }
             }
 
             super.setCurrent(entry, isBack);


### PR DESCRIPTION
It's a bit of a blind fix since I can't reproduce this issue. The scenario should be with racing between navigation and the activity destroy/recreate (with the native back button or don't keep activities and restore). The idea is to tear down the native UI in current/navigating entries while still caching the new entry, so that the app continues from the same entry once the activity is recreated. 

Examining the latest changes [here](https://github.com/NativeScript/NativeScript/commit/4e74c3731376179ff1b72305b982d0937e3415c6#diff-c1ad77120477acf9bacdaabe6af2518d) shows that the bool flags were moved to the end of the block. The current entry flag was moved without the guard.

Fixes https://github.com/NativeScript/NativeScript/issues/5614