### PR TITLE
feat: add rebeccapurple to known CSS colors

### DIFF
--- a/tests/app/xml-declaration/tns.xsd
+++ b/tests/app/xml-declaration/tns.xsd
@@ -744,6 +744,7 @@
                     <xs:enumeration value="Plum"/>
                     <xs:enumeration value="PowderBlue"/>
                     <xs:enumeration value="Purple"/>
+                    <xs:enumeration value="RebeccaPurple"/>
                     <xs:enumeration value="Red"/>
                     <xs:enumeration value="RosyBrown"/>
                     <xs:enumeration value="RoyalBlue"/>

--- a/tns-core-modules/color/known-colors.d.ts
+++ b/tns-core-modules/color/known-colors.d.ts
@@ -115,6 +115,7 @@ export var Pink;
 export var Plum;
 export var PowderBlue;
 export var Purple;
+export var RebeccaPurple;
 export var Red;
 export var RosyBrown;
 export var RoyalBlue;

--- a/tns-core-modules/color/known-colors.ts
+++ b/tns-core-modules/color/known-colors.ts
@@ -112,6 +112,7 @@ export var Pink = "#FFC0CB";
 export var Plum = "#DDA0DD";
 export var PowderBlue = "#B0E0E6";
 export var Purple = "#800080";
+export var RebeccaPurple = "#663399";
 export var Red = "#FF0000";
 export var RosyBrown = "#BC8F8F";
 export var RoyalBlue = "#4169E1";

--- a/tns-core-modules/css/parser.ts
+++ b/tns-core-modules/css/parser.ts
@@ -233,6 +233,7 @@ export enum colors {
     plum = 0xFFDDA0DD,
     powderblue = 0xFFB0E0E6,
     purple = 0xFF800080,
+    rebeccapurple = 0xFF663399,
     red = 0xFFFF0000,
     rosybrown = 0xFFBC8F8F,
     royalblue = 0xFF4169E1,


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [X] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
`rebeccapurple` is not recognized as a color name in NativeScript. (It is a part of the [CSS Color Module Level 4](https://drafts.csswg.org/css-color/#named-colors)).

## What is the new behavior?
`rebeccapurple` will be recognized as `#663399`.

Fixes/Implements/Closes #6818.

