### PR TITLE
fix: require devtools-elements.js with the extension mentioned explicitly

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -42,7 +42,7 @@ let fragmentId = -1;
 export let moduleLoaded: boolean;
 
 if (global && global.__inspector) {
-    const devtools = require("tns-core-modules/debugger/devtools-elements");
+    const devtools = require("tns-core-modules/debugger/devtools-elements.js");
     devtools.attachDOMInspectorEventCallbacks(global.__inspector);
     devtools.attachDOMInspectorCommandCallbacks(global.__inspector);
 }


### PR DESCRIPTION
This is a workaround for the issue with `@ngtools/webpack@6.1.0-rc.2`, described here: https://github.com/NativeScript/nativescript-dev-webpack/issues/607#issuecomment-405209925