### PR TITLE
fix(debugger): Enable iOS inspector modules on creation

### DIFF
--- a/tns-core-modules/debugger/webinspector-css.ios.ts
+++ b/tns-core-modules/debugger/webinspector-css.ios.ts
@@ -18,6 +18,10 @@ export class CSSDomainDebugger implements inspectorCommandTypes.CSSDomain.CSSDom
         this.commands = {};
 
         attachCSSInspectorCommandCallbacks(this.commands);
+
+        // By default start enabled because we can miss the "enable" event when
+        // running with `--debug-brk` -- the frontend will send it before we've been created
+        this.enable();
     }
 
     get enabled(): boolean {

--- a/tns-core-modules/debugger/webinspector-dom.ios.ts
+++ b/tns-core-modules/debugger/webinspector-dom.ios.ts
@@ -20,6 +20,10 @@ export class DOMDomainDebugger implements inspectorCommandTypes.DOMDomain.DOMDom
 
         attachDOMInspectorEventCallbacks(this.events);
         attachDOMInspectorCommandCallbacks(this.commands);
+
+        // By default start enabled because we can miss the "enable event when
+        // running with `--debug-brk` -- the frontend will send it before we've been created
+        this.enable();
     }
 
     get enabled(): boolean {

--- a/tns-core-modules/debugger/webinspector-network.ios.ts
+++ b/tns-core-modules/debugger/webinspector-network.ios.ts
@@ -64,7 +64,7 @@ export class Request {
                 this._resourceType = "Other";
                 return;
             }
-            
+
             this._mimeType = value;
 
             var resourceType = "Other";
@@ -112,19 +112,19 @@ export class Request {
                 this._resourceType = value;
         }
     }
-    
+
     public responseReceived(response: inspectorCommandTypes.NetworkDomain.Response): void {
         if (this._networkDomainDebugger.enabled) {
             this._networkDomainDebugger.events.responseReceived(this.requestID, frameId, loaderId, __inspectorTimestamp(), <any>this.resourceType, response);
         }
     }
-    
+
     public loadingFinished(): void {
         if (this._networkDomainDebugger.enabled) {
             this._networkDomainDebugger.events.loadingFinished(this.requestID, __inspectorTimestamp());
         }
     }
-    
+
     public requestWillBeSent(request: inspectorCommandTypes.NetworkDomain.Request): void {
         if (this._networkDomainDebugger.enabled) {
             this._networkDomainDebugger.events.requestWillBeSent(this.requestID, frameId, loaderId, request.url, request, __inspectorTimestamp(), { type: "Script" });
@@ -136,9 +136,13 @@ export class Request {
 export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomain.NetworkDomainDispatcher {
     private _enabled: boolean;
     public events: inspectorCommandTypes.NetworkDomain.NetworkFrontend;
-   
+
     constructor() {
         this.events = new inspectorCommands.NetworkDomain.NetworkFrontend();
+
+        // By default start enabled because we can miss the "enable" event when
+        // running with `--debug-brk` -- the frontend will send it before we've been created
+        this.enable();
     }
 
     get enabled(): boolean {
@@ -156,7 +160,7 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
         }
         this._enabled = true;
     }
-    
+
     /**
      * Disables network tracking, prevents network events from being sent to the client.
      */
@@ -166,14 +170,14 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
         }
         this._enabled = false;
     }
-    
+
     /**
      * Specifies whether to always send extra HTTP headers with the requests from this page.
      */
     setExtraHTTPHeaders(params: inspectorCommandTypes.NetworkDomain.SetExtraHTTPHeadersMethodArguments): void {
         //
     }
-    
+
     /**
      * Returns content served for the given request.
      */
@@ -187,9 +191,9 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
                  body: body,
                  base64Encoded: !resource_data.hasTextContent
              };
-        } 
+        }
     }
-    
+
     /**
      * Tells whether clearing browser cache is supported.
      */
@@ -198,14 +202,14 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
             result: false
         };
     }
-    
+
     /**
      * Clears browser cache.
      */
     clearBrowserCache(): void {
         //
     }
-    
+
     /**
      * Tells whether clearing browser cookies is supported.
      */
@@ -214,21 +218,21 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
             result: false
         };
     }
-    
+
     /**
      * Clears browser cookies.
      */
     clearBrowserCookies(): void {
         //
     }
-    
+
     /**
      * Toggles ignoring cache for each request. If <code>true</code>, cache will not be used.
      */
     setCacheDisabled(params: inspectorCommandTypes.NetworkDomain.SetCacheDisabledMethodArguments): void {
         //
     }
-    
+
     /**
      * Loads a resource in the context of a frame on the inspected page without cross origin checks.
      */
@@ -245,7 +249,7 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
             status: 200
         }
     }
-    
+
     public static idSequence: number = 0;
     create(): Request {
         let id = (++NetworkDomainDebugger.idSequence).toString();


### PR DESCRIPTION
When the application is being debugged with `--debug-brk --bundle`
options, the JS implementation objects handling the debugging protocol
are created after their corresponding domains' `enable` methods have
been called by the debugger frontend. As a workaround we now manually
call `enable` in their constructors.

related to https://github.com/NativeScript/ios-runtime/issues/1055 and https://github.com/NativeScript/ios-runtime/issues/1057

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
The Elements, DOM, CSS, and Networking inspector modules are enabled when the `enable` event is received from the debugger.
## What is the new behavior?
The Elements, DOM, CSS, and Networking inspector modules are enabled explicitly in their constructors.