### PR TITLE
refactor: add better err msg for missing main entry

### DIFF
--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -273,16 +273,15 @@ function createRootView(v?: View) {
     let rootView = v;
     if (!rootView) {
         // try to navigate to the mainEntry (if specified)
-        if (mainEntry) {
+        if (!mainEntry) {
+            throw new Error("Main entry is missing. App cannot be started. Verify app bootstrap.");
+        } else {
             if (createRootFrame.value) {
                 const frame = rootView = new Frame();
                 frame.navigate(mainEntry);
             } else {
                 rootView = createViewFromEntry(mainEntry);
             }
-        } else {
-            // TODO: Throw an exception?
-            throw new Error("A Frame must be used to navigate to a Page.");
         }
     }
 

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -1171,6 +1171,10 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 
         if (!rootView) {
             const mainEntry = application.getMainEntry();
+            if (!mainEntry) {
+                throw new Error("Main entry is missing. App cannot be started. Verify app bootstrap.");
+            }
+
             const intent = activity.getIntent();
 
             if (fireLaunchEvent) {


### PR DESCRIPTION
Handles a scenario with NS Playground where it's possible to start the app from a notification, but the app itself doesn't have bootstrap `application.run()` or alternatives on Angular and Vue called.