### PR TITLE
fix: crash on Android Tab-View #6466

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -229,6 +229,8 @@ function initializeNativeClasses() {
             }
         }
     }
+    
+    PagerAdapter = FragmentPagerAdapter;
 }
 
 function createTabItemSpec(item: TabViewItem): org.nativescript.widgets.TabItemSpec {

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -211,6 +211,10 @@ function initializeNativeClasses() {
         }
 
         saveState(): android.os.Parcelable {
+            if (this.mCurTransaction != null) {
+                (<any>this.mCurTransaction).commitNowAllowingStateLoss();
+                this.mCurTransaction = null;
+            }
             return null;
         }
 

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -200,10 +200,7 @@ function initializeNativeClasses() {
         }
 
         finishUpdate(container: android.view.ViewGroup): void {
-            if (this.mCurTransaction != null) {
-                (<any>this.mCurTransaction).commitNowAllowingStateLoss();
-                this.mCurTransaction = null;
-            }
+            this._commitCurrentTransaction();
         }
 
         isViewFromObject(view: android.view.View, object: java.lang.Object): boolean {
@@ -211,10 +208,9 @@ function initializeNativeClasses() {
         }
 
         saveState(): android.os.Parcelable {
-            if (this.mCurTransaction != null) {
-                (<any>this.mCurTransaction).commitNowAllowingStateLoss();
-                this.mCurTransaction = null;
-            }
+            // Commit the current transaction on save to prevent "No view found for id 0xa" exception on restore.
+            // Related to: https://github.com/NativeScript/NativeScript/issues/6466
+            this._commitCurrentTransaction();
             return null;
         }
 
@@ -225,10 +221,14 @@ function initializeNativeClasses() {
         getItemId(position: number): number {
             return position;
         }
-    }
 
-    PagerAdapter = FragmentPagerAdapter;
-}
+        private _commitCurrentTransaction() {
+            if (this.mCurTransaction != null) {
+                this.mCurTransaction.commitNowAllowingStateLoss();
+                this.mCurTransaction = null;
+            }
+        }
+    }
 
 function createTabItemSpec(item: TabViewItem): org.nativescript.widgets.TabItemSpec {
     const result = new org.nativescript.widgets.TabItemSpec();

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -229,6 +229,7 @@ function initializeNativeClasses() {
             }
         }
     }
+}
 
 function createTabItemSpec(item: TabViewItem): org.nativescript.widgets.TabItemSpec {
     const result = new org.nativescript.widgets.TabItemSpec();


### PR DESCRIPTION
This fix has been tested in production with no new issues occurring.

Long-term solution would be one of the following, though:
1. reintroduce overrides for `saveState`/`restoreState` in the current PagerAdapter implementation (removed on this commit NativeScript@ac04ede#diff-f1459d509d1432b432c29bcd30e462fbL97)
2. use FragmentPagerAdapter
3. use FragmentStatePagerAdapter

Both 2 and 3 manage the save/restore cycles. The main difference between 2 and 3 is that 2 uses more memory, but allows for quicker switching between Fragments than 3. Since tabs should usually be limited to 5 or less, this may be the best choice to maintain performance, which is important for top level navigation tabs.

When I have more time I may experiment with these options myself to see what the difference to performance and memory consumption is for each.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
~2% Crash Rate on Crashlytics:

```
Caused by java.lang.IllegalArgumentException
No view found for id 0xa (unknown) for fragment Fragment_script_37_1236368_r{1a141ad #11 id=0xa android:viewpager:10:2}
android.support.v4.app.FragmentManagerImpl.moveToState (FragmentManager.java:1454)
android.support.v4.app.FragmentManagerImpl.moveFragmentToExpectedState (FragmentManager.java:1784)
android.support.v4.app.FragmentManagerImpl.moveToState (FragmentManager.java:1852)
android.support.v4.app.BackStackRecord.executeOps (BackStackRecord.java:802)
android.support.v4.app.FragmentManagerImpl.executeOps (FragmentManager.java:2625)
android.support.v4.app.FragmentManagerImpl.executeOpsTogether (FragmentManager.java:2411)
android.support.v4.app.FragmentManagerImpl.removeRedundantOperationsAndExecute (FragmentManager.java:2366)
android.support.v4.app.FragmentManagerImpl.execPendingActions (FragmentManager.java:2273)
android.support.v4.app.FragmentController.execPendingActions (FragmentController.java:391)
android.support.v4.app.FragmentActivity.onResume (FragmentActivity.java:517)
android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1361)
android.app.Activity.performResume (Activity.java:7344)
android.app.ActivityThread.performResumeActivity (ActivityThread.java:3763)
android.app.ActivityThread.handleResumeActivity (ActivityThread.java:3828)
android.app.ActivityThread$H.handleMessage (ActivityThread.java:1746)
android.os.Handler.dispatchMessage (Handler.java:105)
android.os.Looper.loop (Looper.java:164)
android.app.ActivityThread.main (ActivityThread.java:6938)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
```

## What is the new behavior?
No crash.

Fixes/Implements/Closes #6466.