### PR TITLE
fix(android/platform): reinitialise screen metrics on orientation change

### DIFF
--- a/tns-core-modules/platform/platform.android.ts
+++ b/tns-core-modules/platform/platform.android.ts
@@ -101,16 +101,8 @@ class Device implements DeviceDefinition {
 
 class MainScreen implements ScreenMetricsDefinition {
     private _metrics: android.util.DisplayMetrics;
-    
-    constructor() {
-        appModule.on(appModule.orientationChangedEvent, () => {
-            if (this._metrics) {
-                this.initMetrics();
-            }
-        });
-    }
 
-    private cssChanged(args: appModule.CssChangedEventData): void {
+    private reinitMetrics(): void {
         if (!this._metrics) {
             this._metrics = new android.util.DisplayMetrics();
         }
@@ -125,7 +117,8 @@ class MainScreen implements ScreenMetricsDefinition {
     private get metrics(): android.util.DisplayMetrics {
         if (!this._metrics) {
             // NOTE: This will be memory leak but we MainScreen is singleton
-            appModule.on("cssChanged", this.cssChanged, this);
+            appModule.on("cssChanged", this.reinitMetrics, this);
+            appModule.on(appModule.orientationChangedEvent, this.reinitMetrics, this);
 
             this._metrics = new android.util.DisplayMetrics();
             this.initMetrics();

--- a/tns-core-modules/platform/platform.android.ts
+++ b/tns-core-modules/platform/platform.android.ts
@@ -102,6 +102,14 @@ class Device implements DeviceDefinition {
 class MainScreen implements ScreenMetricsDefinition {
     private _metrics: android.util.DisplayMetrics;
     
+    constructor() {
+        appModule.on(appModule.orientationChangedEvent, () => {
+            if (this._metrics) {
+                this.initMetrics();
+            }
+        });
+    }
+
     private cssChanged(args: appModule.CssChangedEventData): void {
         if (!this._metrics) {
             this._metrics = new android.util.DisplayMetrics();


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When getting the screen width/height on android those are the same, no matter if you rotate the device or not. Unlike iOS where the properties always reflect the actual device width/height. 

## What is the new behavior?
`platform.screen.mainScreen` width and height properties will always show the actual values like on iOS. 

Fixes #4588.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

