### PR TITLE
fix(back-navigation): app freeze on going back in parent frame

### DIFF
--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -616,7 +616,7 @@ export function goBack(): boolean {
             if (parentFrame && parentFrame.canGoBack()) {
                 parentFrameCanGoBack = true;
             } else {
-                parentFrame = <FrameBase>getAncestor(top, "Frame");
+                parentFrame = <FrameBase>getAncestor(parentFrame, "Frame");
             }
         }
 


### PR DESCRIPTION
Endless loop while searching for parent frame that can go back.
Caught in Angular app when trying to go back from nested named lazy loaded outlet using the android hadrware back button.
