### PR TITLE
fix(grunt): Add platforms folder to produced NPM package

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
         if (blockCommentPrivate.test(content)) {
             return false;
         }
-        
+
         var processed = content;
         processed = processed.replace(/\/\/[\/\s]*@private[^]*?\/\/[\/\s]*?@endprivate/gm, "");
         return processed;
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
         copyAppsSrc.push("!" + localCfg.srcAppDirs[i] + "/**/*.map");
         copyAppsSrc.push("!" + localCfg.srcAppDirs[i] + "/**/*.ts");
     }
-    
+
     var nodeTestEnv = JSON.parse(JSON.stringify(process.env));
     nodeTestEnv.NODE_PATH = localCfg.outTnsCoreModules;
     localCfg.nodeTestsDir = path.join(localCfg.outDir, 'unit-tests');
@@ -236,6 +236,11 @@ module.exports = function(grunt) {
                 ],
                 dest: localCfg.outDir + "/"
             },
+            platformsFiles: {
+                expand: true,
+                src: "tns-core-modules/platforms/**/*.*",
+                dest: localCfg.outDir + "/"
+            },
             apps: {
                 expand: true,
                 src: copyAppsSrc,
@@ -321,6 +326,7 @@ module.exports = function(grunt) {
     // Register Tasks
     grunt.registerTask("collect-modules-raw-files", [
         "copy:jsLibs",
+        "copy:platformsFiles",
         "copy:license"
     ]);
 
@@ -372,7 +378,7 @@ module.exports = function(grunt) {
         "copy:modulesPackageDef",
         "exec:packModules"
     ]);
-    
+
     grunt.registerTask("compile-modules", [
         "clean:build",
         "shell:getGitSHA",
@@ -446,7 +452,7 @@ module.exports = function(grunt) {
             shelljs.exec("npm pack", {cwd: outAppDir});
         });
     });
-    
+
     grunt.registerTask("get-ready-packages", ["copy:readyPackages"]);
 
     grunt.registerTask("default", (skipTsLint ? [] : ["shell:tslint"]).concat([


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`platforms` folder is still excluded from the built NPM package
## What is the new behavior?
<!-- Describe the changes. -->
`platforms` folder is now being added by `grunt` build
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

