### PR TITLE
fix(android): suppress reflection for default animations

### DIFF
--- a/tns-core-modules/ui/frame/fragment.transitions.d.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.d.ts
@@ -24,7 +24,6 @@ export function _setAndroidFragmentTransitions(
     currentEntry: BackstackEntry,
     newEntry: BackstackEntry,
     fragmentTransaction: any,
-    manager: any /* android.support.v4.app.FragmentManager */,
     frameId: number): void;
 /**
  * @private

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -337,10 +337,7 @@ export class Frame extends FrameBase {
         // https://github.com/NativeScript/NativeScript/issues/4895
         const navigationTransition = this._currentEntry ? this._getNavigationTransition(newEntry.entry) : null;
 
-        _setAndroidFragmentTransitions(animated, navigationTransition, currentEntry, newEntry, transaction, manager, this._android.frameId);
-        // if (clearHistory) {
-        //     deleteEntries(this.backStack);
-        // }
+        _setAndroidFragmentTransitions(animated, navigationTransition, currentEntry, newEntry, transaction, this._android.frameId);
 
         if (currentEntry && animated && !navigationTransition) {
             transaction.setTransition(android.support.v4.app.FragmentTransaction.TRANSIT_FRAGMENT_OPEN);


### PR DESCRIPTION
Fixes `Error: java.lang.CloneNotSupportedException: Class android.support.v4.app.FragmentManagerImpl$AnimationOrAnimator doesn't implement Cloneable` in specific projects.

I was able to reproduce the problem when added the firebase plugin to a working hello-world app (cli next, android runtime next, tns-core-modules next). The root of the problem is the fact that different versions of the support library expose different API for android.support.v4.app.FragmentManagerImpl.loadAnimations(...) -- one returns Animation, the other AnimationOrAnimatior (that is not cloneable). Might be related to 
https://github.com/NativeScript/nativescript-cli/issues/3773 as we are really unsure which support library version is used (and why).


Related to #5785
Related to #6129 

BREAKING CHANGE


Before:
Default fragment enter animation was Android version specific

After:
Default fragment enter animation is now fade animation for all Android versions

You can customise the transition per navigation entry or globally via the [navigation transitions API](
https://docs.nativescript.org/core-concepts/navigation#navigation-transitions)