### PR TITLE
fix(ios): disable default tab reselect behavior

### DIFF
--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -90,6 +90,10 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
             owner._handleTwoNavigationBars(backToMoreWillBeVisible);
         }
 
+        if ((<any>tabBarController).selectedViewController === viewController) {
+            return false;
+        }
+
         (<any>tabBarController)._willSelectViewController = viewController;
 
         return true;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
On iOS by default the TabView resets the navigation in a single tab when the tab is re-selected. This breaks navigation as it's not handled by NS.

## What is the new behavior?
This behavior is disabled.

Fixes https://github.com/NativeScript/nativescript-angular/issues/1466

