### PR TITLE
feat: add hints options for username and paossword fileds in the logi…

### DIFF
--- a/tns-core-modules/ui/dialogs/dialogs.android.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.android.ts
@@ -231,17 +231,38 @@ export function login(arg: any): Promise<LoginResult> {
             options = arguments[0];
         }
     } else if (arguments.length === 2) {
-        if (isString(arguments[0]) && isString(arguments[1])) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3])) {
             options = defaultOptions;
             options.message = arguments[0];
-            options.userName = arguments[1];
+            options.userNameHint = arguments[1];
         }
     } else if (arguments.length === 3) {
-        if (isString(arguments[0]) && isString(arguments[1]) && isString(arguments[2])) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3])) {
             options = defaultOptions;
             options.message = arguments[0];
-            options.userName = arguments[1];
-            options.password = arguments[2];
+            options.userNameHint = arguments[1];
+            options.passwordHint = arguments[2];
+        }
+    } else if (arguments.length === 4) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3])) {
+            options = defaultOptions;
+            options.message = arguments[0];
+            options.userNameHint = arguments[1];
+            options.passwordHint = arguments[2];
+            options.userName = arguments[3];
+        }
+    } else if (arguments.length === 5) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3]) && isString(arguments[4])) {
+            options = defaultOptions;
+            options.message = arguments[0];
+            options.userNameHint = arguments[1];
+            options.passwordHint = arguments[2];
+            options.userName = arguments[3];
+            options.password = arguments[4];
         }
     }
 
@@ -252,11 +273,22 @@ export function login(arg: any): Promise<LoginResult> {
             const alert = createAlertDialog(options);
 
             const userNameInput = new android.widget.EditText(context);
-            userNameInput.setText(options.userName ? options.userName : "");
-
+            if (!options.userName) {
+                userNameInput.setHint(options.userNameHint ? options.userNameHint : "");
+            } else {
+                userNameInput.setHint(options.userNameHint ? options.userNameHint : "");
+                userNameInput.setText(options.userName ? options.userName : "");
+            }
+            
             const passwordInput = new android.widget.EditText(context);
             passwordInput.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
-            passwordInput.setText(options.password ? options.password : "");
+            passwordInput.setTypeface(android.graphics.Typeface.DEFAULT);
+            if (!options.password) {
+                passwordInput.setHint(options.passwordHint ? options.passwordHint : "");
+            } else {
+                passwordInput.setHint(options.userNameHint ? options.userNameHint : "");
+                passwordInput.setText(options.password ? options.password : "");
+            }
 
             const layout = new android.widget.LinearLayout(context);
             layout.setOrientation(1);
@@ -274,11 +306,9 @@ export function login(arg: any): Promise<LoginResult> {
             });
 
             showDialog(alert);
-
         } catch (ex) {
             reject(ex);
         }
-
     });
 }
 

--- a/tns-core-modules/ui/dialogs/dialogs.d.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.d.ts
@@ -213,6 +213,15 @@ export interface PromptOptions extends ConfirmOptions {
  * Provides options for the login dialog.
  */
 export interface LoginOptions extends ConfirmOptions {
+       /**
+     * Gets or sets the default text to display as hint in the user name input box.
+     */
+    userNameHint?: string;
+
+    /**
+     * Gets or sets the default text to display as hint in the password input box.
+     */
+    passwordHint?: string;
     /**
      * Gets or sets the default text to display in the user name input box.
      */

--- a/tns-core-modules/ui/dialogs/dialogs.ios.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.ios.ts
@@ -154,17 +154,38 @@ export function login(): Promise<LoginResult> {
             options = arguments[0];
         }
     } else if (arguments.length === 2) {
-        if (isString(arguments[0]) && isString(arguments[1])) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3])) {
             options = defaultOptions;
             options.message = arguments[0];
-            options.userName = arguments[1];
+            options.userNameHint = arguments[1];
         }
     } else if (arguments.length === 3) {
-        if (isString(arguments[0]) && isString(arguments[1]) && isString(arguments[2])) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3])) {
             options = defaultOptions;
             options.message = arguments[0];
-            options.userName = arguments[1];
-            options.password = arguments[2];
+            options.userNameHint = arguments[1];
+            options.passwordHint = arguments[2];
+        }
+    } else if (arguments.length === 4) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3])) {
+            options = defaultOptions;
+            options.message = arguments[0];
+            options.userNameHint = arguments[1];
+            options.passwordHint = arguments[2];
+            options.userName = arguments[3];
+        }
+    } else if (arguments.length === 5) {
+        console.log("arguments.length: ", arguments.length);
+        if (isString(arguments[0]) && isString(arguments[3]) && isString(arguments[4])) {
+            options = defaultOptions;
+            options.message = arguments[0];
+            options.userNameHint = arguments[1];
+            options.passwordHint = arguments[2];
+            options.userName = arguments[3];
+            options.password = arguments[4];
         }
     }
 
