### PR TITLE
feat(TabView): support to hide/show tab bar

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -534,6 +534,18 @@ export class TabView extends TabViewBase {
         super.disposeNativeView();
     }
 
+    public hideTabs() {
+      if (this._tabLayout) {
+        this._tabLayout.setVisibility(android.view.View.GONE);
+      }
+    }
+
+    public showTabs() {
+      if (this._tabLayout) {
+        this._tabLayout.setVisibility(android.view.View.VISIBLE);
+      }
+    }
+
     public onBackPressed(): boolean {
         const currentView = this._selectedView;
         if (currentView) {

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -12,7 +12,7 @@ import { fromFileOrResource } from "../../image-source";
 import { profile } from "../../profiling";
 import { Frame } from "../frame";
 import { ios as iosUtils } from "../../utils/utils"
-import { device } from "../../platform";
+import { device, screen } from "../../platform";
 export * from "./tab-view-common";
 
 const majorVersion = iosUtils.MajorVersion;
@@ -252,6 +252,23 @@ export class TabView extends TabViewBase {
         this._delegate = null;
         this._moreNavigationControllerDelegate = null;
         super.disposeNativeView();
+    }
+
+    public hideTabs() {
+      const tabBar = this.ios.tabBar;
+      let height = tabBar.frame.size.height;
+      if (majorVersion > 10) {
+        // supports safeAreaInsets (account for them)
+        height = height - 59;
+      }
+      this.ios.view.frame = CGRectMake(0, 0, tabBar.frame.size.width, (screen.mainScreen.heightDIPs + height));
+      this.ios.tabBar.hidden = true;
+    }
+
+    public showTabs() {
+      const tabBar = this.ios.tabBar;
+      this.ios.view.frame = CGRectMake(0, 0, tabBar.frame.size.width, screen.mainScreen.heightDIPs);
+      this.ios.tabBar.hidden = false;
     }
 
     @profile


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

No simple/easy way to toggle show/hide tabbar when using TabView. 

## What is the new behavior?

User's can now get the `TabView` instance and call `tabView.showTabs()` or `tabView.hideTabs()`. Works on both iOS and Android.

The question on how to do this has been asked all over the place in the community with no proper response on how to achieve affectively and easily:
https://stackoverflow.com/questions/40367926/nativescript-how-to-hide-tab-buttons-from-tabview
https://discourse.nativescript.org/t/remove-tabs-from-tabview/1609/2
https://stackoverflow.com/questions/39019146/tabview-without-the-tabs

