### PR TITLE
fix(docs): Move `NativeScriptError` declaration to a separate file

### DIFF
--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -39,7 +39,7 @@ import {
     iOSApplication,
     LoadAppCSSEventData,
     UnhandledErrorEventData,
-    DiscardedErrorEventData
+    DiscardedErrorEventData,
 } from "./application";
 
 export { UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData };

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -2,8 +2,8 @@
  * Contains the application abstraction with all related methods.
  * @module "application"
  */ /** */
+/// <reference path="../nativescript-error.d.ts" />
 
-///<reference path="../tns-core-modules.d.ts" /> Include global typings
 import { NavigationEntry, View, Observable, EventData } from "../ui/frame";
 
 /**

--- a/tns-core-modules/module.d.ts
+++ b/tns-core-modules/module.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./nativescript-error.d.ts" />
 declare var global: NodeJS.Global;
 
 interface ModuleResolver {
@@ -84,16 +85,6 @@ interface ModuleContext {
      * The path of the module for replacement.
      */
     path: string;
-}
-
-/**
- * An extended JavaScript Error which will have the nativeError property initialized in case the error is caused by executing platform-specific code.
- */
-interface NativeScriptError extends Error {
-    /**
-     * Represents the native error object.
-     */
-    nativeError: any;
 }
 
 // Define a minimal subset of NodeRequire and NodeModule so user apps can compile without

--- a/tns-core-modules/nativescript-error.d.ts
+++ b/tns-core-modules/nativescript-error.d.ts
@@ -1,0 +1,9 @@
+/**
+ * An extended JavaScript Error which will have the nativeError property initialized in case the error is caused by executing platform-specific code.
+ */
+declare interface NativeScriptError extends Error {
+    /**
+     * Represents the native error object.
+     */
+    nativeError: any;
+}

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -2,7 +2,6 @@
  * @module "ui/core/view"
  */ /** */
 
-///<reference path="../../../tns-core-modules.d.ts" /> Include global typings
 import { ViewBase, Property, InheritedProperty, EventData, Color } from "../view-base";
 import { Animation, AnimationDefinition, AnimationPromise } from "../../animation";
 import { HorizontalAlignment, VerticalAlignment, Visibility, Length, PercentLength } from "../../styling/style-properties";

--- a/tns-core-modules/ui/page/page.d.ts
+++ b/tns-core-modules/ui/page/page.d.ts
@@ -3,7 +3,6 @@
  * @module "ui/page"
  */ /** */
 
-///<reference path="../../tns-core-modules.d.ts" /> Include global typings
 import { ShownModallyData } from "../core/view";
 import { ContentView, EventData, Property, Color, CssProperty, Style } from "../content-view";
 import { Frame } from "../frame";
@@ -106,7 +105,7 @@ export class Page extends ContentView {
 
     /**
      * A basic method signature to hook an event listener (shortcut alias to the addEventListener method).
-     * @param eventNames - String corresponding to events (e.g. "propertyChange"). Optionally could be used more events separated by `,` (e.g. "propertyChange", "change"). 
+     * @param eventNames - String corresponding to events (e.g. "propertyChange"). Optionally could be used more events separated by `,` (e.g. "propertyChange", "change").
      * @param callback - Callback function which will be executed when event is raised.
      * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
      */


### PR DESCRIPTION
It is used by `application.d.ts` and needs to be documented. The reason
that it wasn't included in the documentation by now is that `tns-core-modules.d.ts`
(which imports `module.d.ts`) defines types which are part of the internal
modules and runtimes APIs. As such they are excluded from the generation
of API documentation.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

related to https://github.com/NativeScript/docs/issues/1541