### PR TITLE
fix(modals): application activityBackPressed event not fired for modals

### DIFF
--- a/e2e/modal-navigation/app/android-back-button/android-back-button-page.ts
+++ b/e2e/modal-navigation/app/android-back-button/android-back-button-page.ts
@@ -1,0 +1,32 @@
+import { android as androidApp, AndroidActivityBackPressedEventData } from "tns-core-modules/application";
+import { fromObject, Observable } from "tns-core-modules/data/observable"
+
+let context: Observable;
+function activityBackPressedCallback(args: AndroidActivityBackPressedEventData) {
+    if (context && context.get("shouldCancel")) {
+        context.set("shouldCancel", false);
+        context.set("message", "Back-pressed canceled!");
+        args.cancel = true;
+    }
+}
+export function onLoaded(args) {
+    console.log("back-button modal test loaded");
+    context = fromObject({
+        message: "First back-press will be canceled",
+        shouldCancel: true
+    });
+
+    args.object.bindingContext = context;
+
+    if (androidApp) {
+        androidApp.on("activityBackPressed", activityBackPressedCallback);
+    }
+}
+
+export function onUnloaded(args) {
+    console.log("back-button modal test unloaded");
+
+    if (androidApp) {
+        androidApp.off("activityBackPressed", activityBackPressedCallback);
+    }
+}

--- a/e2e/modal-navigation/app/android-back-button/android-back-button-page.xml
+++ b/e2e/modal-navigation/app/android-back-button/android-back-button-page.xml
@@ -1,0 +1,4 @@
+<StackLayout loaded="onLoaded" unloaded="onUnloaded">
+    <Label text="{{ message }}" />
+    <Label text="{{ 'will cancel next back press: ' + shouldCancel }}" />
+</StackLayout>

--- a/e2e/modal-navigation/app/home/home-page.ts
+++ b/e2e/modal-navigation/app/home/home-page.ts
@@ -57,6 +57,15 @@ export function onModalLayout(args: EventData) {
         false);
 }
 
+export function onAndroidBackEvents(args: EventData) {
+    const view = args.object as View;
+    view.showModal(
+        "android-back-button/android-back-button-page",
+        null,
+        () => console.log("android-back-button modal page layout closed"),
+        true, true, true);
+}
+
 export function onModalTabView(args: EventData) {
     const fullscreen = false;
     const animated = false;

--- a/e2e/modal-navigation/app/home/home-page.xml
+++ b/e2e/modal-navigation/app/home/home-page.xml
@@ -19,5 +19,6 @@
         <Button text="Reset Frame Root View" tap="onFrameRootViewReset" />
         <Button text="Reset Tab Root View" tap="onTabRootViewReset" />
         <Button text="Reset Layout Root View" tap="onLayoutRootViewReset" />
+        <Button text="Android Back Btn Events" tap="onAndroidBackEvents" />
     </StackLayout>
 </Page>

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -1,7 +1,6 @@
 // Definitions.
 import { Point, CustomLayoutView as CustomLayoutViewDefinition, dip } from ".";
 import { GestureTypes, GestureEventData } from "../../gestures";
-import { AndroidActivityBackPressedEventData } from "../../../application";
 // Types.
 import {
     ViewCommon, layout, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty,
@@ -22,6 +21,7 @@ import {
 import { Background, ad as androidBackground } from "../../styling/background";
 import { profile } from "../../../profiling";
 import { topmost } from "../../frame/frame-stack";
+import { AndroidActivityBackPressedEventData, android as androidApp } from "../../../application";
 
 export * from "./view-common";
 
@@ -112,6 +112,13 @@ function initializeDialogFragment() {
                 activity: view._context,
                 cancel: false,
             };
+
+            // Fist fire application.android global event
+            androidApp.notify(args);
+            if (args.cancel) {
+                return;
+            }
+
             view.notify(args);
 
             if (!args.cancel && !view.onBackPressed()) {


### PR DESCRIPTION
## What is the current behavior?
`application.android.on("activityBackPressed", () => { ... })` event is not fired when pressing the back button while showing modal.

## What is the new behavior?
The event is now fired and can be canceled.

Resolves #3908

cc @SvetoslavTsenov Test page added in `e2e\modal-navigation` app -> `Android Back Btn Events` button
