### PR TITLE
fix(ios-frame): tearDownUI and reset UINavigationController

### DIFF
--- a/tests/app/navigation/navigation-tests.ts
+++ b/tests/app/navigation/navigation-tests.ts
@@ -101,8 +101,11 @@ export function test_backAndForwardParentPage_nestedFrames() {
     helper.waitUntilNavigatedTo(parentPage1, () => frame.goBack());
     currentPageMustBe("ParentPage1");
 
-    helper.waitUntilNavigatedTo(parentPage2, () => topmost.navigate({ create: () => parentPage2 }));
-    currentPageMustBe("ParentPage2");
+    const innerPage3 = page("InnerPage3");
+    const parentPage3 = parentPage("ParentPage3", innerPage3);
+
+    helper.waitUntilNavigatedTo(parentPage3, () => topmost.navigate({ create: () => parentPage3 }));
+    currentPageMustBe("ParentPage3");
 
     back(2);
     TKUnit.waitUntilReady(() => topmostFrame().navigationQueueIsEmpty());

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -37,6 +37,8 @@ export class Frame extends FrameBase {
 
     public disposeNativeView() {
         this._removeFromFrameStack();
+        this.viewController = null;
+        this._ios.controller = null;
         super.disposeNativeView();
     }
 
@@ -389,9 +391,8 @@ class UINavigationControllerImpl extends UINavigationController {
         const owner = this._owner.get();
         if (owner && owner.isLoaded && !owner.parent && !this.presentedViewController) {
             owner.callUnloaded();
+            owner._tearDownUI(true);
 
-            owner.viewController = null;
-            owner.ios.controller = null;
         }
     }
 


### PR DESCRIPTION
**The problem**: The memory allocated for the modal view, with Frame inside, is not released.

**Solution**: [iOS] Reset reference to UINavigationController in Frame when UINavigationController view disappeared. _`_teadDownUI` method will call `disposeNativeView` where the clean up is done_