### PR TITLE
fix(ios): textview content clipped on every other newline

### DIFF
--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -95,6 +95,16 @@ class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
     }
 }
 
+class NoScrollAnimationUITextView extends UITextView {
+    // see https://github.com/NativeScript/NativeScript/issues/6863
+    // UITextView internally scrolls the text you are currently typing to visible when newline character
+    // is typed but the scroll animation is not needed because at the same time we are expanding
+    // the textview (setting its frame)
+    public setContentOffsetAnimated(contentOffset: CGPoint, animated: boolean): void {
+        super.setContentOffsetAnimated(contentOffset, false);
+    }
+}
+
 @CSSType("TextView")
 export class TextView extends EditableTextBase implements TextViewDefinition {
     nativeViewProtected: UITextView;
@@ -103,7 +113,7 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     public _isEditing: boolean;
 
     createNativeView() {
-        const textView = UITextView.new();
+        const textView = NoScrollAnimationUITextView.new();
         if (!textView.font) {
             textView.font = UIFont.systemFontOfSize(12);
         }


### PR DESCRIPTION
Fixes: https://github.com/NativeScript/NativeScript/issues/6863

