### PR TITLE
Resolve incorrect name of listener when unsubscribing causing Views to be leaked in memory

### DIFF
--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -506,7 +506,7 @@ export class CssState {
         this._appliedChangeMap.forEach((changes, view) => {
             if (changes.attributes) {
                 changes.attributes.forEach(attribute => {
-                    view.removeEventListener("onPropertyChanged:" + attribute, this._onDynamicStateChangeHandler);
+                    view.removeEventListener(attribute + "Change", this._onDynamicStateChangeHandler);
                 });
             }
             if (changes.pseudoClasses) {


### PR DESCRIPTION
This is a resurrection of the https://github.com/NativeScript/NativeScript/pull/6353 but it fixed the source rather than the effect that causes memory leak in NativeScript + Angular apps that use `ListView` or `RadListView` from _nativescript-ui-listview_ plugin.

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - Due to having to profile the JS heap I am not sure how we can efficiently make a unit test for that

## What is the current behavior?
When using the Angular `createEmbeddeedView` from the `ViewContainerRef`, after calling `clear()` the created NativeScript Views are left in the memory

## What is the new behavior?
When using the Angular `createEmbeddeedView` from the `ViewContainerRef`, after calling `clear()` the created NativeScript Views are collected by the GC and a no longer in the memory

Fixes/Implements/Closes #[Issue Number].
https://github.com/telerik/nativescript-ui-feedback/issues/825