### PR TITLE
fix: prevent errors on launching manual testing app

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -13,7 +13,8 @@
     }
   },
   "dependencies": {
-    "tns-core-modules": "*"
+    "tns-core-modules": "*",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "babel-traverse": "6.10.4",

--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -1,23 +1,28 @@
 {
-    "extends": "../tsconfig.shared",
-    "exclude": [
-        "node_modules",
-        "platforms"
-    ],
     "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "*": [
-                "./node_modules/tns-core-modules/*",
-                "./node_modules/*"
-            ],
-            "~/*": [
-                "app/*"
-            ]
-        },
+        "module": "commonjs",
+        "target": "es5",
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "noEmitHelpers": true,
+        "noEmitOnError": true,
         "lib": [
             "es6",
             "dom"
-        ]
-    }
+        ],
+        "baseUrl": ".",
+        "paths": {
+            "~/*": [
+                "app/*"
+            ],
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
+    },
+    "exclude": [
+        "node_modules",
+        "platforms"
+    ]
 }

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -10,6 +10,7 @@
         "removeComments": true,
         "experimentalDecorators": true,
         "diagnostics": true,
+        "sourceMap": true,
         "jsx": "react",
         "reactNamespace": "UIBuilder",
         "lib": [

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -10,7 +10,6 @@
         "removeComments": true,
         "experimentalDecorators": true,
         "diagnostics": true,
-        "sourceMap": true,
         "jsx": "react",
         "reactNamespace": "UIBuilder",
         "lib": [


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
tns run ios --path apps doesn't launch the manual testing app because the tslib module isn't found. Also, there are error messages about 'sourceMap' cannot be specified with option 'inlineSourceMap'.

## What is the new behavior?
<!-- Describe the changes. -->
The manual testing app does launch, and the sourceMap errors are gone.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

