### PR TITLE
fix(ios): native view frame optimizations in nested scenario

### DIFF
--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -225,8 +225,6 @@ export class View extends ViewCommon {
         const { sizeChanged } = this._setCurrentLayoutBounds(left, top, right, bottom);
         this.updateBackground(sizeChanged);
         this._privateFlags &= ~PFLAG_LAYOUT_REQUIRED;
-        // NOTE: if there is transformation this frame will be incorrect.
-        this._cachedFrame = this.nativeViewProtected.frame;
     }
 
     public focus(): boolean {


### PR DESCRIPTION
[Setting native view frame optimizations](https://github.com/NativeScript/NativeScript/blob/19dfd163e090ef8de789d1b62a39538e0ffc9892/tns-core-modules/ui/core/view/view.ios.ts#L157) were effectively disabled by changing the value of the cached frame and this was particularly visible in nested frame scenarios (resulting in multiple layout passes both top-down and bottom-up).

Fixes: https://github.com/NativeScript/NativeScript/issues/6728