### PR TITLE
Make NodeRequire declaration match the latest webpack-env one.

### DIFF
--- a/tns-core-modules/tns-core-modules.d.ts
+++ b/tns-core-modules/tns-core-modules.d.ts
@@ -22,12 +22,15 @@ declare var console: Console;
 declare var require: NodeRequire;
 
 // Extend NodeRequire with the webpack's require context extension.
+interface RequireContext {
+    keys(): string[];
+    (id: string): any;
+    <T>(id: string): T;
+    resolve(id: string): string;
+}
+
 interface NodeRequire {
-    context(root: string, recursive: boolean, filter: RegExp): {
-        (module: string): any;
-        id: number;
-        keys(): string[];
-    }
+    context(path: string, deep?: boolean, filter?: RegExp): RequireContext;
 }
 
 declare var __dirname: string;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

See https://github.com/NativeScript/NativeScript/issues/6961

## What is the new behavior?

Now there are no linter errors if using `webpack-env` dependency.

Closes https://github.com/NativeScript/NativeScript/issues/6961

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

