### PR TITLE
fix(ui/enums) make exported enums compatible with TypeScript and the corresponding properties

### DIFF
--- a/tns-core-modules/ui/enums/enums.d.ts
+++ b/tns-core-modules/ui/enums/enums.d.ts
@@ -17,6 +17,30 @@ import {
     TextDecoration as BaseTextDecoration
 } from "../text-base";
 
+import { 
+    Orientation as BaseOrientation 
+} from "../layouts/stack-layout";
+
+import {
+    Dock as BaseDock
+} from "../layouts/dock-layout";
+
+import {
+    BackgroundRepeat as BaseBackgroundRepeat,
+    Visibility as BaseVisibility,
+    HorizontalAlignment as BaseHorizontalAlignment,
+    VerticalAlignment as BaseVerticalAlignment
+} from "../styling/style-properties";
+
+import {
+    Stretch as BaseStretch
+} from "../image";
+
+import {
+    FontStyle as BaseFontStyle,
+    FontWeight as BaseFontWeight
+} from "../styling/font-common";
+
 /**
  * Represents a soft keyboard flavor.
  */
@@ -113,11 +137,11 @@ export module Orientation {
     /**
      * Layout should be horizontally oriented.
      */
-    export var horizontal: string;
+    export var horizontal: BaseOrientation;
     /**
      * Layout should be vertically oriented.
      */
-    export var vertical: string;
+    export var vertical: BaseOrientation;
 }
 
 /**
@@ -145,22 +169,22 @@ export module HorizontalAlignment {
     /**
      * An element should be left aligned.
      */
-    export var left: string;
+    export var left: BaseHorizontalAlignment;
 
     /**
      * An element should be center aligned.
      */
-    export var center: string;
+    export var center: BaseHorizontalAlignment;
 
     /**
      * An element should be right aligned.
      */
-    export var right: string;
+    export var right: BaseHorizontalAlignment;
 
     /**
      * An element should be stretched to fill all the available size.
      */
-    export var stretch: string;
+    export var stretch: BaseHorizontalAlignment;
 }
 
 /**
@@ -170,27 +194,27 @@ export module VerticalAlignment {
     /**
      * An element should be top aligned.
      */
-    export var top: string;
+    export var top: BaseVerticalAlignment;
 
     /**
      * An element should be center aligned.
      */
-    export var center: string;
+    export var center: BaseVerticalAlignment;
 
     /**
      * Same as center. An element should be aligned in the middle.
      */
-    export var middle: string;
+    export var middle: BaseVerticalAlignment;
 
     /**
      * An element should be bottom aligned.
      */
-    export var bottom: string;
+    export var bottom: BaseVerticalAlignment;
 
     /**
      * An element should be stretched to fill all the available size.
      */
-    export var stretch: string;
+    export var stretch: BaseVerticalAlignment;
 }
 
 /**
@@ -200,25 +224,25 @@ export module Stretch {
     /**
      * The image preserves its original size.
      */
-    export var none: string;
+    export var none: BaseStretch;
 
     /**
      * The image is resized to fill in the destination dimensions while it preserves its native aspect ratio.
      * If the aspect ratio of the destination rectangle differs from the image, the image is clipped to fill
      * in the destination.
      */
-    export var aspectFill: string;
+    export var aspectFill: BaseStretch;
 
     /**
      * The image is resized to fit the destination dimensions while it preserves
      * its native aspect ratio.
      */
-    export var aspectFit: string;
+    export var aspectFit: BaseStretch;
 
     /**
      * The image is resized to fill the destination dimensions. The aspect ratio is not preserved.
      */
-    export var fill: string;
+    export var fill: BaseStretch;
 }
 
 /**
@@ -228,17 +252,17 @@ export module Visibility {
     /**
      * The view is visible.
      */
-    export var visible: string;
+    export var visible: BaseVisibility;
 
     /**
      * The view is not visible and won't take place in the layout.
      */
-    export var collapse: string;
+    export var collapse: BaseVisibility;
 
     /**
      * The view is not visible but will take place in the layout.
      */
