### PR TITLE
fix: expose missing css background* properties on View

### DIFF
--- a/apps/app/ui-tests-app/css/background-image.css
+++ b/apps/app/ui-tests-app/css/background-image.css
@@ -1,0 +1,5 @@
+.testBtn {
+    background-image: url("res://icon");
+    background-repeat: no-repeat;
+    color: black;
+}

--- a/apps/app/ui-tests-app/css/background-image.xml
+++ b/apps/app/ui-tests-app/css/background-image.xml
@@ -1,0 +1,29 @@
+<Page>
+    <GridLayout rows="*,*,*,*,*,*" >
+        <Button backgroundImage="url('~/ui-tests-app/resources/images/no-image.png')" 
+            borderRadius='125' borderWidth='2' borderColor='black' 
+            backgroundRepeat="repeat" backgroundSize="contain" 
+            />
+        <Button row="1" backgroundImage="url('~/ui-tests-app/resources/images/no-image.png')" 
+            borderRadius='5' borderWidth='2' borderColor='black' 
+            backgroundRepeat="repeat-y"
+            />
+        <Button row="2" backgroundImage="url('~/ui-tests-app/resources/images/no-image.png')" 
+            borderRadius='25' borderWidth='2' borderColor='black' 
+            backgroundRepeat="repeat-x"
+            />
+         <Button row="3" backgroundImage="url('res://icon')" 
+            borderRadius='10' borderWidth='2' borderColor='black' 
+            backgroundRepeat="no-repeat"
+            backgroundSize="contain" 
+            height="80" width="180"
+            />
+        <Button row="4" text="css background no-repeat" class="testBtn"/>
+        <Button row="5" backgroundImage="url('res://icon')" 
+            borderRadius='10' borderWidth='2' borderColor='black' 
+            style="background-repeat: no-repeat"
+            backgroundSize="contain" 
+            height="80" width="180"
+            />
+    </GridLayout>
+</Page>

--- a/apps/app/ui-tests-app/css/main-page.ts
+++ b/apps/app/ui-tests-app/css/main-page.ts
@@ -43,5 +43,6 @@ export function loadExamples() {
     examples.set("missing-background-image", "css/missing-background-image");
     examples.set("background-shorthand", "css/background-shorthand");
     examples.set("background-image-linear-gradient", "css/background-image-linear-gradient");
+    examples.set("background-image", "css/background-image");
     return examples;
 }

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -24,6 +24,7 @@ import {
 import { createViewFromEntry } from "../../builder";
 import { StyleScope } from "../../styling/style-scope";
 import { LinearGradient } from "../../styling/linear-gradient";
+import { BackgroundRepeat } from "../../styling/style-properties";
 
 export * from "../../styling/style-properties";
 export * from "../view-base";
@@ -470,6 +471,27 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
     }
     set backgroundImage(value: string | LinearGradient) {
         this.style.backgroundImage = value;
+    }
+
+    get backgroundSize(): string {
+        return this.style.backgroundSize;
+    }
+    set backgroundSize(value: string) {
+        this.style.backgroundSize = value;
+    }
+
+    get backgroundPosition(): string {
+        return this.style.backgroundPosition;
+    }
+    set backgroundPosition(value: string) {
+        this.style.backgroundPosition = value;
+    }
+
+    get backgroundRepeat(): BackgroundRepeat {
+        return this.style.backgroundRepeat;
+    }
+    set backgroundRepeat(value: BackgroundRepeat) {
+        this.style.backgroundRepeat = value;
     }
 
     get minWidth(): Length {


### PR DESCRIPTION
Expose backgroundSize, backgroundRepeat, and backgroundPosition on View. Previously they were only accessible through View.style property and could not be set through xml markup, only css.

This will now work:
``` xml
<Button backgroundImage="url('https://d2odgkulk9w7if.cloudfront.net/images/default-source/home/header-graphic-hp-min.png?sfvrsn=31b70efe_6')"
    borderRadius='125' borderWidth='1' borderColor='black'
    backgroundRepeat="no-repeat" backgroundSize="contain"
    backgroundPosition="center" height='150' width='150' />
```

Fixes: https://github.com/NativeScript/NativeScript/issues/6978