### PR TITLE
 feat(frame): back in parent frame when back states available

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -204,8 +204,8 @@ export class Frame extends FrameBase {
         // however, we must add a fragment.isAdded() guard as our logic will try to 
         // explicitly remove the already removed child fragment causing an 
         // IllegalStateException: Fragment has not been attached yet.
-        if (!this._currentEntry || 
-            !this._currentEntry.fragment || 
+        if (!this._currentEntry ||
+            !this._currentEntry.fragment ||
             !this._currentEntry.fragment.isAdded()) {
             return;
         }
@@ -423,6 +423,7 @@ export class Frame extends FrameBase {
         }
 
         this._android.rootViewGroup = null;
+        this._removeFromFrameStack();
         super.disposeNativeView();
     }
 

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -36,6 +36,11 @@ export class Frame extends FrameBase {
         return this.viewController.view;
     }
 
+    public disposeNativeView() {
+        this._removeFromFrameStack();
+        super.disposeNativeView();
+    }
+
     public get ios(): iOSFrame {
         return this._ios;
     }


### PR DESCRIPTION
- Navigate __back__ in parent frame, if canGoBack in parent is true, when no back states available.
- Set current frame as topmost after every back navigation
- Unit test added

_Note: required when nesting frames, since __back__ in inner frame could lead to app exit even if there are previous pages on its parent frame._

