### PR TITLE
fix(android-next): force frame fragment disposal on unload

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -197,21 +197,8 @@ export class Frame extends FrameBase {
 
         const manager: android.support.v4.app.FragmentManager = this._getFragmentManager();
         const transaction = manager.beginTransaction();
-        const androidSdkVersion = sdkVersion();
-
-        if (androidSdkVersion !== 21 && androidSdkVersion !== 22) {
-            transaction.remove(this._currentEntry.fragment);
-        } else {
-            // https://github.com/NativeScript/NativeScript/issues/5674
-            // HACK: Add and remove dummy fragment to workaround a Lollipop issue
-            // with inFragment passed as null when adding transition targets: https://android.googlesource.com/platform/frameworks/base.git/+/lollipop-release/core/java/android/app/BackStackRecord.java#1127  
-            const dummyFragmentTag = "dummy";
-            const dummyFragment = this.createFragment(<BackstackEntry>{}, dummyFragmentTag);
-            transaction.replace(this.containerViewId, dummyFragment, dummyFragmentTag);
-            transaction.remove(dummyFragment);
-        }
-
-        transaction.commitAllowingStateLoss();
+        transaction.remove(this._currentEntry.fragment);
+        transaction.commitNowAllowingStateLoss();
     }
 
     private createFragment(backstackEntry: BackstackEntry, fragmentTag: string): android.support.v4.app.Fragment {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -201,13 +201,7 @@ function initializeNativeClasses() {
 
         finishUpdate(container: android.view.ViewGroup): void {
             if (this.mCurTransaction != null) {
-                if (android.os.Build.VERSION.SDK_INT >= 24) {
-                    (<any>this.mCurTransaction).commitNowAllowingStateLoss();
-                } else {
-                    this.mCurTransaction.commitAllowingStateLoss();
-                    this.owner._getFragmentManager().executePendingTransactions();
-                }
-
+                (<any>this.mCurTransaction).commitNowAllowingStateLoss();
                 this.mCurTransaction = null;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/NativeScript/NativeScript/issues/6188

Related to https://github.com/NativeScript/NativeScript/pull/6129
Related to https://github.com/NativeScript/NativeScript/pull/5700 (cleaned up some hacks that are no longer necessary with support library APIs)

Also, cleaned up combination of transaction.commitAllowingStateLoss() + fragmentManager.executePendingTransactions for all API levels (with support library APIs fragmentManager.commitNowAllowingStateLoss() is available for all API levels).