### PR TITLE
fix: Clear the "view" to avoid left over referenced once the View is detached and should be collected by GC

### DIFF
--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -377,6 +377,9 @@ export class CssState {
 
     public onUnloaded(): void {
         this.unsubscribeFromDynamicUpdates();
+        this.view = undefined;
+        this._matchInvalid = false;
+        this._match = undefined;
     }
 
     @profile


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - Due to having to profile the JS heap I am not sure how we can efficiently make a unit test for that

## What is the current behavior?
When using the Angular `createEmbeddeedView` from the `ViewContainerRef`, after calling `clear()` the created NativeScript Views are left in the memory

## What is the new behavior?
When using the Angular `createEmbeddeedView` from the `ViewContainerRef`, after calling `clear()` the created NativeScript Views are collected by the GC and a no longer in the memory

Fixes/Implements/Closes #[Issue Number].
https://github.com/telerik/nativescript-ui-feedback/issues/825