-    export var hidden: string;
+    export var hidden: BaseVisibility;
 }
 
 /**
@@ -313,22 +337,22 @@ export module Dock {
     /**
      * A child element that is positioned on the left side of the DockLayout.
      */
-    export var left: string;
+    export var left: BaseDock;
 
     /**
      * A child element that is positioned on the top side of the DockLayout.
      */
-    export var top: string;
+    export var top: BaseDock;
 
     /**
      * A child element that is positioned on the right side of the DockLayout.
      */
-    export var right: string;
+    export var right: BaseDock;
 
     /**
      * A child element that is positioned on the bottom side of the DockLayout.
      */
-    export var bottom: string;
+    export var bottom: BaseDock;
 }
 
 /**
@@ -432,12 +456,12 @@ export module FontStyle {
     /**
      * Normal font style.
      */
-    export var normal: string;
+    export var normal: BaseFontStyle;
 
     /**
      * Italic font style.
      */
-    export var italic: string;
+    export var italic: BaseFontStyle;
 }
 
 /**
@@ -507,57 +531,57 @@ export module FontWeight {
     /**
      * Thin font weight. CSS font-weight 100.
      */
-    export var thin: string;
+    export var thin: BaseFontWeight;
     
     /**
      * Extra-light / Ultra-light font weight. CSS font-weight 200.
      */
-    export var extraLight: string;
+    export var extraLight: BaseFontWeight;
     
     /**
      * Light font weight. CSS font-weight 300.
      */
-    export var light: string;
+    export var light: BaseFontWeight;
 
     /**
      * Normal font weight. CSS font-weight 400.
      */
-    export var normal: string;
+    export var normal: BaseFontWeight;
 
     /**
      * Medium font weight. CSS font-weight 500.
      */
-    export var medium: string;
+    export var medium: BaseFontWeight;
 
     /**
      * Semi-bold / Demi-bold font weight. CSS font-weight 600.
      */
-    export var semiBold: string;
+    export var semiBold: BaseFontWeight;
     
     /**
      * Bold font weight. CSS font-weight 700.
      */
-    export var bold: string;
+    export var bold: BaseFontWeight;
 
     /**
      * Extra-bold / Ultra-bold font weight. CSS font-weight 800.
      */
-    export var extraBold: string;
+    export var extraBold: BaseFontWeight;
 
     /**
      * Black font weight. CSS font-weight 900.
      */
-    export var black: string;
+    export var black: BaseFontWeight;
 }
 
 /**
  * Specifies background repeat.
  */
 export module BackgroundRepeat {
-    export var repeat: string;
-    export var repeatX: string;
-    export var repeatY: string;
-    export var noRepeat: string;
+    export var repeat: BaseBackgroundRepeat;
+    export var repeatX: BaseBackgroundRepeat;
+    export var repeatY: BaseBackgroundRepeat;
+    export var noRepeat: BaseBackgroundRepeat;
 }
 
 /**

--- a/tns-core-modules/ui/enums/enums.d.ts
+++ b/tns-core-modules/ui/enums/enums.d.ts
@@ -3,6 +3,19 @@
  */ /** */
 
 import * as animationModule from "../animation";
+import { 
+    KeyboardType as BaseKeyboardType,
+    ReturnKeyType as BaseReturnKeyType,
+    UpdateTextTrigger as BaseUpdateTrigger,
+    AutocapitalizationType as BaseAutocapitalizationType
+} from "../editable-text-base";
+
+import {
+    WhiteSpace as BaseWhiteSpace,
+    TextAlignment as BaseTextAlignment,
+    TextTransform as BaseTextTransform,
+    TextDecoration as BaseTextDecoration
+} from "../text-base";
 
 /**
  * Represents a soft keyboard flavor.
@@ -12,31 +25,30 @@ export module KeyboardType {
      * Android: [TYPE_CLASS_DATETIME](http://developer.android.com/reference/android/text/InputType.html#TYPE_CLASS_DATETIME) | [TYPE_DATETIME_VARIATION_NORMAL](http://developer.android.com/reference/android/text/InputType.html#TYPE_DATETIME_VARIATION_NORMAL)
      * iOS:  [UIKeyboardTypeNumbersAndPunctuation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
      */
