### PR TITLE
fix: layoutChanged event in landscape

### DIFF
--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -190,6 +190,9 @@ export class View extends ViewCommon {
         } else if (!this._isLaidOut) {
             // Rects could be equal on the first layout and an event should be raised.
             this._raiseLayoutChangedEvent();
+            // But make sure event is raised only once if rects are equal on the first layout as
+            // this method is called twice with equal rects in landscape mode (vs only once in portrait)
+            this._isLaidOut = true;
         }
     }
 


### PR DESCRIPTION
Make sure layoutChanged event is raised only once on first layout (if rects are equal) as in landscape the logic is triggered twice with equal rects.

Related to: https://github.com/NativeScript/NativeScript/pull/6457
Related to: https://github.com/NativeScript/NativeScript/pull/6462