### PR TITLE
feat(): local icon handling in actionbar and tabview

### DIFF
--- a/apps/app/ui-tests-app/action-bar/icons.ts
+++ b/apps/app/ui-tests-app/action-bar/icons.ts
@@ -1,0 +1,5 @@
+﻿import * as frame from "tns-core-modules/ui/frame";
+
+export function navigate(args) {
+    frame.topmost().navigate("ui-tests-app/action-bar/clean");
+}

--- a/apps/app/ui-tests-app/action-bar/icons.xml
+++ b/apps/app/ui-tests-app/action-bar/icons.xml
@@ -1,0 +1,13 @@
+<Page>
+  <Page.actionBar>
+    <ActionBar>
+      <ActionBar.actionItems>
+        <ActionItem icon="res://icon" tap="navigate"/>
+        <ActionItem icon="res://add_to_fav" tap="navigate"/>
+      </ActionBar.actionItems>
+    </ActionBar>
+  </Page.actionBar>
+  <StackLayout>
+    <Button text="go to cleared page" tap="navigate"/>
+  </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/action-bar/local-icons.ts
+++ b/apps/app/ui-tests-app/action-bar/local-icons.ts
@@ -1,0 +1,5 @@
+﻿import * as frame from "tns-core-modules/ui/frame";
+
+export function navigate(args) {
+    frame.topmost().navigate("ui-tests-app/action-bar/clean");
+}

--- a/apps/app/ui-tests-app/action-bar/local-icons.xml
+++ b/apps/app/ui-tests-app/action-bar/local-icons.xml
@@ -1,0 +1,13 @@
+<Page>
+  <Page.actionBar>
+    <ActionBar>
+      <ActionBar.actionItems>
+        <ActionItem icon="~/ui-tests-app/resources/images/icon.png" tap="navigate"/>
+        <ActionItem icon="~/ui-tests-app/resources/images/add_to_fav@3x.png" tap="navigate"/>
+      </ActionBar.actionItems>
+    </ActionBar>
+  </Page.actionBar>
+  <StackLayout>
+    <Button text="go to cleared page" tap="navigate"/>
+  </StackLayout>
+</Page>

