### PR TITLE
 feat(image-asset): add saveToFile method to ImageAsset

### DIFF
--- a/tns-core-modules/image-asset/image-asset-common.ts
+++ b/tns-core-modules/image-asset/image-asset-common.ts
@@ -2,14 +2,14 @@ import * as definition from ".";
 import * as observable from "../data/observable";
 import * as platform from "../platform";
 
-export class ImageAsset  extends observable.Observable implements definition.ImageAsset {
+export class ImageAsset extends observable.Observable implements definition.ImageAsset {
     private _options: definition.ImageAssetOptions;
     private _nativeImage: any;
 
     ios: PHAsset;
     android: string;
 
-    constructor () {
+    constructor() {
         super();
         this._options = { keepAspectRatio: true };
     }
@@ -31,6 +31,10 @@ export class ImageAsset  extends observable.Observable implements definition.Ima
     }
 
     public getImageAsync(callback: (image: any, error: Error) => void) {
+        //
+    }
+
+    public saveToFile(fileName: string, callback: (imagePath: string, error: any) => void) {
         //
     }
 }

--- a/tns-core-modules/image-asset/image-asset.android.ts
+++ b/tns-core-modules/image-asset/image-asset.android.ts
@@ -42,7 +42,7 @@ export class ImageAsset extends common.ImageAsset {
             let error = null;
             // read as minimum bitmap as possible (slightly bigger than the requested size)
             bitmap = android.graphics.BitmapFactory.decodeFile(this.android, finalBitmapOptions);
-            
+
             if (bitmap) {
                 if (requestedSize.width !== bitmap.getWidth() || requestedSize.height !== bitmap.getHeight()) {
                     // scale to exact size
@@ -66,6 +66,10 @@ export class ImageAsset extends common.ImageAsset {
         catch (ex) {
             callback(null, ex);
         }
+    }
+
+    public saveToFile(fileName: string, callback: (imagePath: string, error: any) => void) {
+        callback(this.android, null);
     }
 }
 

--- a/tns-core-modules/image-asset/image-asset.d.ts
+++ b/tns-core-modules/image-asset/image-asset.d.ts
@@ -6,6 +6,13 @@ import { Observable } from "../data/observable";
 
 export class ImageAsset extends Observable {
     constructor(asset: any);
+
+    /**
+    * Saves this instance to the Temporary (Caches) folder for the current application.
+    * @param fileName The name of the image file (without extension).
+    * @param callback Callback function which will be executed when the file is created. Returns the new full image path string.
+    */
+    saveToFile(fileName: string, callback: (imagePath: string, error: any) => void);
     getImageAsync(callback: (image: any, error: any) => void); //UIImage for iOS and android.graphics.Bitmap for Android
     ios: any; //PHAsset
     nativeImage: any; //UIImage for iOS and android.graphics.Bitmap for Android

--- a/tns-core-modules/image-asset/image-asset.d.ts
+++ b/tns-core-modules/image-asset/image-asset.d.ts
@@ -24,4 +24,5 @@ export interface ImageAssetOptions {
     width?: number;
     height?: number;
     keepAspectRatio?: boolean;
+    quality?: number;
 }


### PR DESCRIPTION
Expose `ImageAsset.saveToFile` method that:
- __[iOS]__ Can copy the original image file, without modifying it, inside Temporary (Cache) folder of the app.
- __[iOS and Android]__ Can create new resized image file (If width/height provided as `options` of the ImageAsset) inside Temporary (Cache) folder of the app. 

  _The mimeType/extension of the image should be automatically detected in order to use the proper compression (PNG vs JPEG)._
 
---
__Why `saveToFile` method for `ImageAsset`?__
Imagine a common scenario where you have to upload an image from the phone gallery, using `nativescript-imagepicker`, to the cloud.  Currently the lack of a method that saves ImageAsset as a file (inside the current application directory) imposes the use of `ImageSource.saveToFile()` in order to upload image.

Upload steps:
  1. Select an image from the gallery
  2. Convert the result returned from `nativescript-imagepicker` to `ImageSource` since it is an `ImageAsset` object.
 3. Create new image file inside Temporary (Cache) folder of the app using `ImageSource.saveToFile` method.

    _`ImageSource.saveToFile` expects `format` param which means you have to manually find the correct image extension/mimeType_ of the image.

    _`ImageSource.saveToFile` will always perform image compression while saving file, which can affect the file size, even if no resizing is required (no `width` and `height` options set for `ImageAsset`)_

 4. Use the newly created image file path for upload.
---

__Less code for our templates__:
[template-master-detail](https://github.com/NativeScript/template-master-detail/blob/b5f90da3e325bfb180d909fd64974c9d9bf5bafd/cars/car-detail-edit-page/car-detail-edit-view-model.js#L83) template could switch to `saveToFile` instead of using the above approach.
[template-construction-sites](https://github.com/NativeScript/template-construction-sites/blob/371966e8433d5cfe57871c5fb33077acde0daa59/app/construction-sites/construction-site-edit/construction-site-edit.component.ts#L125) template manually creates a copy of the selected image file for iOS. 