### PR TITLE
 chore: add npm version script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Here are some guides on how to do that:
  - [Requesting New Features](#features)
  - [Submitting a PR](#pr)
  - [Commit Message Guidelines](#commit-messages)
+ - [Releasing new versions](#release)
 
 ##  <a name="coc"></a> Code of Conduct
 Help us keep a healthy and open community. We expect all participants in this project to adhere to the [NativeScript Code Of Conduct](https://github.com/NativeScript/codeofconduct).
@@ -209,3 +210,42 @@ If you want to contribute, but you are not sure where to start - look for [issue
 
 
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
+
+## <a name="release"></a> Releasing new versions
+
+1. Run `npm install` to install the dependencies:
+```bash
+npm install
+```
+
+2. Add the following to your `.npmrc`:
+```
+tag-version-prefix=""
+message="release: cut the %s release"
+```
+
+3. Create new branch for the release:
+```bash
+git checkout -b username/release-version
+```
+
+4. Run `npm version` to bump the version in the `package.json` file of the `tns-platform-declarations` plugin:
+```bash
+cd tns-platform-declarations
+npm --no-git-tag-version version [patch|minor|major]
+cd ..
+```
+
+5. Run `npm version` to bump the version in the `package.json` file of the `tns-core-modules` plugin, tag the release and update the CHANGELOG.md:
+```bash
+cd tns-core-modules
+npm version [patch|minor|major]
+cd ..
+```
+
+6. Push all changes to your branch and create a PR:
+```bash
+git push --set-upstream origin username/release-version --tags
+```
+
+7. Publish the packages built on CI to `npm` after the PR is merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,9 @@ If you want to contribute, but you are not sure where to start - look for [issue
 
 ## <a name="release"></a> Releasing new versions
 
-1. Run `npm install` to install the dependencies:
+Instructions how to release a new version for **NativeScript Core Team Members**.
+
+1. Execute `npm install` to install dependencies:
 ```bash
 npm install
 ```
@@ -224,28 +226,28 @@ tag-version-prefix=""
 message="release: cut the %s release"
 ```
 
-3. Create new branch for the release:
+3. Create new branch based on `master`:
 ```bash
 git checkout -b username/release-version
 ```
 
-4. Run `npm version` to bump the version in the `package.json` file of the `tns-platform-declarations` plugin:
+4. Execute [`npm version`](https://docs.npmjs.com/cli/version) to bump the version of `tns-platform-declarations`:
 ```bash
 cd tns-platform-declarations
 npm --no-git-tag-version version [patch|minor|major]
 cd ..
 ```
 
-5. Run `npm version` to bump the version in the `package.json` file of the `tns-core-modules` plugin, tag the release and update the CHANGELOG.md:
+5. Execute [`npm version`](https://docs.npmjs.com/cli/version) to bump the version of `tns-core-modules`, tag the release and update the CHANGELOG.md:
 ```bash
 cd tns-core-modules
 npm version [patch|minor|major]
 cd ..
 ```
 
-6. Push all changes to your branch and create a PR:
+6. Push all the changes to your branch and open a pull request:
 ```bash
 git push --set-upstream origin username/release-version --tags
 ```
 
-7. Publish the packages built on CI to `npm` after the PR is merged.
+7. Create `release` branch after the pull request is merged to `master` and publish the packages built on CI to `npm`.

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-core-modules",
   "description": "Telerik NativeScript Core Modules",
-  "version": "4.3.0",
+  "version": "4.2.0",
   "homepage": "https://www.nativescript.org",
   "repository": {
     "type": "git",

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -32,6 +32,9 @@
     "@types/node": "~7.0.5",
     "tns-platform-declarations": "*"
   },
+  "scripts": {
+    "version": "rm package-lock.json && conventional-changelog -p angular -i ../CHANGELOG.md -s && git add ../CHANGELOG.md"
+  },
   "nativescript": {
     "platforms": {
       "ios": "4.0.0",

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
-    "tns-core-modules-widgets": "4.2.0"
+    "tns-core-modules-widgets": "next"
   },
   "devDependencies": {
     "@types/node": "~7.0.5",

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -33,7 +33,7 @@
     "tns-platform-declarations": "*"
   },
   "scripts": {
-    "version": "rm package-lock.json && conventional-changelog -p angular -i ../CHANGELOG.md -s && git add ../CHANGELOG.md"
+    "version": "conventional-changelog -p angular -i ../CHANGELOG.md -s && git add ../CHANGELOG.md"
   },
   "nativescript": {
     "platforms": {

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
-    "tns-core-modules-widgets": "next"
+    "tns-core-modules-widgets": "4.2.0"
   },
   "devDependencies": {
     "@types/node": "~7.0.5",

--- a/tns-platform-declarations/package.json
+++ b/tns-platform-declarations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tns-platform-declarations",
-  "version": "4.3.0",
+  "version": "4.2.0",
   "description": "Platform-specific TypeScript declarations for NativeScript for accessing native objects",
   "main": "",
   "scripts": {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the new behavior?
<!-- Describe the changes. -->

Merge tag `4.2.0` - the latest tag respected by the `conventional-changelog` tool as *previousTag* and returned by `git describe --tags`.

The versions of packages in `master` to reflect the `latest` official release in `npm`.

Bumping up versions will execute in CI job through the `npm --no-git-tag-version version minor` command with this [pull request](https://github.com/NativeScript/jenkins/pull/39).

Add *Releasing new versions* section to `CONTRIBUTING.md` on how to bump versions, tag releases and generate changelogs for **NativeScript Core Team Members**.

This is to unify the release process across the `NativeScript`, `nativescript-angular` and `nativescript-dev-webpack` repositories.

Documentation of the [`npm version`](https://docs.npmjs.com/cli/version) command.

![changelog](https://user-images.githubusercontent.com/12251337/43851749-3e479fde-9b44-11e8-852e-3d6e1278762b.png)