--- a/apps/app/ui-tests-app/action-bar/main-page.ts
+++ b/apps/app/ui-tests-app/action-bar/main-page.ts
@@ -15,6 +15,8 @@ export function loadExamples() {
     examples.set("actBG", "action-bar/background");
     examples.set("actStyle", "action-bar/all");
     examples.set("actIcons", "action-bar/system-icons");
+    examples.set("actLocalIcons", "action-bar/local-icons");
+    examples.set("actResIcons", "action-bar/icons");
     examples.set("actView", "action-bar/action-view");
     examples.set("actionItemPosition", "action-bar/action-item-position");
     examples.set("actBGCss", "action-bar/background-css");

--- a/apps/app/ui-tests-app/tab-view/main-page.ts
+++ b/apps/app/ui-tests-app/tab-view/main-page.ts
@@ -19,6 +19,7 @@ export function loadExamples() {
     examples.set("tabmore", "tab-view/tab-view-more");
     examples.set("tabViewCss", "tab-view/tab-view-css");
     examples.set("tab-view-icons", "tab-view/tab-view-icon");
+    examples.set("tab-view-icons-local", "tab-view/tab-view-icon-local");
     examples.set("tab-view-icon-change", "tab-view/tab-view-icon-change");
     examples.set("text-transform", "tab-view/text-transform");
     examples.set("tab-view-bottom-position", "tab-view/tab-view-bottom-position");

--- a/apps/app/ui-tests-app/tab-view/tab-view-icon-local.ts
+++ b/apps/app/ui-tests-app/tab-view/tab-view-icon-local.ts
@@ -1,0 +1,21 @@
+import { EventData } from "tns-core-modules/data/observable";
+import { Button } from "tns-core-modules/ui/button";
+import { TabView } from "tns-core-modules/ui/tab-view";
+
+let iconModes = ["automatic", "alwaysOriginal", "alwaysTemplate", undefined];
+
+export const onNavigate = updateButtons;
+
+export function onChangeRenderingMode(args: EventData) {
+    let tabView = (<Button>args.object).page.getViewById<TabView>("tab-view");
+    tabView.iosIconRenderingMode = <"automatic" | "alwaysOriginal" | "alwaysTemplate">iconModes[(iconModes.indexOf(tabView.iosIconRenderingMode) + 1) % iconModes.length];
+    updateButtons(args);
+}
+
+function updateButtons(args) {
+    let button = (<Button>args.object);
+    let tabView = button.page.getViewById<TabView>("tab-view");
+    for (let i = 0, length = tabView.items.length; i < length; i++) {
+        (<Button>tabView.items[i].view).text = "" + tabView.iosIconRenderingMode;
+    }
+}

--- a/apps/app/ui-tests-app/tab-view/tab-view-icon-local.xml
+++ b/apps/app/ui-tests-app/tab-view/tab-view-icon-local.xml
@@ -1,0 +1,26 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="onNavigate">
+    <TabView id="tab-view" tabTextColor="green" selectedTabTextColor="red" tabBackgroundColor="yellow">
+        <TabView.items>
+            <TabViewItem iconSource="~/ui-tests-app/resources/images/icon.png">
+                <TabViewItem.view>
+                    <Button text="undefined" tap="onChangeRenderingMode"/>
+                </TabViewItem.view>
+            </TabViewItem>
+            <TabViewItem iconSource="~/ui-tests-app/resources/images/add_to_fav@3x.png">
+                <TabViewItem.view>
+                    <Button text="undefined" tap="onChangeRenderingMode"/>
+                </TabViewItem.view>
+            </TabViewItem>
+            <TabViewItem iconSource="~/ui-tests-app/resources/images/icon.png" title="NativeScript">
+                <TabViewItem.view>
+                    <Button text="undefined" tap="onChangeRenderingMode"/>
+                </TabViewItem.view>
+            </TabViewItem>
+            <TabViewItem iconSource="~/ui-tests-app/resources/images/add_to_fav@3x.png" title="Favorites">
+                <TabViewItem.view>
+                    <Button text="undefined" tap="onChangeRenderingMode"/>
+                </TabViewItem.view>
+            </TabViewItem>
+        </TabView.items>
+    </TabView>
+</Page>

--- a/tns-core-modules/ui/action-bar/action-bar-common.ts
+++ b/tns-core-modules/ui/action-bar/action-bar-common.ts
@@ -29,6 +29,7 @@ export class ActionBarBase extends View implements ActionBarDefinition {
 
     public title: string;
     public flat: boolean;
+    public iosIconRenderingMode: "automatic" | "alwaysOriginal" | "alwaysTemplate";
 
     get navigationButton(): NavigationButton {
         return this._navigationButton;
@@ -87,6 +88,10 @@ export class ActionBarBase extends View implements ActionBarDefinition {
 
             this.update();
         }
+    }
+    
+    get ios(): any {
+        return undefined;
     }
 
     get android(): AndroidActionBarSettings {
@@ -345,6 +350,9 @@ export function traceMissingIcon(icon: string) {
         traceCategories.Error,
         traceMessageType.error);
 }
+
+export const iosIconRenderingModeProperty = new Property<ActionBarBase, "automatic" | "alwaysOriginal" | "alwaysTemplate">({ name: "iosIconRenderingMode", defaultValue: "alwaysOriginal" });
+iosIconRenderingModeProperty.register(ActionBarBase);
 
 export const textProperty = new Property<ActionItemBase, string>({ name: "text", defaultValue: "", valueChanged: onItemChanged });
 textProperty.register(ActionItemBase);

--- a/tns-core-modules/ui/action-bar/action-bar.android.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.android.ts
@@ -437,7 +437,7 @@ function getDrawableOrResourceId(icon: string, resources: android.content.res.Re
 
         let is = fromFileOrResource(icon);
         if (is) {
-            drawable = new android.graphics.drawable.BitmapDrawable(is.android);
+            drawable = new android.graphics.drawable.BitmapDrawable(appResources, is.android);
         }
 
         result = drawable;

--- a/tns-core-modules/ui/action-bar/action-bar.d.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.d.ts
@@ -42,6 +42,20 @@ export class ActionBar extends View {
     android: AndroidActionBarSettings;
 
     /**
+     * Gets the native iOS [UINavigationBar](https://developer.apple.com/documentation/uikit/uinavigationbar) that represents the user interface for this component. Valid only when running on iOS.
+     */
+    ios: any /* UITabBarController */;
+
+    /**
+     * Gets or set the UIImageRenderingMode of the action bar icons in iOS. Defaults to "alwaysOriginal" 
+     * Valid values are:
+     *  - automatic
+     *  - alwaysOriginal
+     *  - alwaysTemplate  
+     */
+    iosIconRenderingMode: "automatic" | "alwaysOriginal" | "alwaysTemplate";
+
+    /**
      * Updates the action bar.
      */
     update();

--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -120,6 +120,18 @@ export class ActionBar extends ActionBarBase {
         this.layout(0, 0, width, height, false);
     }
 
+    private _getIconRenderingMode(): UIImageRenderingMode {
+        switch (this.iosIconRenderingMode) {
+            case "alwaysOriginal":
+                return UIImageRenderingMode.AlwaysOriginal;
+            case "alwaysTemplate":
+                return UIImageRenderingMode.AlwaysTemplate;
+            case "automatic":
+            default:
+                return UIImageRenderingMode.Automatic;
+        }
+    }
+
     public update() {
         const page = this.page;
         // Page should be attached to frame to update the action bar.
@@ -241,7 +253,8 @@ export class ActionBar extends ActionBarBase {
             barButtonItem = UIBarButtonItem.alloc().initWithBarButtonSystemItemTargetAction(id, tapHandler, "tap");
         } else if (item.icon) {
             const img = loadActionIconFromFileOrResource(item.icon);
-            barButtonItem = UIBarButtonItem.alloc().initWithImageStyleTargetAction(img, UIBarButtonItemStyle.Plain, tapHandler, "tap");
+            const image = img.imageWithRenderingMode(this._getIconRenderingMode());
+            barButtonItem = UIBarButtonItem.alloc().initWithImageStyleTargetAction(image, UIBarButtonItemStyle.Plain, tapHandler, "tap");
         } else {
             barButtonItem = UIBarButtonItem.alloc().initWithTitleStyleTargetAction(item.text + "", UIBarButtonItemStyle.Plain, tapHandler, "tap");
         }

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -12,6 +12,7 @@ import { textTransformProperty, TextTransform, getTransformedText } from "../tex
 import { fromFileOrResource } from "../../image-source";
 import { RESOURCE_PREFIX, ad } from "../../utils/utils";
 import { Frame } from "../frame";
+import * as application from "../../application";
 
 export * from "./tab-view-common";
 
@@ -242,7 +243,7 @@ function createTabItemSpec(item: TabViewItem): org.nativescript.widgets.TabItemS
             const is = fromFileOrResource(item.iconSource);
             if (is) {
                 // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
-                result.iconDrawable = new android.graphics.drawable.BitmapDrawable(is.android);
+                result.iconDrawable = new android.graphics.drawable.BitmapDrawable(application.android.context.getResources(), is.android);
             } else {
                 traceMissingIcon(item.iconSource);
             }

--- a/tns-core-modules/ui/tab-view/tab-view.d.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.d.ts
@@ -100,7 +100,7 @@ export class TabView extends View {
     ios: any /* UITabBarController */;
 
     /**
-     * Gets or set the UIImageRenderingMode of the tab icons in iOS. 
+     * Gets or set the UIImageRenderingMode of the tab icons in iOS.  Defaults to "automatic" 
      * Valid values are:
      *  - automatic
      *  - alwaysOriginal


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
On Android, icons rendered in TabView and Actionbar are not scaled correctly due to the use of a deprecated native Android constructor https://developer.android.com/reference/android/graphics/drawable/BitmapDrawable#BitmapDrawable(android.graphics.Bitmap). 

On iOS, there was no property on ActionBar to specify icon rendering mode and it is hard coded to `alwaysOriginal`, which made the use of image icons limited.

## What is the new behavior?
Fixed the Android issue with the use of the new constructor.

Added `iosIconRenderingMode` on ActionBar. To avoid breaking changes, on ActionBar this property defaults to `alwaysOriginal` and on TabView, it defaults to `automatic`. We should probably change this for 6.0.

Fixes https://github.com/NativeScript/NativeScript/issues/5887

## Tests
* Added 2 new e2e tests for Action Bar - actLocalIcons and actResIcons.
* Added 1 new e2e test for TabView - tab-view-icons-local

