### PR TITLE
fix: no trace message on empty app.css

### DIFF
--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -168,7 +168,8 @@ class CSSSource {
                 if (!this._source && this._file) {
                     this.load();
                 }
-                if (this._source) {
+                // [object Object] check guards against empty app.css file
+                if (this._source && this.source !== "[object Object]") {
                     this.parseCSSAst();
                 }
             }


### PR DESCRIPTION
Currently our happy path for loading css (no webpack) is expected to throw https://github.com/NativeScript/NativeScript/blob/c5e046e3edc14b6caca5e22387a0386f5ae3bd13/tns-core-modules/ui/styling/style-scope.ts#L86 (global.require on css file) so we always fall back to loading css from file https://github.com/NativeScript/NativeScript/blob/c5e046e3edc14b6caca5e22387a0386f5ae3bd13/tns-core-modules/ui/styling/style-scope.ts#L103

However, when app.css is empty the global.require(...) passes and tries to load css via https://github.com/NativeScript/NativeScript/blob/c5e046e3edc14b6caca5e22387a0386f5ae3bd13/tns-core-modules/ui/styling/style-scope.ts#L96 but cssOrAst variable does not contain actionable string source but [object Object] instead.

Guarding against [object Object] is not the most elegant solution but we do not want to add additional checks / file reads just to short-circuit the case where app.css is empty.

Fixes: https://github.com/NativeScript/NativeScript/issues/6404