### PR TITLE
fix(ios): opaque bars break ui layout

### DIFF
--- a/apps/app/ui-tests-app/action-bar/flat-layout.xml
+++ b/apps/app/ui-tests-app/action-bar/flat-layout.xml
@@ -4,7 +4,7 @@
         <Label text="flat action bar"></Label>
     </ActionBar>
 
-    <ScrollView backgroundColor="red">
+    <StackLayout backgroundColor="red">
         <Label text="lorem ipsum" backgroundColor="green"></Label>
-    </ScrollView>
+    </StackLayout>
 </Page>

--- a/apps/app/ui-tests-app/action-bar/flat-tab-opaque-bar.ts
+++ b/apps/app/ui-tests-app/action-bar/flat-tab-opaque-bar.ts
@@ -1,0 +1,7 @@
+import { EventData } from "tns-core-modules/data/observable";
+import { TabView } from "tns-core-modules/ui/tab-view";
+
+export function onLoaded(args: EventData) {
+    const tabView = <TabView>args.object;
+    tabView.ios.tabBar.translucent = false;
+}

--- a/apps/app/ui-tests-app/action-bar/flat-tab-opaque-bar.xml
+++ b/apps/app/ui-tests-app/action-bar/flat-tab-opaque-bar.xml
@@ -1,0 +1,13 @@
+<Page backgroundColor="yellow">
+  <ActionBar flat="true" backgroundColor="blue">
+      <Label text="flat action bar"></Label>
+  </ActionBar>
+
+  <TabView androidTabsPosition="bottom" loaded="onLoaded">
+      <TabViewItem title="First">
+          <StackLayout backgroundColor="red">
+            <Label text="First View" backgroundColor="green"/>
+          </StackLayout>
+      </TabViewItem>
+  </TabView>
+</Page>

--- a/apps/app/ui-tests-app/action-bar/flat-tab.xml
+++ b/apps/app/ui-tests-app/action-bar/flat-tab.xml
@@ -1,13 +1,13 @@
-<Page xmlns="http://schemas.nativescript.org/tns.xsd">
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" backgroundColor="yellow">
 
-    <ActionBar flat="true">
+    <ActionBar flat="true" backgroundColor="blue">
         <Label text="flat action bar"></Label>
     </ActionBar>
 
     <TabView selectedTabTextColor="green">
         <TabViewItem title="First">
-            <GridLayout backgroundColor="red">
-                <Button text="test" backgroundColor="yellow"></Button> 
+            <GridLayout backgroundColor="green">
+                <Button text="test" backgroundColor="red"></Button> 
             </GridLayout>
         </TabViewItem>
     </TabView>

--- a/apps/app/ui-tests-app/action-bar/flat.xml
+++ b/apps/app/ui-tests-app/action-bar/flat.xml
@@ -1,9 +1,11 @@
-<Page navigatedTo="onNavigateTo" >
-  <Page.actionBar>
-    <ActionBar title="Flat property"/>
-  </Page.actionBar>
-  <StackLayout>
+<Page navigatedTo="onNavigateTo" backgroundColor="yellow">
+  
+  <ActionBar flat="true" backgroundColor="blue">
+      <Label text="flat action bar"></Label>
+  </ActionBar>
+
+  <StackLayout backgroundColor="red">
     <Button margin="30" text="change flat property" tap="changeFlatPropertyValue"/>
-    <Label id="flatPropertyValue" />
+    <Label id="flatPropertyValue" backgroundColor="green" />
   </StackLayout>
 </Page>

--- a/apps/app/ui-tests-app/action-bar/main-page.ts
+++ b/apps/app/ui-tests-app/action-bar/main-page.ts
@@ -23,6 +23,8 @@ export function loadExamples() {
     examples.set("modalShownActBar", "action-bar/modal-test-with-action-bar");
     examples.set("flat", "action-bar/flat");
     examples.set("flat-tab", "action-bar/flat-tab");
+    examples.set("flat-tab-opaque-bar", "action-bar/flat-tab-opaque-bar");
+    examples.set("flat-layout", "action-bar/flat-layout");
     examples.set("flat-scrollview", "action-bar/flat-scrollview");
 
     return examples;

--- a/apps/app/ui-tests-app/nested-frames/mid-screen-y-n-flat.xml
+++ b/apps/app/ui-tests-app/nested-frames/mid-screen-y-n-flat.xml
@@ -7,6 +7,6 @@
     <GridLayout rows="200, *" backgroundColor="blue">
         <GridLayout row="1">
             <Frame id="nestedFrame" defaultPage="ui-tests-app/nested-frames/nested-page" actionBarVisibility="never"></Frame>
-        </GridLayout>>
+        </GridLayout>
     </GridLayout>
 </Page>

--- a/tests/app/ui/styling/style-tests.ts
+++ b/tests/app/ui/styling/style-tests.ts
@@ -674,6 +674,23 @@ export function test_CSS_isAppliedOnPage_From_addCssFile() {
     });
 }
 
