### PR TITLE
fix-next(android): restore fade animation for simulated nav

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -364,7 +364,7 @@ export class Frame extends FrameBase {
         const newFragmentTag = `fragment${fragmentId}[${navDepth}]`;
         const newFragment = this.createFragment(newEntry, newFragmentTag);
         const transaction = manager.beginTransaction();
-        const animated = currentEntry ? this._getIsAnimatedNavigation(newEntry.entry) : false;
+        const animated = this._getIsAnimatedNavigation(newEntry.entry);
         // NOTE: Don't use transition for the initial navigation (same as on iOS)
         // On API 21+ transition won't be triggered unless there was at least one
         // layout pass so we will wait forever for transitionCompleted handler...


### PR DESCRIPTION
Restore animation (default fade) for simulated first navigation that was removed with https://github.com/NativeScript/NativeScript/pull/6421.

Reason is that without animation the flickering when navigating between bottom-positioned tabs in a TabView is even more pronounced than with the fade animation (eventually we should fix the flicker altogether).