### PR TITLE
fix-next: undefined root view when reapplying styles

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -89,7 +89,7 @@ export function livesync(context?: HmrContext) {
         reapplyAppCss = extensions.some(ext => context.module === fileName.concat(ext));
     }
 
-    if (reapplyAppCss) {
+    if (reapplyAppCss && getRootView()) {
         getRootView()._onCssStateChange();
     } else if (liveSyncCore) {
         liveSyncCore();

--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -89,8 +89,9 @@ export function livesync(context?: HmrContext) {
         reapplyAppCss = extensions.some(ext => context.module === fileName.concat(ext));
     }
 
-    if (reapplyAppCss && getRootView()) {
-        getRootView()._onCssStateChange();
+    const rootView = getRootView();
+    if (reapplyAppCss && rootView) {
+        rootView._onCssStateChange();
     } else if (liveSyncCore) {
         liveSyncCore();
     }


### PR DESCRIPTION
Error:
```
JS ERROR TypeError: undefined is not an object (evaluating
'application_1.getRootView()._onCssStateChange')
```

Steps:
- `tns run <platform> --hmr`
- make a change in application styles
- restart the application

