### PR TITLE
feat(image-asset-ios): add autoScaleFactor option to switch auto scaling

### DIFF
--- a/tests/app/image-source/image-source-tests.ts
+++ b/tests/app/image-source/image-source-tests.ts
@@ -111,20 +111,37 @@ export function testFromAssetSimple(done) {
     });
 }
 
-export function testFromAssetWithScaling(done) {
+export function testFromAssetWithExactScaling(done) {
     let asset = new imageAssetModule.ImageAsset(splashscreenPath);
     let scaleWidth = 10;
     let scaleHeight = 11;
     asset.options = {
         width: scaleWidth,
         height: scaleHeight,
-        keepAspectRatio: false
+        keepAspectRatio: false,
+        autoScaleFactor: false
     };
 
-    let img = imageSource.fromAsset(asset).then((source) => {
+    imageSource.fromAsset(asset).then((source) => {
         TKUnit.assertEqual(source.width, scaleWidth);
         TKUnit.assertEqual(source.height, scaleHeight);
-        done();
+
+        const targetFilename = `splashscreenTemp.png`;
+        const tempPath = fs.knownFolders.temp().path;
+        const localFullPath = fs.path.join(tempPath, targetFilename);
+
+        const fullImageSaved = source.saveToFile(localFullPath, "png");
+
+        if (fullImageSaved) {
+            let sourceImage = new imageSource.ImageSource();
+            sourceImage.fromFile(localFullPath).then(() => {
+                TKUnit.assertEqual(sourceImage.width, scaleWidth);
+                TKUnit.assertEqual(sourceImage.height, scaleHeight);
+                done();
+            });
+        } else {
+            done(`Error saving photo to local temp folder: ${localFullPath}`);
+        }
     }, (error) => {
         done(error);
     });

--- a/tns-core-modules/image-asset/image-asset-common.ts
+++ b/tns-core-modules/image-asset/image-asset-common.ts
@@ -2,16 +2,16 @@ import * as definition from ".";
 import * as observable from "../data/observable";
 import * as platform from "../platform";
 
-export class ImageAsset  extends observable.Observable implements definition.ImageAsset {
+export class ImageAsset extends observable.Observable implements definition.ImageAsset {
     private _options: definition.ImageAssetOptions;
     private _nativeImage: any;
 
     ios: PHAsset;
     android: string;
 
-    constructor () {
+    constructor() {
         super();
-        this._options = { keepAspectRatio: true };
+        this._options = { keepAspectRatio: true, autoScaleFactor: true };
     }
 
     get options(): definition.ImageAssetOptions {

--- a/tns-core-modules/image-asset/image-asset.d.ts
+++ b/tns-core-modules/image-asset/image-asset.d.ts
@@ -17,4 +17,5 @@ export interface ImageAssetOptions {
     width?: number;
     height?: number;
     keepAspectRatio?: boolean;
+    autoScaleFactor?: boolean;
 }

--- a/tns-core-modules/image-asset/image-asset.ios.ts
+++ b/tns-core-modules/image-asset/image-asset.ios.ts
@@ -50,7 +50,7 @@ export class ImageAsset extends common.ImageAsset {
         let imageRequestOptions = PHImageRequestOptions.alloc().init();
         imageRequestOptions.deliveryMode = PHImageRequestOptionsDeliveryMode.HighQualityFormat;
         imageRequestOptions.networkAccessAllowed = true;
-        
+
         PHImageManager.defaultManager().requestImageForAssetTargetSizeContentModeOptionsResultHandler(this.ios, requestedSize, PHImageContentMode.AspectFit, imageRequestOptions,
             (image, imageResultInfo) => {
                 if (image) {
@@ -64,8 +64,11 @@ export class ImageAsset extends common.ImageAsset {
         );
     }
 
-    private scaleImage(image: UIImage, requestedSize: {width: number, height: number}): UIImage {
-        UIGraphicsBeginImageContextWithOptions(requestedSize, false, 0.0);
+    private scaleImage(image: UIImage, requestedSize: { width: number, height: number }): UIImage {
+        // scaleFactor = 0 takes the scale factor of the devices's main screen.
+        const scaleFactor = this.options && this.options.autoScaleFactor === false ? 1.0 : 0.0;
+
+        UIGraphicsBeginImageContextWithOptions(requestedSize, false, scaleFactor);
         image.drawInRect(CGRectMake(0, 0, requestedSize.width, requestedSize.height));
         let resultImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();

--- a/tns-core-modules/image-source/image-source.ios.ts
+++ b/tns-core-modules/image-source/image-source.ios.ts
@@ -190,7 +190,7 @@ function getFileName(path: string): string {
     return fileName;
 }
 
-function getImageData(instance: UIImage, format: "png" | "jpeg" | "jpg", quality = 1.0): NSData {
+function getImageData(instance: UIImage, format: "png" | "jpeg" | "jpg", quality = 0.9): NSData {
     var data = null;
     switch (format) {
         case "png":


### PR DESCRIPTION
__iOS Specific__: Currently `imageSource.fromAsset` returns an ImageSource that is automatically rescaled with the scale factor of the devices's main screen (depending on the Retina display 1x/2x/3x). This results in bigger images even if the user has specified an explicit `width/height` (inside`ImageAsset` options). See this [issue](https://github.com/NativeScript/NativeScript/issues/6011) for reference. 

Changes:
 - Introduce `autoScaleFactor` option for `ImageAssetOptions` that can disable auto scaling.
_NOTE:`autoScaleFactor` remains `true` by default_

- Reduce default JPEG compression quality to 0.9 to lower final image size ([see this for more info on the topic](https://stackoverflow.com/questions/26330492/what-should-compressionquality-be-when-using-uiimagejpegrepresentation)

- Modify ImageSource scaling test to verify the final image file resolution