### PR TITLE
docs: gather snippets from apps app folder only

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -27,7 +27,7 @@ extract_snippets() {
 
     npm install markdown-snippet-injector
 
-    for SNIPPET_DIR in {tests,apps,tns-core-modules} ; do
+    for SNIPPET_DIR in {tests/app,apps/app,tns-core-modules} ; do
         echo "Extracting snippets from: $SNIPPET_DIR"
         node "$BIN" --root="$SNIPPET_DIR" --target="$TARGET_DIR" \
             --sourceext=".js|.ts|.xml|.html|.css"


### PR DESCRIPTION
Right now the docs build fails if you have already built either the /apps or /tests apps.