### PR TITLE
tests: set usesCleartextTraffic in apps to enable http calls in CI

### DIFF
--- a/apps/app/App_Resources/Android/AndroidManifest.xml
+++ b/apps/app/App_Resources/Android/AndroidManifest.xml
@@ -24,7 +24,8 @@
 		android:allowBackup="true"
 		android:icon="@drawable/icon"
 		android:label="@string/app_name"
-		android:theme="@style/AppTheme" >
+		android:theme="@style/AppTheme" 
+		android:usesCleartextTraffic="true" >
 		<meta-data android:name="debugLayouts" android:value="true" />
 		<activity
 			android:name="com.tns.NativeScriptActivity"


### PR DESCRIPTION
The test app (`cuteness.io`) makes some local `http` calls on CI. To enable that in android API 28 `android:usesCleartextTraffic` should be set in `AndroidManifest.xml`.

[Link to SO issue on the topic](https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted/52371375)