### PR TITLE
fix-next: restrict to safe area when transform

### DIFF
--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -159,6 +159,7 @@ export class View extends ViewCommon {
                 traceWrite(this + " :_setNativeViewFrame: " + JSON.stringify(ios.getPositionFromFrame(frame)), traceCategories.Layout);
             }
             this._cachedFrame = frame;
+            let adjustedFrame = null;
             if (this._hasTransfrom) {
                 // Always set identity transform before setting frame;
                 const transform = nativeView.transform;
@@ -167,11 +168,11 @@ export class View extends ViewCommon {
                 nativeView.transform = transform;
             } else {
                 nativeView.frame = frame;
-            }
-
-            const adjustedFrame = this.applySafeAreaInsets(frame);
-            if (adjustedFrame) {
-                nativeView.frame = adjustedFrame;
+                // apply safe area insets only if no transform is in place
+                adjustedFrame = this.applySafeAreaInsets(frame);
+                if (adjustedFrame) {
+                    nativeView.frame = adjustedFrame;
+                }
             }
 
             const boundsOrigin = nativeView.bounds.origin;


### PR DESCRIPTION
Applying the safe area adjustments while there is a transform on the UIView leads to unexpected/undefined results. See warning in https://developer.apple.com/documentation/uikit/uiview/1622459-transform. This PR restricts the safe area logic when there is a transform set on the view. This should lead to the same behavior as 4.0.

An alternative would be to remove the transform, adjust the safe area, then re-apply the transform. Will check how this behaves.

Test with Groceries and NS-ng animations demo