### PR TITLE
Use passwordHint for password placeholder @ android

### DIFF
--- a/tns-core-modules/ui/dialogs/dialogs.android.ts
+++ b/tns-core-modules/ui/dialogs/dialogs.android.ts
@@ -241,7 +241,7 @@ export function login(...args: any[]): Promise<LoginResult> {
             passwordInput.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
             passwordInput.setTypeface(android.graphics.Typeface.DEFAULT);
 
-            passwordInput.setHint(options.userNameHint ? options.userNameHint : "");
+            passwordInput.setHint(options.passwordHint ? options.passwordHint : "");
             passwordInput.setText(options.password ? options.password : "");
 
             const layout = new android.widget.LinearLayout(context);


### PR DESCRIPTION
**Environment**
 - CLI: 5.1.0
 - Cross-platform modules: 5.1.1
 - Android Runtime: 5.1.0
 - iOS Runtime: _irelevant_
 - Plugin(s): _irelevant_

**Describe the bug**
Android only:
Login dialog uses the userNameHint option as a placeholder for passwordHint, causing the same placeholder to appear twice.

**To Reproduce**
`               login({    title: "Login",

                    message: "Sign in using your credentials",

                    okButtonText: "Sign In",

                    cancelButtonText: "Cancel",

                    userNameHint: 'Email',

                    passwordHint: 'Password',

                    userName: this.loginData.email,

                    password: this.loginData.password
                })
`

**Expected behavior**
Password placeholder should be 'Password', instead displays 'Email'
