### PR TITLE
feat(android): add Bluetooth connectivity type for Android

### DIFF
--- a/tns-core-modules/connectivity/connectivity.android.ts
+++ b/tns-core-modules/connectivity/connectivity.android.ts
@@ -4,12 +4,14 @@ export enum connectionType {
     none = 0,
     wifi = 1,
     mobile = 2,
-    ethernet = 3
+    ethernet = 3,
+    bluetooth = 4
 }
 
 const wifi = "wifi";
 const mobile = "mobile";
 const ethernet = "ethernet";
+const bluetooth = "bluetooth";
 
 // Get Connection Type
 function getConnectivityManager(): android.net.ConnectivityManager {
@@ -42,6 +44,10 @@ export function getConnectionType(): number {
 
     if (type.indexOf(ethernet) !== -1) {
         return connectionType.ethernet;
+    }
+
+    if (type.indexOf(bluetooth) !== -1) {
+        return connectionType.bluetooth;
     }
         
     return connectionType.none;

--- a/tns-core-modules/connectivity/connectivity.d.ts
+++ b/tns-core-modules/connectivity/connectivity.d.ts
@@ -35,7 +35,7 @@ export enum connectionType {
     ethernet = 3,
 
     /**
-     * Denotes an ethernet connection
+     * Denotes an bluetooth connection
      */
     bluetooth = 4
 }

--- a/tns-core-modules/connectivity/connectivity.d.ts
+++ b/tns-core-modules/connectivity/connectivity.d.ts
@@ -32,7 +32,12 @@ export enum connectionType {
     /**
      * Denotes an ethernet connection
      */
-    ethernet = 3
+    ethernet = 3,
+
+    /**
+     * Denotes an ethernet connection
+     */
+    bluetooth = 4
 }
 
 /**


### PR DESCRIPTION
Related to [https://github.com/NativeScript/NativeScript/issues/6158](https://github.com/NativeScript/NativeScript/issues/6158)

Added [Bluetooth](https://developer.android.com/reference/android/net/ConnectivityManager#TYPE_BLUETOOTH) as `connectivityType`.