### PR TITLE
fix(dialogs-ios): dialogs not showing in non Frame based apps

### DIFF
--- a/tns-core-modules/ui/dialogs/dialogs.ios.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.ios.ts
@@ -5,6 +5,7 @@ import { View, ios as iosView } from "../core/view";
 import { ConfirmOptions, PromptOptions, PromptResult, LoginOptions, LoginResult, ActionOptions } from ".";
 import { getCurrentPage, getLabelColor, getButtonColors, getTextFieldColor, isDialogOptions, inputType, ALERT, OK, CONFIRM, CANCEL, PROMPT, LOGIN } from "./dialogs-common";
 import { isString, isDefined, isFunction } from "../../utils/types";
+import { getRootView } from "../../application";
 
 export * from "./dialogs-common";
 
@@ -198,20 +199,16 @@ export function login(): Promise<LoginResult> {
 }
 
 function showUIAlertController(alertController: UIAlertController) {
-    let currentPage = getCurrentPage();
-    if (currentPage) {
-        let view: View = currentPage;
-        let viewController: UIViewController = currentPage.ios;
+    let currentView = getCurrentPage() || getRootView();
 
-        if (currentPage.modal) {
-            view = currentPage.modal;
+    if (currentView) {
+        currentView = currentView.modal || currentView;
 
-            if (view.ios instanceof UIViewController) {
-                viewController = view.ios;
-            } else {
-                const parentWithController = iosView.getParentWithViewController(view);
-                viewController = parentWithController ? parentWithController.viewController : undefined;
-            }
+        let viewController: UIViewController = currentView.ios;
+
+        if (!(currentView.ios instanceof UIViewController)) {
+            const parentWithController = iosView.getParentWithViewController(currentView);
+            viewController = parentWithController ? parentWithController.viewController : undefined;
         }
 
         if (viewController) {


### PR DESCRIPTION
__Solution__: Search for the root view's `viewController` when no current page available (no topmost frame)

__Tests__: e2e tests already available for these scenarios

Fix https://github.com/NativeScript/NativeScript/issues/5931