+export function test_CSS_isAppliedOnPage_From_changeCssFile() {
+    const testButton = new buttonModule.Button();
+    testButton.text = "Test";
+
+    const testCss = "button { color: blue; }";
+
+    const testFunc = function (views: Array<viewModule.View>) {
+        helper.assertViewColor(testButton, "#0000FF");
+        const page: pageModule.Page = <pageModule.Page>views[1];
+        page.changeCssFile("~/ui/styling/test.css");
+        helper.assertViewBackgroundColor(page, "#FF0000");
+        TKUnit.assert(testButton.style.color === undefined, "Color should not have a value");
+    }
+
+    helper.buildUIAndRunTest(testButton, testFunc, { pageCss: testCss });
+}
+
 const invalidCSS = ".invalid { " +
     "color: invalidValue; " +
     "background-color: invalidValue; " +

--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -82,19 +82,23 @@ export function setApplication(instance: iOSApplication | AndroidApplication): v
 export function livesync(rootView: View, context?: ModuleContext) {
     events.notify(<EventData>{ eventName: "livesync", object: app });
     const liveSyncCore = global.__onLiveSyncCore;
-    let reapplyAppCss = false;
+    let reapplyAppStyles = false;
+    let reapplyLocalStyles = false;
 
-    if (context) {
-        const fullFileName = getCssFileName();
-        const fileName = fullFileName.substring(0, fullFileName.lastIndexOf(".") + 1);
+    if (context && context.path) {
         const extensions = ["css", "scss"];
-        reapplyAppCss = extensions.some(ext => context.path === fileName.concat(ext));
+        const appStylesFullFileName = getCssFileName();
+        const appStylesFileName = appStylesFullFileName.substring(0, appStylesFullFileName.lastIndexOf(".") + 1);
+        reapplyAppStyles = extensions.some(ext => context.path === appStylesFileName.concat(ext));
+        if (!reapplyAppStyles) {
+            reapplyLocalStyles = extensions.some(ext => context.path.endsWith(ext));
+        }
     }
 
-    if (reapplyAppCss && rootView) {
+    if (reapplyAppStyles && rootView) {
         rootView._onCssStateChange();
     } else if (liveSyncCore) {
-        liveSyncCore();
+        reapplyLocalStyles ? liveSyncCore(context) : liveSyncCore();
     }
 }
 

--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -225,9 +225,9 @@ class IOSApplication implements IOSApplicationDefinition {
         }
     }
 
-    public _onLivesync(): void {
+    public _onLivesync(context?: ModuleContext): void {
         // If view can't handle livesync set window controller.
-        if (this._rootView && !this._rootView._onLivesync()) {
+        if (this._rootView && !this._rootView._onLivesync(context)) {
             this.setWindowContent();
         }
     }
@@ -264,8 +264,8 @@ exports.ios = iosApp;
 setApplication(iosApp);
 
 // attach on global, so it can be overwritten in NativeScript Angular
-(<any>global).__onLiveSyncCore = function () {
-    iosApp._onLivesync();
+(<any>global).__onLiveSyncCore = function (context?: ModuleContext) {
+    iosApp._onLivesync(context);
 }
 
 let mainEntry: NavigationEntry;

--- a/tns-core-modules/debugger/webinspector-css.ios.ts
+++ b/tns-core-modules/debugger/webinspector-css.ios.ts
@@ -18,6 +18,10 @@ export class CSSDomainDebugger implements inspectorCommandTypes.CSSDomain.CSSDom
         this.commands = {};
 
         attachCSSInspectorCommandCallbacks(this.commands);
+
+        // By default start enabled because we can miss the "enable" event when
+        // running with `--debug-brk` -- the frontend will send it before we've been created
+        this.enable();
     }
 
     get enabled(): boolean {

--- a/tns-core-modules/debugger/webinspector-dom.ios.ts
+++ b/tns-core-modules/debugger/webinspector-dom.ios.ts
@@ -20,6 +20,10 @@ export class DOMDomainDebugger implements inspectorCommandTypes.DOMDomain.DOMDom
 
         attachDOMInspectorEventCallbacks(this.events);
         attachDOMInspectorCommandCallbacks(this.commands);
+
+        // By default start enabled because we can miss the "enable event when
+        // running with `--debug-brk` -- the frontend will send it before we've been created
+        this.enable();
     }
 
     get enabled(): boolean {

--- a/tns-core-modules/debugger/webinspector-network.ios.ts
+++ b/tns-core-modules/debugger/webinspector-network.ios.ts
@@ -64,7 +64,7 @@ export class Request {
                 this._resourceType = "Other";
                 return;
             }
-            
+
             this._mimeType = value;
 
             var resourceType = "Other";
@@ -112,19 +112,19 @@ export class Request {
                 this._resourceType = value;
         }
     }
-    
+
     public responseReceived(response: inspectorCommandTypes.NetworkDomain.Response): void {
         if (this._networkDomainDebugger.enabled) {
             this._networkDomainDebugger.events.responseReceived(this.requestID, frameId, loaderId, __inspectorTimestamp(), <any>this.resourceType, response);
         }
     }
-    
+
     public loadingFinished(): void {
         if (this._networkDomainDebugger.enabled) {
             this._networkDomainDebugger.events.loadingFinished(this.requestID, __inspectorTimestamp());
         }
     }
-    
+
     public requestWillBeSent(request: inspectorCommandTypes.NetworkDomain.Request): void {
         if (this._networkDomainDebugger.enabled) {
             this._networkDomainDebugger.events.requestWillBeSent(this.requestID, frameId, loaderId, request.url, request, __inspectorTimestamp(), { type: "Script" });
@@ -136,9 +136,13 @@ export class Request {
 export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomain.NetworkDomainDispatcher {
     private _enabled: boolean;
     public events: inspectorCommandTypes.NetworkDomain.NetworkFrontend;
-   
+
     constructor() {
         this.events = new inspectorCommands.NetworkDomain.NetworkFrontend();
+
+        // By default start enabled because we can miss the "enable" event when
+        // running with `--debug-brk` -- the frontend will send it before we've been created
+        this.enable();
     }
 
     get enabled(): boolean {
@@ -156,7 +160,7 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
         }
         this._enabled = true;
     }
-    
+
     /**
      * Disables network tracking, prevents network events from being sent to the client.
      */
@@ -166,14 +170,14 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
         }
         this._enabled = false;
     }
-    
+
     /**
      * Specifies whether to always send extra HTTP headers with the requests from this page.
      */
     setExtraHTTPHeaders(params: inspectorCommandTypes.NetworkDomain.SetExtraHTTPHeadersMethodArguments): void {
         //
     }
-    
+
     /**
      * Returns content served for the given request.
      */
@@ -187,9 +191,9 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
                  body: body,
                  base64Encoded: !resource_data.hasTextContent
              };
-        } 
+        }
     }
