### PR TITLE
fix: iOS TimePicker minuteInterval property

### DIFF
--- a/tns-core-modules/ui/time-picker/time-picker.ios.ts
+++ b/tns-core-modules/ui/time-picker/time-picker.ios.ts
@@ -1,5 +1,5 @@
 ﻿import {
-    TimePickerBase, timeProperty,
+    TimePickerBase, timeProperty, minuteIntervalProperty,
     minuteProperty, minMinuteProperty, maxMinuteProperty,
     hourProperty, minHourProperty, maxHourProperty, colorProperty, Color
 } from "./time-picker-common";
@@ -93,10 +93,10 @@ export class TimePicker extends TimePickerBase {
         this.nativeViewProtected.maximumDate = getDate(this.hour, value);
     }
 
-    [timeProperty.getDefault](): number {
+    [minuteIntervalProperty.getDefault](): number {
         return this.nativeViewProtected.minuteInterval;
     }
-    [timeProperty.setNative](value: number) {
+    [minuteIntervalProperty.setNative](value: number) {
         this.nativeViewProtected.minuteInterval = value;
     }
 


### PR DESCRIPTION

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.


Fix for the TimePicker's `minuteInterval` property not working on iOS. 

Fixes [https://github.com/NativeScript/NativeScript/issues/4662](https://github.com/NativeScript/NativeScript/issues/4662)