### PR TITLE
fix: README's images are not visualised in api reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NativeScript [![Build Status](https://travis-ci.org/NativeScript/NativeScript.svg?branch=master)](https://travis-ci.org/NativeScript/NativeScript)
 
-![NativeScript logo](http://i.imgur.com/YmNIMqS.png)
+![NativeScript logo](https://i.imgur.com/YmNIMqS.png)
 
 [NativeScript](http://www.nativescript.org) is a framework for building native iOS and Android apps using JavaScript and CSS. NativeScript renders UIs with the native platform’s rendering engine, no [WebViews](http://developer.telerik.com/featured/what-is-a-webview/), resulting in native-like performance and UX.
 
@@ -32,7 +32,7 @@ Our Getting Started Guides are hands-on tutorials that walk you through installi
 
 Below is a common NativeScript architecture diagram. In more detail, read the [How NativeScript Works article](https://docs.nativescript.org/start/how-it-works).
 
-![Architecture diagram](https://github.com/NativeScript/docs/blob/master/docs/img/ns-common.png)
+![Architecture diagram](https://raw.githubusercontent.com/NativeScript/docs/master/docs/img/ns-common.png)
 
 ## Quick Links
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Images in docs.nativescript.org/api-reference are not visualised.

## What is the new behavior?
Images in docs.nativescript.org/api-reference are visualised correctly.