### PR TITLE
refactor: update getSupportFragmentManager cast

### DIFF
--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -280,7 +280,7 @@ export class View extends ViewCommon {
             }
 
             if (!manager && this._context) {
-                manager = (<android.support.v7.app.AppCompatActivity>this._context).getSupportFragmentManager();
+                manager = (<android.support.v4.app.FragmentActivity>this._context).getSupportFragmentManager();
             }
 
             this._manager = manager;


### PR DESCRIPTION
Behavior does not change but casting this to `android.support.v4.app.FragmentActivity` is semantically more correct as this is the base class where getSupportFragmentManager() is implemented.

Related to https://github.com/NativeScript/NativeScript/pull/6129