### PR TITLE
fix(image): uncaught error in promise with image handling

### DIFF
--- a/tns-core-modules/http/http-request/http-request.ios.ts
+++ b/tns-core-modules/http/http-request/http-request.ios.ts
@@ -70,7 +70,7 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
     return new Promise<http.HttpResponse>((resolve, reject) => {
 
         if (!options.url) {
-          reject('Request url was empty.');
+          reject(new Error('Request url was empty.'));
           return;
         }
 

--- a/tns-core-modules/http/http-request/http-request.ios.ts
+++ b/tns-core-modules/http/http-request/http-request.ios.ts
@@ -70,7 +70,7 @@ export function request(options: http.HttpRequestOptions): Promise<http.HttpResp
     return new Promise<http.HttpResponse>((resolve, reject) => {
 
         if (!options.url) {
-          reject(new Error('Request url was empty.'));
+          reject(new Error("Request url was empty."));
           return;
         }
 

--- a/tns-core-modules/http/http-request/http-request.ios.ts
+++ b/tns-core-modules/http/http-request/http-request.ios.ts
@@ -69,6 +69,11 @@ function ensureImageSource() {
 export function request(options: http.HttpRequestOptions): Promise<http.HttpResponse> {
     return new Promise<http.HttpResponse>((resolve, reject) => {
 
+        if (!options.url) {
+          reject('Request url was empty.');
+          return;
+        }
+
         try {
             var network = domainDebugger.getNetwork();
             var debugRequest = network && network.create();

--- a/tns-core-modules/http/http.ts
+++ b/tns-core-modules/http/http.ts
@@ -31,9 +31,18 @@ export function getJSON<T>(arg: any): Promise<T> {
 }
 
 export function getImage(arg: any): Promise<ImageSource> {
-    return httpRequest
-        .request(typeof arg === "string" ? { url: arg, method: "GET" } : arg)
-        .then(response => response.content.toImage());
+  return new Promise<any>((resolve, reject) => {
+    httpRequest.request(typeof arg === "string" ? { url: arg, method: "GET" } : arg)
+        .then(r => {
+          try {
+            resolve(r.content.toImage());
+          } catch (err) {
+            reject(err);
+          }
+        }, err => {
+          reject(err);
+        });
+  });
 }
 
 export function getFile(arg: any, destinationFilePath?: string): Promise<any> {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

Apps can error if url is invalid or response content is invalid.

## What is the new behavior?

Error is properly caught and rejected to avoid `Error: Uncaught (in promise)` errors.