-    export var datetime: string;
-
+    export var datetime: BaseKeyboardType
     /**
      * Android: [TYPE_CLASS_PHONE](http://developer.android.com/reference/android/text/InputType.html#TYPE_CLASS_PHONE)
      * iOS:  [UIKeyboardTypePhonePad](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
      */
-    export var phone: string;
+    export var phone: BaseKeyboardType
 
     /**
      * Android: [TYPE_CLASS_NUMBER](http://developer.android.com/reference/android/text/InputType.html#TYPE_CLASS_NUMBER) | [TYPE_NUMBER_VARIATION_NORMAL](http://developer.android.com/intl/es/reference/android/text/InputType.html#TYPE_NUMBER_VARIATION_NORMAL) | [TYPE_NUMBER_FLAG_SIGNED](http://developer.android.com/reference/android/text/InputType.html#TYPE_NUMBER_FLAG_SIGNED) | [TYPE_NUMBER_FLAG_DECIMAL](http://developer.android.com/reference/android/text/InputType.html#TYPE_NUMBER_FLAG_DECIMAL)
      * iOS:  [UIKeyboardTypeNumbersAndPunctuation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
      */
-    export var number: string;
+    export var number: BaseKeyboardType
 
     /**
      * Android: [TYPE_CLASS_TEXT](http://developer.android.com/reference/android/text/InputType.html#TYPE_CLASS_TEXT) | [TYPE_TEXT_VARIATION_URI](http://developer.android.com/reference/android/text/InputType.html#TYPE_TEXT_VARIATION_URI)
      * iOS:  [UIKeyboardTypeURL](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
      */
-    export var url: string;
+    export var url: BaseKeyboardType
 
     /**
      * Android: [TYPE_CLASS_TEXT](http://developer.android.com/reference/android/text/InputType.html#TYPE_CLASS_TEXT) | [TYPE_TEXT_VARIATION_EMAIL_ADDRESS](http://developer.android.com/reference/android/text/InputType.html#TYPE_TEXT_VARIATION_EMAIL_ADDRESS)
      * iOS:  [UIKeyboardTypeEmailAddress](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
      */
-    export var email: string;
+    export var email: BaseKeyboardType
 }
 
 /**
@@ -47,25 +59,25 @@ export module ReturnKeyType {
      * Android: [IME_ACTION_DONE](http://developer.android.com/reference/android/view/inputmethod/EditorInfo.html#IME_ACTION_DONE)
      * iOS: [UIReturnKeyDone](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIReturnKeyType)
      */
-    export var done: string;
+    export var done: BaseReturnKeyType;
 
     /**
      * Android: [IME_ACTION_NEXT](http://developer.android.com/reference/android/view/inputmethod/EditorInfo.html#IME_ACTION_NEXT)
      * iOS: [UIReturnKeyNext](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIReturnKeyType)
      */
-    export var next: string;
+    export var next: BaseReturnKeyType;
 
     /**
      * Android: [IME_ACTION_GO](http://developer.android.com/reference/android/view/inputmethod/EditorInfo.html#IME_ACTION_GO)
      * iOS: [UIReturnKeyGo](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIReturnKeyType)
      */
-    export var go: string;
+    export var go: BaseReturnKeyType;
 
     /**
      * Android: [IME_ACTION_SEARCH](http://developer.android.com/reference/android/view/inputmethod/EditorInfo.html#IME_ACTION_SEARCH)
      * iOS: [UIReturnKeySearch](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIReturnKeyType)
      */
-    export var search: string;
+    export var search: BaseReturnKeyType;
 
     /**
      * Android: [IME_ACTION_SEND](http://developer.android.com/reference/android/view/inputmethod/EditorInfo.html#IME_ACTION_SEND)
@@ -81,17 +93,17 @@ export module TextAlignment {
     /**
      * Represents left text-align.
      */
-    export var left: string;
+    export var left: BaseTextAlignment;
 
     /**
      * Represents center text-align.
      */
-    export var center: string;
+    export var center: BaseTextAlignment;
 
     /**
      * Represents right text-align.
      */
