### PR TITLE
release: cut the 4.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Cross Platform Modules Changelog
 ==============================
 
+<a name="4.1.1"></a>
+# [4.1.1](https://github.com/NativeScript/NativeScript/compare/4.1.0...4.1.1) (2018-07-18)
+
+
+### Bug Fixes
+
+* require devtools-elements.js with the extension mentioned explicitly ([#6079](https://github.com/NativeScript/NativeScript/issues/6079)) ([1a15aa2](https://github.com/NativeScript/NativeScript/commit/1a15aa2))
+
+
 <a name="4.1.0"></a>
 # [4.1.0](https://github.com/NativeScript/NativeScript/compare/4.0.1...4.1.0) (2018-05-28)
 

--- a/tns-core-modules/globals/globals.ts
+++ b/tns-core-modules/globals/globals.ts
@@ -206,7 +206,7 @@ export function Deprecated(target: Object, key?: string | symbol, descriptor?: a
         var originalMethod = descriptor.value;
 
         descriptor.value = function (...args: any[]) {
-            console.log(`${key} is deprecated`);
+            console.log(`${key.toString()} is deprecated`);
 
             return originalMethod.apply(this, args);
         }
@@ -225,7 +225,7 @@ export function Experimental(target: Object, key?: string | symbol, descriptor?:
         var originalMethod = descriptor.value;
 
         descriptor.value = function (...args: any[]) {
-            console.log(`${key} is experimental`);
+            console.log(`${key.toString()} is experimental`);
 
             return originalMethod.apply(this, args);
         }

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-core-modules",
   "description": "Telerik NativeScript Core Modules",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "homepage": "https://www.nativescript.org",
   "repository": {
     "type": "git",

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -42,7 +42,7 @@ let fragmentId = -1;
 export let moduleLoaded: boolean;
 
 if (global && global.__inspector) {
-    const devtools = require("tns-core-modules/debugger/devtools-elements");
+    const devtools = require("tns-core-modules/debugger/devtools-elements.js");
     devtools.attachDOMInspectorEventCallbacks(global.__inspector);
     devtools.attachDOMInspectorCommandCallbacks(global.__inspector);
 }


### PR DESCRIPTION
- fix: require devtools-elements.js with the extension mentioned explicly
This is a workaround for the issue with `@ngtools/webpack@6.1.0-rc.2`, described here: NativeScript/nativescript-dev-webpack#607 (comment)

- chore: Fix TS transpile error with 2.9 (#5906)