### PR TITLE
enabling reportProgress property for NativeScirpt Angular's HTTPClient

### DIFF
--- a/tns-core-modules/xhr/xhr.ts
+++ b/tns-core-modules/xhr/xhr.ts
@@ -165,7 +165,7 @@ export class XMLHttpRequest {
     private _listeners: Map<string, Array<Function>> = new Map<string, Array<Function>>();
 
     public addEventListener(eventName: string, handler: Function) {
-        if (eventName !== "load" && eventName !== "error") {
+        if (eventName !== "load" && eventName !== "error" && eventName !== "progress") {
             throw new Error("Event not supported: " + eventName);
         }
 


### PR DESCRIPTION
enabling `reportProgress` property for NativeScirpt Angular's HTTPClient