### PR TITLE
fix: Don't crash on missing resources in tab-view and action-bar

### DIFF
--- a/tns-core-modules/ui/action-bar/action-bar-common.ts
+++ b/tns-core-modules/ui/action-bar/action-bar-common.ts
@@ -9,7 +9,13 @@ import { profile } from "../../profiling";
 
 export * from "../core/view";
 
-import { View, ViewBase, Property, unsetValue, booleanConverter, horizontalAlignmentProperty, verticalAlignmentProperty, CSSType } from "../core/view";
+import {
+    View, ViewBase, Property,
+    unsetValue, booleanConverter,
+    horizontalAlignmentProperty,
+    verticalAlignmentProperty, CSSType,
+    traceWrite, traceCategories, traceMessageType
+} from "../core/view";
 
 export module knownCollections {
     export var actionItems = "actionItems";
@@ -332,6 +338,12 @@ function onItemChanged(item: ActionItemBase, oldValue: string, newValue: string)
 
 function onVisibilityChanged(item: ActionItemBase, oldValue: string, newValue: string) {
     item._onVisibilityChanged(newValue);
+}
+
+export function traceMissingIcon(icon: string) {
+    traceWrite("Could not load action bar icon: " + icon,
+        traceCategories.Error,
+        traceMessageType.error);
 }
 
 export const textProperty = new Property<ActionItemBase, string>({ name: "text", defaultValue: "", valueChanged: onItemChanged });

--- a/tns-core-modules/ui/tab-view/tab-view-common.ts
+++ b/tns-core-modules/ui/tab-view/tab-view-common.ts
@@ -1,7 +1,8 @@
 ﻿import { TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition, SelectedIndexChangedEventData } from ".";
 import {
     View, ViewBase, Style, Property, CssProperty, CoercibleProperty,
-    Color, isIOS, AddArrayFromBuilder, AddChildFromBuilder, EventData, CSSType
+    Color, isIOS, AddArrayFromBuilder, AddChildFromBuilder, EventData, CSSType,
+    traceWrite, traceCategories, traceMessageType
 } from "../core/view";
 
 export * from "../core/view";
@@ -201,6 +202,10 @@ export class TabViewBase extends View implements TabViewDefinition, AddChildFrom
 export interface TabViewBase {
     on(eventNames: string, callback: (data: EventData) => void, thisArg?: any);
     on(event: "selectedIndexChanged", callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any);
+}
+
+export function traceMissingIcon(icon: string) {
+    traceWrite("Could not load tab bar icon: " + icon, traceCategories.Error, traceMessageType.error);
 }
 
 export const selectedIndexProperty = new CoercibleProperty<TabViewBase, number>({

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -6,7 +6,7 @@ import {
     tabTextColorProperty, tabBackgroundColorProperty, tabTextFontSizeProperty, selectedTabTextColorProperty,
     androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty,
     fontSizeProperty, fontInternalProperty, layout, traceCategory, traceEnabled,
-    traceWrite, Color
+    traceWrite, Color, traceMissingIcon
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
 import { fromFileOrResource } from "../../image-source";
@@ -233,11 +233,16 @@ function createTabItemSpec(item: TabViewItem): org.nativescript.widgets.TabItemS
     if (item.iconSource) {
         if (item.iconSource.indexOf(RESOURCE_PREFIX) === 0) {
             result.iconId = ad.resources.getDrawableId(item.iconSource.substr(RESOURCE_PREFIX.length));
+            if (result.iconId === 0) {
+                traceMissingIcon(item.iconSource);
+            }
         } else {
             const is = fromFileOrResource(item.iconSource);
             if (is) {
                 // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
                 result.iconDrawable = new android.graphics.drawable.BitmapDrawable(is.android);
+            } else {
+                traceMissingIcon(item.iconSource);
             }
         }
     }

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -5,7 +5,7 @@ import { ios as iosView, ViewBase } from "../core/view";
 import {
     TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty,
     tabTextColorProperty, tabTextFontSizeProperty, tabBackgroundColorProperty, selectedTabTextColorProperty, iosIconRenderingModeProperty,
-    View, fontInternalProperty, layout, traceEnabled, traceWrite, traceCategories, Color
+    View, fontInternalProperty, layout, traceEnabled, traceWrite, traceCategories, Color, traceMissingIcon
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
 import { fromFileOrResource } from "../../image-source";
@@ -451,6 +451,8 @@ export class TabView extends TabViewBase {
                 const originalRenderedImage = is.ios.imageWithRenderingMode(this._getIconRenderingMode());
                 this._iconsCache[iconSource] = originalRenderedImage;
                 image = originalRenderedImage;
+            } else {
+                traceMissingIcon(iconSource);
             }
         }
 


### PR DESCRIPTION
Referring missing icons in ActionBar and TabView items should not cause crashes. They should log a console error with the name of the missing resource instead.