### PR TITLE
test(safe-area): fix ios 12 landscape tests

### DIFF
--- a/tests/app/ui/layouts/layout-tests-helper.ts
+++ b/tests/app/ui/layouts/layout-tests-helper.ts
@@ -39,6 +39,12 @@ export function lessOrCloseEnough(a: number, b: number, message?: string) {
     message ? TKUnit.assertTrue(less || close, message) : TKUnit.assertTrue(less || close);
 }
 
+export function greaterOrCloseEnough(a: number, b: number, message?: string) {
+    const greater = a > b;
+    const close = Math.abs(a - b) <= EPS;
+    message ? TKUnit.assertTrue(greater || close, message) : TKUnit.assertTrue(greater || close);
+}
+
 export function notEqual<T>(a: T, b: T, message?: string) {
     message ? TKUnit.assertNotEqual(a, b, message) : TKUnit.assertNotEqual(a, b);
 }

--- a/tests/app/ui/layouts/safe-area-tests.ts
+++ b/tests/app/ui/layouts/safe-area-tests.ts
@@ -8,7 +8,7 @@ import * as helper from "../helper";
 import { parse } from "tns-core-modules/ui/builder";
 import {
     dipToDp, left, top, right, bottom, height, width,
-    equal, closeEnough, lessOrCloseEnough, check,
+    equal, closeEnough, lessOrCloseEnough, greaterOrCloseEnough, check,
     isLeftAlignedWith, isRightAlignedWith, isTopAlignedWith, isBottomAlignedWith,
     isLeftWith, isAboveWith, isRightWith, isBelowWith
 } from "./layout-tests-helper";
@@ -1011,13 +1011,15 @@ export class SafeAreaTests extends testModule.UITest<any> {
                 isBottomAlignedWith(grid, cells[2][1]);
                 isBottomAlignedWith(grid, cells[2][2]);
 
-                check(height(cells[0][1]) >= height(cells[1][1]), `cell01 height<${height(cells[0][1])}> not greater or equal cell11 height<${height(cells[1][1])}>`);
-                lessOrCloseEnough(height(cells[1][1]), height(cells[2][1]), `cell11 height<${height(cells[1][1])}> not less or equal cell21 height<${height(cells[2][1])}>`);
+                greaterOrCloseEnough(height(cells[0][1]), height(cells[1][1]), `cell01 height<${height(cells[0][1])}> not greater or close enough cell11 height<${height(cells[1][1])}>`);
+                lessOrCloseEnough(height(cells[1][1]), height(cells[2][1]), `cell11 height<${height(cells[1][1])}> not less or close enough cell21 height<${height(cells[2][1])}>`);
+
                 const sumOfNestedGridHeights = height(cells[0][1]) + height(cells[1][1]) + height(cells[2][1]);
                 equal(height(grid), sumOfNestedGridHeights, `grid height<${height(grid)}> sum of nested grids height <${sumOfNestedGridHeights}>`);
 
-                check(width(cells[1][0]) >= width(cells[1][1]), `cell10 width<${width(cells[1][0])}> not greater or equal cell11 width<${width(cells[1][1])}>`);
-                check(width(cells[1][1]) <= width(cells[1][2]), `cell11 width<${width(cells[1][1])}> not less or equal cell12 width<${width(cells[1][2])}>`);
+                greaterOrCloseEnough(width(cells[1][0]), width(cells[1][1]), `cell10 width<${width(cells[1][0])}> not greater or close enough cell11 width<${width(cells[1][1])}>`);
+                lessOrCloseEnough(width(cells[1][1]), width(cells[1][2]), `cell11 width<${width(cells[1][1])}> not less or close enough cell12 width<${width(cells[1][2])}>`);
+                
                 const sumOfNestedGridWidths = width(cells[1][0]) + width(cells[1][1]) + width(cells[1][2])
                 equal(width(grid), sumOfNestedGridWidths, `grid width<${width(grid)}> sum of nested grids width <${sumOfNestedGridWidths}>`);
             },
