### PR TITLE
Remove all export * from ....

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "**/*.js": true,
         "**/*.js.map": true
     },
-    "tslint.configFile": "./build/tslint.json"
+    "tslint.configFile": "./build/tslint.json",
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/apps/app/modaltest/main-page.ts
+++ b/apps/app/modaltest/main-page.ts
@@ -1,4 +1,5 @@
-import { View, EventData } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
+import { EventData } from "tns-core-modules/data/observable";
 
 export function onNavigatingTo(args: EventData) {
     const page = args.object;

--- a/apps/app/modaltest/modal-tab.ts
+++ b/apps/app/modaltest/modal-tab.ts
@@ -1,4 +1,5 @@
-import { View, EventData } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
+import { EventData } from "tns-core-modules/data/observable";
 
 const colors = ["red", "orange", "magenta"];
 let x = 0;

--- a/apps/app/modaltest/page.2.ts
+++ b/apps/app/modaltest/page.2.ts
@@ -1,4 +1,5 @@
-import { View, EventData, ShownModallyData } from "tns-core-modules/ui/core/view";
+import { View, ShownModallyData } from "tns-core-modules/ui/core/view";
+import { EventData } from "tns-core-modules/data/observable";
 
 var x = 0;
 

--- a/apps/app/ui-tests-app/action-bar/icons.ts
+++ b/apps/app/ui-tests-app/action-bar/icons.ts
@@ -1,7 +1,7 @@
 ﻿import * as frame from "tns-core-modules/ui/frame";
-import { EventData } from "tns-core-modules/ui/frame";
 import { Button } from "tns-core-modules/ui/button";
 import { ActionBar } from "tns-core-modules/ui/action-bar";
+import { EventData } from "tns-core-modules/data/observable";
 
 const iconModes = ["automatic", "alwaysOriginal", "alwaysTemplate", undefined];
 

--- a/apps/app/ui-tests-app/action-bar/local-icons.ts
+++ b/apps/app/ui-tests-app/action-bar/local-icons.ts
@@ -1,7 +1,7 @@
 ﻿import * as frame from "tns-core-modules/ui/frame";
-import { EventData } from "tns-core-modules/ui/frame";
 import { Button } from "tns-core-modules/ui/button";
 import { ActionBar } from "tns-core-modules/ui/action-bar";
+import { EventData } from "tns-core-modules/data/observable";
 
 const iconModes = ["automatic", "alwaysOriginal", "alwaysTemplate", undefined];
 

--- a/apps/app/ui-tests-app/action-bar/modal-page-hidden-action-bar.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-page-hidden-action-bar.ts
@@ -1,4 +1,4 @@
-import { ShownModallyData } from "tns-core-modules/ui/page";
+import { ShownModallyData } from "tns-core-modules/ui/core/view";
 
 let closeCallback: Function;
 

--- a/apps/app/ui-tests-app/action-bar/modal-page.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-page.ts
@@ -1,4 +1,4 @@
-import { ShownModallyData } from 'tns-core-modules/ui/core/view';
+import { ShownModallyData } from "tns-core-modules/ui/core/view";
 import { Button } from "tns-core-modules/ui/button";
 import { Label } from "tns-core-modules/ui/label"
 import { Page } from "tns-core-modules/ui/page"

--- a/apps/app/ui-tests-app/action-bar/modal-page.ts
+++ b/apps/app/ui-tests-app/action-bar/modal-page.ts
@@ -1,4 +1,4 @@
-import { ShownModallyData } from "tns-core-modules/ui/page";
+import { ShownModallyData } from 'tns-core-modules/ui/core/view';
 import { Button } from "tns-core-modules/ui/button";
 import { Label } from "tns-core-modules/ui/label"
 import { Page } from "tns-core-modules/ui/page"

--- a/apps/app/ui-tests-app/action-bar/transparent-bg-css.ts
+++ b/apps/app/ui-tests-app/action-bar/transparent-bg-css.ts
@@ -1,4 +1,4 @@
-﻿import frame = require("tns-core-modules/ui/frame");
+﻿import * as frame from "tns-core-modules/ui/frame";
 
 export function navigate(args) {
     frame.topmost().navigate("ui-tests-app/action-bar/clean");

--- a/apps/app/ui-tests-app/css/line-height.ts
+++ b/apps/app/ui-tests-app/css/line-height.ts
@@ -1,4 +1,5 @@
-﻿import { EventData, TextBase } from "tns-core-modules/ui/text-base";
+﻿import { TextBase } from "tns-core-modules/ui/text-base";
+import { EventData } from "tns-core-modules/data/observable";
 
 const values = [3, 7, 13];
 

--- a/apps/app/ui-tests-app/css/margins-paddings-with-percentage.ts
+++ b/apps/app/ui-tests-app/css/margins-paddings-with-percentage.ts
@@ -2,6 +2,7 @@ import * as view from "tns-core-modules/ui/core/view";
 import * as pages from "tns-core-modules/ui/page";
 import { EventData } from "tns-core-modules/data/observable";
 import * as button from "tns-core-modules/ui/button";
+import { getViewById } from "tns-core-modules/ui/core/view-base";
 
 const cssPercentage = `
     Page { background-color: orange; font-size: 8; } 
@@ -47,7 +48,7 @@ export function applyTap(args: EventData) {
 function getBtnText(args: EventData) {
     var parent = (<view.View>args.object).parent;
     if (parent) {
-        var btn = <button.Button>view.getViewById(parent, "button");
+        var btn = <button.Button>getViewById(parent, "button");
         if (btn) {
             if (isSCCWithPercentage) {
                 btn.text = "css with %";

--- a/apps/app/ui-tests-app/css/text-decoration.ts
+++ b/apps/app/ui-tests-app/css/text-decoration.ts
@@ -1,4 +1,5 @@
-﻿import { EventData, TextBase, TextDecoration } from "tns-core-modules/ui/text-base";
+﻿import { TextBase, TextDecoration } from "tns-core-modules/ui/text-base";
+import { EventData } from "tns-core-modules/data/observable";
 
 const possibleValues = [
     "none",

--- a/apps/app/ui-tests-app/font/button.ts
+++ b/apps/app/ui-tests-app/font/button.ts
@@ -1,10 +1,11 @@
 import * as stack from "tns-core-modules/ui/layouts/stack-layout";
 import * as view from "tns-core-modules/ui/core/view";
-import { unsetValue } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
+import { eachDescendant } from "tns-core-modules/ui/core/view-base";
 
 export function resetStyles(args) {
     var stackLayout = <stack.StackLayout>args.object.parent.parent;
-    view.eachDescendant(stackLayout, function (v: view.View) {
+    eachDescendant(stackLayout, function (v: view.View) {
         v.style.fontFamily = unsetValue;
         v.style.fontSize = unsetValue;
         v.style.fontStyle = unsetValue;

--- a/apps/app/ui-tests-app/font/label.ts
+++ b/apps/app/ui-tests-app/font/label.ts
@@ -1,5 +1,7 @@
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
-import { View, unsetValue, eachDescendant } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
+import { eachDescendant } from "tns-core-modules/ui/core/view-base";
+import { unsetValue } from "tns-core-modules/ui/core/properties";
 
 export function resetStyles(args) {
     var stackLayout = <StackLayout>args.object.parent;

--- a/apps/app/ui-tests-app/font/text-field.ts
+++ b/apps/app/ui-tests-app/font/text-field.ts
@@ -1,5 +1,7 @@
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
-import { View, unsetValue, eachDescendant } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
+import { eachDescendant } from "tns-core-modules/ui/core/view-base";
+import { unsetValue } from "tns-core-modules/ui/core/properties";
 
 export function resetStyles(args) {
     var stackLayout = <StackLayout>args.object.parent;

--- a/apps/app/ui-tests-app/font/text-view.ts
+++ b/apps/app/ui-tests-app/font/text-view.ts
@@ -1,5 +1,7 @@
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
-import { View, unsetValue, eachDescendant } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
+import { eachDescendant } from "tns-core-modules/ui/core/view-base";
+import { unsetValue } from "tns-core-modules/ui/core/properties";
 
 export function resetStyles(args) {
     var stackLayout = <StackLayout>args.object.parent;

--- a/apps/app/ui-tests-app/layouts-percent/myview.ts
+++ b/apps/app/ui-tests-app/layouts-percent/myview.ts
@@ -1,5 +1,6 @@
-import { View, PercentLength } from "tns-core-modules/ui/layouts/layout-base";
 import { ViewModelBase } from "../layouts/myview-base";
+import { PercentLength } from "tns-core-modules/ui/styling/style-properties";
+import { View } from "tns-core-modules/ui/core/view";
 
 export class ViewModelWithPercentage extends ViewModelBase {
 

--- a/apps/app/ui-tests-app/layouts/myview-base.ts
+++ b/apps/app/ui-tests-app/layouts/myview-base.ts
@@ -1,4 +1,6 @@
-﻿import { LayoutBase, View, Observable } from "tns-core-modules/ui/layouts/layout-base";
+﻿import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
+import { Observable } from "tns-core-modules/data/observable";
+import { View } from "tns-core-modules/ui/core/view";
 
 export class ViewModelBase extends Observable {
 

--- a/apps/app/ui-tests-app/layouts/myview.ts
+++ b/apps/app/ui-tests-app/layouts/myview.ts
@@ -1,5 +1,5 @@
-﻿import { View } from "tns-core-modules/ui/layouts/layout-base";
-import { ViewModelBase } from "./myview-base";
+﻿import { ViewModelBase } from "./myview-base";
+import { View } from "tns-core-modules/ui/core/view";
 
 export class ViewModel extends ViewModelBase {
 

--- a/apps/app/ui-tests-app/layouts/passThroughParent.ts
+++ b/apps/app/ui-tests-app/layouts/passThroughParent.ts
@@ -1,5 +1,6 @@
-import { EventData, Page } from "tns-core-modules/ui/page/page";
+import { Page } from "tns-core-modules/ui/page/page";
 import { Label } from "tns-core-modules/ui/label/label";
+import { EventData } from "tns-core-modules/data/observable";
 
 const setLabelTextAndLog = (args, text: string) => {
     const page = <Page>args.object.page;

--- a/apps/app/ui-tests-app/list-picker/issue_2895.ts
+++ b/apps/app/ui-tests-app/list-picker/issue_2895.ts
@@ -1,6 +1,5 @@
 import { Page } from "tns-core-modules/ui/page";
-import { Observable } from "tns-core-modules/data/observable";
-import { EventData } from "tns-core-modules/ui/core/view";
+import { Observable, EventData } from "tns-core-modules/data/observable";
 
 export function navigatingTo(args: EventData) {
     let page = <Page>args.object;

--- a/apps/app/ui-tests-app/modal-view/login-page.ts
+++ b/apps/app/ui-tests-app/modal-view/login-page.ts
@@ -1,5 +1,6 @@
-﻿import { Page, ShownModallyData } from "tns-core-modules/ui/page";
+﻿import { Page } from "tns-core-modules/ui/page";
 import { EventData, fromObject } from "tns-core-modules/data/observable";
+import { ShownModallyData } from "tns-core-modules/ui/core/view/view";
 
 export function onShowingModally(args: ShownModallyData) {
     console.log("login-page.onShowingModally, context: " + args.context);

--- a/apps/app/ui-tests-app/text-view/hint-text-color.ts
+++ b/apps/app/ui-tests-app/text-view/hint-text-color.ts
@@ -1,5 +1,5 @@
 import { Page } from "tns-core-modules/ui/page";
-import { unsetValue } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
 import { TextView } from "tns-core-modules/ui/text-view";
 import { TextField } from "tns-core-modules/ui/text-field";
 

--- a/tests/app/navigation/navigation-tests.ts
+++ b/tests/app/navigation/navigation-tests.ts
@@ -1,11 +1,12 @@
 ﻿import * as TKUnit from "../TKUnit";
-import { EventData, Page, NavigatedData } from "tns-core-modules/ui/page";
+import { Page, NavigatedData } from "tns-core-modules/ui/page";
 import { topmost as topmostFrame, NavigationTransition } from "tns-core-modules/ui/frame";
 import { StackLayout, } from "tns-core-modules/ui/layouts/stack-layout";
 import { GridLayout, } from "tns-core-modules/ui/layouts/grid-layout";
 import { Color } from "tns-core-modules/color";
 import * as helper from "../ui/helper";
 import * as frame from "tns-core-modules/ui/frame";
+import { EventData } from "tns-core-modules/data/observable";
 // Creates a random colorful page full of meaningless stuff.
 let id = 0;
 let pageFactory = function (): Page {

--- a/tests/app/pages/fonts-test.ts
+++ b/tests/app/pages/fonts-test.ts
@@ -1,5 +1,5 @@
 import * as stack from "tns-core-modules/ui/layouts/stack-layout";
-import { unsetValue } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
 
 export function buttonTap(args) {
     var stackLayout = <stack.StackLayout>args.object.parent;

--- a/tests/app/pages/page7.ts
+++ b/tests/app/pages/page7.ts
@@ -1,6 +1,6 @@
 ﻿import * as pages from "tns-core-modules/ui/page";
 import * as buttons from "tns-core-modules/ui/button";
-import { VerticalAlignment } from "tns-core-modules/ui/core/view";
+import { VerticalAlignment } from "tns-core-modules/ui/styling/style-properties";
 
 export function createPage() {
     var page = new pages.Page();

--- a/tests/app/ui/action-bar/action-bar-tests-common.ts
+++ b/tests/app/ui/action-bar/action-bar-tests-common.ts
@@ -4,12 +4,13 @@ import * as builder from "tns-core-modules/ui/builder";
 import { Label } from "tns-core-modules/ui/label";
 import { Button } from "tns-core-modules/ui/button";
 import { Page } from "tns-core-modules/ui/page";
-import { View, isIOS } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { fromObject } from "tns-core-modules/data/observable";
 import { topmost } from "tns-core-modules/ui/frame";
 
 // >> actionbar-common-require
 import * as actionBarModule from "tns-core-modules/ui/action-bar";
+import { isIOS } from "tns-core-modules/platform/platform";
 // << actionbar-common-require
 
 export function test_actionItem_inherit_bindingContext() {

--- a/tests/app/ui/frame/frame-tests.android.ts
+++ b/tests/app/ui/frame/frame-tests.android.ts
@@ -1,6 +1,7 @@
 import * as frameModule from "tns-core-modules/ui/frame";
 import * as TKUnit from "../../TKUnit";
-import { unsetValue, PercentLength } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
+import { PercentLength } from "tns-core-modules/ui/styling/style-properties";
 
 export * from "./frame-tests-common";
 

--- a/tests/app/ui/helper.ts
+++ b/tests/app/ui/helper.ts
@@ -1,5 +1,5 @@
 ﻿import * as frame from "tns-core-modules/ui/frame";
-import { ViewBase, View, unsetValue, isIOS } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { Page } from "tns-core-modules/ui/page";
 import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
@@ -11,10 +11,11 @@ import { Color } from "tns-core-modules/color";
 
 import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
 import { FormattedString, Span } from "tns-core-modules/text/formatted-string";
-import { _getProperties, _getStyleProperties } from "tns-core-modules/ui/core/properties";
-import { device } from "tns-core-modules/platform";
+import { _getProperties, _getStyleProperties, unsetValue } from "tns-core-modules/ui/core/properties";
+import { device, isIOS } from "tns-core-modules/platform";
 // TODO: Remove this and get it from global to decouple builder for angular
 import { createViewFromEntry } from "tns-core-modules/ui/builder";
+import { ViewBase } from "tns-core-modules/ui/core/view-base";
 
 const DELTA = 0.1;
 const sdkVersion = parseInt(device.sdkVersion);

--- a/tests/app/ui/layouts/common-layout-tests.ts
+++ b/tests/app/ui/layouts/common-layout-tests.ts
@@ -1,8 +1,10 @@
 ﻿import * as TKUnit from "../../TKUnit";
 import * as layoutHelper from "./layout-helper";
 import * as testModule from "../../ui-test";
-import { LayoutBase, unsetValue, PercentLength } from "tns-core-modules/ui/layouts/layout-base";
+import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
 import * as platform from "tns-core-modules/platform";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
+import { PercentLength } from "tns-core-modules/ui/styling/style-properties";
 
 function getNativeLayoutParams(nativeView: android.view.View): org.nativescript.widgets.CommonLayoutParams {
     var lp = <org.nativescript.widgets.CommonLayoutParams>nativeView.getLayoutParams();

--- a/tests/app/ui/layouts/flexbox-layout-tests.ts
+++ b/tests/app/ui/layouts/flexbox-layout-tests.ts
@@ -51,7 +51,7 @@ export namespace AlignSelf {
     export const STRETCH: "stretch" = "stretch";
 }
 
-import { View, unsetValue, Length, PercentLength } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { Label } from "tns-core-modules/ui/label";
 import * as TKUnit from "../../TKUnit";
 import * as helper from "../helper";
@@ -63,6 +63,8 @@ import { dipToDp, left, top, right, bottom, height, width,
     isLeftAlignedWith, isRightAlignedWith, isTopAlignedWith, isBottomAlignedWith,
     isLeftOf, isRightOf, isBelow, isAbove,
     isLeftWith, isAboveWith, isRightWith, isBelowWith } from "./layout-tests-helper";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
+import { Length, PercentLength } from "tns-core-modules/ui/styling/style-properties";
 
 function waitUntilTestElementLayoutIsValid(view: View, timeoutSec?: number): void {
     TKUnit.waitUntilReady(() => {

--- a/tests/app/ui/layouts/grid-layout-tests.ts
+++ b/tests/app/ui/layouts/grid-layout-tests.ts
@@ -3,7 +3,7 @@ import { GridLayout, ItemSpec } from "tns-core-modules/ui/layouts/grid-layout";
 import { Button } from "tns-core-modules/ui/button";
 import * as TKUnit from "../../TKUnit";
 import * as view from "tns-core-modules/ui/core/view";
-import { unsetValue } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
 import * as builder from "tns-core-modules/ui/builder";
 import * as testModule from "../../ui-test";
 import * as layoutHelper from "./layout-helper";

--- a/tests/app/ui/layouts/layout-tests-helper.ts
+++ b/tests/app/ui/layouts/layout-tests-helper.ts
@@ -1,8 +1,9 @@
-import { View, Length } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import * as TKUnit from "../../TKUnit";
 import { layout } from "tns-core-modules/utils/utils";
 
 import round = layout.round;
+import { Length } from "tns-core-modules/ui/styling/style-properties";
 export const dipToDp = layout.toDevicePixels;
 
 const EPS = 1;

--- a/tests/app/ui/lifecycle/pages/button-counter.ts
+++ b/tests/app/ui/lifecycle/pages/button-counter.ts
@@ -1,5 +1,6 @@
 import * as button from "tns-core-modules/ui/button";
 import * as view from "tns-core-modules/ui/core/view";
+import { colorProperty, backgroundInternalProperty, fontInternalProperty } from "tns-core-modules/ui/styling/style-properties";
 
 export class Button extends button.Button {
     nativeBackgroundRedraws = 0;
@@ -13,21 +14,21 @@ export class Button extends button.Button {
         this.style.on("colorChange", () => this.colorPropertyChangeCount++);
     }
 
-    [view.backgroundInternalProperty.setNative](value) {
+    [backgroundInternalProperty.setNative](value) {
         this.backgroundInternalSetNativeCount++;
-        return super[view.backgroundInternalProperty.setNative](value);
+        return super[backgroundInternalProperty.setNative](value);
     }
-    [view.fontInternalProperty.setNative](value) {
+    [fontInternalProperty.setNative](value) {
         this.fontInternalSetNativeCount++;
-        return super[view.fontInternalProperty.setNative](value);
+        return super[fontInternalProperty.setNative](value);
     }
     _redrawNativeBackground(value: any): void {
         this.nativeBackgroundRedraws++;
         super._redrawNativeBackground(value);
     }
-    [view.colorProperty.setNative](value) {
+    [colorProperty.setNative](value) {
         this.colorSetNativeCount++;
-        return super[view.colorProperty.setNative](value);
+        return super[colorProperty.setNative](value);
     }
 }
 Button.prototype.recycleNativeView = "never";

--- a/tests/app/ui/page/modal-page.ts
+++ b/tests/app/ui/page/modal-page.ts
@@ -1,6 +1,7 @@
 ﻿import { topmost } from "tns-core-modules/ui/frame";
 import * as TKUnit from "../../TKUnit";
-import { Page, ShownModallyData } from "tns-core-modules/ui/page";
+import { Page } from "tns-core-modules/ui/page";
+import { ShownModallyData } from "tns-core-modules/ui/core/view/view";
 
 export var modalPage: Page;
 export function onShowingModally(args) {

--- a/tests/app/ui/page/page-tests-common.ts
+++ b/tests/app/ui/page/page-tests-common.ts
@@ -1,5 +1,5 @@
 // >> article-require-page-module
-import { Page, ShownModallyData, NavigatedData } from "tns-core-modules/ui/page";
+import { Page, NavigatedData } from "tns-core-modules/ui/page";
 // FrameModule is needed in order to have an option to navigate to the new page.
 import { topmost, NavigationEntry } from "tns-core-modules/ui/frame";
 // << article-require-page-module
@@ -17,13 +17,17 @@ exports.pageLoaded = pageLoaded;
 import * as TKUnit from "../../TKUnit";
 import * as helper from "../helper";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
-import { View, PercentLength, unsetValue, EventData, isIOS } from "tns-core-modules/ui/core/view";
+import { View, ShownModallyData } from "tns-core-modules/ui/core/view";
 import { Frame, stack } from "tns-core-modules/ui/frame";
 import { Label } from "tns-core-modules/ui/label";
 import { Color } from "tns-core-modules/color";
 import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view/tab-view";
 import { _resetRootView } from "tns-core-modules/application";
 import { Button } from "tns-core-modules/ui/button/button";
+import { EventData } from "tns-core-modules/data/observable";
+import { isIOS } from "tns-core-modules/platform/platform";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
+import { PercentLength } from "tns-core-modules/ui/styling/style-properties";
 
 export function addLabelToPage(page: Page, text?: string) {
     const label = new Label();

--- a/tests/app/ui/page/page-tests.ios.ts
+++ b/tests/app/ui/page/page-tests.ios.ts
@@ -1,12 +1,14 @@
 ﻿import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view";
-import { Page, layout, View, EventData } from "tns-core-modules/ui/page";
-import { ios as iosView } from "tns-core-modules/ui/core/view";
+import { Page } from "tns-core-modules/ui/page";
+import { ios as iosView, View } from "tns-core-modules/ui/core/view";
 import { Label } from "tns-core-modules/ui/label";
 import { topmost } from "tns-core-modules/ui/frame";
 import * as uiUtils from "tns-core-modules/ui/utils";
 import * as TKUnit from "../../TKUnit";
 import * as helper from "../helper";
 import * as PageTestCommon from "./page-tests-common";
+import { EventData } from "tns-core-modules/data/observable";
+import { layout } from "tns-core-modules/utils/utils";
 
 global.moduleMerge(PageTestCommon, exports);
 

--- a/tests/app/ui/page/page21.ts
+++ b/tests/app/ui/page/page21.ts
@@ -1,4 +1,4 @@
-﻿import { ShownModallyData } from "tns-core-modules/ui/page";
+﻿import { ShownModallyData } from "tns-core-modules/ui/core/view/view";
 
 export function onShownModally(args: ShownModallyData) {
     args.context.childPage = args.object;

--- a/tests/app/ui/root-view/root-view-tests.ts
+++ b/tests/app/ui/root-view/root-view-tests.ts
@@ -1,11 +1,12 @@
 import * as TKUnit from "../../TKUnit";
-import { Page, View } from "tns-core-modules/ui/page";
+import { Page } from "tns-core-modules/ui/page";
 import { Frame, NavigationEntry, stack } from "tns-core-modules/ui/frame";
 import { _resetRootView, getRootView } from "tns-core-modules/application";
 import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view";
 import { GridLayout } from "tns-core-modules/ui/layouts/grid-layout";
 import * as myCustomControlWithoutXml from "./mymodule/MyControl";
 import * as helper from "../helper";
+import { View } from "tns-core-modules/ui/core/view/view";
 
 function createTestFrameRootEntry() {
     const page = new Page();

--- a/tests/app/ui/scroll-view/scroll-view-tests.ts
+++ b/tests/app/ui/scroll-view/scroll-view-tests.ts
@@ -1,6 +1,6 @@
 ﻿import * as TKUnit from "../../TKUnit";
 import { Button } from "tns-core-modules/ui/button";
-import { Page, isIOS } from "tns-core-modules/ui/page";
+import { Page } from "tns-core-modules/ui/page";
 import { UITest } from "../../ui-test";
 import * as layoutHelper from "../layouts/layout-helper";
 import * as frame from "tns-core-modules/ui/frame";
@@ -8,6 +8,7 @@ import * as helper from "../helper";
 
 // >> article-require-scrollview-module
 import { ScrollView, ScrollEventData } from "tns-core-modules/ui/scroll-view";
+import { isIOS } from "tns-core-modules/platform";
 // << article-require-scrollview-module
 
 class ScrollLayoutTest extends UITest<ScrollView> {

--- a/tests/app/ui/styling/style-properties-tests.ts
+++ b/tests/app/ui/styling/style-properties-tests.ts
@@ -8,8 +8,8 @@ import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
 import { Color } from "tns-core-modules/color";
 import { isAndroid, isIOS } from "tns-core-modules/platform";
 import { View } from "tns-core-modules/ui/core/view";
-import { Length, PercentLength } from "tns-core-modules/ui/core/view";
 import * as fontModule from "tns-core-modules/ui/styling/font";
+import { Length, PercentLength } from "tns-core-modules/ui/styling/style-properties";
 
 export function test_setting_textDecoration_property_from_CSS_is_applied_to_Style() {
     test_property_from_CSS_is_applied_to_style("textDecoration", "text-decoration", "underline");

--- a/tests/app/ui/styling/style-tests.ts
+++ b/tests/app/ui/styling/style-tests.ts
@@ -10,7 +10,7 @@ import * as helper from "../../ui/helper";
 import * as types from "tns-core-modules/utils/types";
 import * as viewModule from "tns-core-modules/ui/core/view";
 import { resolveFileNameFromUrl, removeTaggedAdditionalCSS, addTaggedAdditionalCSS } from "tns-core-modules/ui/styling/style-scope";
-import { unsetValue } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
 import * as color from "tns-core-modules/color";
 
 export function test_css_dataURI_is_applied_to_backgroundImageSource() {

--- a/tests/app/ui/styling/value-source-tests.ts
+++ b/tests/app/ui/styling/value-source-tests.ts
@@ -3,7 +3,7 @@ import * as button from "tns-core-modules/ui/button";
 import * as stack from "tns-core-modules/ui/layouts/stack-layout";
 import * as helper from "../helper";
 import * as TKUnit from "../../TKUnit";
-import { unsetValue } from "tns-core-modules/ui/core/view";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
 
 export var test_value_Inherited_after_unset = function () {
     let page = helper.getCurrentPage();

--- a/tests/app/ui/tab-view/tab-view-root-tests.ts
+++ b/tests/app/ui/tab-view/tab-view-root-tests.ts
@@ -1,4 +1,4 @@
-import TKUnit = require("../../TKUnit");
+import * as TKUnit from "../../TKUnit";
 import { isAndroid } from "tns-core-modules/platform";
 import { _resetRootView } from "tns-core-modules/application/";
 import { Frame, NavigationEntry, topmost } from "tns-core-modules/ui/frame";

--- a/tests/app/ui/tab-view/tab-view-tests-native.ios.ts
+++ b/tests/app/ui/tab-view/tab-view-tests-native.ios.ts
@@ -1,4 +1,4 @@
-import tabViewModule = require("tns-core-modules/ui/tab-view");
+import * as tabViewModule from "tns-core-modules/ui/tab-view";
 import * as utils from "tns-core-modules/utils/utils";
 import getter = utils.ios.getter;
 

--- a/tests/app/ui/tab-view/tab-view-tests.ts
+++ b/tests/app/ui/tab-view/tab-view-tests.ts
@@ -1,7 +1,6 @@
 import { UITest } from "../../ui-test";
 import { Label } from "tns-core-modules/ui/label";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
-import { unsetValue } from "tns-core-modules/ui/core/view";
 import * as TKUnit from "../../TKUnit";
 import * as helper from "../helper";
 import * as tabViewTestsNative from "./tab-view-tests-native";
@@ -9,6 +8,7 @@ import * as tabViewTestsNative from "./tab-view-tests-native";
 // Using a TabView requires the "ui/tab-view" module.
 // >> article-require-tabview-module
 import * as tabViewModule from "tns-core-modules/ui/tab-view";
+import { unsetValue } from "tns-core-modules/ui/core/properties";
 // << article-require-tabview-module
 
 export class TabViewTest extends UITest<tabViewModule.TabView> {

--- a/tests/app/ui/text-field/text-field-tests.ts
+++ b/tests/app/ui/text-field/text-field-tests.ts
@@ -1,6 +1,6 @@
 ﻿import * as TKUnit from "../../TKUnit";
 import * as helper from "../helper";
-import { View, isIOS } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { Page } from "tns-core-modules/ui/page";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
 import { Color } from "tns-core-modules/color";
@@ -20,6 +20,7 @@ import { TextField } from "tns-core-modules/ui/text-field";
 import { BindingOptions } from "tns-core-modules/ui/core/bindable";
 
 import { Observable } from "tns-core-modules/data/observable";
+import { isIOS } from "tns-core-modules/platform/platform";
 // << require-observable-binding-options-textfield
 
 // ### Binding two TextFields text property to observable view-model property.

--- a/tests/app/ui/view/view-tests-common.ts
+++ b/tests/app/ui/view/view-tests-common.ts
@@ -1,5 +1,5 @@
 ﻿import * as TKUnit from "../../TKUnit";
-import { View, eachDescendant, getViewById, InheritedProperty, CssProperty, CssAnimationProperty, ShorthandProperty, Property, Style } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { topmost } from "tns-core-modules/ui/frame";
 import { Page } from "tns-core-modules/ui/page";
 import { Button } from "tns-core-modules/ui/button";
@@ -14,6 +14,9 @@ import * as bindable from "tns-core-modules/ui/core/bindable";
 import * as definition from "./view-tests";
 import { isIOS, isAndroid } from "tns-core-modules/platform";
 import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
+import { eachDescendant, getViewById } from "tns-core-modules/ui/core/view-base/view-base";
+import { CssProperty, CssAnimationProperty, Property, ShorthandProperty, InheritedProperty } from "tns-core-modules/ui/core/properties/properties";
+import { Style } from "tns-core-modules/ui/styling/style/style";
 
 export function test_eachDescendant() {
     const test = function (views: Array<View>) {

--- a/tests/app/ui/view/view-tests.android.ts
+++ b/tests/app/ui/view/view-tests.android.ts
@@ -1,7 +1,7 @@
 ﻿import * as TKUnit from "../../TKUnit";
 import * as commonTests from "./view-tests-common";
 import * as helper from "../../ui/helper";
-import { View, isIOS, unsetValue } from "tns-core-modules/ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { Button } from "tns-core-modules/ui/button";
 import * as types from "tns-core-modules/utils/types";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
@@ -9,6 +9,8 @@ import { Label } from "tns-core-modules/ui/label";
 import * as frame from "tns-core-modules/ui/frame";
 import * as trace from "tns-core-modules/trace";
 import { Color } from "tns-core-modules/color";
+import { isIOS } from "tns-core-modules/platform/platform";
+import { unsetValue } from "tns-core-modules/ui/core/properties/properties";
 // enable the trace, it is disabled by default
 trace.enable();
 

--- a/tests/app/xml-declaration/xml-declaration-tests.ts
+++ b/tests/app/xml-declaration/xml-declaration-tests.ts
@@ -82,7 +82,7 @@ export function test_loadInheritedPageAndResolveFromChild() {
         let discoveredAncestorByBaseType = viewBaseModule.getAncestor(contentLabel, Page);
         TKUnit.assertEqual(page, discoveredAncestorByBaseType);
 
-        let discoveredAncestorByInheritedTypeName = viewBaseModule.getAncestor(contentLabel, 'InheritedPage');
+        let discoveredAncestorByInheritedTypeName = viewBaseModule.getAncestor(contentLabel, "InheritedPage");
         TKUnit.assertEqual(page, discoveredAncestorByInheritedTypeName);
     });
 }

--- a/tests/app/xml-declaration/xml-declaration-tests.ts
+++ b/tests/app/xml-declaration/xml-declaration-tests.ts
@@ -21,11 +21,12 @@ import * as myCustomControlWithoutXml from "./mymodule/MyControl";
 import * as listViewModule from "tns-core-modules/ui/list-view";
 import * as helper from "../ui/helper";
 import * as viewModule from "tns-core-modules/ui/core/view";
+import * as viewBaseModule from "tns-core-modules/ui/core/view-base";
 import * as platform from "tns-core-modules/platform";
 import * as gesturesModule from "tns-core-modules/ui/gestures";
 import * as segmentedBar from "tns-core-modules/ui/segmented-bar";
 import { Source } from "tns-core-modules/utils/debug";
-import { PercentLength, Length } from "tns-core-modules/ui/core/view";
+import { Length, PercentLength } from "tns-core-modules/ui/styling/style-properties";
 
 export function test_load_IsDefined() {
     TKUnit.assertTrue(types.isFunction(builder.load), "ui/builder should have load method!");
@@ -78,10 +79,10 @@ export function test_loadInheritedPageAndResolveFromChild() {
         let discoveredPage = contentLabel.page;
         TKUnit.assertEqual(page, discoveredPage);
 
-        let discoveredAncestorByBaseType = viewModule.getAncestor(contentLabel, Page);
+        let discoveredAncestorByBaseType = viewBaseModule.getAncestor(contentLabel, Page);
         TKUnit.assertEqual(page, discoveredAncestorByBaseType);
 
-        let discoveredAncestorByInheritedTypeName = viewModule.getAncestor(contentLabel, "InheritedPage");
+        let discoveredAncestorByInheritedTypeName = viewBaseModule.getAncestor(contentLabel, 'InheritedPage');
         TKUnit.assertEqual(page, discoveredAncestorByInheritedTypeName);
     });
 }
@@ -678,7 +679,7 @@ export function test_parse_NestedRepeaters() {
     function testAction(views: Array<viewModule.View>) {
         p.bindingContext = [["0", "1"], ["2", "3"]];
         let lbls = new Array<Label>();
-        view.eachDescendant(p, (v) => {
+        viewBaseModule.eachDescendant(p, (v) => {
             if (v instanceof Label) {
                 lbls.push(v);
             }

--- a/tns-core-modules/application/application-common.ts
+++ b/tns-core-modules/application/application-common.ts
@@ -40,7 +40,7 @@ import {
     LoadAppCSSEventData,
     UnhandledErrorEventData,
     DiscardedErrorEventData,
-} from "./application";
+} from ".";
 
 export { UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData };
 

--- a/tns-core-modules/application/application.android.ts
+++ b/tns-core-modules/application/application.android.ts
@@ -14,7 +14,8 @@ import { profile } from "../profiling";
 export * from "./application-common";
 
 // types
-import { NavigationEntry, View, AndroidActivityCallbacks } from "../ui/frame";
+import { NavigationEntry, AndroidActivityCallbacks } from "../ui/frame";
+import { View } from "../ui/core/view";
 
 const ActivityCreated = "activityCreated";
 const ActivityDestroyed = "activityDestroyed";

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -7,8 +7,8 @@
 /// <reference path="../tns-core-modules.d.ts" />
 
 import { NavigationEntry } from "../ui/frame";
-import { EventData, Observable } from '../data/observable';
-import { View } from '../ui/core/view';
+import { EventData, Observable } from "../data/observable";
+import { View } from "../ui/core/view";
 
 /**
  * String value used when hooking to launch event.

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -6,7 +6,9 @@
 /// <reference path="../nativescript-error.d.ts" />
 /// <reference path="../tns-core-modules.d.ts" />
 
-import { NavigationEntry, View, Observable, EventData } from "../ui/frame";
+import { NavigationEntry } from "../ui/frame";
+import { EventData, Observable } from '../data/observable';
+import { View } from '../ui/core/view';
 
 /**
  * String value used when hooking to launch event.

--- a/tns-core-modules/debugger/dom-node.ts
+++ b/tns-core-modules/debugger/dom-node.ts
@@ -2,7 +2,7 @@ import { CSSComputedStyleProperty } from "./css-agent";
 import { InspectorEvents } from "./devtools-elements";
 
 // Needed for typings only
-import { ViewBase } from "../ui/core/view";
+import { ViewBase } from "../ui/core/view-base";
 
 const registeredDomNodes = {};
 const ELEMENT_NODE_TYPE = 1;

--- a/tns-core-modules/platform/platform.android.ts
+++ b/tns-core-modules/platform/platform.android.ts
@@ -151,3 +151,4 @@ export module screen {
 }
 
 export const isAndroid = true;
+export const isIOS = false;

--- a/tns-core-modules/platform/platform.ios.ts
+++ b/tns-core-modules/platform/platform.ios.ts
@@ -128,3 +128,4 @@ export module screen {
 }
 
 export const isIOS = true;
+export const isAndroid = false;

--- a/tns-core-modules/text/formatted-string.d.ts
+++ b/tns-core-modules/text/formatted-string.d.ts
@@ -5,7 +5,7 @@
 
 import { Span } from "./span";
 import { ObservableArray } from "../data/observable-array";
-import { ViewBase } from "../ui/core/view";
+import { ViewBase } from "../ui/core/view-base";
 import { Color } from "../color";
 import { FontStyle, FontWeight } from "../ui/styling/font";
 import { TextDecoration } from "../ui/text-base";

--- a/tns-core-modules/text/formatted-string.ts
+++ b/tns-core-modules/text/formatted-string.ts
@@ -2,10 +2,11 @@
 import { Span } from "./span";
 import { Observable, PropertyChangeData } from "../data/observable";
 import { ObservableArray, ChangedData } from "../data/observable-array";
-import { ViewBase, AddArrayFromBuilder, AddChildFromBuilder } from "../ui/core/view";
+import { AddArrayFromBuilder, AddChildFromBuilder } from "../ui/core/view";
 import { Color } from "../color";
 import { FontStyle, FontWeight } from "../ui/styling/font";
 import { TextDecoration } from "../ui/text-base";
+import { ViewBase } from "../ui/core/view-base";
 
 export { Span };
 

--- a/tns-core-modules/text/span.d.ts
+++ b/tns-core-modules/text/span.d.ts
@@ -3,7 +3,7 @@
  */ /** */
 
 import { Color } from "../color";
-import { ViewBase } from "../ui/core/view-base";
+import { ViewBase } from '../ui/core/view-base';
 import { FontStyle, FontWeight } from "../ui/styling/font";
 import { TextDecoration } from "../ui/text-base";
 

--- a/tns-core-modules/text/span.d.ts
+++ b/tns-core-modules/text/span.d.ts
@@ -3,7 +3,7 @@
  */ /** */
 
 import { Color } from "../color";
-import { ViewBase } from '../ui/core/view-base';
+import { ViewBase } from "../ui/core/view-base";
 import { FontStyle, FontWeight } from "../ui/styling/font";
 import { TextDecoration } from "../ui/text-base";
 

--- a/tns-core-modules/text/span.ts
+++ b/tns-core-modules/text/span.ts
@@ -1,6 +1,6 @@
 ﻿import { Color } from "../color";
 import { Span as SpanDefinition } from "./span";
-import { ViewBase } from "../ui/core/view";
+import { ViewBase } from "../ui/core/view-base";
 import { FontStyle, FontWeight, } from "../ui/styling/font";
 import { TextDecoration } from "../ui/text-base";
 

--- a/tns-core-modules/ui/action-bar/action-bar-common.ts
+++ b/tns-core-modules/ui/action-bar/action-bar-common.ts
@@ -7,15 +7,15 @@
 
 import { profile } from "../../profiling";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 import {
-    View, ViewBase, Property,
-    unsetValue, booleanConverter,
-    horizontalAlignmentProperty,
-    verticalAlignmentProperty, CSSType,
-    traceWrite, traceCategories, traceMessageType
+    View, CSSType
 } from "../core/view";
+import { unsetValue, Property } from "../core/properties";
+import { traceCategories, traceMessageType, traceWrite } from "../core/bindable";
+import { booleanConverter, ViewBase } from "../core/view-base";
+import { verticalAlignmentProperty, horizontalAlignmentProperty } from "../styling/style-properties";
 
 export module knownCollections {
     export const actionItems = "actionItems";

--- a/tns-core-modules/ui/action-bar/action-bar-common.ts
+++ b/tns-core-modules/ui/action-bar/action-bar-common.ts
@@ -7,8 +7,6 @@
 
 import { profile } from "../../profiling";
 
-// export * from "../core/view";
-
 import {
     View, CSSType
 } from "../core/view";

--- a/tns-core-modules/ui/action-bar/action-bar.android.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.android.ts
@@ -1,12 +1,14 @@
 import { AndroidActionBarSettings as AndroidActionBarSettingsDefinition, AndroidActionItemSettings } from ".";
 import {
     ActionItemBase, ActionBarBase, isVisible,
-    View, layout, colorProperty, flatProperty,
-    Color, traceMissingIcon
+    flatProperty, traceMissingIcon
 } from "./action-bar-common";
-import { RESOURCE_PREFIX } from "../../utils/utils";
+import { RESOURCE_PREFIX, layout } from "../../utils/utils";
 import { fromFileOrResource } from "../../image-source";
 import * as application from "../../application";
+import { View } from "../core/view";
+import { colorProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./action-bar-common";
 

--- a/tns-core-modules/ui/action-bar/action-bar.d.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.d.ts
@@ -3,7 +3,9 @@
  * @module "ui/action-bar"
  */ /** */
 
-import { EventData, ViewBase, View } from "../core/view";
+import { View } from "../core/view";
+import { ViewBase } from "../core/view-base";
+import { EventData } from '../../data/observable';
 
 /**
  * Provides an abstraction over the ActionBar (android) and NavigationBar (iOS).

--- a/tns-core-modules/ui/action-bar/action-bar.d.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.d.ts
@@ -5,7 +5,7 @@
 
 import { View } from "../core/view";
 import { ViewBase } from "../core/view-base";
-import { EventData } from '../../data/observable';
+import { EventData } from "../../data/observable";
 
 /**
  * Provides an abstraction over the ActionBar (android) and NavigationBar (iOS).

--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -1,11 +1,11 @@
 import { IOSActionItemSettings, ActionItem as ActionItemDefinition } from ".";
 import { 
-    ActionItemBase, ActionBarBase, isVisible, View, 
-    colorProperty, backgroundColorProperty, 
-    backgroundInternalProperty, flatProperty, iosIconRenderingModeProperty, 
-    layout, Color, traceMissingIcon } from "./action-bar-common";
+    ActionItemBase, ActionBarBase, isVisible, flatProperty, iosIconRenderingModeProperty, traceMissingIcon } from "./action-bar-common";
 import { fromFileOrResource } from "../../image-source";
-import { ios as iosUtils } from "../../utils/utils";
+import { ios as iosUtils, layout } from "../../utils/utils";
+import { View } from "../core/view";
+import { Color } from "../../color";
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
 
 export * from "./action-bar-common";
 

--- a/tns-core-modules/ui/activity-indicator/activity-indicator-common.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator-common.ts
@@ -1,7 +1,8 @@
 ﻿import { ActivityIndicator as ActivityIndicatorDefinition } from ".";
-import { View, Property, booleanConverter, CSSType } from "../core/view";
-
-export * from "../core/view";
+import { View, CSSType } from "../core/view";
+import { Property } from '../core/properties';
+import { booleanConverter } from "../core/view-base";
+// export * from "../core/view";
 
 @CSSType("ActivityIndicator")
 export class ActivityIndicatorBase extends View implements ActivityIndicatorDefinition {

--- a/tns-core-modules/ui/activity-indicator/activity-indicator-common.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator-common.ts
@@ -1,8 +1,7 @@
 ﻿import { ActivityIndicator as ActivityIndicatorDefinition } from ".";
 import { View, CSSType } from "../core/view";
-import { Property } from '../core/properties';
+import { Property } from "../core/properties";
 import { booleanConverter } from "../core/view-base";
-// export * from "../core/view";
 
 @CSSType("ActivityIndicator")
 export class ActivityIndicatorBase extends View implements ActivityIndicatorDefinition {

--- a/tns-core-modules/ui/activity-indicator/activity-indicator.android.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator.android.ts
@@ -1,4 +1,6 @@
-﻿import { ActivityIndicatorBase, busyProperty, colorProperty, visibilityProperty, Visibility, Color } from "./activity-indicator-common";
+﻿import { ActivityIndicatorBase, busyProperty} from "./activity-indicator-common";
+import { Visibility, visibilityProperty, colorProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./activity-indicator-common";
 

--- a/tns-core-modules/ui/activity-indicator/activity-indicator.android.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator.android.ts
@@ -1,4 +1,4 @@
-﻿import { ActivityIndicatorBase, busyProperty} from "./activity-indicator-common";
+﻿import { ActivityIndicatorBase, busyProperty } from "./activity-indicator-common";
 import { Visibility, visibilityProperty, colorProperty } from "../styling/style-properties";
 import { Color } from "../../color";
 

--- a/tns-core-modules/ui/activity-indicator/activity-indicator.ios.ts
+++ b/tns-core-modules/ui/activity-indicator/activity-indicator.ios.ts
@@ -1,4 +1,6 @@
-import { ActivityIndicatorBase, busyProperty, colorProperty, Color } from "./activity-indicator-common";
+import { ActivityIndicatorBase, busyProperty } from "./activity-indicator-common";
+import { colorProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./activity-indicator-common";
 

--- a/tns-core-modules/ui/animation/animation-common.ts
+++ b/tns-core-modules/ui/animation/animation-common.ts
@@ -12,7 +12,7 @@ import { View } from "../core/view";
 import { Color } from "../../color";
 import { isEnabled as traceEnabled, write as traceWrite, categories as traceCategories, messageType as traceType } from "../../trace";
 
-export { Color, traceEnabled, traceWrite, traceCategories, traceType };
+export { traceEnabled, traceWrite, traceCategories, traceType };
 export { AnimationPromise } from ".";
 
 export module Properties {

--- a/tns-core-modules/ui/animation/animation.android.ts
+++ b/tns-core-modules/ui/animation/animation.android.ts
@@ -2,7 +2,7 @@
 import { AnimationDefinition } from ".";
 import { View } from "../core/view";
 
-import { AnimationBase, Properties, PropertyAnimation, CubicBezierAnimationCurve, AnimationPromise, Color, traceWrite, traceEnabled, traceCategories, traceType } from "./animation-common";
+import { AnimationBase, Properties, PropertyAnimation, CubicBezierAnimationCurve, AnimationPromise, traceWrite, traceEnabled, traceCategories, traceType } from "./animation-common";
 import {
     opacityProperty, backgroundColorProperty, rotateProperty,
     translateXProperty, translateYProperty, scaleXProperty, scaleYProperty
@@ -11,6 +11,7 @@ import {
 import { layout } from "../../utils/utils";
 import { device } from "../../platform";
 import lazy from "../../utils/lazy";
+import { Color } from "../../color";
 
 export * from "./animation-common";
 

--- a/tns-core-modules/ui/animation/animation.d.ts
+++ b/tns-core-modules/ui/animation/animation.d.ts
@@ -2,7 +2,8 @@
  * @module "ui/animation"
  */ /** */
 
-import { View, Color } from "../core/view";
+import { View } from "../core/view";
+import { Color } from "../../color";
 
 /**
  * Defines animation options for the View.animate method.

--- a/tns-core-modules/ui/animation/keyframe-animation.ts
+++ b/tns-core-modules/ui/animation/keyframe-animation.ts
@@ -8,7 +8,7 @@ import {
     KeyframeAnimation as KeyframeAnimationDefinition,
 } from "./keyframe-animation";
 
-import { View, Color } from "../core/view";
+import { View } from "../core/view";
 
 import { AnimationCurve } from "../enums";
 
@@ -23,6 +23,7 @@ import {
     translateXProperty, translateYProperty,
     rotateProperty, opacityProperty
 } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export class Keyframes implements KeyframesDefinition {
     name: string;

--- a/tns-core-modules/ui/border/border.ts
+++ b/tns-core-modules/ui/border/border.ts
@@ -1,5 +1,7 @@
 import { Border as BorderDefinition } from ".";
-import { ContentView, View, layout, CSSType } from "../content-view";
+import { ContentView } from "../content-view";
+import { CSSType, View } from "../core/view";
+import { layout } from "../../utils/utils";
 
 @Deprecated
 @CSSType("Border")

--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -1,6 +1,6 @@
 ﻿// Definitions.
 import { LoadOptions } from ".";
-import { View, ViewBase, Template, KeyedTemplate } from "../core/view";
+import { View, Template, KeyedTemplate } from "../core/view";
 import { ViewEntry } from "../frame";
 import * as traceModule from "../../trace";
 
@@ -13,6 +13,7 @@ import { ComponentModule, setPropertyValue, getComponentModule } from "./compone
 import { platformNames, device } from "../../platform";
 import { resolveFileName } from "../../file-system/file-name-resolver";
 import { profile } from "../../profiling";
+import { ViewBase } from "../core/view-base";
 
 const ios = platformNames.ios.toLowerCase();
 const android = platformNames.android.toLowerCase();

--- a/tns-core-modules/ui/button/button-common.ts
+++ b/tns-core-modules/ui/button/button-common.ts
@@ -1,7 +1,9 @@
 ﻿import { Button as ButtonDefinition } from ".";
-import { TextBase, booleanConverter, CSSType } from "../text-base";
+import { TextBase } from "../text-base";
+import { CSSType } from "../core/view";
+import { booleanConverter } from "../core/view-base";
 
-export * from "../text-base";
+// export * from "../text-base";
 
 @CSSType("Button")
 export abstract class ButtonBase extends TextBase implements ButtonDefinition {

--- a/tns-core-modules/ui/button/button-common.ts
+++ b/tns-core-modules/ui/button/button-common.ts
@@ -3,8 +3,6 @@ import { TextBase } from "../text-base";
 import { CSSType } from "../core/view";
 import { booleanConverter } from "../core/view-base";
 
-// export * from "../text-base";
-
 @CSSType("Button")
 export abstract class ButtonBase extends TextBase implements ButtonDefinition {
     public static tapEvent = "tap";

--- a/tns-core-modules/ui/button/button.android.ts
+++ b/tns-core-modules/ui/button/button.android.ts
@@ -1,10 +1,11 @@
 ﻿import {
-    ButtonBase, PseudoClassHandler,
-    paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty,
-    Length, zIndexProperty, textAlignmentProperty, TextAlignment
+    ButtonBase
 } from "./button-common";
 import { profile } from "../../profiling";
 import { TouchGestureEventData, GestureTypes, TouchAction } from "../gestures";
+import { PseudoClassHandler } from "../core/view/view";
+import { paddingTopProperty, Length, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, zIndexProperty } from "../styling/style-properties";
+import { textAlignmentProperty, TextAlignment } from "../text-base";
 
 export * from "./button-common";
 

--- a/tns-core-modules/ui/button/button.d.ts
+++ b/tns-core-modules/ui/button/button.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/button"
  */ /** */
 
-import { TextBase, EventData } from "../text-base";
+import { TextBase } from "../text-base";
+import { EventData } from "../../data/observable";
 
 /**
  * Represents a standard Button widget.

--- a/tns-core-modules/ui/button/button.ios.ts
+++ b/tns-core-modules/ui/button/button.ios.ts
@@ -1,10 +1,11 @@
 ﻿import { ControlStateChangeListener } from "../core/control-state-change";
 import {
-    ButtonBase, PseudoClassHandler, Length, layout,
-    borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty,
-    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty,
-    whiteSpaceProperty, WhiteSpace, textAlignmentProperty, TextAlignment, View
+    ButtonBase
 } from "./button-common";
+import { PseudoClassHandler, View } from "../core/view";
+import { borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, Length } from "../styling/style-properties";
+import { layout } from "../../utils/utils";
+import { textAlignmentProperty, TextAlignment, whiteSpaceProperty, WhiteSpace } from "../text-base";
 
 export * from "./button-common";
 

--- a/tns-core-modules/ui/content-view/content-view.d.ts
+++ b/tns-core-modules/ui/content-view/content-view.d.ts
@@ -5,8 +5,6 @@
 
 import { View, AddChildFromBuilder } from "../core/view";
 
-// export * from "../core/view";
-
 /**
  * Represents a View that has a single child - content.
  * The View itself does not have visual representation and serves as a placeholder for its content in the logical tree.

--- a/tns-core-modules/ui/content-view/content-view.d.ts
+++ b/tns-core-modules/ui/content-view/content-view.d.ts
@@ -5,7 +5,7 @@
 
 import { View, AddChildFromBuilder } from "../core/view";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 /**
  * Represents a View that has a single child - content.

--- a/tns-core-modules/ui/content-view/content-view.ts
+++ b/tns-core-modules/ui/content-view/content-view.ts
@@ -1,7 +1,9 @@
 ﻿import { ContentView as ContentViewDefinition } from ".";
-import { View, CustomLayoutView, AddChildFromBuilder, layout, isIOS } from "../core/view";
+import { View, CustomLayoutView, AddChildFromBuilder } from "../core/view";
+import { isIOS } from '../../platform';
+import { layout } from '../../utils/utils';
 
-export * from "../core/view";
+// export * from "../core/view";
 
 export class ContentView extends CustomLayoutView implements ContentViewDefinition, AddChildFromBuilder {
     private _content: View;

--- a/tns-core-modules/ui/content-view/content-view.ts
+++ b/tns-core-modules/ui/content-view/content-view.ts
@@ -1,9 +1,7 @@
 ﻿import { ContentView as ContentViewDefinition } from ".";
 import { View, CustomLayoutView, AddChildFromBuilder } from "../core/view";
-import { isIOS } from '../../platform';
-import { layout } from '../../utils/utils';
-
-// export * from "../core/view";
+import { isIOS } from "../../platform";
+import { layout } from "../../utils/utils";
 
 export class ContentView extends CustomLayoutView implements ContentViewDefinition, AddChildFromBuilder {
     private _content: View;

--- a/tns-core-modules/ui/core/bindable/bindable.d.ts
+++ b/tns-core-modules/ui/core/bindable/bindable.d.ts
@@ -14,7 +14,6 @@ import {
     isCategorySet } from "../../../trace";
 
 export {
-    Observable, WrappedValue, PropertyChangeData, EventData,
     traceEnabled, traceWrite, traceError, traceCategories, traceNotifyEvent,
     traceMessageType, isCategorySet
 };

--- a/tns-core-modules/ui/core/bindable/bindable.ts
+++ b/tns-core-modules/ui/core/bindable/bindable.ts
@@ -2,7 +2,7 @@
 import { ViewBase } from "../view-base";
 
 import { unsetValue } from "../properties";
-import { Observable, WrappedValue, PropertyChangeData, EventData } from "../../../data/observable";
+import { Observable, PropertyChangeData } from "../../../data/observable";
 import { addWeakEventListener, removeWeakEventListener } from "../weak-event-listener";
 import { bindingConstants, parentsRegex } from "../../builder/binding-builder";
 import { escapeRegexSymbols } from "../../../utils/utils";
@@ -21,7 +21,6 @@ import * as applicationCommon from "../../../application/application-common";
 import * as polymerExpressions from "../../../js-libs/polymer-expressions";
 
 export {
-    Observable, WrappedValue, PropertyChangeData, EventData,
     traceEnabled, traceWrite, traceError, traceCategories, traceNotifyEvent, traceMessageType, isCategorySet
 };
 

--- a/tns-core-modules/ui/core/dependency-observable/dependency-observable.ts
+++ b/tns-core-modules/ui/core/dependency-observable/dependency-observable.ts
@@ -5,8 +5,9 @@
 } from ".";
 import { Observable, WrappedValue } from "../../../data/observable";
 import { getClassInfo, isString } from "../../../utils/types";
-
 import { unsetValue } from "../properties";
+
+// import { unsetValue } from "../properties";
 
 // use private variables in the scope of the module rather than static members of the class since a member is still accessible through JavaScript and may be changed.
 const propertyFromKey = {};

--- a/tns-core-modules/ui/core/properties/properties.d.ts
+++ b/tns-core-modules/ui/core/properties/properties.d.ts
@@ -5,7 +5,7 @@
 import { ViewBase } from "../view-base";
 import { Style } from "../../styling/style";
 
-export { Style };
+// export { Style };
 
 /**
  * Value specifing that Property should be set to its initial value.

--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -1,5 +1,4 @@
 // Definitions.
-import * as definitions from "../view-base";
 import { ViewBase } from "../view-base";
 
 // Types.
@@ -7,8 +6,9 @@ import { WrappedValue, PropertyChangeData } from "../../../data/observable";
 import { Style } from "../../styling/style";
 
 import { profile } from "../../../profiling";
+import { PropertyOptions, CoerciblePropertyOptions, CssPropertyOptions, CssAnimationPropertyOptions, ShorthandPropertyOptions } from ".";
 
-export { Style };
+// export { Style };
 
 export const unsetValue: any = new Object();
 
@@ -56,7 +56,7 @@ function getPropertiesFromMap(map): Property<any, any>[] | CssProperty<any, any>
     return props;
 }
 
-export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<U>, definitions.Property<T, U> {
+export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<U>, Property<T, U> {
     private registered: boolean;
 
     public readonly name: string;
@@ -76,7 +76,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
     public enumerable: boolean = true;
     public configurable: boolean = true;
 
-    constructor(options: definitions.PropertyOptions<T, U>) {
+    constructor(options: PropertyOptions<T, U>) {
         const propertyName = options.name;
         this.name = propertyName;
 
@@ -226,10 +226,10 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 }
 Property.prototype.isStyleProperty = false;
 
-export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> implements definitions.CoercibleProperty<T, U> {
+export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> implements CoercibleProperty<T, U> {
     public readonly coerce: (target: T) => void;
 
-    constructor(options: definitions.CoerciblePropertyOptions<T, U>) {
+    constructor(options: CoerciblePropertyOptions<T, U>) {
         super(options);
 
         const propertyName = options.name;
@@ -339,11 +339,11 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
     }
 }
 
-export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> implements definitions.InheritedProperty<T, U> {
+export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> implements InheritedProperty<T, U> {
     public readonly sourceKey: symbol;
     public readonly setInheritedValue: (value: U) => void;
 
-    constructor(options: definitions.PropertyOptions<T, U>) {
+    constructor(options: PropertyOptions<T, U>) {
         super(options);
         const name = options.name;
         const key = this.key;
@@ -411,7 +411,7 @@ export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> imp
     }
 }
 
-export class CssProperty<T extends Style, U> implements definitions.CssProperty<T, U> {
+export class CssProperty<T extends Style, U> implements CssProperty<T, U> {
     private registered: boolean;
 
     public readonly name: string;
@@ -430,7 +430,7 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
     public readonly defaultValueKey: symbol;
     public readonly defaultValue: U;
 
-    constructor(options: definitions.CssPropertyOptions<T, U>) {
+    constructor(options: CssPropertyOptions<T, U>) {
         const propertyName = options.name;
         this.name = propertyName;
 
@@ -647,7 +647,7 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
 }
 CssProperty.prototype.isStyleProperty = true;
 
-export class CssAnimationProperty<T extends Style, U> implements definitions.CssAnimationProperty<T, U> {
+export class CssAnimationProperty<T extends Style, U> implements CssAnimationProperty<T, U> {
     public readonly name: string;
     public readonly cssName: string;
     public readonly cssLocalName: string;
@@ -670,7 +670,7 @@ export class CssAnimationProperty<T extends Style, U> implements definitions.Css
 
     public _valueConverter?: (value: string) => any;
 
-    constructor(options: definitions.CssAnimationPropertyOptions<T, U>) {
+    constructor(options: CssAnimationPropertyOptions<T, U>) {
         const { valueConverter, equalityComparer, valueChanged, defaultValue } = options;
         const propertyName = options.name;
         this.name = propertyName;
@@ -839,10 +839,10 @@ export class CssAnimationProperty<T extends Style, U> implements definitions.Css
 }
 CssAnimationProperty.prototype.isStyleProperty = true;
 
-export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> implements definitions.InheritedCssProperty<T, U> {
+export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> implements InheritedCssProperty<T, U> {
     public setInheritedValue: (value: U) => void;
 
-    constructor(options: definitions.CssPropertyOptions<T, U>) {
+    constructor(options: CssPropertyOptions<T, U>) {
         super(options);
         const propertyName = options.name;
 
@@ -971,7 +971,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
     }
 }
 
-export class ShorthandProperty<T extends Style, P> implements definitions.ShorthandProperty<T, P> {
+export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<T, P> {
     private registered: boolean;
 
     public readonly key: symbol;
@@ -985,7 +985,7 @@ export class ShorthandProperty<T extends Style, P> implements definitions.Shorth
 
     public readonly sourceKey: symbol;
 
-    constructor(options: definitions.ShorthandPropertyOptions<P>) {
+    constructor(options: ShorthandPropertyOptions<P>) {
         this.name = options.name;
 
         const key = Symbol(this.name + ":propertyKey");

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -18,11 +18,6 @@ import { DOMNode } from "../../../debugger/dom-node";
 import { Observable } from "../../../data/observable";
 import { Style } from "../../styling/style";
 
-// export { isIOS, isAndroid, layout, Color };
-
-// export * from "../properties";
-// export * from "../bindable";
-
 /**
  * Iterates through all child views (via visual tree) and executes a function.
  * @param view - Starting view (parent container).

--- a/tns-core-modules/ui/core/view-base/view-base.d.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.d.ts
@@ -1,8 +1,8 @@
 /**
  * @module "ui/core/view-base"
  */ /** */
-import { Property, CssProperty, CssAnimationProperty, InheritedProperty, Style } from "../properties";
-import { BindingOptions, Observable } from "../bindable";
+import { Property, CssProperty, CssAnimationProperty, InheritedProperty } from "../properties";
+import { BindingOptions } from "../bindable";
 
 import { SelectorCore } from "../../styling/css-selector";
 import { isIOS, isAndroid } from "../../../platform";
@@ -15,11 +15,13 @@ import { Color } from "../../../color";
 import { Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf } from "../../layouts/flexbox-layout";
 import { Length } from "../../styling/style-properties";
 import { DOMNode } from "../../../debugger/dom-node";
+import { Observable } from "../../../data/observable";
+import { Style } from "../../styling/style";
 
-export { isIOS, isAndroid, layout, Color };
+// export { isIOS, isAndroid, layout, Color };
 
-export * from "../properties";
-export * from "../bindable";
+// export * from "../properties";
+// export * from "../bindable";
 
 /**
  * Iterates through all child views (via visual tree) and executes a function.

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -6,22 +6,16 @@ import { Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf } from "../../la
 // Types.
 import { Property, CssProperty, CssAnimationProperty, InheritedProperty, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView } from "../properties";
 import { Source } from "../../../utils/debug";
-import { Observable, PropertyChangeData, WrappedValue } from '../../../data/observable';
+import { Observable, PropertyChangeData, WrappedValue } from "../../../data/observable";
 import { Binding, BindingOptions, traceEnabled, traceWrite, traceCategories } from "../bindable";
 import { isAndroid } from "../../../platform";
 import { Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../../styling/style-properties";
-import { Style } from '../../styling/style';
+import { Style } from "../../styling/style";
 
 // TODO: Remove this import!
 import * as types from "../../../utils/types";
 
-// import { Color } from "../../../color";
-
 import { profile } from "../../../profiling";
-
-// export { isIOS, isAndroid, layout, Color };
-// export * from "../bindable";
-// export * from "../properties";
 
 import * as ssm from "../../styling/style-scope";
 

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -4,28 +4,30 @@ import { Page } from "../../page";
 import { Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf } from "../../layouts/flexbox-layout";
 
 // Types.
-import { Property, CssProperty, CssAnimationProperty, InheritedProperty, Style, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView } from "../properties";
+import { Property, CssProperty, CssAnimationProperty, InheritedProperty, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView } from "../properties";
 import { Source } from "../../../utils/debug";
-import { Binding, BindingOptions, Observable, WrappedValue, PropertyChangeData, traceEnabled, traceWrite, traceCategories } from "../bindable";
-import { isIOS, isAndroid } from "../../../platform";
-import { layout } from "../../../utils/utils";
+import { Observable, PropertyChangeData, WrappedValue } from '../../../data/observable';
+import { Binding, BindingOptions, traceEnabled, traceWrite, traceCategories } from "../bindable";
+import { isAndroid } from "../../../platform";
 import { Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../../styling/style-properties";
+import { Style } from '../../styling/style';
 
 // TODO: Remove this import!
 import * as types from "../../../utils/types";
 
-import { Color } from "../../../color";
+// import { Color } from "../../../color";
 
 import { profile } from "../../../profiling";
 
-export { isIOS, isAndroid, layout, Color };
-export * from "../bindable";
-export * from "../properties";
+// export { isIOS, isAndroid, layout, Color };
+// export * from "../bindable";
+// export * from "../properties";
 
 import * as ssm from "../../styling/style-scope";
 
 // import { DOMNode } from "../../../debugger/dom-node";
 import * as dnm from "../../../debugger/dom-node";
+
 let domNodeModule: typeof dnm;
 
 function ensuredomNodeModule(): void {

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -23,16 +23,14 @@ import { StyleScope } from "../../styling/style-scope";
 import { LinearGradient } from "../../styling/linear-gradient";
 import { BackgroundRepeat } from "../../styling/style-properties";
 
-// export * from "../../styling/style-properties";
-// export * from "../view-base";
 export { LinearGradient };
 
 import * as am from "../../animation";
-import { EventData } from '../../../data/observable';
+import { EventData } from "../../../data/observable";
 import { traceEnabled, traceWrite, traceCategories, getEventOrGestureName } from "../bindable";
 import { InheritedProperty, Property } from "../properties";
-import { Color } from '../../../color';
-import { layout } from '../../../utils/utils';
+import { Color } from "../../../color";
+import { layout } from "../../../utils/utils";
 
 let animationModule: typeof am;
 function ensureAnimationModule() {

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -1,14 +1,11 @@
 // Definitions.
 import {
-    View as ViewDefinition, Point, Size, Color, dip,
+    View as ViewDefinition, Point, Size, dip,
     ShownModallyData
 } from ".";
 
 import {
-    ViewBase, Property, booleanConverter, eachDescendant, EventData, layout,
-    getEventOrGestureName, traceEnabled, traceWrite, traceCategories,
-    InheritedProperty,
-    ShowModalOptions
+    ViewBase, booleanConverter, eachDescendant, ShowModalOptions
 } from "../view-base";
 
 import { HorizontalAlignment, VerticalAlignment, Visibility, Length, PercentLength } from "../../styling/style-properties";
@@ -26,11 +23,17 @@ import { StyleScope } from "../../styling/style-scope";
 import { LinearGradient } from "../../styling/linear-gradient";
 import { BackgroundRepeat } from "../../styling/style-properties";
 
-export * from "../../styling/style-properties";
-export * from "../view-base";
+// export * from "../../styling/style-properties";
+// export * from "../view-base";
 export { LinearGradient };
 
 import * as am from "../../animation";
+import { EventData } from '../../../data/observable';
+import { traceEnabled, traceWrite, traceCategories, getEventOrGestureName } from "../bindable";
+import { InheritedProperty, Property } from "../properties";
+import { Color } from '../../../color';
+import { layout } from '../../../utils/utils';
+
 let animationModule: typeof am;
 function ensureAnimationModule() {
     if (!animationModule) {

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -3,10 +3,7 @@ import { Point, CustomLayoutView as CustomLayoutViewDefinition, dip } from ".";
 import { GestureTypes, GestureEventData } from "../../gestures";
 // Types.
 import {
-    ViewCommon, layout, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty,
-    traceEnabled, traceWrite, traceCategories, traceNotifyEvent,
-    paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty,
-    Color, EventData, ShowModalOptions
+    ViewCommon, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty
 } from "./view-common";
 
 import {
@@ -15,13 +12,18 @@ import {
     minWidthProperty, minHeightProperty, widthProperty, heightProperty,
     marginLeftProperty, marginTopProperty, marginRightProperty, marginBottomProperty,
     rotateProperty, scaleXProperty, scaleYProperty, translateXProperty, translateYProperty,
-    zIndexProperty, backgroundInternalProperty
+    zIndexProperty, backgroundInternalProperty, paddingBottomProperty, paddingRightProperty, paddingTopProperty, paddingLeftProperty
 } from "../../styling/style-properties";
 
 import { Background, ad as androidBackground } from "../../styling/background";
 import { profile } from "../../../profiling";
 import { topmost } from "../../frame/frame-stack";
 import { AndroidActivityBackPressedEventData, android as androidApp } from "../../../application";
+import { EventData } from '../../../data/observable';
+import { ShowModalOptions } from "../view-base";
+import { layout } from "../../../utils/utils";
+import { Color } from '../../../color';
+import { traceWrite, traceEnabled, traceCategories, traceNotifyEvent } from "../bindable";
 
 export * from "./view-common";
 

--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -19,10 +19,10 @@ import { Background, ad as androidBackground } from "../../styling/background";
 import { profile } from "../../../profiling";
 import { topmost } from "../../frame/frame-stack";
 import { AndroidActivityBackPressedEventData, android as androidApp } from "../../../application";
-import { EventData } from '../../../data/observable';
+import { EventData } from "../../../data/observable";
 import { ShowModalOptions } from "../view-base";
 import { layout } from "../../../utils/utils";
-import { Color } from '../../../color';
+import { Color } from "../../../color";
 import { traceWrite, traceEnabled, traceCategories, traceNotifyEvent } from "../bindable";
 
 export * from "./view-common";

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -4,15 +4,18 @@
 
 /// <reference path="../../../tns-core-modules.d.ts" />
 
-import { ViewBase, Property, InheritedProperty, EventData, Color } from "../view-base";
+import { ViewBase } from "../view-base";
 import { Animation, AnimationDefinition, AnimationPromise } from "../../animation";
 import { HorizontalAlignment, VerticalAlignment, Visibility, Length, PercentLength } from "../../styling/style-properties";
 import { GestureTypes, GestureEventData, GesturesObserver } from "../../gestures";
 import { LinearGradient } from "../../styling/gradient";
+import { EventData } from '../../../data/observable';
+import { InheritedProperty, Property } from '../properties';
+import { Color } from '../../../color';
 
-export * from "../view-base";
-export * from "../../styling/style-properties";
-export { LinearGradient };
+// export * from "../view-base";
+// export * from "../../styling/style-properties";
+// export { LinearGradient };
 
 export function PseudoClassHandler(...pseudoClasses: string[]): MethodDecorator;
 
@@ -85,7 +88,7 @@ export interface Size {
 /**
  * Defines the data for the shownModally event.
  */
-export interface ShownModallyData extends EventData {
+export interface ShownModallyData extends GestureEventData {
     /**
      * The context (optional, may be undefined) passed to the view when shown modally.
      */

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -9,9 +9,9 @@ import { Animation, AnimationDefinition, AnimationPromise } from "../../animatio
 import { HorizontalAlignment, VerticalAlignment, Visibility, Length, PercentLength } from "../../styling/style-properties";
 import { GestureTypes, GestureEventData, GesturesObserver } from "../../gestures";
 import { LinearGradient } from "../../styling/gradient";
-import { EventData } from '../../../data/observable';
-import { InheritedProperty, Property } from '../properties';
-import { Color } from '../../../color';
+import { EventData } from "../../../data/observable";
+import { InheritedProperty, Property } from "../properties";
+import { Color } from "../../../color";
 
 export function PseudoClassHandler(...pseudoClasses: string[]): MethodDecorator;
 

--- a/tns-core-modules/ui/core/view/view.d.ts
+++ b/tns-core-modules/ui/core/view/view.d.ts
@@ -13,10 +13,6 @@ import { EventData } from '../../../data/observable';
 import { InheritedProperty, Property } from '../properties';
 import { Color } from '../../../color';
 
-// export * from "../view-base";
-// export * from "../../styling/style-properties";
-// export { LinearGradient };
-
 export function PseudoClassHandler(...pseudoClasses: string[]): MethodDecorator;
 
 /**

--- a/tns-core-modules/ui/core/view/view.ios.ts
+++ b/tns-core-modules/ui/core/view/view.ios.ts
@@ -1,14 +1,13 @@
 // Definitions.
 import { Point, View as ViewDefinition, dip } from ".";
-import { ViewBase } from "../view-base";
+import { ViewBase, ShowModalOptions } from "../view-base";
 
 import {
-    ViewCommon, layout, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty,
-    traceEnabled, traceWrite, traceCategories, traceError, traceMessageType, ShowModalOptions
+    ViewCommon, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty
 } from "./view-common";
 
 import { ios as iosBackground, Background } from "../../styling/background";
-import { ios as iosUtils } from "../../../utils/utils";
+import { ios as iosUtils, layout } from "../../../utils/utils";
 import {
     Visibility,
     visibilityProperty, opacityProperty,
@@ -17,6 +16,7 @@ import {
     backgroundInternalProperty, clipPathProperty
 } from "../../styling/style-properties";
 import { profile } from "../../../profiling";
+import { traceEnabled, traceWrite, traceCategories, traceMessageType, traceError } from "../bindable";
 
 export * from "./view-common";
 

--- a/tns-core-modules/ui/date-picker/date-picker-common.ts
+++ b/tns-core-modules/ui/date-picker/date-picker-common.ts
@@ -1,7 +1,8 @@
 ﻿import { DatePicker as DatePickerDefinition } from ".";
-import { View, Property, CSSType } from "../core/view";
+import { View, CSSType } from "../core/view";
+import { Property } from "../core/properties";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 const defaultDate = new Date();
 const dateComparer = (x: Date, y: Date): boolean => (x <= y && x >= y);

--- a/tns-core-modules/ui/date-picker/date-picker-common.ts
+++ b/tns-core-modules/ui/date-picker/date-picker-common.ts
@@ -2,8 +2,6 @@
 import { View, CSSType } from "../core/view";
 import { Property } from "../core/properties";
 
-// export * from "../core/view";
-
 const defaultDate = new Date();
 const dateComparer = (x: Date, y: Date): boolean => (x <= y && x >= y);
 

--- a/tns-core-modules/ui/date-picker/date-picker.d.ts
+++ b/tns-core-modules/ui/date-picker/date-picker.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/date-picker"
  */ /** */
 
-import { View, Property } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties";
 
 export const yearProperty: Property<DatePicker, number>;
 export const monthProperty: Property<DatePicker, number>;

--- a/tns-core-modules/ui/date-picker/date-picker.ios.ts
+++ b/tns-core-modules/ui/date-picker/date-picker.ios.ts
@@ -1,9 +1,11 @@
 ﻿import {
     DatePickerBase, yearProperty, monthProperty, dayProperty,
-    dateProperty, maxDateProperty, minDateProperty, colorProperty, Color
+    dateProperty, maxDateProperty, minDateProperty
 } from "./date-picker-common";
 
 import { ios } from "../../utils/utils";
+import { colorProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./date-picker-common";
 

--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -1,11 +1,9 @@
 ﻿import { EditableTextBase as EditableTextBaseDefinition, KeyboardType, ReturnKeyType, UpdateTextTrigger, AutocapitalizationType } from ".";
 import { TextBase } from "../text-base";
 import { Color } from "../../color";
-import { Property, CssProperty, makeParser, makeValidator } from '../core/properties';
+import { Property, CssProperty, makeParser, makeValidator } from "../core/properties";
 import { booleanConverter } from "../core/view-base";
 import { Style } from "../styling/style";
-
-// export * from "../text-base";
 
 export abstract class EditableTextBase extends TextBase implements EditableTextBaseDefinition {
     public static blurEvent = "blur";

--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -1,7 +1,11 @@
 ﻿import { EditableTextBase as EditableTextBaseDefinition, KeyboardType, ReturnKeyType, UpdateTextTrigger, AutocapitalizationType } from ".";
-import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser } from "../text-base";
+import { TextBase } from "../text-base";
+import { Color } from "../../color";
+import { Property, CssProperty, makeParser, makeValidator } from '../core/properties';
+import { booleanConverter } from "../core/view-base";
+import { Style } from "../styling/style";
 
-export * from "../text-base";
+// export * from "../text-base";
 
 export abstract class EditableTextBase extends TextBase implements EditableTextBaseDefinition {
     public static blurEvent = "blur";

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -1,11 +1,12 @@
 ﻿import {
     EditableTextBase as EditableTextBaseCommon, keyboardTypeProperty,
     returnKeyTypeProperty, editableProperty,
-    autocapitalizationTypeProperty, autocorrectProperty, hintProperty, resetSymbol,
-    textProperty, placeholderColorProperty, Color, textTransformProperty, maxLengthProperty
+    autocapitalizationTypeProperty, autocorrectProperty, hintProperty, placeholderColorProperty, maxLengthProperty
 } from "./editable-text-base-common";
 
 import { ad } from "../../utils/utils";
+import { textProperty, resetSymbol, textTransformProperty } from "../text-base";
+import { Color } from "../../color";
 
 export * from "./editable-text-base-common";
 

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
@@ -89,5 +89,3 @@ export const maxLengthProperty: Property<EditableTextBase, number>;
  */
 export function _updateCharactersInRangeReplacementString(formattedText: FormattedString, rangeLocation: number, rangeLength: number, replacementString: string): void;
 //@endprivate
-
-// export * from "../text-base";

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
@@ -2,10 +2,10 @@
  * @module "ui/editor-text-base"
  */ /** */
 
-import { Color } from '../../color';
-import { FormattedString } from '../../text/formatted-string';
+import { Color } from "../../color";
+import { FormattedString } from "../../text/formatted-string";
 import { CssProperty, Property } from "../core/properties";
-import { Style } from '../styling/style';
+import { Style } from "../styling/style";
 import { TextBase } from "../text-base";
 
 /**

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.d.ts
@@ -2,7 +2,11 @@
  * @module "ui/editor-text-base"
  */ /** */
 
-import { TextBase, Property, CssProperty, Style, Color, FormattedString } from "../text-base";
+import { Color } from '../../color';
+import { FormattedString } from '../../text/formatted-string';
+import { CssProperty, Property } from "../core/properties";
+import { Style } from '../styling/style';
+import { TextBase } from "../text-base";
 
 /**
  * Represents the base class for all editable text views.
@@ -86,4 +90,4 @@ export const maxLengthProperty: Property<EditableTextBase, number>;
 export function _updateCharactersInRangeReplacementString(formattedText: FormattedString, rangeLocation: number, rangeLength: number, replacementString: string): void;
 //@endprivate
 
-export * from "../text-base";
+// export * from "../text-base";

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
@@ -1,8 +1,9 @@
 ﻿import {
     EditableTextBase as EditableTextBaseCommon, keyboardTypeProperty,
     returnKeyTypeProperty,
-    autocapitalizationTypeProperty, autocorrectProperty, FormattedString
+    autocapitalizationTypeProperty, autocorrectProperty
 } from "./editable-text-base-common";
+import { FormattedString } from '../../text/formatted-string';
 
 export * from "./editable-text-base-common";
 

--- a/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.ios.ts
@@ -3,7 +3,7 @@
     returnKeyTypeProperty,
     autocapitalizationTypeProperty, autocorrectProperty
 } from "./editable-text-base-common";
-import { FormattedString } from '../../text/formatted-string';
+import { FormattedString } from "../../text/formatted-string";
 
 export * from "./editable-text-base-common";
 

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -3,13 +3,16 @@ import { Frame as FrameDefinition, NavigationEntry, BackstackEntry, NavigationTr
 import { Page } from "../page";
 
 // Types.
-import { getAncestor } from "../core/view/view-common";
-import { View, CustomLayoutView, isIOS, isAndroid, traceEnabled, traceWrite, traceCategories, Property, CSSType } from "../core/view";
+import { View, CustomLayoutView, CSSType } from "../core/view";
 import { createViewFromEntry } from "../builder";
 import { profile } from "../../profiling";
 
 import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack } from "./frame-stack";
-export * from "../core/view";
+import { traceWrite, traceEnabled, traceCategories } from "../core/bindable";
+import { getAncestor } from "../core/view-base";
+import { isAndroid, isIOS } from '../../platform';
+import { Property } from "../core/properties";
+// export * from "../core/view";
 
 function buildEntryFromArgs(arg: any): NavigationEntry {
     let entry: NavigationEntry;

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -10,9 +10,8 @@ import { profile } from "../../profiling";
 import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack } from "./frame-stack";
 import { traceWrite, traceEnabled, traceCategories } from "../core/bindable";
 import { getAncestor } from "../core/view-base";
-import { isAndroid, isIOS } from '../../platform';
+import { isAndroid, isIOS } from "../../platform";
 import { Property } from "../core/properties";
-// export * from "../core/view";
 
 function buildEntryFromArgs(arg: any): NavigationEntry {
     let entry: NavigationEntry;

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -8,8 +8,7 @@ import { Page } from "../page";
 // Types.
 import * as application from "../../application";
 import {
-    FrameBase, stack, goBack, View, Observable,
-    traceEnabled, traceWrite, traceCategories, traceError
+    FrameBase, stack, goBack
 } from "./frame-common";
 
 import {
@@ -21,6 +20,9 @@ import { profile } from "../../profiling";
 
 // TODO: Remove this and get it from global to decouple builder for angular
 import { createViewFromEntry } from "../builder";
+import { View } from "../core/view";
+import { traceError, traceEnabled, traceWrite, traceCategories } from "../core/bindable";
+import { Observable } from "../../data/observable";
 
 export * from "./frame-common";
 

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -6,7 +6,7 @@
 import { Page } from "../page";
 import { Transition } from "../transition";
 import { View } from "../core/view/view";
-import { EventData, Observable } from '../../data/observable';
+import { EventData, Observable } from "../../data/observable";
 
 /**
  * Represents the logical View unit that is responsible for navigation withing an application.

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -3,10 +3,12 @@
  * @module "ui/frame"
  */ /** */
 
-import { Page, View, Observable, EventData } from "../page";
+import { Page } from "../page";
 import { Transition } from "../transition";
+import { View } from "../core/view/view";
+import { EventData, Observable } from '../../data/observable';
 
-export * from "../page";
+// export * from "../page";
 
 /**
  * Represents the logical View unit that is responsible for navigation withing an application.

--- a/tns-core-modules/ui/frame/frame.d.ts
+++ b/tns-core-modules/ui/frame/frame.d.ts
@@ -8,8 +8,6 @@ import { Transition } from "../transition";
 import { View } from "../core/view/view";
 import { EventData, Observable } from '../../data/observable';
 
-// export * from "../page";
-
 /**
  * Represents the logical View unit that is responsible for navigation withing an application.
  * Typically an application will have a Frame object at a root level.

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -4,10 +4,12 @@ import { Page } from "../page";
 import { profile } from "../../profiling";
 
 //Types.
-import { FrameBase, View, layout, traceEnabled, traceWrite, traceCategories, isCategorySet } from "./frame-common";
+import { FrameBase } from "./frame-common";
 import { _createIOSAnimatedTransitioning } from "./fragment.transitions";
 
 import * as utils from "../../utils/utils";
+import { traceEnabled, traceWrite, traceCategories, isCategorySet } from "../core/bindable";
+import { View } from "../core/view";
 
 export * from "./frame-common";
 
@@ -255,11 +257,11 @@ export class Frame extends FrameBase {
     }
 
     public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-        const width = layout.getMeasureSpecSize(widthMeasureSpec);
-        const widthMode = layout.getMeasureSpecMode(widthMeasureSpec);
+        const width = utils.layout.getMeasureSpecSize(widthMeasureSpec);
+        const widthMode = utils.layout.getMeasureSpecMode(widthMeasureSpec);
 
-        const height = layout.getMeasureSpecSize(heightMeasureSpec);
-        const heightMode = layout.getMeasureSpecMode(heightMeasureSpec);
+        const height = utils.layout.getMeasureSpecSize(heightMeasureSpec);
+        const heightMode = utils.layout.getMeasureSpecMode(heightMeasureSpec);
 
         const widthAndState = View.resolveSizeAndState(width, width, widthMode, 0);
         const heightAndState = View.resolveSizeAndState(height, height, heightMode, 0);

--- a/tns-core-modules/ui/gestures/gestures.android.ts
+++ b/tns-core-modules/ui/gestures/gestures.android.ts
@@ -1,6 +1,6 @@
 ﻿// Definitions.
 import { GestureEventData, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData } from ".";
-import { View, EventData } from "../core/view";
+import { View } from "../core/view";
 
 // Types.
 import {
@@ -9,6 +9,7 @@ import {
 
 // Import layout from utils directly to avoid circular references
 import { layout } from "../../utils/utils";
+import { EventData } from "../../data/observable";
 
 export * from "./gestures-common";
 

--- a/tns-core-modules/ui/gestures/gestures.d.ts
+++ b/tns-core-modules/ui/gestures/gestures.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/gestures"
  */ /** */
 
-import { View, EventData } from "../core/view";
+import { View } from "../core/view";
+import { EventData } from '../../data/observable';
 
 /**
  * Defines an enum with supported gesture types.
@@ -119,19 +120,19 @@ export interface GestureEventData extends EventData {
     /**
      * Gets the type of the gesture.
      */
-    type: GestureTypes;
+    type?: GestureTypes;
     /**
      * Gets the view which originates the gesture.
      */
-    view: View;
+    view?: View;
     /**
      * Gets the underlying native iOS specific [UIGestureRecognizer](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIGestureRecognizer_Class/).
      */
-    ios: any /* UIGestureRecognizer */;
+    ios?: any /* UIGestureRecognizer */;
     /**
      * Gets the underlying native android specific [gesture detector](http://developer.android.com/reference/android/view/GestureDetector.html).
      */
-    android: any
+    android?: any
 }
 
 /**

--- a/tns-core-modules/ui/gestures/gestures.d.ts
+++ b/tns-core-modules/ui/gestures/gestures.d.ts
@@ -4,7 +4,7 @@
  */ /** */
 
 import { View } from "../core/view";
-import { EventData } from '../../data/observable';
+import { EventData } from "../../data/observable";
 
 /**
  * Defines an enum with supported gesture types.

--- a/tns-core-modules/ui/gestures/gestures.ios.ts
+++ b/tns-core-modules/ui/gestures/gestures.ios.ts
@@ -1,9 +1,10 @@
 ﻿// Definitions.
 import { GestureEventData, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData, PinchGestureEventData } from ".";
-import { View, EventData } from "../core/view";
+import { View } from "../core/view";
 
 // Types.
 import { GesturesObserverBase, toString, TouchAction, GestureStateTypes, GestureTypes, SwipeDirection } from "./gestures-common";
+import { EventData } from "../../data/observable";
 
 export * from "./gestures-common";
 

--- a/tns-core-modules/ui/html-view/html-view-common.ts
+++ b/tns-core-modules/ui/html-view/html-view-common.ts
@@ -2,8 +2,6 @@
 import { View, CSSType } from "../core/view";
 import { Property } from "../core/properties";
 
-// export * from "../core/view";
-
 @CSSType("HtmlView")
 export class HtmlViewBase extends View implements HtmlViewDefinition {
     public html: string;

--- a/tns-core-modules/ui/html-view/html-view-common.ts
+++ b/tns-core-modules/ui/html-view/html-view-common.ts
@@ -1,7 +1,8 @@
 ﻿import { HtmlView as HtmlViewDefinition } from ".";
-import { View, Property, CSSType } from "../core/view";
+import { View, CSSType } from "../core/view";
+import { Property } from "../core/properties";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 @CSSType("HtmlView")
 export class HtmlViewBase extends View implements HtmlViewDefinition {

--- a/tns-core-modules/ui/html-view/html-view.d.ts
+++ b/tns-core-modules/ui/html-view/html-view.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/html-view"
  */ /** */
 
-import { View, Property } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties";
 
 /**
  * Represents a view with html content. Use this component instead WebView when you want to show just static HTML content.

--- a/tns-core-modules/ui/html-view/html-view.ios.ts
+++ b/tns-core-modules/ui/html-view/html-view.ios.ts
@@ -1,6 +1,8 @@
 ﻿import {
-    HtmlViewBase, View, layout, htmlProperty
+    HtmlViewBase, htmlProperty
 } from "./html-view-common";
+import { layout } from "../../utils/utils";
+import { View } from "../core/view";
 
 export * from "./html-view-common";
 

--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -1,9 +1,17 @@
 ﻿import { Image as ImageDefinition, Stretch } from ".";
-import { View, Property, InheritedCssProperty, Length, Style, Color, isIOS, booleanConverter, CSSType, traceEnabled, traceWrite, traceCategories } from "../core/view";
+import { View, CSSType,  } from "../core/view";
 import { ImageAsset } from "../../image-asset";
 import { ImageSource, fromAsset, fromNativeSource, fromUrl } from "../../image-source";
 import { isDataURI, isFileOrResourcePath, RESOURCE_PREFIX } from "../../utils/utils";
-export * from "../core/view";
+import { Length } from "../styling/style-properties";
+import { Color } from '../../color';
+import { traceEnabled, traceWrite, traceCategories } from "../core/bindable";
+import { InheritedCssProperty } from "../core/properties";
+import { Property } from "../core/properties";
+import { Style } from "../styling/style";
+import { isIOS } from '../../platform';
+import { booleanConverter } from "../core/view-base";
+// export * from "../core/view";
 export { ImageSource, ImageAsset, fromAsset, fromNativeSource, fromUrl, isDataURI, isFileOrResourcePath, RESOURCE_PREFIX };
 
 @CSSType("Image")

--- a/tns-core-modules/ui/image/image-common.ts
+++ b/tns-core-modules/ui/image/image-common.ts
@@ -4,14 +4,13 @@ import { ImageAsset } from "../../image-asset";
 import { ImageSource, fromAsset, fromNativeSource, fromUrl } from "../../image-source";
 import { isDataURI, isFileOrResourcePath, RESOURCE_PREFIX } from "../../utils/utils";
 import { Length } from "../styling/style-properties";
-import { Color } from '../../color';
+import { Color } from "../../color";
 import { traceEnabled, traceWrite, traceCategories } from "../core/bindable";
 import { InheritedCssProperty } from "../core/properties";
 import { Property } from "../core/properties";
 import { Style } from "../styling/style";
-import { isIOS } from '../../platform';
+import { isIOS } from "../../platform";
 import { booleanConverter } from "../core/view-base";
-// export * from "../core/view";
 export { ImageSource, ImageAsset, fromAsset, fromNativeSource, fromUrl, isDataURI, isFileOrResourcePath, RESOURCE_PREFIX };
 
 @CSSType("Image")

--- a/tns-core-modules/ui/image/image.android.ts
+++ b/tns-core-modules/ui/image/image.android.ts
@@ -1,10 +1,12 @@
 ﻿import {
-    ImageSource, ImageAsset, ImageBase, stretchProperty, imageSourceProperty, srcProperty, tintColorProperty, Color,
-    isDataURI, isFileOrResourcePath, RESOURCE_PREFIX, Length
+    ImageSource, ImageAsset, ImageBase, stretchProperty, imageSourceProperty, srcProperty, tintColorProperty,
+    isDataURI, isFileOrResourcePath, RESOURCE_PREFIX
 } from "./image-common";
 import { knownFolders } from "../../file-system";
 
 import * as platform from "../../platform";
+import { Length } from "../styling/style-properties";
+import { Color } from "../../color";
 export * from "./image-common";
 
 const FILE_PREFIX = "file:///";

--- a/tns-core-modules/ui/image/image.d.ts
+++ b/tns-core-modules/ui/image/image.d.ts
@@ -3,8 +3,12 @@
  * @module "ui/image"
  */ /** */
 
-import { View, Property, InheritedCssProperty, Color, Style, Length } from "../core/view";
+import { View } from "../core/view";
 import { ImageSource } from "../../image-source";
+import { Color } from "../../color";
+import { Property, InheritedCssProperty } from "../core/properties";
+import { Style } from "../styling/style";
+import { Length } from "../styling/style-properties";
 
 /**
  * Represents a class that provides functionality for loading and streching image(s).

--- a/tns-core-modules/ui/image/image.ios.ts
+++ b/tns-core-modules/ui/image/image.ios.ts
@@ -1,7 +1,9 @@
 import {
-    ImageSource, ImageBase, stretchProperty, imageSourceProperty, tintColorProperty, srcProperty, layout, Color,
-    traceEnabled, traceWrite, traceCategories
+    ImageSource, ImageBase, stretchProperty, imageSourceProperty, tintColorProperty, srcProperty
 } from "./image-common";
+import { Color } from "../../color";
+import { layout } from "../../utils/utils";
+import { traceEnabled, traceWrite, traceCategories } from "../core/bindable";
 
 export * from "./image-common";
 

--- a/tns-core-modules/ui/label/label.android.ts
+++ b/tns-core-modules/ui/label/label.android.ts
@@ -1,8 +1,10 @@
 ﻿import { Label as LabelDefinition } from ".";
-import { TextBase, WhiteSpace, whiteSpaceProperty, booleanConverter, CSSType } from "../text-base";
+import { TextBase, WhiteSpace, whiteSpaceProperty } from "../text-base";
 import { profile } from "../../profiling";
+import { CSSType } from "../core/view";
+import { booleanConverter } from "../core/view-base";
 
-export * from "../text-base";
+// export * from "../text-base";
 
 let TextView: typeof android.widget.TextView;
 

--- a/tns-core-modules/ui/label/label.android.ts
+++ b/tns-core-modules/ui/label/label.android.ts
@@ -4,8 +4,6 @@ import { profile } from "../../profiling";
 import { CSSType } from "../core/view";
 import { booleanConverter } from "../core/view-base";
 
-// export * from "../text-base";
-
 let TextView: typeof android.widget.TextView;
 
 @CSSType("Label")

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -11,8 +11,6 @@ import { layout } from "../../utils/utils";
 import { Length, borderRightWidthProperty, borderTopWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../styling/style-properties";
 import { booleanConverter } from "../core/view-base";
 
-// export * from "../text-base";
-
 enum FixedSize {
     NONE = 0,
     WIDTH = 1,

--- a/tns-core-modules/ui/label/label.ios.ts
+++ b/tns-core-modules/ui/label/label.ios.ts
@@ -1,15 +1,17 @@
 ﻿import { Label as LabelDefinition } from ".";
 import { Background } from "../styling/background";
 import {
-    TextBase, View, layout,
-    borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty,
-    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, whiteSpaceProperty,
-    Length, WhiteSpace, booleanConverter, CSSType
+    TextBase, whiteSpaceProperty,
+    WhiteSpace
 } from "../text-base";
 
 import { ios } from "../styling/background";
+import { CSSType, View } from "../core/view";
+import { layout } from "../../utils/utils";
+import { Length, borderRightWidthProperty, borderTopWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../styling/style-properties";
+import { booleanConverter } from "../core/view-base";
 
-export * from "../text-base";
+// export * from "../text-base";
 
 enum FixedSize {
     NONE = 0,

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout-common.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout-common.ts
@@ -1,10 +1,9 @@
 ﻿import { AbsoluteLayout as AbsoluteLayoutDefinition } from ".";
 import { LayoutBase } from "../layout-base";
-import { View, CSSType } from '../../core/view';
+import { View, CSSType } from "../../core/view";
 
-import { Property } from '../../core/properties';
-import { Length, zeroLength } from '../../styling/style-properties';
-// export * from "../layout-base";
+import { Property } from "../../core/properties";
+import { Length, zeroLength } from "../../styling/style-properties";
 
 View.prototype.effectiveLeft = 0;
 View.prototype.effectiveTop = 0;

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout-common.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout-common.ts
@@ -1,7 +1,10 @@
 ﻿import { AbsoluteLayout as AbsoluteLayoutDefinition } from ".";
-import { LayoutBase, View, Property, Length, zeroLength, CSSType } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { View, CSSType } from '../../core/view';
 
-export * from "../layout-base";
+import { Property } from '../../core/properties';
+import { Length, zeroLength } from '../../styling/style-properties';
+// export * from "../layout-base";
 
 View.prototype.effectiveLeft = 0;
 View.prototype.effectiveTop = 0;

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.android.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.android.ts
@@ -1,4 +1,6 @@
-﻿import { AbsoluteLayoutBase, View, leftProperty, topProperty, Length } from "./absolute-layout-common";
+﻿import { AbsoluteLayoutBase, leftProperty, topProperty } from "./absolute-layout-common";
+import { View } from "../../core/view";
+import { Length } from "../../styling/style-properties";
 
 export * from "./absolute-layout-common";
 

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.d.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.d.ts
@@ -3,9 +3,9 @@
  */ /** */
 
 import { LayoutBase } from "../layout-base";
-import { Property } from '../../core/properties';
+import { Property } from "../../core/properties";
 import { Length } from "../../styling/style-properties";
-import { View } from '../../core/view';
+import { View } from "../../core/view";
 
 /**
  *  A layout that lets you specify exact locations (left/top coordinates) of its children.

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.d.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.d.ts
@@ -2,7 +2,10 @@
  * @module "ui/layouts/absolute-layout"
  */ /** */
 
-import { LayoutBase, View, Property, Length } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Property } from '../../core/properties';
+import { Length } from "../../styling/style-properties";
+import { View } from '../../core/view';
 
 /**
  *  A layout that lets you specify exact locations (left/top coordinates) of its children.

--- a/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/absolute-layout/absolute-layout.ios.ts
@@ -1,4 +1,7 @@
-﻿import { AbsoluteLayoutBase, View, layout, Length } from "./absolute-layout-common";
+﻿import { AbsoluteLayoutBase } from "./absolute-layout-common";
+import { View } from "../..//core/view";
+import { layout } from "../../../utils/utils";
+import { Length } from "../../styling/style-properties";
 
 export * from "./absolute-layout-common";
 

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout-common.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout-common.ts
@@ -1,5 +1,9 @@
 ﻿import { DockLayout as DockLayoutDefinition, Dock } from ".";
-import { LayoutBase, View, Property, isIOS, booleanConverter, makeValidator, makeParser, CSSType } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { makeParser, makeValidator, Property } from '../../core/properties';
+import { isIOS } from '../../../platform';
+import { booleanConverter } from '../../core/view-base';
+import { View, CSSType } from '../../core/view';
 
 function validateArgs(element: View): View {
     if (!element) {
@@ -8,7 +12,7 @@ function validateArgs(element: View): View {
     return element;
 }
 
-export * from "../layout-base";
+// export * from "../layout-base";
 
 @CSSType("DockLayout")
 export class DockLayoutBase extends LayoutBase implements DockLayoutDefinition {

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout-common.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout-common.ts
@@ -1,9 +1,9 @@
 ﻿import { DockLayout as DockLayoutDefinition, Dock } from ".";
 import { LayoutBase } from "../layout-base";
-import { makeParser, makeValidator, Property } from '../../core/properties';
-import { isIOS } from '../../../platform';
-import { booleanConverter } from '../../core/view-base';
-import { View, CSSType } from '../../core/view';
+import { makeParser, makeValidator, Property } from "../../core/properties";
+import { isIOS } from "../../../platform";
+import { booleanConverter } from "../../core/view-base";
+import { View, CSSType } from "../../core/view";
 
 function validateArgs(element: View): View {
     if (!element) {
@@ -11,8 +11,6 @@ function validateArgs(element: View): View {
     }
     return element;
 }
-
-// export * from "../layout-base";
 
 @CSSType("DockLayout")
 export class DockLayoutBase extends LayoutBase implements DockLayoutDefinition {

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout.android.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout.android.ts
@@ -1,4 +1,5 @@
-﻿import { DockLayoutBase, View, dockProperty, stretchLastChildProperty } from "./dock-layout-common";
+﻿import { DockLayoutBase, dockProperty, stretchLastChildProperty } from "./dock-layout-common";
+import { View } from "../../core/view";
 
 export * from "./dock-layout-common";
 

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout.d.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout.d.ts
@@ -2,7 +2,9 @@
  * @module "ui/layouts/dock-layout"
  */ /** */
 
-import { LayoutBase, View, Property } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Property } from '../../core/properties';
+import { View } from '../../core/view';
 
 /**
  * A Layout that arranges its children at its outer edges, and allows its last child to take up the remaining space. 

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout.d.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout.d.ts
@@ -3,8 +3,8 @@
  */ /** */
 
 import { LayoutBase } from "../layout-base";
-import { Property } from '../../core/properties';
-import { View } from '../../core/view';
+import { Property } from "../../core/properties";
+import { View } from "../../core/view";
 
 /**
  * A Layout that arranges its children at its outer edges, and allows its last child to take up the remaining space. 

--- a/tns-core-modules/ui/layouts/dock-layout/dock-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/dock-layout/dock-layout.ios.ts
@@ -1,4 +1,6 @@
-﻿import { DockLayoutBase, View, layout } from "./dock-layout-common";
+﻿import { DockLayoutBase } from "./dock-layout-common";
+import { View } from "../../core/view";
+import { layout } from "../../../utils/utils";
 
 export * from "./dock-layout-common";
 

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
@@ -1,6 +1,10 @@
-import { LayoutBase, View, Style, CssProperty, isIOS, ShorthandProperty, makeValidator, makeParser, unsetValue, CSSType } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { View, CSSType } from '../../core/view';
+import { makeValidator, makeParser, CssProperty, ShorthandProperty, unsetValue } from "../../core/properties/properties";
+import { Style } from "../../styling/style/style";
+import { isIOS } from "../../../platform";
 
-export * from "../layout-base";
+// export * from "../layout-base";
 
 export type Basis = "auto" | number;
 

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout-common.ts
@@ -1,10 +1,8 @@
 import { LayoutBase } from "../layout-base";
-import { View, CSSType } from '../../core/view';
+import { View, CSSType } from "../../core/view";
 import { makeValidator, makeParser, CssProperty, ShorthandProperty, unsetValue } from "../../core/properties/properties";
 import { Style } from "../../styling/style/style";
 import { isIOS } from "../../../platform";
-
-// export * from "../layout-base";
 
 export type Basis = "auto" | number;
 

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
@@ -1,7 +1,6 @@
 import {
     FlexDirection, FlexWrap, JustifyContent, AlignItems, AlignContent,
-    FlexboxLayoutBase, View,
-    Length,
+    FlexboxLayoutBase, 
     orderProperty, Order,
     flexGrowProperty, FlexGrow,
     flexShrinkProperty, FlexShrink,
@@ -9,6 +8,8 @@ import {
     alignSelfProperty, AlignSelf,
     flexDirectionProperty, flexWrapProperty, justifyContentProperty, alignItemsProperty, alignContentProperty
 } from "./flexbox-layout-common";
+import { View } from '../../core/view';
+import { Length } from "../../styling/style-properties";
 
 export * from "./flexbox-layout-common";
 

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.android.ts
@@ -8,7 +8,7 @@ import {
     alignSelfProperty, AlignSelf,
     flexDirectionProperty, flexWrapProperty, justifyContentProperty, alignItemsProperty, alignContentProperty
 } from "./flexbox-layout-common";
-import { View } from '../../core/view';
+import { View } from "../../core/view";
 import { Length } from "../../styling/style-properties";
 
 export * from "./flexbox-layout-common";

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.d.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.d.ts
@@ -3,9 +3,9 @@
  */ /** */
 
 import { LayoutBase } from "../layout-base";
-import { Property, CssProperty } from '../../core/properties';
+import { Property, CssProperty } from "../../core/properties";
 import { Style } from "../../styling/style";
-import { View } from '../../core/view';
+import { View } from "../../core/view";
 
 export type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
 export type FlexWrap = "nowrap" | "wrap" | "wrap-reverse";

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.d.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.d.ts
@@ -2,7 +2,10 @@
  * @module "ui/layouts/flexbox-layout"
  */ /** */
 
-import { LayoutBase, View, Style, CssProperty } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Property, CssProperty } from '../../core/properties';
+import { Style } from "../../styling/style";
+import { View } from '../../core/view';
 
 export type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
 export type FlexWrap = "nowrap" | "wrap" | "wrap-reverse";

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
@@ -38,7 +38,7 @@ import makeMeasureSpec = layout.makeMeasureSpec;
 import getMeasureSpecMode = layout.getMeasureSpecMode;
 import getMeasureSpecSize = layout.getMeasureSpecSize;
 import { layout } from "tns-core-modules/utils/utils";
-import { View } from '../../core/view';
+import { View } from "../../core/view";
 
 // `eachLayoutChild` iterates over children, and we need more - indexed access.
 // This class tries to accomodate that by collecting all children in an

--- a/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/flexbox-layout/flexbox-layout.ios.ts
@@ -1,6 +1,6 @@
 import {
     FlexDirection, FlexWrap, JustifyContent, AlignItems, AlignContent,
-    FlexboxLayoutBase, View, layout,
+    FlexboxLayoutBase,
     FlexBasisPercent,
     orderProperty, flexGrowProperty, flexShrinkProperty, flexWrapBeforeProperty, alignSelfProperty
 } from "./flexbox-layout-common";
@@ -37,6 +37,8 @@ const MAX_SIZE = 0x00FFFFFF & MEASURED_SIZE_MASK;
 import makeMeasureSpec = layout.makeMeasureSpec;
 import getMeasureSpecMode = layout.getMeasureSpecMode;
 import getMeasureSpecSize = layout.getMeasureSpecSize;
+import { layout } from "tns-core-modules/utils/utils";
+import { View } from '../../core/view';
 
 // `eachLayoutChild` iterates over children, and we need more - indexed access.
 // This class tries to accomodate that by collecting all children in an

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
@@ -1,7 +1,10 @@
 ﻿import { GridLayout as GridLayoutDefinition, ItemSpec as ItemSpecDefinition } from ".";
-import { LayoutBase, View, Observable, Property, makeParser, makeValidator, CSSType } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Observable } from "../../../data/observable";
+import { Property, makeValidator, makeParser } from "../../core/properties/properties";
+import { View, CSSType } from '../../core/view';
 
-export * from "../layout-base";
+// export * from "../layout-base";
 
 function validateArgs(element: View): View {
     if (!element) {

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
@@ -2,9 +2,7 @@
 import { LayoutBase } from "../layout-base";
 import { Observable } from "../../../data/observable";
 import { Property, makeValidator, makeParser } from "../../core/properties/properties";
-import { View, CSSType } from '../../core/view';
-
-// export * from "../layout-base";
+import { View, CSSType } from "../../core/view";
 
 function validateArgs(element: View): View {
     if (!element) {

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.android.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.android.ts
@@ -1,7 +1,9 @@
 ﻿import {
-    GridLayoutBase, ItemSpec as ItemSpecBase, View, layout,
+    GridLayoutBase, ItemSpec as ItemSpecBase,
     rowProperty, columnProperty, rowSpanProperty, columnSpanProperty, GridUnitType
 } from "./grid-layout-common";
+import { View } from "../../core/view";
+import { layout } from "../../../utils/utils";
 
 export * from "./grid-layout-common";
 

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.d.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.d.ts
@@ -3,8 +3,8 @@
  */ /** */
 
 import { LayoutBase } from "../layout-base";
-import { Property } from '../../core/properties';
-import { View } from '../../core/view';
+import { Property } from "../../core/properties";
+import { View } from "../../core/view";
 
 /**
  * Defines row/column specific properties that apply to GridLayout elements.

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.d.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.d.ts
@@ -2,7 +2,9 @@
  * @module "ui/layouts/grid-layout"
  */ /** */
 
-import { LayoutBase, Property, View } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Property } from '../../core/properties';
+import { View } from '../../core/view';
 
 /**
  * Defines row/column specific properties that apply to GridLayout elements.

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
@@ -1,6 +1,8 @@
 ﻿import {
-    GridLayoutBase, ItemSpec, View, layout
+    GridLayoutBase, ItemSpec
 } from "./grid-layout-common";
+import { View } from '../../core/view';
+import { layout } from "../../../utils/utils";
 
 export * from "./grid-layout-common";
 

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
@@ -1,7 +1,7 @@
 ﻿import {
     GridLayoutBase, ItemSpec
 } from "./grid-layout-common";
-import { View } from '../../core/view';
+import { View } from "../../core/view";
 import { layout } from "../../../utils/utils";
 
 export * from "./grid-layout-common";

--- a/tns-core-modules/ui/layouts/layout-base-common.ts
+++ b/tns-core-modules/ui/layouts/layout-base-common.ts
@@ -4,8 +4,6 @@ import { getViewById, booleanConverter } from "../core/view-base";
 import { Property } from "../core/properties";
 import { Length } from "../styling/style-properties";
 
-// export * from "../core/view";
-
 export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefinition, AddChildFromBuilder {
 
     private _subViews = new Array<View>();

--- a/tns-core-modules/ui/layouts/layout-base-common.ts
+++ b/tns-core-modules/ui/layouts/layout-base-common.ts
@@ -1,7 +1,10 @@
 ﻿import { LayoutBase as LayoutBaseDefinition } from "./layout-base";
-import { View, CustomLayoutView, Property, AddChildFromBuilder, getViewById, Length, booleanConverter } from "../core/view";
+import { View, CustomLayoutView, AddChildFromBuilder } from "../core/view";
+import { getViewById, booleanConverter } from "../core/view-base";
+import { Property } from "../core/properties";
+import { Length } from "../styling/style-properties";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefinition, AddChildFromBuilder {
 

--- a/tns-core-modules/ui/layouts/layout-base.android.ts
+++ b/tns-core-modules/ui/layouts/layout-base.android.ts
@@ -1,7 +1,7 @@
 ﻿import {
-    LayoutBaseCommon, clipToBoundsProperty, isPassThroughParentEnabledProperty,
-    paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length
+    LayoutBaseCommon, clipToBoundsProperty, isPassThroughParentEnabledProperty
 } from "./layout-base-common";
+import { paddingTopProperty, Length, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../styling/style-properties";
 
 export * from "./layout-base-common";
 

--- a/tns-core-modules/ui/layouts/layout-base.d.ts
+++ b/tns-core-modules/ui/layouts/layout-base.d.ts
@@ -2,9 +2,11 @@
  * @module "ui/layouts/layout-base"
  */ /** */
 
-import { View, CustomLayoutView, Property, Length } from "../core/view";
+import { View, CustomLayoutView } from "../core/view";
+import { Property, CssProperty } from '../core/properties';
+import { Length } from "../styling/style-properties";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 /**
  * Base class for all views that supports children positioning.

--- a/tns-core-modules/ui/layouts/layout-base.d.ts
+++ b/tns-core-modules/ui/layouts/layout-base.d.ts
@@ -3,7 +3,7 @@
  */ /** */
 
 import { View, CustomLayoutView } from "../core/view";
-import { Property, CssProperty } from '../core/properties';
+import { Property, CssProperty } from "../core/properties";
 import { Length } from "../styling/style-properties";
 
 /**

--- a/tns-core-modules/ui/layouts/layout-base.d.ts
+++ b/tns-core-modules/ui/layouts/layout-base.d.ts
@@ -6,8 +6,6 @@ import { View, CustomLayoutView } from "../core/view";
 import { Property, CssProperty } from '../core/properties';
 import { Length } from "../styling/style-properties";
 
-// export * from "../core/view";
-
 /**
  * Base class for all views that supports children positioning.
  */

--- a/tns-core-modules/ui/layouts/layout-base.ios.ts
+++ b/tns-core-modules/ui/layouts/layout-base.ios.ts
@@ -1,6 +1,7 @@
 import { 
-    LayoutBaseCommon, clipToBoundsProperty, isPassThroughParentEnabledProperty, View
+    LayoutBaseCommon, clipToBoundsProperty, isPassThroughParentEnabledProperty
 } from "./layout-base-common";
+import { View } from "../core/view";
 
 export * from "./layout-base-common";
 

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout-common.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout-common.ts
@@ -2,9 +2,7 @@
 import { LayoutBase } from "../layout-base";
 import { makeParser, makeValidator, Property } from "../../core/properties";
 import { isIOS } from "../../../platform";
-import { CSSType } from '../../core/view/view';
-
-// export * from "../layout-base";
+import { CSSType } from "../../core/view";
 
 @CSSType("StackLayout")
 export class StackLayoutBase extends LayoutBase implements StackLayoutDefinition {

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout-common.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout-common.ts
@@ -1,7 +1,10 @@
 ﻿import { StackLayout as StackLayoutDefinition, Orientation } from ".";
-import { LayoutBase, Property, isIOS, makeValidator, makeParser, CSSType } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { makeParser, makeValidator, Property } from "../../core/properties";
+import { isIOS } from "../../../platform";
+import { CSSType } from '../../core/view/view';
 
-export * from "../layout-base";
+// export * from "../layout-base";
 
 @CSSType("StackLayout")
 export class StackLayoutBase extends LayoutBase implements StackLayoutDefinition {

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout.d.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout.d.ts
@@ -2,7 +2,7 @@
  * @module "ui/layouts/stack-layout"
  */ /** */
 import { LayoutBase } from "../layout-base";
-import { Property } from '../../core/properties';
+import { Property } from "../../core/properties";
 /**
  * A Layout that arranges its children horizontally or vertically. The direction can be set by orientation property.
  */

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout.d.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout.d.ts
@@ -1,8 +1,8 @@
 ﻿/**
  * @module "ui/layouts/stack-layout"
  */ /** */
-import { LayoutBase, Property } from "../layout-base";
-
+import { LayoutBase } from "../layout-base";
+import { Property } from '../../core/properties';
 /**
  * A Layout that arranges its children horizontally or vertically. The direction can be set by orientation property.
  */

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout.ios.ts
@@ -2,7 +2,7 @@
 import * as trace from "../../../trace";
 import { layout } from "../../../utils/utils";
 import { VerticalAlignment, HorizontalAlignment } from "../../styling/style-properties";
-import { View } from '../../core/view';
+import { View } from "../../core/view";
 
 export * from "./stack-layout-common";
 

--- a/tns-core-modules/ui/layouts/stack-layout/stack-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/stack-layout/stack-layout.ios.ts
@@ -1,5 +1,8 @@
-﻿import { StackLayoutBase, View, layout, VerticalAlignment, HorizontalAlignment } from "./stack-layout-common";
+﻿import { StackLayoutBase } from "./stack-layout-common";
 import * as trace from "../../../trace";
+import { layout } from "../../../utils/utils";
+import { VerticalAlignment, HorizontalAlignment } from "../../styling/style-properties";
+import { View } from '../../core/view';
 
 export * from "./stack-layout-common";
 

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout-common.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout-common.ts
@@ -1,7 +1,11 @@
 ﻿import { WrapLayout as WrapLayoutDefinition, Orientation } from ".";
-import { LayoutBase, Property, isIOS, Length, makeValidator, makeParser, CSSType } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Property, makeParser, makeValidator } from "../../core/properties/properties";
+import { isIOS } from "../../../platform";
+import { Length } from "../..//styling/style-properties";
+import { CSSType } from "../../core/view/view";
 
-export * from "../layout-base";
+// export * from "../layout-base";
 
 @CSSType("WrapLayout")
 export class WrapLayoutBase extends LayoutBase implements WrapLayoutDefinition {

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout-common.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout-common.ts
@@ -5,8 +5,6 @@ import { isIOS } from "../../../platform";
 import { Length } from "../..//styling/style-properties";
 import { CSSType } from "../../core/view/view";
 
-// export * from "../layout-base";
-
 @CSSType("WrapLayout")
 export class WrapLayoutBase extends LayoutBase implements WrapLayoutDefinition {
     public orientation: Orientation;

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.android.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.android.ts
@@ -1,4 +1,5 @@
-﻿import { WrapLayoutBase, orientationProperty, itemWidthProperty, itemHeightProperty, Length } from "./wrap-layout-common";
+﻿import { WrapLayoutBase, orientationProperty, itemWidthProperty, itemHeightProperty } from "./wrap-layout-common";
+import { Length } from "../../styling/style-properties";
 
 export * from "./wrap-layout-common";
 

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.d.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.d.ts
@@ -2,7 +2,9 @@
  * @module "ui/layouts/wrap-layout"
  */ /** */
 
-import { LayoutBase, Property, Length } from "../layout-base";
+import { LayoutBase } from "../layout-base";
+import { Length } from "../../styling/style-properties";
+import { Property } from "../../core/properties";
 
 /**
  * WrapLayout position children in rows or columns depending on orientation property

--- a/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/wrap-layout/wrap-layout.ios.ts
@@ -1,4 +1,6 @@
-﻿import { WrapLayoutBase, View, layout } from "./wrap-layout-common";
+﻿import { WrapLayoutBase } from "./wrap-layout-common";
+import { layout } from "../../../utils/utils";
+import { View } from "../../core/view";
 
 export * from "./wrap-layout-common";
 

--- a/tns-core-modules/ui/list-picker/list-picker-common.ts
+++ b/tns-core-modules/ui/list-picker/list-picker-common.ts
@@ -1,7 +1,8 @@
-﻿import { ListPicker as ListPickerDefinition, ItemsSource } from ".";
-import { View, Property, CoercibleProperty, CSSType } from "../core/view";
+﻿import { ItemsSource, ListPicker as ListPickerDefinition } from ".";
+import { CoercibleProperty, Property } from "../core/properties";
+import { CSSType, View } from "../core/view";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 @CSSType("ListPicker")
 export class ListPickerBase extends View implements ListPickerDefinition {

--- a/tns-core-modules/ui/list-picker/list-picker-common.ts
+++ b/tns-core-modules/ui/list-picker/list-picker-common.ts
@@ -2,8 +2,6 @@
 import { CoercibleProperty, Property } from "../core/properties";
 import { CSSType, View } from "../core/view";
 
-// export * from "../core/view";
-
 @CSSType("ListPicker")
 export class ListPickerBase extends View implements ListPickerDefinition {
 

--- a/tns-core-modules/ui/list-picker/list-picker.android.ts
+++ b/tns-core-modules/ui/list-picker/list-picker.android.ts
@@ -1,5 +1,7 @@
-﻿import { ListPickerBase, selectedIndexProperty, itemsProperty, colorProperty, Color } from "./list-picker-common";
+﻿import { ListPickerBase, selectedIndexProperty, itemsProperty } from "./list-picker-common";
 import { ItemsSource } from ".";
+import { colorProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./list-picker-common";
 

--- a/tns-core-modules/ui/list-picker/list-picker.d.ts
+++ b/tns-core-modules/ui/list-picker/list-picker.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/list-picker"
  */ /** */
 
-import { View, Property } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties";
 
 /**
  * Represents an list picker.

--- a/tns-core-modules/ui/list-picker/list-picker.ios.ts
+++ b/tns-core-modules/ui/list-picker/list-picker.ios.ts
@@ -1,6 +1,8 @@
-﻿import { ListPickerBase, Color, selectedIndexProperty, itemsProperty, backgroundColorProperty, colorProperty } from "./list-picker-common";
+﻿import { ListPickerBase, selectedIndexProperty, itemsProperty } from "./list-picker-common";
 import { ItemsSource } from ".";
 import { profile } from "../../profiling";
+import { backgroundColorProperty, colorProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./list-picker-common";
 

--- a/tns-core-modules/ui/list-view/list-view-common.ts
+++ b/tns-core-modules/ui/list-view/list-view-common.ts
@@ -1,6 +1,6 @@
 import { ItemEventData, ItemsSource, ListView as ListViewDefinition, TemplatedItemsView } from ".";
-import { Color } from '../../color';
-import { EventData, Observable } from '../../data/observable';
+import { Color } from "../../color";
+import { EventData, Observable } from "../../data/observable";
 import { ChangedData, ObservableArray } from "../../data/observable-array";
 import { parse, parseMultipleTemplates } from "../builder";
 import { CoercibleProperty, CssProperty } from "../core/properties";
@@ -10,8 +10,6 @@ import { addWeakEventListener, removeWeakEventListener } from "../core/weak-even
 import { Label } from "../label";
 import { Style } from "../styling/style";
 import { Length } from "../styling/style-properties";
-
-// export * from "../core/view";
 
 // TODO: Think of a way to register these instead of relying on hardcoded values.
 export module knownTemplates {

--- a/tns-core-modules/ui/list-view/list-view-common.ts
+++ b/tns-core-modules/ui/list-view/list-view-common.ts
@@ -1,11 +1,17 @@
-import { ListView as ListViewDefinition, ItemsSource, ItemEventData, TemplatedItemsView } from ".";
-import { CoercibleProperty, CssProperty, Style, View, ContainerView, Template, KeyedTemplate, Length, Property, Color, Observable, EventData, CSSType } from "../core/view";
+import { ItemEventData, ItemsSource, ListView as ListViewDefinition, TemplatedItemsView } from ".";
+import { Color } from '../../color';
+import { EventData, Observable } from '../../data/observable';
+import { ChangedData, ObservableArray } from "../../data/observable-array";
 import { parse, parseMultipleTemplates } from "../builder";
-import { Label } from "../label";
-import { ObservableArray, ChangedData } from "../../data/observable-array";
+import { CoercibleProperty, CssProperty } from "../core/properties";
+import { Property } from "../core/properties/properties";
+import { ContainerView, CSSType, KeyedTemplate, Template, View } from "../core/view";
 import { addWeakEventListener, removeWeakEventListener } from "../core/weak-event-listener";
+import { Label } from "../label";
+import { Style } from "../styling/style";
+import { Length } from "../styling/style-properties";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 // TODO: Think of a way to register these instead of relying on hardcoded values.
 export module knownTemplates {

--- a/tns-core-modules/ui/list-view/list-view.android.ts
+++ b/tns-core-modules/ui/list-view/list-view.android.ts
@@ -1,12 +1,17 @@
 ﻿import { ItemEventData, ItemsSource } from ".";
 import {
-    ListViewBase, View, KeyedTemplate, Length, unsetValue, Observable, Color,
+    ListViewBase,
     separatorColorProperty, itemTemplatesProperty
 } from "./list-view-common";
 import { StackLayout } from "../layouts/stack-layout";
 import { ProxyViewContainer } from "../proxy-view-container";
 import { LayoutBase } from "../layouts/layout-base";
 import { profile } from "../../profiling";
+import { Observable } from "../../data/observable";
+import { Color } from "../../color";
+import { unsetValue } from "../core/properties";
+import { Length } from "../styling/style-properties";
+import { View, KeyedTemplate } from "../core/view";
 
 export * from "./list-view-common";
 

--- a/tns-core-modules/ui/list-view/list-view.d.ts
+++ b/tns-core-modules/ui/list-view/list-view.d.ts
@@ -3,8 +3,8 @@
  * @module "ui/list-view"
  */ /** */
 
-import { Color } from '../../color';
-import { EventData } from '../../data/observable';
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
 import { CssProperty, Property } from "../core/properties";
 import { KeyedTemplate, Template, View } from "../core/view";
 import { Style } from "../styling/style";

--- a/tns-core-modules/ui/list-view/list-view.d.ts
+++ b/tns-core-modules/ui/list-view/list-view.d.ts
@@ -3,7 +3,12 @@
  * @module "ui/list-view"
  */ /** */
 
-import { EventData, View, Template, KeyedTemplate, Length, Property, CssProperty, Color, Style } from "../core/view";
+import { Color } from '../../color';
+import { EventData } from '../../data/observable';
+import { CssProperty, Property } from "../core/properties";
+import { KeyedTemplate, Template, View } from "../core/view";
+import { Style } from "../styling/style";
+import { Length } from "../styling/style-properties";
 
 /**
  * Known template names.

--- a/tns-core-modules/ui/list-view/list-view.ios.ts
+++ b/tns-core-modules/ui/list-view/list-view.ios.ts
@@ -1,12 +1,17 @@
 import { ItemEventData } from ".";
 import {
-    ListViewBase, View, KeyedTemplate, Length, Observable, Color,
-    separatorColorProperty, itemTemplatesProperty, iosEstimatedRowHeightProperty, layout, EventData
+    ListViewBase,
+    separatorColorProperty, itemTemplatesProperty, iosEstimatedRowHeightProperty
 } from "./list-view-common";
 import { StackLayout } from "../layouts/stack-layout";
 import { ProxyViewContainer } from "../proxy-view-container";
 import { profile } from "../../profiling";
 import * as trace from "../../trace";
+import { layout } from "tns-core-modules/utils/utils";
+import { View, KeyedTemplate } from "../core/view";
+import { EventData, Observable } from "../../data/observable";
+import { Color } from "../../color";
+import { Length } from "../styling/style-properties";
 
 export * from "./list-view-common";
 

--- a/tns-core-modules/ui/page/page-common.ts
+++ b/tns-core-modules/ui/page/page-common.ts
@@ -1,14 +1,18 @@
-﻿import { Page as PageDefinition, NavigatedData, ShownModallyData } from ".";
-import {
-    ContentView, View, Property, CssProperty, Color, isIOS,
-    booleanConverter, Style, EventData, CSSType
-} from "../content-view";
-import { Frame } from "../frame";
+﻿import { NavigatedData, Page as PageDefinition } from ".";
+import { Color } from '../../color';
+import { EventData } from '../../data/observable';
+import { isIOS } from '../../platform';
+import { profile } from "../../profiling";
 import { ActionBar } from "../action-bar";
 import { KeyframeAnimationInfo } from "../animation/keyframe-animation";
-import { profile } from "../../profiling";
+import { ContentView } from "../content-view";
+import { CssProperty, Property } from "../core/properties";
+import { CSSType, ShownModallyData, View } from "../core/view";
+import { booleanConverter } from "../core/view-base";
+import { Frame } from "../frame";
+import { Style } from "../styling/style";
 
-export * from "../content-view";
+// export * from "../content-view";
 
 @CSSType("Page")
 export class PageBase extends ContentView implements PageDefinition {

--- a/tns-core-modules/ui/page/page-common.ts
+++ b/tns-core-modules/ui/page/page-common.ts
@@ -1,7 +1,7 @@
 ﻿import { NavigatedData, Page as PageDefinition } from ".";
-import { Color } from '../../color';
-import { EventData } from '../../data/observable';
-import { isIOS } from '../../platform';
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
+import { isIOS } from "../../platform";
 import { profile } from "../../profiling";
 import { ActionBar } from "../action-bar";
 import { KeyframeAnimationInfo } from "../animation/keyframe-animation";
@@ -11,8 +11,6 @@ import { CSSType, ShownModallyData, View } from "../core/view";
 import { booleanConverter } from "../core/view-base";
 import { Frame } from "../frame";
 import { Style } from "../styling/style";
-
-// export * from "../content-view";
 
 @CSSType("Page")
 export class PageBase extends ContentView implements PageDefinition {

--- a/tns-core-modules/ui/page/page.android.ts
+++ b/tns-core-modules/ui/page/page.android.ts
@@ -4,7 +4,7 @@ import { GridLayout } from "../layouts/grid-layout";
 import { device } from "../../platform";
 import { profile } from "../../profiling";
 import { View } from "../core/view";
-import { Color } from '../../color';
+import { Color } from "../../color";
 
 export * from "./page-common";
 

--- a/tns-core-modules/ui/page/page.android.ts
+++ b/tns-core-modules/ui/page/page.android.ts
@@ -1,8 +1,10 @@
-﻿import { View, PageBase, Color, actionBarHiddenProperty, statusBarStyleProperty, androidStatusBarBackgroundProperty } from "./page-common";
+﻿import { PageBase, actionBarHiddenProperty, statusBarStyleProperty, androidStatusBarBackgroundProperty } from "./page-common";
 import { ActionBar } from "../action-bar";
 import { GridLayout } from "../layouts/grid-layout";
 import { device } from "../../platform";
 import { profile } from "../../profiling";
+import { View } from "../core/view";
+import { Color } from '../../color';
 
 export * from "./page-common";
 

--- a/tns-core-modules/ui/page/page.d.ts
+++ b/tns-core-modules/ui/page/page.d.ts
@@ -5,17 +5,18 @@
 
 /// <reference path="../../tns-core-modules.d.ts" />
 
-import { ShownModallyData } from "../core/view";
-import { ContentView, EventData, Property, Color, CssProperty, Style } from "../content-view";
-import { Frame } from "../frame";
+import { Color } from '../../color';
+import { EventData } from '../../data/observable';
 import { ActionBar } from "../action-bar";
 import { KeyframeAnimationInfo } from "../animation/keyframe-animation";
+import { ContentView } from "../content-view";
+import { CssProperty, Property } from "../core/properties";
+import { Frame } from "../frame";
+import { Style } from "../styling/style";
 
-//@private
-import * as styleScope from "../styling/style-scope";
 //@endprivate
 
-export * from "../content-view";
+// export * from "../content-view";
 
 /**
  * Defines the data for the page navigation events.

--- a/tns-core-modules/ui/page/page.d.ts
+++ b/tns-core-modules/ui/page/page.d.ts
@@ -5,8 +5,8 @@
 
 /// <reference path="../../tns-core-modules.d.ts" />
 
-import { Color } from '../../color';
-import { EventData } from '../../data/observable';
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
 import { ActionBar } from "../action-bar";
 import { KeyframeAnimationInfo } from "../animation/keyframe-animation";
 import { ContentView } from "../content-view";

--- a/tns-core-modules/ui/page/page.d.ts
+++ b/tns-core-modules/ui/page/page.d.ts
@@ -16,8 +16,6 @@ import { Style } from "../styling/style";
 
 //@endprivate
 
-// export * from "../content-view";
-
 /**
  * Defines the data for the page navigation events.
  */

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -2,14 +2,15 @@
 import { Frame } from "../frame";
 
 // Types.
-import { ios as iosView } from "../core/view";
+import { ios as iosView, View } from "../core/view";
 import {
-    PageBase, View, layout,
-    actionBarHiddenProperty, statusBarStyleProperty, Color
+    PageBase,
+    actionBarHiddenProperty, statusBarStyleProperty
 } from "./page-common";
 
 import { profile } from "../../profiling";
-import { ios as iosUtils } from "../../utils/utils";
+import { ios as iosUtils, layout } from "../../utils/utils";
+import { Color } from "../../color";
 
 export * from "./page-common";
 

--- a/tns-core-modules/ui/placeholder/placeholder.android.ts
+++ b/tns-core-modules/ui/placeholder/placeholder.android.ts
@@ -1,5 +1,6 @@
 ﻿import { Placeholder as PlaceholderDefinition, CreateViewEventData } from "."
-import { View, EventData, CSSType } from "../core/view"
+import { View, CSSType } from "../core/view"
+import { EventData } from "../../data/observable";
 
 @CSSType("Placeholder")
 export class Placeholder extends View implements PlaceholderDefinition {

--- a/tns-core-modules/ui/placeholder/placeholder.d.ts
+++ b/tns-core-modules/ui/placeholder/placeholder.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/placeholder"
  */ /** */
 
-import { View, EventData } from "../core/view";
+import { View } from "../core/view";
+import { EventData } from "../../data/observable";
 
 /**
  * Represents a Placeholder, which is used to add a native view to the visual tree.

--- a/tns-core-modules/ui/placeholder/placeholder.ts
+++ b/tns-core-modules/ui/placeholder/placeholder.ts
@@ -1,5 +1,6 @@
 ﻿import { Placeholder as PlaceholderDefinition, CreateViewEventData } from "."
-import { View, EventData } from "../core/view"
+import { View } from "../core/view"
+import { EventData } from "../../data/observable";
 
 export class Placeholder extends View implements PlaceholderDefinition {
     public static creatingViewEvent = "creatingView";

--- a/tns-core-modules/ui/progress/progress-common.ts
+++ b/tns-core-modules/ui/progress/progress-common.ts
@@ -1,7 +1,8 @@
 ﻿import { Progress as ProgressDefinition } from ".";
-import { View, Property, CoercibleProperty, CSSType } from "../core/view";
+import { CoercibleProperty, Property } from "../core/properties";
+import { CSSType, View } from "../core/view";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 @CSSType("Progress")
 export class ProgressBase extends View implements ProgressDefinition {

--- a/tns-core-modules/ui/progress/progress-common.ts
+++ b/tns-core-modules/ui/progress/progress-common.ts
@@ -2,8 +2,6 @@
 import { CoercibleProperty, Property } from "../core/properties";
 import { CSSType, View } from "../core/view";
 
-// export * from "../core/view";
-
 @CSSType("Progress")
 export class ProgressBase extends View implements ProgressDefinition {
     public value: number;

--- a/tns-core-modules/ui/progress/progress.android.ts
+++ b/tns-core-modules/ui/progress/progress.android.ts
@@ -1,7 +1,8 @@
 ﻿import {
-    Color, ProgressBase, valueProperty, maxValueProperty,
-    colorProperty, backgroundColorProperty, backgroundInternalProperty
+    ProgressBase, valueProperty, maxValueProperty
 } from "./progress-common";
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./progress-common";
 

--- a/tns-core-modules/ui/progress/progress.d.ts
+++ b/tns-core-modules/ui/progress/progress.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/progress"
  */ /** */
 
-import { View, Property } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties";
 
 /**
  * Represents a progress component.

--- a/tns-core-modules/ui/progress/progress.ios.ts
+++ b/tns-core-modules/ui/progress/progress.ios.ts
@@ -1,7 +1,8 @@
 ﻿import {
-    ProgressBase, Color, valueProperty, maxValueProperty,
-    colorProperty, backgroundColorProperty, backgroundInternalProperty
+    ProgressBase, valueProperty, maxValueProperty
 } from "./progress-common";
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./progress-common";
 

--- a/tns-core-modules/ui/proxy-view-container/proxy-view-container.ts
+++ b/tns-core-modules/ui/proxy-view-container/proxy-view-container.ts
@@ -1,5 +1,7 @@
 ﻿import { ProxyViewContainer as ProxyViewContainerDefinition } from ".";
-import { LayoutBase, View, traceEnabled, traceWrite, traceCategories, CSSType } from "../layouts/layout-base";
+import { LayoutBase } from "../layouts/layout-base";
+import { traceEnabled, traceWrite, traceCategories } from "../core/bindable";
+import { CSSType, View } from "../core/view";
 /**
  * Proxy view container that adds all its native children directly to the parent. 
  * To be used as a logical grouping container of views.

--- a/tns-core-modules/ui/repeater/repeater.d.ts
+++ b/tns-core-modules/ui/repeater/repeater.d.ts
@@ -3,7 +3,9 @@
  * @module "ui/repeater"
  */ /** */
 
-import { LayoutBase, CustomLayoutView, Template, Property } from "../layouts/layout-base";
+import { LayoutBase } from "../layouts/layout-base";
+import { CustomLayoutView, Template } from "../core/view";
+import { Property } from "../core/properties";
 
 /**
  * Represents a UI Repeater component.

--- a/tns-core-modules/ui/repeater/repeater.ts
+++ b/tns-core-modules/ui/repeater/repeater.ts
@@ -6,11 +6,9 @@ import { ObservableArray, ChangedData } from "../../data/observable-array";
 import { addWeakEventListener, removeWeakEventListener } from "../core/weak-event-listener";
 import { parse } from "../builder";
 import { profile } from "../../profiling";
-import { layout } from '../../utils/utils';
+import { layout } from "../../utils/utils";
 import { Property } from "../core/properties";
 import { CSSType, CustomLayoutView, Template, View } from "../core/view";
-
-// export * from "../layouts/layout-base";
 
 export module knownTemplates {
     export const itemTemplate = "itemTemplate";

--- a/tns-core-modules/ui/repeater/repeater.ts
+++ b/tns-core-modules/ui/repeater/repeater.ts
@@ -1,13 +1,16 @@
 ﻿import { Repeater as RepeaterDefinition, ItemsSource } from ".";
 import { Label } from "../label";
-import { LayoutBase, CustomLayoutView, View, Template, Property, layout, CSSType } from "../layouts/layout-base";
+import { LayoutBase } from "../layouts/layout-base";
 import { StackLayout } from "../layouts/stack-layout";
 import { ObservableArray, ChangedData } from "../../data/observable-array";
 import { addWeakEventListener, removeWeakEventListener } from "../core/weak-event-listener";
 import { parse } from "../builder";
 import { profile } from "../../profiling";
+import { layout } from '../../utils/utils';
+import { Property } from "../core/properties";
+import { CSSType, CustomLayoutView, Template, View } from "../core/view";
 
-export * from "../layouts/layout-base";
+// export * from "../layouts/layout-base";
 
 export module knownTemplates {
     export const itemTemplate = "itemTemplate";

--- a/tns-core-modules/ui/scroll-view/scroll-view-common.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view-common.ts
@@ -1,8 +1,12 @@
 ﻿import { ScrollView as ScrollViewDefinition, Orientation, ScrollEventData } from ".";
-import { ContentView, Property, makeParser, makeValidator, EventData, booleanConverter, CSSType } from "../content-view";
+import { ContentView } from "../content-view";
 import { profile } from "../../profiling";
+import { CSSType } from "../core/view/view";
+import { EventData } from "../../data/observable";
+import { makeParser, makeValidator, Property } from "../core/properties";
+import { booleanConverter } from "../core/view-base";
 
-export * from "../content-view";
+// export * from "../content-view";
 
 @CSSType("ScrollView")
 export abstract class ScrollViewBase extends ContentView implements ScrollViewDefinition {

--- a/tns-core-modules/ui/scroll-view/scroll-view-common.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view-common.ts
@@ -6,8 +6,6 @@ import { EventData } from "../../data/observable";
 import { makeParser, makeValidator, Property } from "../core/properties";
 import { booleanConverter } from "../core/view-base";
 
-// export * from "../content-view";
-
 @CSSType("ScrollView")
 export abstract class ScrollViewBase extends ContentView implements ScrollViewDefinition {
     private _scrollChangeCount: number = 0;

--- a/tns-core-modules/ui/scroll-view/scroll-view.android.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.android.ts
@@ -1,8 +1,10 @@
 ﻿import { ScrollEventData } from ".";
 import { 
-    ScrollViewBase, layout, scrollBarIndicatorVisibleProperty,
-    isUserInteractionEnabledProperty, isScrollEnabledProperty 
+    ScrollViewBase, scrollBarIndicatorVisibleProperty,
+    isScrollEnabledProperty 
 } from "./scroll-view-common";
+import { layout } from "../../utils/utils";
+import { isUserInteractionEnabledProperty } from "../core/view";
 
 export * from "./scroll-view-common";
 

--- a/tns-core-modules/ui/scroll-view/scroll-view.d.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.d.ts
@@ -3,7 +3,9 @@
  * @module "ui/scroll-view"
  */ /** */
 
-import { ContentView, EventData, Property } from "../content-view";
+import { ContentView } from "../content-view";
+import { EventData } from "../../data/observable";
+import { Property } from "../core/properties";
 
 /**
  * Represents a scrollable area that can have content that is larger than its bounds.

--- a/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
+++ b/tns-core-modules/ui/scroll-view/scroll-view.ios.ts
@@ -1,8 +1,9 @@
 ﻿import { ScrollEventData } from ".";
 import {
-    View, layout, ScrollViewBase, scrollBarIndicatorVisibleProperty, isScrollEnabledProperty
+    ScrollViewBase, scrollBarIndicatorVisibleProperty, isScrollEnabledProperty
 } from "./scroll-view-common";
-import { ios as iosUtils } from "../../utils/utils";
+import { ios as iosUtils, layout } from "../../utils/utils";
+import { View } from "../core/view";
 
 export * from "./scroll-view-common";
 

--- a/tns-core-modules/ui/search-bar/search-bar-common.ts
+++ b/tns-core-modules/ui/search-bar/search-bar-common.ts
@@ -1,10 +1,8 @@
 ﻿import { SearchBar as SearchBarDefinition } from ".";
 import { View, CSSType } from "../core/view";
 import { Property } from "../core/properties";
-import { Color } from '../../color';
-import { isIOS } from '../../platform';
-
-// export * from "../core/view";
+import { Color } from "../../color";
+import { isIOS } from "../../platform";
 
 @CSSType("SearchBar")
 export abstract class SearchBarBase extends View implements SearchBarDefinition {

--- a/tns-core-modules/ui/search-bar/search-bar-common.ts
+++ b/tns-core-modules/ui/search-bar/search-bar-common.ts
@@ -1,7 +1,10 @@
 ﻿import { SearchBar as SearchBarDefinition } from ".";
-import { View, Property, Color, isIOS, CSSType } from "../core/view";
+import { View, CSSType } from "../core/view";
+import { Property } from "../core/properties";
+import { Color } from '../../color';
+import { isIOS } from '../../platform';
 
-export * from "../core/view";
+// export * from "../core/view";
 
 @CSSType("SearchBar")
 export abstract class SearchBarBase extends View implements SearchBarDefinition {

--- a/tns-core-modules/ui/search-bar/search-bar.android.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.android.ts
@@ -1,10 +1,12 @@
 ﻿import { Font } from "../styling/font";
 import {
-    SearchBarBase, Color, colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty,
-    textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty, fontSizeProperty,
-    isEnabledProperty, isUserInteractionEnabledProperty
+    SearchBarBase,
+    textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty
 } from "./search-bar-common";
 import { ad } from "../../utils/utils";
+import { isEnabledProperty, isUserInteractionEnabledProperty } from "../core/view";
+import { backgroundColorProperty, colorProperty, fontSizeProperty, fontInternalProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./search-bar-common";
 

--- a/tns-core-modules/ui/search-bar/search-bar.d.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.d.ts
@@ -3,7 +3,10 @@
  * @module "ui/search-bar"
  */ /** */
 
-import { View, Property, EventData, Color } from "../core/view";
+import { View } from "../core/view";
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
+import { Property } from "../core/properties";
 
 /**
  * Represents a search bar component.

--- a/tns-core-modules/ui/search-bar/search-bar.ios.ts
+++ b/tns-core-modules/ui/search-bar/search-bar.ios.ts
@@ -1,9 +1,12 @@
 ﻿import { Font } from "../styling/font";
 import {
-    SearchBarBase, Color, colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty,
-    textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty, isEnabledProperty
+    SearchBarBase,
+    textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty
 } from "./search-bar-common";
 import { ios as iosUtils } from "../../utils/utils";
+import { isEnabledProperty } from "../core/view";
+import { backgroundColorProperty, colorProperty, fontInternalProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./search-bar-common";
 

--- a/tns-core-modules/ui/segmented-bar/segmented-bar-common.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar-common.ts
@@ -1,10 +1,12 @@
-﻿import { SegmentedBar as SegmentedBarDefinition, SegmentedBarItem as SegmentedBarItemDefinition, SelectedIndexChangedEventData } from ".";
-import {
-    ViewBase, View, AddChildFromBuilder, AddArrayFromBuilder,
-    Property, CoercibleProperty, InheritedCssProperty, Color, Style, EventData, CSSType
-} from "../core/view";
+﻿import { SegmentedBar as SegmentedBarDefinition, SegmentedBarItem, SegmentedBarItem as SegmentedBarItemDefinition, SelectedIndexChangedEventData } from ".";
+import { Color } from '../../color';
+import { EventData } from '../../data/observable';
+import { CoercibleProperty, InheritedCssProperty, Property } from "../core/properties";
+import { AddArrayFromBuilder, AddChildFromBuilder, CSSType, View } from "../core/view";
+import { ViewBase } from "../core/view-base";
+import { Style } from "../styling/style";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 export module knownCollections {
     export const items = "items";
@@ -82,7 +84,7 @@ export abstract class SegmentedBarBase extends View implements SegmentedBarDefin
     }
 
     // TODO: Make _addView to keep its children so this method is not needed!
-    public eachChild(callback: (child: ViewBase) => boolean): void {
+    public eachChild(callback: (child: SegmentedBarItem) => boolean): void {
         const items = this.items;
         if (items) {
             items.forEach((item, i) => {

--- a/tns-core-modules/ui/segmented-bar/segmented-bar-common.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar-common.ts
@@ -1,12 +1,10 @@
 ﻿import { SegmentedBar as SegmentedBarDefinition, SegmentedBarItem, SegmentedBarItem as SegmentedBarItemDefinition, SelectedIndexChangedEventData } from ".";
-import { Color } from '../../color';
-import { EventData } from '../../data/observable';
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
 import { CoercibleProperty, InheritedCssProperty, Property } from "../core/properties";
 import { AddArrayFromBuilder, AddChildFromBuilder, CSSType, View } from "../core/view";
 import { ViewBase } from "../core/view-base";
 import { Style } from "../styling/style";
-
-// export * from "../core/view";
 
 export module knownCollections {
     export const items = "items";

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.android.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.android.ts
@@ -1,8 +1,10 @@
 ﻿import { Font } from "../styling/font";
 import {
-    SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty,
-    colorProperty, fontInternalProperty, fontSizeProperty, Color, layout
+    SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty
 } from "./segmented-bar-common";
+import { layout } from '../../utils/utils';
+import { colorProperty, fontSizeProperty, fontInternalProperty } from "../styling/style-properties";
+import { Color } from '../../color';
 
 export * from "./segmented-bar-common";
 

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.android.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.android.ts
@@ -2,9 +2,9 @@
 import {
     SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty
 } from "./segmented-bar-common";
-import { layout } from '../../utils/utils';
+import { layout } from "../../utils/utils";
 import { colorProperty, fontSizeProperty, fontInternalProperty } from "../styling/style-properties";
-import { Color } from '../../color';
+import { Color } from "../../color";
 
 export * from "./segmented-bar-common";
 

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.d.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.d.ts
@@ -4,8 +4,8 @@
  * Contains the SegmentedBar class, which represents a SegmentedBar component.
  */ /** */
 
-import { Color } from '../../color';
-import { EventData } from '../../data/observable';
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
 import { CoercibleProperty, CssProperty, Property } from "../core/properties";
 import { AddArrayFromBuilder, AddChildFromBuilder, View } from "../core/view";
 import { ViewBase } from "../core/view-base";

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.d.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.d.ts
@@ -4,10 +4,12 @@
  * Contains the SegmentedBar class, which represents a SegmentedBar component.
  */ /** */
 
-import {
-    ViewBase, View, AddChildFromBuilder, AddArrayFromBuilder,
-    Property, CoercibleProperty, EventData, Color, CssProperty, Style
-} from "../core/view";
+import { Color } from '../../color';
+import { EventData } from '../../data/observable';
+import { CoercibleProperty, CssProperty, Property } from "../core/properties";
+import { AddArrayFromBuilder, AddChildFromBuilder, View } from "../core/view";
+import { ViewBase } from "../core/view-base";
+import { Style } from "../styling/style";
 
 /**
  * Represents a SegmentedBar item.

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
@@ -1,8 +1,9 @@
 ﻿import { Font } from "../styling/font";
 import {
-    SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty,
-    colorProperty, fontInternalProperty, Color
+    SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty
 } from "./segmented-bar-common";
+import { Color } from "../../color";
+import { colorProperty, fontInternalProperty } from "../styling/style-properties";
 
 export * from "./segmented-bar-common";
 

--- a/tns-core-modules/ui/slider/slider-common.ts
+++ b/tns-core-modules/ui/slider/slider-common.ts
@@ -3,8 +3,6 @@ import { isIOS } from "../../platform";
 import { CoercibleProperty, Property } from "../core/properties";
 import { CSSType, View } from "../core/view";
 
-// export * from "../core/view";
-
 // TODO: Extract base Range class for slider and progress
 @CSSType("Slider")
 export class SliderBase extends View implements SliderDefinition {

--- a/tns-core-modules/ui/slider/slider-common.ts
+++ b/tns-core-modules/ui/slider/slider-common.ts
@@ -1,7 +1,9 @@
 ﻿import { Slider as SliderDefinition } from ".";
-import { View, Property, CoercibleProperty, isIOS, CSSType } from "../core/view";
+import { isIOS } from "../../platform";
+import { CoercibleProperty, Property } from "../core/properties";
+import { CSSType, View } from "../core/view";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 // TODO: Extract base Range class for slider and progress
 @CSSType("Slider")

--- a/tns-core-modules/ui/slider/slider.android.ts
+++ b/tns-core-modules/ui/slider/slider.android.ts
@@ -1,8 +1,9 @@
 ﻿import { Background } from "../styling/background";
 import {
-    SliderBase, valueProperty, minValueProperty, maxValueProperty,
-    colorProperty, backgroundColorProperty, backgroundInternalProperty, Color
+    SliderBase, valueProperty, minValueProperty, maxValueProperty
 } from "./slider-common";
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./slider-common";
 

--- a/tns-core-modules/ui/slider/slider.d.ts
+++ b/tns-core-modules/ui/slider/slider.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/slider"
  */ /** */
 
-import { View, Property, CoercibleProperty } from "../core/view";
+import { View } from "../core/view";
+import { CoercibleProperty, Property } from "../core/properties";
 
 /**
  * Represents a slider component.

--- a/tns-core-modules/ui/slider/slider.ios.ts
+++ b/tns-core-modules/ui/slider/slider.ios.ts
@@ -1,10 +1,10 @@
 ﻿import { Background } from "../styling/background";
 
 import {
-    SliderBase, valueProperty, minValueProperty, maxValueProperty,
-    colorProperty, backgroundColorProperty, backgroundInternalProperty,
-    Color
+    SliderBase, valueProperty, minValueProperty, maxValueProperty
 } from "./slider-common";
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./slider-common";
 

--- a/tns-core-modules/ui/styling/background-common.ts
+++ b/tns-core-modules/ui/styling/background-common.ts
@@ -1,9 +1,9 @@
 // Deifinitions.
 import { Background as BackgroundDefinition } from "./background";
-import { BackgroundRepeat } from "../core/view";
 import { LinearGradient } from "./linear-gradient";
 // Types.
 import { Color } from "../../color";
+import { BackgroundRepeat } from "./style-properties";
 
 export class Background implements BackgroundDefinition {
     public static default = new Background();

--- a/tns-core-modules/ui/styling/background.d.ts
+++ b/tns-core-modules/ui/styling/background.d.ts
@@ -3,7 +3,9 @@
  */ /** */
 
 import { Color } from "../../color";
-import { View, BackgroundRepeat, LinearGradient } from "../core/view";
+import { View } from "../core/view";
+import { LinearGradient } from "./linear-gradient";
+import { BackgroundRepeat } from "./style-properties";
 
 export class Background {
     public static default: Background;

--- a/tns-core-modules/ui/styling/style-properties.ts
+++ b/tns-core-modules/ui/styling/style-properties.ts
@@ -1,5 +1,5 @@
 // Types
-import { unsetValue, Style,
+import { unsetValue,
     CssProperty, CssAnimationProperty,
     ShorthandProperty, InheritedCssProperty,
     makeValidator, makeParser } from "../core/properties";
@@ -28,6 +28,7 @@ import {
 
 import * as parser from "../../css/parser";
 import { LinearGradient } from "./linear-gradient";
+import { Style } from "./style";
 
 export type LengthDipUnit = { readonly unit: "dip", readonly value: dip };
 export type LengthPxUnit = { readonly unit: "px", readonly value: px };

--- a/tns-core-modules/ui/styling/style/style.d.ts
+++ b/tns-core-modules/ui/styling/style/style.d.ts
@@ -12,7 +12,7 @@ import {
     Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf
 } from "../../layouts/flexbox-layout";
 import { LinearGradient } from "../gradient";
-import { Observable } from '../../../data/observable';
+import { Observable } from "../../../data/observable";
 import { VerticalAlignment, HorizontalAlignment, PercentLength, Visibility, Length } from "../style-properties";
 import { BackgroundRepeat } from "../../../css/parser";
 import { ViewBase } from "../../core/view-base";

--- a/tns-core-modules/ui/styling/style/style.d.ts
+++ b/tns-core-modules/ui/styling/style/style.d.ts
@@ -2,7 +2,7 @@
  * @module "ui/styling/style"
  */ /** */
 
-import { Length, PercentLength, ViewBase, Observable, BackgroundRepeat, Visibility, HorizontalAlignment, VerticalAlignment, dip } from "../../core/view";
+import { dip } from "../../core/view";
 import { Color } from "../../../color";
 import { Background } from "../background";
 import { Font, FontStyle, FontWeight } from "../font";
@@ -12,6 +12,10 @@ import {
     Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf
 } from "../../layouts/flexbox-layout";
 import { LinearGradient } from "../gradient";
+import { Observable } from '../../../data/observable';
+import { VerticalAlignment, HorizontalAlignment, PercentLength, Visibility, Length } from "../style-properties";
+import { BackgroundRepeat } from "../../../css/parser";
+import { ViewBase } from "../../core/view-base";
 
 export interface Thickness {
     left: number;

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -2,8 +2,7 @@ import { Style as StyleDefinition } from ".";
 import { Color } from "../../../color";
 import { Font, FontStyle, FontWeight } from "../font";
 import { Background } from "../background";
-import { Length, PercentLength, ViewBase, BackgroundRepeat, Visibility,
-    HorizontalAlignment, VerticalAlignment, dip, LinearGradient } from "../../core/view";
+import { dip } from "../../core/view";
 import { Observable } from "../../../data/observable";
 
 import {
@@ -12,6 +11,9 @@ import {
 } from "../../layouts/flexbox-layout";
 
 import { TextAlignment, TextDecoration, TextTransform, WhiteSpace } from "../../text-base";
+import { ViewBase } from "tns-core-modules/ui/core/view-base/view-base";
+import { Visibility, PercentLength, HorizontalAlignment, VerticalAlignment, Length, BackgroundRepeat } from "../style-properties";
+import { LinearGradient } from "../linear-gradient";
 
 export class Style extends Observable implements StyleDefinition {
     constructor(public view: ViewBase) {

--- a/tns-core-modules/ui/switch/switch-common.ts
+++ b/tns-core-modules/ui/switch/switch-common.ts
@@ -3,8 +3,6 @@ import { View, CSSType } from "../core/view";
 import { Property } from "../core/properties";
 import { booleanConverter } from "../core/view-base";
 
-// export * from "../core/view";
-
 @CSSType("Switch")
 export class SwitchBase extends View implements SwitchDefinition {
     public checked: boolean;

--- a/tns-core-modules/ui/switch/switch-common.ts
+++ b/tns-core-modules/ui/switch/switch-common.ts
@@ -1,7 +1,9 @@
 ﻿import { Switch as SwitchDefinition } from ".";
-import { View, Property, booleanConverter, CSSType } from "../core/view";
+import { View, CSSType } from "../core/view";
+import { Property } from "../core/properties";
+import { booleanConverter } from "../core/view-base";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 @CSSType("Switch")
 export class SwitchBase extends View implements SwitchDefinition {

--- a/tns-core-modules/ui/switch/switch.android.ts
+++ b/tns-core-modules/ui/switch/switch.android.ts
@@ -1,6 +1,8 @@
 ﻿import {
-    SwitchBase, Color, colorProperty, backgroundColorProperty, backgroundInternalProperty, checkedProperty
+    SwitchBase, checkedProperty
 } from "./switch-common";
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./switch-common";
 

--- a/tns-core-modules/ui/switch/switch.d.ts
+++ b/tns-core-modules/ui/switch/switch.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/switch"
  */ /** */
 
-import { View, Property } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties";
 
 /**
  * Represents a switch component.

--- a/tns-core-modules/ui/switch/switch.ios.ts
+++ b/tns-core-modules/ui/switch/switch.ios.ts
@@ -1,6 +1,9 @@
 ﻿import {
-    SwitchBase, layout, Color, colorProperty, backgroundColorProperty, backgroundInternalProperty, checkedProperty
+    SwitchBase, checkedProperty
 } from "./switch-common";
+import { layout } from '../../utils/utils';
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./switch-common";
 

--- a/tns-core-modules/ui/switch/switch.ios.ts
+++ b/tns-core-modules/ui/switch/switch.ios.ts
@@ -1,7 +1,7 @@
 ﻿import {
     SwitchBase, checkedProperty
 } from "./switch-common";
-import { layout } from '../../utils/utils';
+import { layout } from "../../utils/utils";
 import { colorProperty, backgroundColorProperty, backgroundInternalProperty } from "../styling/style-properties";
 import { Color } from "../../color";
 

--- a/tns-core-modules/ui/tab-view/tab-view-common.ts
+++ b/tns-core-modules/ui/tab-view/tab-view-common.ts
@@ -1,12 +1,15 @@
-﻿import { TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition, SelectedIndexChangedEventData } from ".";
-import {
-    View, ViewBase, Style, Property, CssProperty, CoercibleProperty,
-    Color, isIOS, AddArrayFromBuilder, AddChildFromBuilder, EventData, CSSType,
-    traceWrite, traceCategories, traceMessageType, booleanConverter
-} from "../core/view";
-
-export * from "../core/view";
+﻿import { SelectedIndexChangedEventData, TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition } from ".";
+import { Color } from '../../color';
+import { EventData } from '../../data/observable';
+import { isIOS } from '../../platform';
+import { traceCategories, traceMessageType, traceWrite } from "../core/bindable";
+import { CoercibleProperty, CssProperty, Property } from "../core/properties";
+import { AddArrayFromBuilder, AddChildFromBuilder, CSSType, View } from "../core/view";
+import { ViewBase, booleanConverter } from "../core/view-base";
+import { Style } from "../styling/style";
+// export * from "../core/view";
 import { TextTransform } from "../text-base";
+
 
 export const traceCategory = "TabView";
 

--- a/tns-core-modules/ui/tab-view/tab-view-common.ts
+++ b/tns-core-modules/ui/tab-view/tab-view-common.ts
@@ -1,15 +1,13 @@
 ﻿import { SelectedIndexChangedEventData, TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition } from ".";
-import { Color } from '../../color';
-import { EventData } from '../../data/observable';
-import { isIOS } from '../../platform';
+import { Color } from "../../color";
+import { EventData } from "../../data/observable";
+import { isIOS } from "../../platform";
 import { traceCategories, traceMessageType, traceWrite } from "../core/bindable";
 import { CoercibleProperty, CssProperty, Property } from "../core/properties";
 import { AddArrayFromBuilder, AddChildFromBuilder, CSSType, View } from "../core/view";
 import { ViewBase, booleanConverter } from "../core/view-base";
 import { Style } from "../styling/style";
-// export * from "../core/view";
 import { TextTransform } from "../text-base";
-
 
 export const traceCategory = "TabView";
 

--- a/tns-core-modules/ui/tab-view/tab-view.android.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.android.ts
@@ -5,14 +5,16 @@ import {
     TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty,
     tabTextColorProperty, tabBackgroundColorProperty, tabTextFontSizeProperty, selectedTabTextColorProperty,
     androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty,
-    fontSizeProperty, fontInternalProperty, layout, traceCategory, traceEnabled,
-    traceWrite, Color, traceMissingIcon
+    traceCategory, traceMissingIcon
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
 import { fromFileOrResource } from "../../image-source";
-import { RESOURCE_PREFIX, ad } from "../../utils/utils";
+import { RESOURCE_PREFIX, ad, layout } from "../../utils/utils";
 import { Frame } from "../frame";
 import * as application from "../../application";
+import { traceEnabled, traceWrite } from "../core/bindable";
+import { fontSizeProperty, fontInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
 
 export * from "./tab-view-common";
 

--- a/tns-core-modules/ui/tab-view/tab-view.d.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.d.ts
@@ -4,7 +4,7 @@
  */ /** */
 
 import { Color } from "../../color";
-import { EventData } from '../../data/observable';
+import { EventData } from "../../data/observable";
 import { CssProperty, Property } from "../core/properties";
 import { View } from "../core/view";
 import { ViewBase } from "../core/view-base";

--- a/tns-core-modules/ui/tab-view/tab-view.d.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.d.ts
@@ -3,7 +3,12 @@
  * @module "ui/tab-view"
  */ /** */
 
-import { View, ViewBase, Property, CssProperty, Style, EventData, Color } from "../core/view";
+import { Color } from "../../color";
+import { EventData } from '../../data/observable';
+import { CssProperty, Property } from "../core/properties";
+import { View } from "../core/view";
+import { ViewBase } from "../core/view-base";
+import { Style } from "../styling/style";
 import { TextTransform } from "../text-base";
 /**
  * Represents a tab view entry.

--- a/tns-core-modules/ui/tab-view/tab-view.ios.ts
+++ b/tns-core-modules/ui/tab-view/tab-view.ios.ts
@@ -1,18 +1,21 @@
 ﻿import { TabViewItem as TabViewItemDefinition } from ".";
 import { Font } from "../styling/font";
 
-import { ios as iosView, ViewBase } from "../core/view";
+import { ios as iosView, View } from "../core/view";
 import {
     TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty,
-    tabTextColorProperty, tabTextFontSizeProperty, tabBackgroundColorProperty, selectedTabTextColorProperty, iosIconRenderingModeProperty,
-    View, fontInternalProperty, layout, traceEnabled, traceWrite, traceCategories, Color, traceMissingIcon
+    tabTextColorProperty, tabTextFontSizeProperty, tabBackgroundColorProperty, selectedTabTextColorProperty, iosIconRenderingModeProperty, traceMissingIcon
 } from "./tab-view-common"
 import { textTransformProperty, TextTransform, getTransformedText } from "../text-base";
 import { fromFileOrResource } from "../../image-source";
 import { profile } from "../../profiling";
 import { Frame } from "../frame";
-import { ios as iosUtils } from "../../utils/utils"
+import { ios as iosUtils, layout } from "../../utils/utils"
 import { device } from "../../platform";
+import { traceEnabled, traceWrite, traceCategories } from "../core/bindable";
+import { ViewBase } from "../core/view-base";
+import { Color } from "../../color";
+import { fontInternalProperty } from "../styling/style-properties";
 export * from "./tab-view-common";
 
 const majorVersion = iosUtils.MajorVersion;

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -1,7 +1,7 @@
 // Definitions.
 import { TextAlignment, TextBase as TextBaseDefinition, TextDecoration, TextTransform, WhiteSpace } from ".";
 import { Observable, PropertyChangeData } from "../../data/observable";
-import { isAndroid, isIOS } from '../../platform';
+import { isAndroid, isIOS } from "../../platform";
 import { FormattedString } from "../../text/formatted-string";
 import { CssProperty, InheritedCssProperty, makeParser, makeValidator, Property } from "../core/properties";
 // Types.
@@ -10,10 +10,6 @@ import { ViewBase } from "../core/view-base";
 import { FontStyle, FontWeight } from "../styling/font";
 import { Style } from "../styling/style";
 import { Length } from "../styling/style-properties";
-
-
-// export { FormattedString, Span };
-// export * from "../core/view";
 
 const CHILD_SPAN = "Span";
 const CHILD_FORMATTED_TEXT = "formattedText";

--- a/tns-core-modules/ui/text-base/text-base-common.ts
+++ b/tns-core-modules/ui/text-base/text-base-common.ts
@@ -1,14 +1,19 @@
 // Definitions.
-import { TextBase as TextBaseDefinition, TextAlignment, TextDecoration, TextTransform, WhiteSpace } from ".";
-import { FontStyle, FontWeight } from "../styling/font";
-import { PropertyChangeData } from "../../data/observable";
-
+import { TextAlignment, TextBase as TextBaseDefinition, TextDecoration, TextTransform, WhiteSpace } from ".";
+import { Observable, PropertyChangeData } from "../../data/observable";
+import { isAndroid, isIOS } from '../../platform';
+import { FormattedString } from "../../text/formatted-string";
+import { CssProperty, InheritedCssProperty, makeParser, makeValidator, Property } from "../core/properties";
 // Types.
-import { View, ViewBase, Property, CssProperty, InheritedCssProperty, Style, isAndroid, isIOS, Observable, makeValidator, makeParser, Length } from "../core/view";
-import { FormattedString, Span } from "../../text/formatted-string";
+import { View } from "../core/view";
+import { ViewBase } from "../core/view-base";
+import { FontStyle, FontWeight } from "../styling/font";
+import { Style } from "../styling/style";
+import { Length } from "../styling/style-properties";
 
-export { FormattedString, Span };
-export * from "../core/view";
+
+// export { FormattedString, Span };
+// export * from "../core/view";
 
 const CHILD_SPAN = "Span";
 const CHILD_FORMATTED_TEXT = "formattedText";

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -1,13 +1,16 @@
 ﻿import { TextDecoration, TextAlignment, TextTransform, WhiteSpace } from "./text-base";
 import { Font } from "../styling/font";
-import { backgroundColorProperty } from "../styling/style-properties";
+import { backgroundColorProperty, colorProperty, fontSizeProperty, fontInternalProperty, paddingTopProperty, Length, paddingRightProperty, paddingBottomProperty, paddingLeftProperty } from "../styling/style-properties";
 import {
-    TextBaseCommon, formattedTextProperty, textAlignmentProperty, textDecorationProperty, fontSizeProperty,
-    textProperty, textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty,
-    paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length,
-    whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold, resetSymbol
+    TextBaseCommon, formattedTextProperty, textAlignmentProperty, textDecorationProperty,
+    textProperty, textTransformProperty, letterSpacingProperty,
+    whiteSpaceProperty, lineHeightProperty, isBold, resetSymbol
 } from "./text-base-common";
 import { isString } from "../../utils/types";
+import { Color } from '../../color';
+import { layout } from "../../utils/utils";
+import { FormattedString } from "../../text/formatted-string";
+import { Span } from "../../text/span";
 
 export * from "./text-base-common";
 

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -7,7 +7,7 @@ import {
     whiteSpaceProperty, lineHeightProperty, isBold, resetSymbol
 } from "./text-base-common";
 import { isString } from "../../utils/types";
-import { Color } from '../../color';
+import { Color } from "../../color";
 import { layout } from "../../utils/utils";
 import { FormattedString } from "../../text/formatted-string";
 import { Span } from "../../text/span";

--- a/tns-core-modules/ui/text-base/text-base.d.ts
+++ b/tns-core-modules/ui/text-base/text-base.d.ts
@@ -2,11 +2,14 @@
  * @module "ui/text-base"
  */ /** */
 
-import { View, AddChildFromBuilder, Property, CssProperty, InheritedCssProperty, Style, Length } from "../core/view";
+import { View, AddChildFromBuilder } from "../core/view";
 import { FormattedString } from "../../text/formatted-string";
+import { Length } from "../styling/style-properties";
+import { Property, InheritedCssProperty, CssProperty } from "../core/properties";
+import { Style } from "../styling/style";
 
-export * from "../core/view";
-export { FormattedString } from "../../text/formatted-string";
+// export * from "../core/view";
+// export { FormattedString } from "../../text/formatted-string";
 
 export class TextBase extends View implements AddChildFromBuilder {
 

--- a/tns-core-modules/ui/text-base/text-base.d.ts
+++ b/tns-core-modules/ui/text-base/text-base.d.ts
@@ -8,9 +8,6 @@ import { Length } from "../styling/style-properties";
 import { Property, InheritedCssProperty, CssProperty } from "../core/properties";
 import { Style } from "../styling/style";
 
-// export * from "../core/view";
-// export { FormattedString } from "../../text/formatted-string";
-
 export class TextBase extends View implements AddChildFromBuilder {
 
     /**

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -8,8 +8,8 @@ import {
 import { isString } from "../../utils/types";
 import { colorProperty, fontInternalProperty } from "../styling/style-properties";
 import { Color } from "../../color";
-import { FormattedString } from '../../text/formatted-string';
-import { Span } from '../../text/span';
+import { FormattedString } from "../../text/formatted-string";
+import { Span } from "../../text/span";
 
 export * from "./text-base-common";
 

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -2,10 +2,14 @@
 import { Font } from "../styling/font";
 import {
     TextBaseCommon, textProperty, formattedTextProperty, textAlignmentProperty, textDecorationProperty,
-    textTransformProperty, letterSpacingProperty, colorProperty, fontInternalProperty, lineHeightProperty,
-    FormattedString, Span, Color, isBold, resetSymbol
+    textTransformProperty, letterSpacingProperty, lineHeightProperty,
+    isBold, resetSymbol
 } from "./text-base-common";
 import { isString } from "../../utils/types";
+import { colorProperty, fontInternalProperty } from "../styling/style-properties";
+import { Color } from "../../color";
+import { FormattedString } from '../../text/formatted-string';
+import { Span } from '../../text/span';
 
 export * from "./text-base-common";
 

--- a/tns-core-modules/ui/text-field/text-field-common.ts
+++ b/tns-core-modules/ui/text-field/text-field-common.ts
@@ -4,8 +4,6 @@ import { CSSType } from "../core/view";
 import { Property } from "../core/properties";
 import { booleanConverter } from "../core/view-base";
 
-// export * from "../editable-text-base";
-
 @CSSType("TextField")
 export class TextFieldBase extends EditableTextBase implements TextFieldDefinition {
     public static returnPressEvent = "returnPress";

--- a/tns-core-modules/ui/text-field/text-field-common.ts
+++ b/tns-core-modules/ui/text-field/text-field-common.ts
@@ -1,7 +1,10 @@
 ﻿import { TextField as TextFieldDefinition } from ".";
-import { EditableTextBase, Property, booleanConverter, CSSType } from "../editable-text-base";
+import { EditableTextBase } from "../editable-text-base";
+import { CSSType } from "../core/view";
+import { Property } from "../core/properties";
+import { booleanConverter } from "../core/view-base";
 
-export * from "../editable-text-base";
+// export * from "../editable-text-base";
 
 @CSSType("TextField")
 export class TextFieldBase extends EditableTextBase implements TextFieldDefinition {

--- a/tns-core-modules/ui/text-field/text-field.android.ts
+++ b/tns-core-modules/ui/text-field/text-field.android.ts
@@ -1,4 +1,6 @@
-﻿import { TextFieldBase, secureProperty, whiteSpaceProperty, WhiteSpace, keyboardTypeProperty } from "./text-field-common";
+﻿import { TextFieldBase, secureProperty } from "./text-field-common";
+import { keyboardTypeProperty } from '../editable-text-base';
+import { whiteSpaceProperty, WhiteSpace } from "../text-base";
 
 export * from "./text-field-common";
 

--- a/tns-core-modules/ui/text-field/text-field.android.ts
+++ b/tns-core-modules/ui/text-field/text-field.android.ts
@@ -1,5 +1,5 @@
 ﻿import { TextFieldBase, secureProperty } from "./text-field-common";
-import { keyboardTypeProperty } from '../editable-text-base';
+import { keyboardTypeProperty } from "../editable-text-base";
 import { whiteSpaceProperty, WhiteSpace } from "../text-base";
 
 export * from "./text-field-common";

--- a/tns-core-modules/ui/text-field/text-field.d.ts
+++ b/tns-core-modules/ui/text-field/text-field.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/text-field"
  */ /** */
 
-import { EditableTextBase, Property } from "../editable-text-base";
+import { EditableTextBase } from "../editable-text-base";
+import { Property } from "../core/properties";
 
 export const secureProperty: Property<TextField, boolean>;
 

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -1,6 +1,6 @@
 ﻿import { Color } from "../../color";
 import { profile } from "../../profiling";
-import { layout } from '../../utils/utils';
+import { layout } from "../../utils/utils";
 import { hintProperty, _updateCharactersInRangeReplacementString, placeholderColorProperty } from "../editable-text-base";
 import { colorProperty, Length, paddingBottomProperty, paddingLeftProperty, paddingRightProperty, paddingTopProperty } from "../styling/style-properties";
 import { textProperty } from "../text-base";

--- a/tns-core-modules/ui/text-field/text-field.ios.ts
+++ b/tns-core-modules/ui/text-field/text-field.ios.ts
@@ -1,8 +1,10 @@
-﻿import {
-    TextFieldBase, secureProperty, textProperty, hintProperty, colorProperty, placeholderColorProperty,
-    Length, paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty, _updateCharactersInRangeReplacementString, Color, layout
-} from "./text-field-common";
+﻿import { Color } from "../../color";
 import { profile } from "../../profiling";
+import { layout } from '../../utils/utils';
+import { hintProperty, _updateCharactersInRangeReplacementString, placeholderColorProperty } from "../editable-text-base";
+import { colorProperty, Length, paddingBottomProperty, paddingLeftProperty, paddingRightProperty, paddingTopProperty } from "../styling/style-properties";
+import { textProperty } from "../text-base";
+import { secureProperty, TextFieldBase } from "./text-field-common";
 
 export * from "./text-field-common";
 

--- a/tns-core-modules/ui/text-view/text-view.android.ts
+++ b/tns-core-modules/ui/text-view/text-view.android.ts
@@ -2,8 +2,6 @@
 import { EditableTextBase } from "../editable-text-base";
 import { CSSType } from "../core/view";
 
-// export * from "../text-base";
-
 @CSSType("TextView")
 export class TextView extends EditableTextBase implements TextViewDefinition {
 

--- a/tns-core-modules/ui/text-view/text-view.android.ts
+++ b/tns-core-modules/ui/text-view/text-view.android.ts
@@ -1,7 +1,8 @@
 ﻿import { TextView as TextViewDefinition } from ".";
-import { EditableTextBase, CSSType } from "../editable-text-base";
+import { EditableTextBase } from "../editable-text-base";
+import { CSSType } from "../core/view";
 
-export * from "../text-base";
+// export * from "../text-base";
 
 @CSSType("TextView")
 export class TextView extends EditableTextBase implements TextViewDefinition {

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -1,5 +1,5 @@
 ﻿import { TextView as TextViewDefinition } from ".";
-import { Color } from '../../color';
+import { Color } from "../../color";
 import { profile } from "../../profiling";
 import { layout } from "../../utils/utils";
 import { CSSType } from "../core/view";
@@ -7,7 +7,6 @@ import { editableProperty, EditableTextBase, hintProperty, placeholderColorPrope
 import { ScrollEventData } from "../scroll-view";
 import { borderBottomWidthProperty, borderLeftWidthProperty, borderRightWidthProperty, borderTopWidthProperty, colorProperty, Length, paddingBottomProperty, paddingLeftProperty, paddingRightProperty, paddingTopProperty } from "../styling/style-properties";
 import { textProperty } from "../text-base";
-
 
 export * from "../editable-text-base";
 

--- a/tns-core-modules/ui/text-view/text-view.ios.ts
+++ b/tns-core-modules/ui/text-view/text-view.ios.ts
@@ -1,14 +1,13 @@
-﻿import { ScrollEventData } from "../scroll-view";
-import { TextView as TextViewDefinition } from ".";
-import {
-    EditableTextBase, editableProperty, hintProperty, textProperty, colorProperty, placeholderColorProperty,
-    borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty,
-    paddingTopProperty, paddingRightProperty, paddingBottomProperty, paddingLeftProperty,
-    Length, _updateCharactersInRangeReplacementString, Color, layout,
-    CSSType
-} from "../editable-text-base";
-
+﻿import { TextView as TextViewDefinition } from ".";
+import { Color } from '../../color';
 import { profile } from "../../profiling";
+import { layout } from "../../utils/utils";
+import { CSSType } from "../core/view";
+import { editableProperty, EditableTextBase, hintProperty, placeholderColorProperty, _updateCharactersInRangeReplacementString } from "../editable-text-base";
+import { ScrollEventData } from "../scroll-view";
+import { borderBottomWidthProperty, borderLeftWidthProperty, borderRightWidthProperty, borderTopWidthProperty, colorProperty, Length, paddingBottomProperty, paddingLeftProperty, paddingRightProperty, paddingTopProperty } from "../styling/style-properties";
+import { textProperty } from "../text-base";
+
 
 export * from "../editable-text-base";
 

--- a/tns-core-modules/ui/time-picker/time-picker-common.ts
+++ b/tns-core-modules/ui/time-picker/time-picker-common.ts
@@ -1,7 +1,8 @@
 ﻿import { TimePicker as TimePickerDefinition } from ".";
-import { View, Property, CSSType } from "../core/view";
+import { View, CSSType } from "../core/view";
+import { Property } from "../core/properties";
 
-export * from "../core/view";
+// export * from "../core/view";
 
 interface Time {
     hour: number;

--- a/tns-core-modules/ui/time-picker/time-picker-common.ts
+++ b/tns-core-modules/ui/time-picker/time-picker-common.ts
@@ -2,8 +2,6 @@
 import { View, CSSType } from "../core/view";
 import { Property } from "../core/properties";
 
-// export * from "../core/view";
-
 interface Time {
     hour: number;
     minute: number;

--- a/tns-core-modules/ui/time-picker/time-picker.d.ts
+++ b/tns-core-modules/ui/time-picker/time-picker.d.ts
@@ -3,7 +3,8 @@
  * @module "ui/time-picker"
  */ /** */
 
-import { View, Property } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties";
 
 /**
  * Represents an time picker.

--- a/tns-core-modules/ui/time-picker/time-picker.ios.ts
+++ b/tns-core-modules/ui/time-picker/time-picker.ios.ts
@@ -1,8 +1,10 @@
 ﻿import {
     TimePickerBase, timeProperty, minuteIntervalProperty,
     minuteProperty, minMinuteProperty, maxMinuteProperty,
-    hourProperty, minHourProperty, maxHourProperty, colorProperty, Color
+    hourProperty, minHourProperty, maxHourProperty
 } from "./time-picker-common";
+import { Color } from "../../color";
+import { colorProperty } from "../styling/style-properties";
 
 export * from "./time-picker-common";
 

--- a/tns-core-modules/ui/web-view/web-view-common.ts
+++ b/tns-core-modules/ui/web-view/web-view-common.ts
@@ -2,10 +2,9 @@ import { WebView as WebViewDefinition, LoadEventData, NavigationType } from ".";
 import { ContainerView, CSSType } from "../core/view";
 import { File, knownFolders, path } from "../../file-system";
 import { Property } from "../core/properties/properties";
-import { EventData } from '../../data/observable';
+import { EventData } from "../../data/observable";
 
 export { File, knownFolders, path, NavigationType };
-// export * from "../core/view";
 
 export const srcProperty = new Property<WebViewBase, string>({ name: "src" });
 

--- a/tns-core-modules/ui/web-view/web-view-common.ts
+++ b/tns-core-modules/ui/web-view/web-view-common.ts
@@ -1,9 +1,11 @@
 import { WebView as WebViewDefinition, LoadEventData, NavigationType } from ".";
-import { ContainerView, Property, EventData, CSSType } from "../core/view";
+import { ContainerView, CSSType } from "../core/view";
 import { File, knownFolders, path } from "../../file-system";
+import { Property } from "../core/properties/properties";
+import { EventData } from '../../data/observable';
 
 export { File, knownFolders, path, NavigationType };
-export * from "../core/view";
+// export * from "../core/view";
 
 export const srcProperty = new Property<WebViewBase, string>({ name: "src" });
 

--- a/tns-core-modules/ui/web-view/web-view.android.ts
+++ b/tns-core-modules/ui/web-view/web-view.android.ts
@@ -1,5 +1,5 @@
 import { WebViewBase, knownFolders } from "./web-view-common";
-import { traceWrite, traceEnabled, traceCategories } from '../core/bindable';
+import { traceWrite, traceEnabled, traceCategories } from "../core/bindable";
 
 export * from "./web-view-common";
 

--- a/tns-core-modules/ui/web-view/web-view.android.ts
+++ b/tns-core-modules/ui/web-view/web-view.android.ts
@@ -1,4 +1,5 @@
-import { WebViewBase, knownFolders, traceEnabled, traceWrite, traceCategories } from "./web-view-common";
+import { WebViewBase, knownFolders } from "./web-view-common";
+import { traceWrite, traceEnabled, traceCategories } from '../core/bindable';
 
 export * from "./web-view-common";
 

--- a/tns-core-modules/ui/web-view/web-view.d.ts
+++ b/tns-core-modules/ui/web-view/web-view.d.ts
@@ -3,7 +3,9 @@
  * @module "ui/web-view"
  */ /** */
 
-import { View, Property, EventData } from "../core/view";
+import { View } from "../core/view";
+import { Property } from "../core/properties/properties";
+import { EventData } from '../../data/observable';
 
 /**
  * Represents the observable property backing the Url property of each WebView instance.

--- a/tns-core-modules/ui/web-view/web-view.d.ts
+++ b/tns-core-modules/ui/web-view/web-view.d.ts
@@ -5,7 +5,7 @@
 
 import { View } from "../core/view";
 import { Property } from "../core/properties/properties";
-import { EventData } from '../../data/observable';
+import { EventData } from "../../data/observable";
 
 /**
  * Represents the observable property backing the Url property of each WebView instance.

--- a/tns-core-modules/ui/web-view/web-view.ios.ts
+++ b/tns-core-modules/ui/web-view/web-view.ios.ts
@@ -1,5 +1,6 @@
-import { WebViewBase, knownFolders, traceWrite, traceEnabled, traceCategories, NavigationType } from "./web-view-common";
+import { WebViewBase, knownFolders, NavigationType } from "./web-view-common";
 import { profile } from "../../profiling";
+import { traceWrite, traceEnabled, traceCategories } from "../core/bindable";
 export * from "./web-view-common";
 
 class WKNavigationDelegateImpl extends NSObject


### PR DESCRIPTION
- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

Related to the tree shaking issue https://github.com/NativeScript/NativeScript/issues/7127

## What is the current behavior?
right now a lot of ```tns-core-modules``` modules use ```export * from...```. I suppose this is done out of practicality. However in webpack this has a big consequences when you are trying to use [tree shaking] (https://webpack.js.org/guides/tree-shaking/)
Tree shaking use module concatenation to bundle an app to its smallest size. However the fact that {N} is using all those ```export * from...``` make it so that all those exports need to be referenced in all modules, ending with a much bigger ```vendor.js```.

As a simple example, apply that PR https://github.com/NativeScript/NativeScript/pull/7129 to {N} then try to bundle an app in production with webpack. Thanks to the PR tree shaking will be working in {N} and so will module concatenation. However because of all those ```export * from``` you will end up with a bigger ```vendor.js```. In my test :
- without es2015 and thus without any tree shaking => ```vendor.js```: 1.2Mo
- with es2015 and thus with any tree shaking => ```vendor.js```: 1.5Mo => 20% increase.

Now using this PR combined with the one for es2015 module i end up with a ```vendor.js``` of 1.2Mo. You can then argue that there is no gain there!!! Well yes and that's because of the ```bundle-entries.ts``` file which ensure that all {N} widgets are always bundled.
Those 2 PRs will show their true effects once ```bundle-entries.js```  will be generated at compilation based on the app used widgets.
However the faster we apply those 2 PRs, the less work it requires.

## WARNING

This PR has bad side effects for the user. Some imports might not be good anymore.
If the user use auto completion, it will often end up with imports like this :
``` import { Property } from 'tns-core-modules/core/view```
However that PR breaks all those imports. Instead the user must change it too
``` import { Property } from 'tns-core-modules/ui/core/properties```

I know this is kind of a big deal, however i really feel this is a necessary step into improving {N} apps performances. Maybe this could be part of Nativescript 6.0

Maybe  a migration script could change all those imports?

