### PR TITLE
fix(tab-view): remove onBackPressed override

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -545,15 +545,6 @@ export class TabView extends TabViewBase {
         super.disposeNativeView();
     }
 
-    public onBackPressed(): boolean {
-        const currentView = this._selectedView;
-        if (currentView) {
-            return currentView.onBackPressed();
-        }
-
-        return false;
-    }
-
     public _onRootViewReset(): void {
         super._onRootViewReset();
         


### PR DESCRIPTION
Android back button will exit the app, instead going back to previous list page, when using lazy loaded nested named <page-router-outlets> inside TabViewItems. 

_This happens only if using <TabView> as a root component (template-tab-navigation-ng template)._
 
Remove onBackPressed override, since the topmost() frame is now properly assigned when switching between tab view items.

Fix https://github.com/NativeScript/nativescript-angular/issues/1680