@@ -1364,8 +1366,8 @@ export class SafeAreaTests extends testModule.UITest<any> {
 
     private wrap_horizontal_children_components_in_safe_area(pageOptions?: helper.PageOptions) {
         const snippet = `
-        <WrapLayout id="wrap" orientation="horizontal">
-            <Button id="child0" text="Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet" height="100%"></Button>
+        <WrapLayout id="wrap" orientation="horizontal" backgroundColor="Crimson">
+            <Button id="child0" text="Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet." height="100%"></Button>
             <Button id="child1" text="H" backgroundColor="Pink"></Button>
         </WrapLayout>
         `;
@@ -1400,8 +1402,8 @@ export class SafeAreaTests extends testModule.UITest<any> {
 
     private wrap_vertical_children_components_in_safe_area(pageOptions?: helper.PageOptions) {
         const snippet = `
-        <WrapLayout id="wrap" orientation="vertical">
-            <Button id="child0" text="Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet" height="100%"></Button>
+        <WrapLayout id="wrap" orientation="vertical" backgroundColor="Crimson">
+            <Button id="child0" text="Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet." height="100%"></Button>
             <Button id="child1" text="V" backgroundColor="Pink"></Button>
         </WrapLayout>
         `;
@@ -1438,7 +1440,7 @@ export class SafeAreaTests extends testModule.UITest<any> {
         const snippet = `
         <WrapLayout id="wrap" backgroundColor="Crimson">
             <WrapLayout id="child0" backgroundColor="SkyBlue">
-                <Button text="Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet"/>
+                <Button text="Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet."/>
             </WrapLayout>
         </WrapLayout>
         `;

--- a/tests/app/ui/list-view/list-view-safe-area-tests.ts
+++ b/tests/app/ui/list-view/list-view-safe-area-tests.ts
@@ -9,7 +9,7 @@ import { ViewModel } from "./list-view-view-model";
 import { UITest } from "../../ui-test";
 import {
     dipToDp, left, top, right, bottom, height, width,
-    equal, check, lessOrCloseEnough,
+    equal, check, lessOrCloseEnough, greaterOrCloseEnough,
     isLeftAlignedWith, isRightAlignedWith, isTopAlignedWith
 } from "../layouts/layout-tests-helper";
 
@@ -182,13 +182,15 @@ export class ListViewSafeAreaTest extends UITest<ListView> {
                 isRightAlignedWith(root, cells[1][2]);
                 isRightAlignedWith(root, cells[2][2]);
 
-                check(height(cells[0][1]) >= height(cells[1][1]), `cell01 height<${height(cells[0][1])}> not greater or equal cell11 height<${height(cells[1][1])}>`);
-                lessOrCloseEnough(height(cells[1][1]), height(cells[2][1]), `cell11 height<${height(cells[1][1])}> not less or equal cell21 height<${height(cells[2][1])}>`);
+                greaterOrCloseEnough(height(cells[0][1]), height(cells[1][1]), `cell01 height<${height(cells[0][1])}> not greater or close enough cell11 height<${height(cells[1][1])}>`);
+                lessOrCloseEnough(height(cells[1][1]), height(cells[2][1]), `cell11 height<${height(cells[1][1])}> not less or close enough cell21 height<${height(cells[2][1])}>`);
+
                 const sumOfNestedListViewHeights = height(cells[0][1]) + height(cells[1][1]) + height(cells[2][1]);
                 equal(height(root), sumOfNestedListViewHeights, `grid height<${height(root)}> sum of nested list views height <${sumOfNestedListViewHeights}>`);
 
-                check(width(cells[1][0]) >= width(cells[1][1]), `cell10 width<${width(cells[1][0])}> not greater or equal cell11 width<${width(cells[1][1])}>`);
-                check(width(cells[1][1]) <= width(cells[1][2]), `cell11 width<${width(cells[1][1])}> not less or equal cell12 width<${width(cells[1][2])}>`);
+                greaterOrCloseEnough(width(cells[1][0]), width(cells[1][1]), `cell10 width<${width(cells[1][0])}> not greater or close enough cell11 width<${width(cells[1][1])}>`);
+                lessOrCloseEnough(width(cells[1][1]), width(cells[1][2]), `cell11 width<${width(cells[1][1])}> not less or close enough cell12 width<${width(cells[1][2])}>`);
+
                 const sumOfNestedListViewWidths = width(cells[1][0]) + width(cells[1][1]) + width(cells[1][2])
                 equal(width(root), sumOfNestedListViewWidths, `grid width<${width(root)}> sum of nested list views width <${sumOfNestedListViewWidths}>`);
             },

--- a/tests/app/ui/page/page-tests-common.ts
+++ b/tests/app/ui/page/page-tests-common.ts
@@ -497,6 +497,11 @@ function _test_WhenInnerViewCallsCloseModal(closeModalGetter: (ShownModallyData)
     helper.navigate(masterPageFactory);
 
     TKUnit.waitUntilReady(() => modalClosedWithResult);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 }
 
 export function test_WhenViewBaseCallsShowModal_WithArguments_ShouldOpenModal() {
@@ -554,10 +559,16 @@ export function test_WhenViewBaseCallsShowModal_WithArguments_ShouldOpenModal() 
     helper.navigate(masterPageFactory);
 
     TKUnit.waitUntilReady(() => modalClosed);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 }
 
 export function test_WhenViewBaseCallsShowModal_WithoutArguments_ShouldThrow() {
     let navigatedTo = false;
+    let modalThrows = false;
 
     const createTabItems = function(count: number) {
         var items = new Array<TabViewItem>();
@@ -581,7 +592,11 @@ export function test_WhenViewBaseCallsShowModal_WithoutArguments_ShouldThrow() {
      
         const hostPage = <Page>args.object;
         const tabViewItem = (<TabView>page.content).items[0];
-        TKUnit.assertThrows(() => tabViewItem.showModal());
+        try {
+            tabViewItem.showModal();
+        } catch (e) {
+            modalThrows = true;
+        }
 
         navigatedTo = true;
     }
@@ -601,6 +616,7 @@ export function test_WhenViewBaseCallsShowModal_WithoutArguments_ShouldThrow() {
     helper.navigate(masterPageFactory);
 
     TKUnit.waitUntilReady(() => navigatedTo);
+    TKUnit.assertTrue(modalThrows);
 }
 
 export function test_WhenNavigatingForwardAndBack_IsBackNavigationIsCorrect() {
@@ -696,6 +712,11 @@ export function test_WhenRootTabViewShownModallyItCanCloseModal() {
     helper.navigate(masterPageFactory);
 
     TKUnit.waitUntilReady(() => modalClosed);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 }
 
 export function test_WhenPageIsNavigatedToItCanShowAnotherPageAsModal() {
@@ -775,6 +796,11 @@ export function test_WhenPageIsNavigatedToItCanShowAnotherPageAsModal() {
     TKUnit.assertEqual(modalUnloaded, 1, "modalUnloaded");
 
     masterPage.off(Page.navigatedToEvent, navigatedToEventHandler);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 }
 
 export function test_WhenModalPageShownHostPageNavigationEventsShouldNotBeRaised() {
@@ -845,6 +871,11 @@ export function test_WhenModalPageShownHostPageNavigationEventsShouldNotBeRaised
     helper.navigate(masterPageFactory);
 
     TKUnit.waitUntilReady(() => ready);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 
     // only raised by the initial navigation to the master page
     TKUnit.assertTrue(hostNavigatingToCount === 1);
@@ -926,6 +957,11 @@ export function test_WhenModalPageShownModalNavigationToEventsShouldBeRaised() {
 
     TKUnit.waitUntilReady(() => ready && !modalFrame.isLoaded);
 
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
+
     // only raised by the initial show modal navigation
     TKUnit.assertTrue(modalNavigatingToCount === 1);
     TKUnit.assertTrue(modalNavigatedToCount === 1);
@@ -996,6 +1032,11 @@ export function test_WhenModalFrameShownModalEventsRaisedOnRootModalFrame() {
 
     TKUnit.waitUntilReady(() => ready && !modalFrame.isLoaded);
 
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
+
     TKUnit.assertTrue(showingModallyCount === 1);
     TKUnit.assertTrue(shownModallyCount === 1);
 }
@@ -1052,6 +1093,11 @@ export function test_WhenModalPageShownShowModalEventsRaisedOnRootModalPage() {
     helper.navigate(masterPageFactory);
 
     TKUnit.waitUntilReady(() => ready);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 
     TKUnit.assertTrue(showingModallyCount === 1);
     TKUnit.assertTrue(shownModallyCount === 1);
@@ -1114,6 +1160,11 @@ export function test_WhenModalPageShownShowModalEventsRaisedOnRootModalTabView()
     TKUnit.assertEqual(stack().length, 2, "Host and modal tab frame should be instantiated at this point!");
 
     TKUnit.waitUntilReady(() => ready);
+
+    if (isIOS) {
+        // Remove this line when we have a good way to detect actual modal close on ios
+        TKUnit.waitUntilReady(() => !(<UIViewController>topmost().currentPage.viewController).presentedViewController);
+    }
 
     TKUnit.assertEqual(stack().length, 1, "Single host frame should be instantiated at this point!");
 

--- a/tests/app/ui/scroll-view/scroll-view-safe-area-tests.ts
+++ b/tests/app/ui/scroll-view/scroll-view-safe-area-tests.ts
@@ -10,7 +10,7 @@ import * as helper from "../helper";
 import { parse } from "tns-core-modules/ui/builder";
 import {
     dipToDp, left, top, right, bottom, height, width,
-    equal, check, lessOrCloseEnough,
+    equal, check, lessOrCloseEnough, greaterOrCloseEnough,
     isLeftAlignedWith, isRightAlignedWith, isTopAlignedWith, isBottomAlignedWith,
     isLeftWith, isRightWith, isBelowWith
 } from "../layouts/layout-tests-helper";
@@ -425,13 +425,14 @@ class ScrollLayoutSafeAreaTest extends UITest<ScrollView> {
                 isBottomAlignedWith(grid, cells[2][1]);
                 isBottomAlignedWith(grid, cells[2][2]);
 
-                check(height(cells[0][1]) >= height(cells[1][1]), `cell01 height<${height(cells[0][1])}> not greater or equal cell11 height<${height(cells[1][1])}>`);
-                lessOrCloseEnough(height(cells[1][1]), height(cells[2][1]), `cell11 height<${height(cells[1][1])}> not less or equal cell21 height<${height(cells[2][1])}>`);
+                greaterOrCloseEnough(height(cells[0][1]), height(cells[1][1]), `cell01 height<${height(cells[0][1])}> not greater or close enough cell11 height<${height(cells[1][1])}>`);
+                lessOrCloseEnough(height(cells[1][1]), height(cells[2][1]), `cell11 height<${height(cells[1][1])}> not less or close enough cell21 height<${height(cells[2][1])}>`);
+
                 const sumOfNestedScrollViewHeights = height(cells[0][1]) + height(cells[1][1]) + height(cells[2][1]);
                 equal(height(grid), sumOfNestedScrollViewHeights, `grid height<${height(grid)}> sum of nested scroll views height <${sumOfNestedScrollViewHeights}>`);
 
-                check(width(cells[1][0]) >= width(cells[1][1]), `cell10 width<${width(cells[1][0])}> not greater or equal cell11 width<${width(cells[1][1])}>`);
-                check(width(cells[1][1]) <= width(cells[1][2]), `cell11 width<${width(cells[1][1])}> not less or equal cell12 width<${width(cells[1][2])}>`);
+                greaterOrCloseEnough(width(cells[1][0]), width(cells[1][1]), `cell10 width<${width(cells[1][0])}> not greater or close enough cell11 width<${width(cells[1][1])}>`);
+                lessOrCloseEnough(width(cells[1][1]), width(cells[1][2]), `cell11 width<${width(cells[1][1])}> not less or close enough cell12 width<${width(cells[1][2])}>`);
                 const sumOfNestedScrollViewWidths = width(cells[1][0]) + width(cells[1][1]) + width(cells[1][2])
                 equal(width(grid), sumOfNestedScrollViewWidths, `grid width<${width(grid)}> sum of nested scroll views width <${sumOfNestedScrollViewWidths}>`);
             },


### PR DESCRIPTION
* Add longer text for `WrapLayout` tests, so that the setup is the same in landscape
* Add wait until actual ios modal is closed. This should be a temp fix for unit tests.
* Add `greaterOrCloseEnough` assert method similar to `lessOrCloseEnough`, so that landscape cases are covered.