### PR TITLE
chore: fix app.start deprecation

### DIFF
--- a/tns-core-modules/application/application.android.ts
+++ b/tns-core-modules/application/application.android.ts
@@ -131,9 +131,8 @@ let mainEntry: NavigationEntry;
 let started = false;
 // NOTE: for backwards compatibility. Remove for 4.0.0.
 const createRootFrame = { value: true };
-export function start(entry?: NavigationEntry | string) {
-    console.log("application.start() is deprecated; use application.run() instead");
 
+function _start(entry?: NavigationEntry | string) {
     if (started) {
         throw new Error("Application is already started.");
     }
@@ -146,13 +145,18 @@ export function start(entry?: NavigationEntry | string) {
     }
 }
 
+export function start(entry?: NavigationEntry | string) {
+    console.log("application.start() is deprecated; use application.run() instead");
+    _start(entry);
+}
+
 export function shouldCreateRootFrame(): boolean {
     return createRootFrame.value;
 }
 
 export function run(entry?: NavigationEntry | string) {
     createRootFrame.value = false;
-    start(entry);
+    _start(entry);
 }
 
 const CALLBACKS = "_callbacks";

--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -300,9 +300,7 @@ export function getRootView() {
 // NOTE: for backwards compatibility. Remove for 4.0.0.
 const createRootFrame = { value: true };
 let started: boolean = false;
-export function start(entry?: string | NavigationEntry) {
-    console.log("application.start() is deprecated; use application.run() instead");
-
+function _start(entry?: string | NavigationEntry) {
     mainEntry = typeof entry === "string" ? { moduleName: entry } : entry;
     started = true;
 
@@ -334,9 +332,14 @@ export function start(entry?: string | NavigationEntry) {
     }
 }
 
+export function start(entry?: string | NavigationEntry) {
+    console.log("application.start() is deprecated; use application.run() instead");
+    _start(entry);
+}
+
 export function run(entry?: string | NavigationEntry) {
     createRootFrame.value = false;
-    start(entry);
+    _start(entry);
 }
 
 export function _resetRootView(entry?: NavigationEntry | string) {


### PR DESCRIPTION
Currently app.run relies on app.start so deprecation warning was shown all the time.