-    export var right: string;
+    export var right: BaseTextAlignment;
 }
 
 /**
@@ -271,12 +283,12 @@ export module UpdateTextTrigger {
     /**
      * The text property will be udpaded when the widget loses focus.
      */
-    export var focusLost: string;
+    export var focusLost: BaseUpdateTrigger;
 
     /**
      * The text property will be udpaded on every single character typed by the user.
      */
-    export var textChanged: string;
+    export var textChanged: BaseUpdateTrigger;
 }
 
 /**
@@ -326,22 +338,22 @@ export module AutocapitalizationType {
     /**
      * Do not capitalize any text automatically.
      */
-    export var none: string;
+    export var none: BaseAutocapitalizationType;
 
     /**
      * Capitalize the first letter of each word automatically.
      */
-    export var words: string;
+    export var words: BaseAutocapitalizationType;
 
     /**
      * Capitalize the first letter of each sentence automatically.
      */
-    export var sentences: string;
+    export var sentences: BaseAutocapitalizationType;
 
     /**
      * Capitalize all characters automatically.
      */
-    export var allCharacters: string;
+    export var allCharacters: BaseAutocapitalizationType;
 }
 
 /**
@@ -435,17 +447,17 @@ export module TextDecoration {
     /**
      * No decoration.
      */
-    export var none: string;
+    export var none: BaseTextDecoration;
 
     /**
      * Text decoration underline.
      */
-    export var underline: string;
+    export var underline: BaseTextDecoration;
 
     /**
      * Text decoration line-through.
      */
-    export var lineThrough: string;
+    export var lineThrough: BaseTextDecoration;
 }
 
 /**
@@ -455,22 +467,22 @@ export module TextTransform {
     /**
      * No transform.
      */
-    export var none: string;
+    export var none: BaseTextTransform;
 
     /**
      * Text transform capitalize.
      */
-    export var capitalize: string;
+    export var capitalize: BaseTextTransform;
 
     /**
      * Text transform uppercase.
      */
-    export var uppercase: string;
+    export var uppercase: BaseTextTransform;
 
     /**
      * Text transform lowercase.
      */
-    export var lowercase: string;
+    export var lowercase: BaseTextTransform;
 }
 
 /**
@@ -480,12 +492,12 @@ export module WhiteSpace {
     /**
      * Normal wrap.
      */
-    export var normal: string;
+    export var normal: BaseWhiteSpace;
 
     /**
      * No wrap.
      */
-    export var nowrap: string;
+    export var nowrap: BaseWhiteSpace;
 }
 
 /**


### PR DESCRIPTION
As of this moment most of the modules exported from tns-core-modules/ui/enums are not usable with the corresponding element properties in TypeScript.

For example:
```TypeScript
import { KeyboardType, Orientation } from "tns-core-modules/ui/enums";

export function onTFLoaded(args: EventData) {
    let tf = <TextField>args.object; // TextField
    let stack = <StackLayout>tf.parent; // Stacklayout

    stack.orientation = Orientation.horizontal; // this won't work in as the type of the porperty differs from the type of the exported module("enum")
    // or
    stack.orientation = "horizontal"; // works

    tf.keyboardType = KeyboardType.number; // this won't work in as the type of the porperty differs from the type of the exported module("enum")
    // or
    tf.keyboardType = "number"; ; // works
```

With the PR both options will work as expected

```TypeScript
import { KeyboardType, Orientation } from "tns-core-modules/ui/enums";

export function onTFLoaded(args: EventData) {
    let tf = <TextField>args.object; // TextField
    let stack = <StackLayout>tf.parent; // Stacklayout

    stack.orientation = Orientation.horizontal; // works
    // or
    stack.orientation = "horizontal"; // works

    tf.keyboardType = KeyboardType.number; // works
    // or
    tf.keyboardType = "number"; ; // works
```

Assigned the approrpiate types for all properties with explicitly set own TypeScript types

Demo app demonstraing the above can be found [here](https://github.com/NickIliev/NS-Issues-2018-II/blob/master/test/enums-test/app/main-page.ts)