### PR TITLE
fix(android-animations): reuse animatorSet to prevent high memory usage

### DIFF
--- a/tns-core-modules/ui/animation/animation.d.ts
+++ b/tns-core-modules/ui/animation/animation.d.ts
@@ -126,7 +126,7 @@ export type AnimationPromise = Promise<void> & Cancelable;
  */
 export class Animation {
     constructor(animationDefinitions: Array<AnimationDefinition>, playSequentially?: boolean);
-    public play: () => AnimationPromise;
+    public play: (resetOnFinish?: boolean) => AnimationPromise;
     public cancel: () => void;
     public isPlaying: boolean;
     public _resolveAnimationCurve(curve: any): any;

--- a/tns-core-modules/ui/animation/keyframe-animation.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.ts
@@ -243,8 +243,10 @@ export class KeyframeAnimation implements KeyframeAnimationDefinition {
                 this._nativeAnimations.push(animation);
             }
 
+            const isLastIteration = iterations - 1 <= 0;
+
             // Catch the animation cancel to prevent unhandled promise rejection warnings
-            animation.play().then(() => {
+            animation.play(isLastIteration).then(() => {
                 this.animate(view, index + 1, iterations);
             }, (error: any) => {
                 traceWrite(typeof error === "string" ? error : error.message, traceCategories.Animation, traceType.warn);


### PR DESCRIPTION
Do not recreate native animators when looping animation inside keyframe animation. 

__Android API > 23:__ Reusing animatorSet instead of recreating it on every animation iteration. This results in even less memory usage. Recreating it on every loop will lead to higher memory peaks (that will be collected a bit later by the GC)

_Side note: `pulse` CSS animation consist multiple keyframes that animate the scale of an object to different values in a different times. New Animation is created for every keyframe in the keyframes rule. These animations (keyframes) will play sequentially and will repeat all together for specified iterations (or `infinite`). Every Animation (keyframe) has a AnimatorSet that holds multiple Animators depending on the number of properties it should animate. We do not want to recreate these Animators on every Animation (keyframe) replay._

Fix https://github.com/NativeScript/NativeScript/issues/5731