@@ -178,7 +199,13 @@ export function login(): Promise<LoginResult> {
 
             alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
                 arg.placeholder = "Login";
-                arg.text = isString(options.userName) ? options.userName : "";
+
+                if (!options.userName) {
+                    arg.placeholder = options.userNameHint ? options.userNameHint : "";
+                } else {
+                    arg.placeholder = options.userNameHint ? options.userNameHint : "";
+                    arg.text = isString(options.userName) ? options.userName : "";
+                }
 
                 if (textFieldColor) {
                     arg.textColor = arg.tintColor = textFieldColor.ios;
@@ -188,7 +215,13 @@ export function login(): Promise<LoginResult> {
             alertController.addTextFieldWithConfigurationHandler((arg: UITextField) => {
                 arg.placeholder = "Password";
                 arg.secureTextEntry = true;
-                arg.text = isString(options.password) ? options.password : "";
+                
+                if (!options.password) {
+                    arg.placeholder = options.passwordHint ? options.passwordHint : "";
+                } else {
+                    arg.placeholder = options.passwordHint ? options.passwordHint : "";
+                    arg.text = isString(options.password) ? options.password : "";
+                }
 
                 if (textFieldColor) {
                     arg.textColor = arg.tintColor = textFieldColor.ios;


### PR DESCRIPTION
Related to [https://github.com/NativeScript/NativeScript/issues/6401](https://github.com/NativeScript/NativeScript/issues/6401)

Extending the `LoginOptions` interface and thus adding the feature to provide custom hints for the login dialog.

Possible scenarios:

hints only - not actual text values
```TS
    const loginOptions: LoginOptions = {
        title: "My Login Form",
        message: "Enter your credentials",
        okButtonText: "Login",
        cancelButtonText: "Cancel",
        neutralButtonText: "Neutral",
        userNameHint: "Enter your username",
        passwordHint: "Enter your password"
    };
```

no hints just filed values
```TS
    const loginOptions: LoginOptions = {
        title: "My Login Form",
        message: "Enter your credentials",
        okButtonText: "Login",
        cancelButtonText: "Cancel",
        neutralButtonText: "Neutral",
        userName: "John Smith",
        password: "Enter your password"
    };
```

mixed scenarios (one hint - one value)
```TS
    const loginOptions: LoginOptions = {
        title: "My Login Form",
        message: "Enter your credentials",
        okButtonText: "Login",
        cancelButtonText: "Cancel",
        neutralButtonText: "Neutral",
        userNameHint: "Enter your username",
        password "secret-password-here"
    };
```

no hints and no values
```TS
    const loginOptions: LoginOptions = {
        title: "My Login Form",
        message: "Enter your credentials",
        okButtonText: "Login",
        cancelButtonText: "Cancel",
        neutralButtonText: "Neutral"
    };
```

The feature supports all variations - all of the four `LoginOpitons` are non-mandatory and can be emitted by the user.