-    
+
     /**
      * Tells whether clearing browser cache is supported.
      */
@@ -198,14 +202,14 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
             result: false
         };
     }
-    
+
     /**
      * Clears browser cache.
      */
     clearBrowserCache(): void {
         //
     }
-    
+
     /**
      * Tells whether clearing browser cookies is supported.
      */
@@ -214,21 +218,21 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
             result: false
         };
     }
-    
+
     /**
      * Clears browser cookies.
      */
     clearBrowserCookies(): void {
         //
     }
-    
+
     /**
      * Toggles ignoring cache for each request. If <code>true</code>, cache will not be used.
      */
     setCacheDisabled(params: inspectorCommandTypes.NetworkDomain.SetCacheDisabledMethodArguments): void {
         //
     }
-    
+
     /**
      * Loads a resource in the context of a frame on the inspected page without cross origin checks.
      */
@@ -245,7 +249,7 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
             status: 200
         }
     }
-    
+
     public static idSequence: number = 0;
     create(): Request {
         let id = (++NetworkDomainDebugger.idSequence).toString();

--- a/tns-core-modules/module.d.ts
+++ b/tns-core-modules/module.d.ts
@@ -52,7 +52,7 @@ declare namespace NodeJS {
         __inspector?: any;
         __extends: any;
         __onLiveSync: (context?: { type: string, path: string }) => void;
-        __onLiveSyncCore: () => void;
+        __onLiveSyncCore: (context?: { type: string, path: string }) => void;
         __onUncaughtError: (error: NativeScriptError) => void;
         __onDiscardedError: (error: NativeScriptError) => void;
         TNS_WEBPACK?: boolean;

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-core-modules",
   "description": "Telerik NativeScript Core Modules",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "homepage": "https://www.nativescript.org",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
-    "tns-core-modules-widgets": "5.2.0",
+    "tns-core-modules-widgets": "next",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -105,6 +105,14 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
         this._updateStyleScope(cssFileName);
     }
 
+    public changeCssFile(cssFileName: string): void {
+        const scope = this._styleScope;
+        if (scope && cssFileName) {
+            scope.changeCssFile(cssFileName);
+            this._onCssStateChange();
+        }
+    }
+
     public _updateStyleScope(cssFileName?: string, cssString?: string, css?: string): void {
         let scope = this._styleScope;
         if (!scope) {

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -18,14 +18,14 @@ export function PseudoClassHandler(...pseudoClasses: string[]): MethodDecorator;
 /**
  * Specifies the type name for the instances of this View class,
  * that is used when matching CSS type selectors.
- * 
+ *
  * Usage:
  * ```
  * @CSSType("Button")
  * class Button extends View {
  * }
  * ```
- * 
+ *
  * Internally the decorator set `Button.prototype.cssType = "Button"`.
  * @param type The type name, e. g. "Button", "Label", etc.
  */
@@ -50,8 +50,8 @@ export type px = number;
 export type percent = number;
 
 /**
- * The Point interface describes a two dimensional location. 
- * It has two properties x and y, representing the x and y coordinate of the location. 
+ * The Point interface describes a two dimensional location.
+ * It has two properties x and y, representing the x and y coordinate of the location.
  */
 export interface Point {
     /**
@@ -66,8 +66,8 @@ export interface Point {
 }
 
 /**
- * The Size interface describes abstract dimensions in two dimensional space. 
- * It has two properties width and height, representing the width and height values of the size. 
+ * The Size interface describes abstract dimensions in two dimensional space.
+ * It has two properties width and height, representing the width and height values of the size.
  */
 export interface Size {
     /**
@@ -99,8 +99,8 @@ export interface ShownModallyData extends EventData {
 }
 
 /**
- * This class is the base class for all UI components. 
- * A View occupies a rectangular area on the screen and is responsible for drawing and layouting of all UI components within. 
+ * This class is the base class for all UI components.
+ * A View occupies a rectangular area on the screen and is responsible for drawing and layouting of all UI components within.
  */
 export abstract class View extends ViewBase {
     /**
@@ -475,13 +475,13 @@ export abstract class View extends ViewBase {
      * [Deprecated. Please use the on() instead.] Adds a gesture observer.
      * @param type - Type of the gesture.
      * @param callback - A function that will be executed when gesture is received.
-     * @param thisArg - An optional parameter which will be used as `this` context for callback execution. 
+     * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
      */
     observe(type: GestureTypes, callback: (args: GestureEventData) => void, thisArg?: any);
 
     /**
      * A basic method signature to hook an event listener (shortcut alias to the addEventListener method).
-     * @param eventNames - String corresponding to events (e.g. "propertyChange"). Optionally could be used more events separated by `,` (e.g. "propertyChange", "change") or you can use gesture types. 
+     * @param eventNames - String corresponding to events (e.g. "propertyChange"). Optionally could be used more events separated by `,` (e.g. "propertyChange", "change") or you can use gesture types.
      * @param callback - Callback function which will be executed when event is raised.
      * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
      */
@@ -527,12 +527,12 @@ export abstract class View extends ViewBase {
     modal: View;
 
     /**
-     * Animates one or more properties of the view based on the supplied options. 
+     * Animates one or more properties of the view based on the supplied options.
      */
     public animate(options: AnimationDefinition): AnimationPromise;
 
     /**
-     * Creates an Animation object based on the supplied options. 
+     * Creates an Animation object based on the supplied options.
      */
     public createAnimation(options: AnimationDefinition): Animation;
 
@@ -562,7 +562,7 @@ export abstract class View extends ViewBase {
     public getActualSize(): Size;
 
     /**
-     * Derived classes can override this method to handle Android back button press. 
+     * Derived classes can override this method to handle Android back button press.
      */
     onBackPressed(): boolean;
 
@@ -575,7 +575,7 @@ export abstract class View extends ViewBase {
     /**
      * @private
      * Adds a new values to current css.
-     * @param cssString - A valid css which will be added to current css. 
+     * @param cssString - A valid css which will be added to current css.
      */
     addCss(cssString: string): void;
 
@@ -586,13 +586,20 @@ export abstract class View extends ViewBase {
      */
     addCssFile(cssFileName: string): void;
 
+    /**
+     * @private
+     * Changes the current css to the content of the file.
+     * @param cssFileName - A valid file name (from the application root) which contains a valid css.
+     */
+    changeCssFile(cssFileName: string): void;
+
     // Lifecycle events
     _getNativeViewsCount(): number;
 
     _eachLayoutView(callback: (View) => void): void;
-    
+
     /**
-     * Iterates over children of type View. 
+     * Iterates over children of type View.
      * @param callback Called for each child of type View. Iteration stops if this method returns falsy value.
      */
     public eachChildView(callback: (view: View) => boolean): void;
@@ -673,7 +680,7 @@ export abstract class View extends ViewBase {
     /**
      * @private
      */
-    _onLivesync(): boolean;
+    _onLivesync(context?: { type: string, path: string }): boolean;
     /**
      * @private
      */
@@ -681,9 +688,9 @@ export abstract class View extends ViewBase {
 
     /**
      * Updates styleScope or create new styleScope.
-     * @param cssFileName 
-     * @param cssString 
-     * @param css 
+     * @param cssFileName
+     * @param cssString
+     * @param css
      */
     _updateStyleScope(cssFileName?: string, cssString?: string, css?: string): void;
 
@@ -715,7 +722,7 @@ export abstract class View extends ViewBase {
 }
 
 /**
- * Base class for all UI components that are containers. 
+ * Base class for all UI components that are containers.
  */
 export class ContainerView extends View {
     /**
@@ -725,7 +732,7 @@ export class ContainerView extends View {
 }
 
 /**
- * Base class for all UI components that implement custom layouts. 
+ * Base class for all UI components that implement custom layouts.
  */
 export class CustomLayoutView extends ContainerView {
     //@private

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -946,6 +946,9 @@ export namespace ios {
                 return;
             }
 
+            // Unify translucent and opaque bars layout
+            this.extendedLayoutIncludesOpaqueBars = true;
+
             updateAutoAdjustScrollInsets(this, owner);
 
             if (!owner.parent) {

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -76,7 +76,7 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
                     if (backstackIndex !== -1) {
                         backstack = backstackIndex;
                     } else {
-                        // NOTE: We don't search for entries in navigationQueue because there is no way for 
+                        // NOTE: We don't search for entries in navigationQueue because there is no way for
                         // developer to get reference to BackstackEntry unless transition is completed.
                         // At that point the entry is put in the backstack array.
                         // If we start to return Backstack entry from navigate method then
@@ -153,7 +153,7 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
     //     }
 
     //     let currentPage = this._currentEntry.resolvedPage;
-    //     let currentNavigationEntry = this._currentEntry.entry; 
+    //     let currentNavigationEntry = this._currentEntry.entry;
     //     if (currentPage["isBiOrientational"] && currentNavigationEntry.moduleName) {
     //         if (this.canGoBack()){
     //             this.goBack();
@@ -162,7 +162,7 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
     //             currentNavigationEntry.backstackVisible = false;
     //         }
     //         // Re-navigate to the same page so the other (.port or .land) xml is loaded.
-    //         this.navigate(currentNavigationEntry);                   
+    //         this.navigate(currentNavigationEntry);
     //     }
     // }
 
@@ -224,7 +224,7 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
         newPage.onNavigatedTo(isBack);
 
         // Reset executing entry after NavigatedTo is raised;
-        // we do not want to execute two navigations in parallel in case 
+        // we do not want to execute two navigations in parallel in case
         // additional navigation is triggered from the NavigatedTo handler.
         this._executingEntry = null;
     }
@@ -259,7 +259,7 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
                 return true;
             }
         }
-    
+
         return false;
     }
 
@@ -563,7 +563,7 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
         return result;
     }
 
-    public _onLivesync(): boolean {
+    public _onLivesync(context?: ModuleContext): boolean {
         super._onLivesync();
 
         if (!this._currentEntry || !this._currentEntry.entry) {
@@ -571,6 +571,17 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
         }
 
         const currentEntry = this._currentEntry.entry;
+        if (context && context.path) {
+            // Use topmost instead of this to cover nested frames scenario
+            const topmostFrame = topmost();
+            const moduleName = topmostFrame.currentEntry.moduleName;
+            const reapplyStyles = context.path.includes(moduleName);
+            if (reapplyStyles && moduleName) {
+                topmostFrame.currentPage.changeCssFile(context.path);
+                return true;
+            }
+        }
+
         const newEntry: NavigationEntry = {
             animated: false,
             clearHistory: true,

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -100,6 +100,9 @@ class UIViewControllerImpl extends UIViewController {
             frame._updateActionBar(owner);
         }
 
+        // Unify translucent and opaque bars layout
+        this.extendedLayoutIncludesOpaqueBars = true;
+
         // Set autoAdjustScrollInsets in will appear - as early as possible
         iosView.updateAutoAdjustScrollInsets(this, owner);
 
@@ -235,14 +238,9 @@ class UIViewControllerImpl extends UIViewController {
                 }
 
                 if (frameParent) {
-                    let additionalInsetsTop = 0;
-
-                    // if current page has flat action bar, inherited top insets should be ignored.
-                    if (!owner.actionBar.flat) {
-                        const parentPageInsetsTop = frameParent.nativeViewProtected.safeAreaInsets.top;
-                        const currentInsetsTop = this.view.safeAreaInsets.top;
-                        additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
-                    }
+                    const parentPageInsetsTop = frameParent.nativeViewProtected.safeAreaInsets.top;
+                    const currentInsetsTop = this.view.safeAreaInsets.top;
+                    const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
 
                     const parentPageInsetsBottom = frameParent.nativeViewProtected.safeAreaInsets.bottom;
                     const currentInsetsBottom = this.view.safeAreaInsets.bottom;
@@ -366,12 +364,6 @@ export class Page extends PageBase {
         const childTop = 0 + insets.top;
         const childRight = right - insets.right;
         let childBottom = bottom - insets.bottom;
-
-        if (majorVersion >= 11 && this.actionBar.flat) {
-            // on iOS 11 the flat action bar changes the fullscreen size
-            // the top of the page is the new fullscreen
-            childBottom -= top;
-        }
 
         View.layoutChild(this, this.layoutView, childLeft, childTop, childRight, childBottom);
     }

--- a/tns-core-modules/ui/styling/style-scope.d.ts
+++ b/tns-core-modules/ui/styling/style-scope.d.ts
@@ -29,6 +29,7 @@ export class CssState {
 export class StyleScope {
     public css: string;
     public addCss(cssString: string, cssFileName: string): void;
+    public changeCssFile(cssFileName: string): void;
 
     public static createSelectorsFromCss(css: string, cssFileName: string, keyframes: Object): RuleSet[];
     public static createSelectorsFromImports(tree: SyntaxTree, keyframes: Object): RuleSet[];

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -570,6 +570,19 @@ export class StyleScope {
     }
 
     @profile
+    private changeCssFile(cssFileName: string): void {
+        if (!cssFileName) {
+            return;
+        }
+
+        const cssSelectors = CSSSource.fromURI(cssFileName, this._keyframes);
+        this._css = cssSelectors.source;
+        this._localCssSelectors = cssSelectors.selectors;
+        this._localCssSelectorVersion++;
+        this.ensureSelectors();
+    }
+
+    @profile
     private setCss(cssString: string, cssFileName?): void {
         this._css = cssString;
 

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -36,6 +36,9 @@ class UITabBarControllerImpl extends UITabBarController {
             return;
         }
 
+        // Unify translucent and opaque bars layout
+        this.extendedLayoutIncludesOpaqueBars = true;
+
         iosView.updateAutoAdjustScrollInsets(this, owner);
 
         if (!owner.parent) {

--- a/tns-platform-declarations/package.json
+++ b/tns-platform-declarations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tns-platform-declarations",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Platform-specific TypeScript declarations for NativeScript for accessing native objects",
   "main": "",
   "scripts": {


### PR DESCRIPTION
The `extendedLayoutIncludesOpaqueBars` property set to `true` unifies layout behavior between translucent and opaque bars in iOS. Remove additional special handling for flat action bars.

fixes https://github.com/NativeScript/NativeScript/issues/6891
fixes https://github.com/NativeScript/NativeScript/issues/6684

