### PR TITLE
fix-next(android): popExit fragment animation

### DIFF
--- a/tns-core-modules/ui/frame/fragment.transitions.android.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.android.ts
@@ -151,7 +151,8 @@ export function _setAndroidFragmentTransitions(
 
     // Having transition means we have custom animation
     if (transition) {
-        fragmentTransaction.setCustomAnimations(AnimationType.enterFakeResourceId, AnimationType.exitFakeResourceId, AnimationType.popEnterFakeResourceId, AnimationType.popExitFakeResourceId);
+        // we do not use Android backstack so setting popEnter / popExit is meaningless (3rd and 4th optional args)
+        fragmentTransaction.setCustomAnimations(AnimationType.enterFakeResourceId, AnimationType.exitFakeResourceId);
         setupAllAnimation(newEntry, transition);
         if (currentFragmentNeedsDifferentAnimation) {
             setupExitAndPopEnterAnimation(currentEntry, transition);
@@ -375,7 +376,7 @@ function clearAnimationListener(animator: ExpandedAnimator, listener: android.an
 
     animator.removeListener(listener);
 
-    if (traceEnabled()) {
+    if (animator.entry && traceEnabled()) {
         const entry = animator.entry;
         traceWrite(`Clear ${animator.transitionType} - ${entry.transition} for ${entry.fragmentTag}`, traceCategories.Transition);
     }

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -317,8 +317,13 @@ export class TabViewItem extends TabViewItemBase {
             }
         }
 
+        // TODO: can happen in a modal tabview scenario when the modal dialog fragment is already removed
         if (!tabFragment) {
-            throw new Error(`Could not get child fragment manager for tab item with index ${this.index}`);
+            if (traceEnabled()) {
+                traceWrite(`Could not get child fragment manager for tab item with index ${this.index}`, traceCategory);
+            }
+
+            return (<any>tabView)._getRootFragmentManager();
         }
 
         return tabFragment.getChildFragmentManager();


### PR DESCRIPTION
Fix issues with "popExit" fragment animation when FragmentTransaction.setCustomAnimations(...) are used.
Also reworked fix from https://github.com/NativeScript/NativeScript/pull/6339 

Kudos to @MartoYankov for the assistance! 👍 