### PR TITLE
feat(application-settings): implemented allKeys method

### DIFF
--- a/tests/app/application-settings/application-settings-tests.ts
+++ b/tests/app/application-settings/application-settings-tests.ts
@@ -112,6 +112,17 @@ export var testFlush = function () {
     TKUnit.assert(appSettings.hasKey(stringKey), "There is no key: " + stringKey);
 };
 
+export var testAllKeys = function () {
+    appSettings.setString(stringKey, "String value");
+    appSettings.setBoolean(boolKey, true);
+    appSettings.setNumber(numberKey, 22);
+
+    var allKeys = appSettings.getAllKeys();
+    TKUnit.assert(allKeys.indexOf(stringKey) !== -1, `${stringKey} is missing from .allKeys()`);
+    TKUnit.assert(allKeys.indexOf(boolKey) !== -1, `${boolKey} is missing from .allKeys()`);
+    TKUnit.assert(allKeys.indexOf(numberKey) !== -1, `${numberKey} is missing from .allKeys()`);
+}
+
 export var testInvalidKey = function () {
     try {
         appSettings.hasKey(undefined);

--- a/tns-core-modules/application-settings/application-settings.android.ts
+++ b/tns-core-modules/application-settings/application-settings.android.ts
@@ -83,3 +83,15 @@ export function clear(): void {
 export var flush = function (): boolean {
     return sharedPreferences.edit().commit();
 }
+
+export function getAllKeys(): Array<string> {
+    var mappedPreferences = sharedPreferences.getAll();
+    var iterator = mappedPreferences.keySet().iterator();
+    var result = [];
+    while (iterator.hasNext()) {
+        let key = iterator.next();
+        result.push(key);
+    }
+
+    return result;
+}

--- a/tns-core-modules/application-settings/application-settings.d.ts
+++ b/tns-core-modules/application-settings/application-settings.d.ts
@@ -67,3 +67,9 @@ export function clear(): void;
  * @return {boolean} flag indicating if changes were saved successfully to disk.
  */
 export function flush(): boolean;
+
+/**
+ * Get all stored keys
+ * @return Array containing all stored keys
+ */
+export function getAllKeys(): Array<string>;

--- a/tns-core-modules/application-settings/application-settings.ios.ts
+++ b/tns-core-modules/application-settings/application-settings.ios.ts
@@ -65,3 +65,7 @@ export var clear = function (): void {
 export var flush = function (): boolean {
     return userDefaults.synchronize();
 }
+
+export function getAllKeys(): Array<string> {
+    return utils.ios.collections.nsArrayToJSArray(userDefaults.dictionaryRepresentation().allKeys);
+}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
There is no way to get all key from application-settings.

## What is the new behavior?
There is a method `.allKeys()` that returns all the keys from application-settings.

Fixes #6210.

