### PR TITLE
fix(tab-view-android): change androidOffscreenTabLimit to 1

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -482,7 +482,7 @@ export class TabView extends TabViewBase {
     public _loadUnloadTabItems(newIndex: number) {
         const items = this.items;
         const lastIndex = this.items.length - 1;
-        const offsideItems = this.androidTabsPosition === "top" ? this.androidOffscreenTabLimit : 0;
+        const offsideItems = this.androidTabsPosition === "top" ? this.androidOffscreenTabLimit : 1;
 
         let toUnload = [];
         let toLoad = [];


### PR DESCRIPTION
Change default `androidOffscreenTabLimit` to 1 when using bottom tabs