### PR TITLE
fix: app launch with app.css hot module update

### DIFF
--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -227,7 +227,7 @@ class IOSApplication implements IOSApplicationDefinition {
 
     public _onLivesync(): void {
         // If view can't handle livesync set window controller.
-        if (!this._rootView._onLivesync()) {
+        if (this._rootView && !this._rootView._onLivesync()) {
             this.setWindowContent();
         }
     }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
The application launch is crashing with `JS ERROR TypeError: undefined is not an object (evaluating 'this._rootView._onLivesync')` when there is an app.css change in a hot module update.

## What is the new behavior?
The application launches successfully when there is an app.css change in a hot module update.
