### PR TITLE
fix(android): IllegalStateException with tabview&nested frames

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -859,11 +859,9 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
         if (traceEnabled()) {
             traceWrite(`${fragment}.onDestroy()`, traceCategories.NativeLifecycle);
         }
-        
+
         superFunc.call(fragment);
 
-        // fixes 'java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first'.	
-        // on app resume in nested frame scenarios with support library version greater than 26.0.0	
         const entry = this.entry;
         if (!entry) {
             traceError(`${fragment}.onDestroy: entry is null or undefined`);

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -848,7 +848,40 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
         if (traceEnabled()) {
             traceWrite(`${fragment}.onDestroy()`, traceCategories.NativeLifecycle);
         }
+        
         superFunc.call(fragment);
+
+        // fixes 'java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first'.	
+        // on app resume in nested frame scenarios with support library version greater than 26.0.0	
+        const entry = this.entry;
+        if (!entry) {
+            traceError(`${fragment}.onDestroy: entry is null or undefined`);
+            return null;
+        }
+
+        const page = entry.resolvedPage;
+        if (!page) {
+            traceError(`${fragment}.onDestroy: entry has no resolvedPage`);
+            return null;
+        }
+
+        // fixes 'java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first'.	
+        // on app resume in nested frame scenarios with support library version greater than 26.0.0
+        // HACK: this whole code block shouldn't be necessary as the native view is supposedly removed from its parent 
+        // right after onDestroyView(...) is called but for some reason the fragment view (page) still thinks it has a 
+        // parent while its supposed parent believes it properly removed its children; in order to "force" the child to 
+        // lose its parent we temporarily add it to the parent, and then remove it (addViewInLayout doesn't trigger layout pass)
+        const nativeView = page.nativeViewProtected;
+        if (nativeView != null) {	
+            const parentView = nativeView.getParent();	
+            if (parentView instanceof android.view.ViewGroup) {
+                if (parentView.getChildCount() === 0) {
+                    parentView.addViewInLayout(nativeView, -1, new org.nativescript.widgets.CommonLayoutParams());
+                }
+
+                parentView.removeView(nativeView);	
+            }
+        }
     }
 
     @profile


### PR DESCRIPTION
Fixes: https://github.com/NativeScript/NativeScript/issues/6490
Related to: https://github.com/NativeScript/NativeScript/pull/6339
Related to: https://github.com/NativeScript/NativeScript/pull/6421

This fix was originally applied with https://github.com/NativeScript/NativeScript/pull/6339 but was later reworked with https://github.com/NativeScript/NativeScript/pull/6421 (basically the part in frame.android.ts where disposing the fragments is performed after super.unloaded(...) logic).

The original fix did not work properly when called in onDestroyView(...) as it essentially removed the fragment view too early hence breaking exit transition. I actually tested onDestroy(...) then as well but due to a different bug addressed with https://github.com/NativeScript/NativeScript/pull/6421 and https://github.com/NativeScript/NativeScript/pull/6489 (essentially we need to cache and restore animators because of the simulated first navigation) onDestroyView(...) and onDestroy(...) were called at the same time (now onDestroy(...) is called after the actual exit transition is finished which means we can use it to detach the native view from its parent).

WIP: Add unit test