### PR TITLE
fix(android): NavigationButton was read as "Button" by screenreaders.

### DIFF
--- a/tests/app/ui/action-bar/action-bar-tests.android.ts
+++ b/tests/app/ui/action-bar/action-bar-tests.android.ts
@@ -32,6 +32,19 @@ export function test_navigationButton_visibility() {
     TKUnit.assertNull(toolbar.getNavigationIcon(), "Visibility does not work");
 }
 
+export function test_navigationButton_contentDecription() {
+    const actionItem = new ActionItem();
+    actionItem.icon = "~/small-image.png";
+    const actionItemText = "NavButton with small-image";
+    actionItem.text = actionItemText;
+    const page = actionTestsCommon.createPageAndNavigate();
+    page.actionBar.navigationButton = actionItem;
+
+    const toolbar = <android.support.v7.widget.Toolbar>page.actionBar.nativeViewProtected;
+
+    TKUnit.assertEqual(toolbar.getNavigationContentDescription(), actionItemText, "Navigation Button should have an content decription");
+}
+
 export function test_set_actionView_to_attached_actionItem_propagates_context() {
     const actionItem = new ActionItem();
     const actionButton = new Button();

--- a/tns-core-modules/ui/action-bar/action-bar.android.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.android.ts
@@ -223,6 +223,9 @@ export class ActionBar extends ActionBarBase {
                 this.nativeViewProtected.setNavigationIcon(drawableOrId);
             }
 
+            // Set navigation content descripion, used by screen readers for the vision-impaired users
+            this.nativeViewProtected.setNavigationContentDescription(navButton.text || null);
+
             let navBtn = new WeakRef(navButton);
             this.nativeViewProtected.setNavigationOnClickListener(new android.view.View.OnClickListener({
                 onClick: function (v) {
@@ -285,7 +288,7 @@ export class ActionBar extends ActionBarBase {
             let menuItem = menu.add(android.view.Menu.NONE, item._getItemId(), android.view.Menu.NONE, item.text + "");
 
             if (item.actionView && item.actionView.android) {
-                // With custom action view, the menuitem cannot be displayed in a popup menu. 
+                // With custom action view, the menuitem cannot be displayed in a popup menu.
                 item.android.position = "actionBar";
                 menuItem.setActionView(item.actionView.android);
                 ActionBar._setOnClickListener(item);
@@ -376,7 +379,7 @@ export class ActionBar extends ActionBarBase {
             }
 
             // Fallback to hardcoded falue if we don't find TextView instance...
-            // using new TextView().getTextColors().getDefaultColor() returns different value: -1979711488 
+            // using new TextView().getTextColors().getDefaultColor() returns different value: -1979711488
             defaultTitleTextColor = tv ? tv.getTextColors().getDefaultColor() : -570425344;
         }
 


### PR DESCRIPTION
The navigation button for the vision-impaired users were always read as:
"Button" by the TalkBack service on Android.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes #5948

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGES:
None to my knowledge

[Describe the impact of the changes here.]
Sets navigation content description with the value of NavigationButton.text on android.
Adds a test.

Migration steps:
Not required but NavigationButton property text should be set for the benefit of the vision-impaired users.
