### PR TITLE
5868 observable array reduce bug

### DIFF
--- a/tests/app/data/observable-array-tests.ts
+++ b/tests/app/data/observable-array-tests.ts
@@ -1,7 +1,7 @@
 import * as TKUnit from "../TKUnit";
-import {Label} from "tns-core-modules/ui/label";
+import { Label } from "tns-core-modules/ui/label";
 // >> observable-array-require
-import {ChangedData, ChangeType, ObservableArray} from "tns-core-modules/data/observable-array";
+import { ObservableArray, ChangedData, ChangeType } from "tns-core-modules/data/observable-array";
 // << observable-array-require
 
 export const test_ObservableArray_shouldCopySourceArrayItems = function () {

--- a/tests/app/data/observable-array-tests.ts
+++ b/tests/app/data/observable-array-tests.ts
@@ -1,8 +1,7 @@
 import * as TKUnit from "../TKUnit";
-import { Label } from "tns-core-modules/ui/label";
-
+import {Label} from "tns-core-modules/ui/label";
 // >> observable-array-require
-import { ObservableArray, ChangedData, ChangeType } from "tns-core-modules/data/observable-array";
+import {ChangedData, ChangeType, ObservableArray} from "tns-core-modules/data/observable-array";
 // << observable-array-require
 
 export const test_ObservableArray_shouldCopySourceArrayItems = function () {
@@ -115,7 +114,7 @@ export const test_ObservableArray_popShouldRemoveTheLastElement = function () {
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.pop();
     // << observable-array-join-pop
@@ -158,7 +157,7 @@ export const test_ObservableArray_pushShouldAppendNewElement = function () {
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.push(4);
     // << observable-array-push
@@ -197,7 +196,7 @@ export const test_ObservableArray_pushShouldAppendNewElements = function () {
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.push(4, 5, 6);
     // << observable-array-push-multiple
@@ -236,7 +235,7 @@ export const test_ObservableArray_pushShouldAppendNewElementsFromSourceArray = f
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.push([4, 5, 6]);
     // << observable-array-push-source
@@ -283,7 +282,7 @@ export const test_ObservableArray_shiftShouldRemoveTheFirstElement = function ()
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.shift();
     // << observable-array-shift
@@ -355,7 +354,7 @@ export const test_ObservableArray_spliceShouldRemoveSpecifiedNumberOfElementsSta
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.splice(1, 2);
     // << observable-array-splice
@@ -431,7 +430,7 @@ export const test_ObservableArray_unshiftShouldInsertNewElementsFromTheStart = f
     // >> (hide)
     const viewBase = new Label();
     viewBase.set("testProperty", 0);
-    viewBase.bind({ sourceProperty: "length", targetProperty: "testProperty" }, array);
+    viewBase.bind({sourceProperty: "length", targetProperty: "testProperty"}, array);
     // << (hide)
     const result = array.unshift(4, 5);
     // << observable-array-unshift
@@ -631,6 +630,20 @@ export const test_filter_isDefined = function () {
 
 export const test_reduce_isDefined = function () {
     TKUnit.assert(typeof (array.reduce) === "function", "Method 'reduce()' should be defined!");
+};
+
+export const test_reduce_without_initial_value = function () {
+    const sa = [1, 2, 3];
+    let array: ObservableArray<number> = new ObservableArray(sa);
+    const result = array.reduce((a, b) => a + b);
+    TKUnit.assertEqual(result, 6, "ObservableArray reduce function broken when initialValue is missing");
+};
+
+export const test_reduce_with_initial_value = function () {
+    const sa = [1, 2, 3];
+    let array: ObservableArray<number> = new ObservableArray(sa);
+    const result = array.reduce((a, b) => a + b, 5);
+    TKUnit.assertEqual(result, 11, "ObservableArray reduce function broken when Initial Value is passed.");
 };
 
 export const test_reduceRight_isDefined = function () {

--- a/tns-core-modules/data/observable-array/observable-array.ts
+++ b/tns-core-modules/data/observable-array/observable-array.ts
@@ -49,6 +49,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
     getItem(index: number): T {
         return this._array[index];
     }
+
     setItem(index: number, value: T) {
         let oldValue = this._array[index];
         this._array[index] = value;
@@ -68,6 +69,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
     get length(): number {
         return this._array.length;
     }
+
     set length(value: number) {
         if (types.isNumber(value) && this._array && this._array.length !== value) {
             this.splice(value, this._array.length - value);
@@ -151,7 +153,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
     }
 
     /**
-     * Reverses the elements in an Array. 
+     * Reverses the elements in an Array.
      */
     reverse(): T[] {
         return this._array.reverse();
@@ -172,7 +174,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
         return result;
     }
 
-    /** 
+    /**
      * Returns a section of an array.
      * @param start The beginning of the specified portion of the array.
      * @param end The end of the specified portion of the array.
@@ -281,7 +283,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
 
     /**
      * Performs the specified action for each element in an array.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array. 
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void {
@@ -290,7 +292,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
 
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
-     * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array. 
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[] {
@@ -298,8 +300,8 @@ export class ObservableArray<T> extends observable.Observable implements observa
     }
 
     /**
-     * Returns the elements of an array that meet the condition specified in a callback function. 
-     * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array. 
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[] {
@@ -312,19 +314,21 @@ export class ObservableArray<T> extends observable.Observable implements observa
      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
      */
     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T {
-        return this._array.reduce(callbackfn, initialValue);
+        return initialValue ? this._array.reduce(callbackfn, initialValue) : this._array.reduce(callbackfn);
     }
 
     /**
      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
      */
     reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T {
         return this._array.reduceRight(callbackfn, initialValue);
     }
 }
+
 export interface ObservableArray<T> {
     on(eventNames: string, callback: (data: observable.EventData) => void, thisArg?: any);
+
     on(event: "change", callback: (args: observableArrayDef.ChangedData<T>) => void, thisArg?: any);
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
ObservableArray reduce function fails when the InitialValue is not supplied. This PR is to fix that bug.
## What is the new behavior?
The new behavior is a bug fix where is the InitialValue is not supplied then appropriate array delegate function will be called.

Fixes/Implements/Closes #[Issue Number].
https://github.com/NativeScript/NativeScript/issues/5868
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[ObservableArray reduce function will work even when the InitialValue is not supplied.]

Migration steps:
[The signature of the method remains same so no changes to be done.]
-->

