### PR TITLE
fix(android): resource ID #0xffffffec not found on nav

### DIFF
--- a/tns-core-modules/ui/frame/fragment.transitions.android.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.android.ts
@@ -87,19 +87,19 @@ export function _setAndroidFragmentTransitions(
     }
 
     let useLollipopTransition = !!(name && (name.indexOf("slide") === 0 || name === "fade" || name === "explode") && sdkVersion() >= 21);
-    // [nested frames / fragments] force disable lollipop transitions in case nested fragments 
-    // are detected as applying dummy animator to the nested fragment with the same duration as 
-    // the exit animator of the removing parent fragment as a workaround for 
+    // [nested frames / fragments] force disable lollipop transitions in case nested fragments
+    // are detected as applying dummy animator to the nested fragment with the same duration as
+    // the exit animator of the removing parent fragment as a workaround for
     // https://code.google.com/p/android/issues/detail?id=55228 works only if custom animations are
     // used
     // NOTE: this effectively means you cannot use Explode transition in nested frames scenarios as
     // we have implementations only for slide, fade, and flip
-    if (currentFragment && 
+    if (currentFragment &&
         currentFragment.getChildFragmentManager() &&
         currentFragment.getChildFragmentManager().getFragments().toArray().length > 0) {
         useLollipopTransition = false;
     }
-    
+
     if (!animated) {
         name = "none";
     } else if (transition) {
@@ -114,8 +114,9 @@ export function _setAndroidFragmentTransitions(
     let currentFragmentNeedsDifferentAnimation = false;
     if (currentEntry) {
         _updateTransitions(currentEntry);
-        if (currentEntry.transitionName !== name
-            || currentEntry.transition !== transition) {
+        if (currentEntry.transitionName !== name ||
+            currentEntry.transition !== transition ||
+            !useLollipopTransition) {
             clearExitAndReenterTransitions(currentEntry, true);
             currentFragmentNeedsDifferentAnimation = true;
         }


### PR DESCRIPTION
Fixes: https://github.com/NativeScript/NativeScript/issues/6810

The problem is not related to the sidedrawer and can be reproduced with plain navigation between pages as well:
1. Default home page (no nested frames/fragments)
2. Navigate to a second page that contains tabview (implicitly this means nested frames/fragments)
3. Navigate to a third page (no nested frames/fragments) --> exception occurs

This problem is caused by https://github.com/NativeScript/NativeScript/pull/6677 and basically is triggered by not properly setting up transitions/animators logic upon handling fragments with and without nested fragments upon navigation.