### PR TITLE
Check if onNavigatingFrom exists before calling the event

### DIFF
--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -177,7 +177,7 @@ class UIViewControllerImpl extends UIViewController {
         // or because we are closing a modal page, 
         // or because we are in tab and another controller is selected.
         const tab = this.tabBarController;
-        if (!owner._presentedViewController && !this.presentingViewController && frame && frame.currentPage === owner) {
+        if (owner.onNavigatingFrom && !owner._presentedViewController && !this.presentingViewController && frame && frame.currentPage === owner) {
             const willSelectViewController = tab && (<any>tab)._willSelectViewController;
             if (!willSelectViewController
                 || willSelectViewController === tab.selectedViewController) {


### PR DESCRIPTION
I ran into an issue where `owner.onNavigatingFrom` didn't exist when rendering a view was blocked by the biometric scanner and the user hit the back button to navigate back.

This code simply adds a check to see if `onNavigatingFrom` exists on the owner.

This happened on a barebone `nativescript-vue` prototype app and I tracked it down to the part in the fix. 

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

