### PR TITLE
fix(ios): application.displayedEvent does not depend on trace to fire

### DIFF
--- a/tests/app/app/app.ts
+++ b/tests/app/app/app.ts
@@ -8,24 +8,6 @@ else {
 
 import * as application from "tns-core-modules/application";
 
-// Specify custom UIApplicationDelegate.
-/*
-class MyDelegate extends UIResponder implements UIApplicationDelegate {
-    public static ObjCProtocols = [UIApplicationDelegate];
-
-    applicationDidFinishLaunchingWithOptions(application: UIApplication, launchOptions: NSDictionary): boolean {
-        console.log("applicationWillFinishLaunchingWithOptions: " + launchOptions)
-        return true;
-    }
-
-    applicationDidBecomeActive(application: UIApplication): void {
-        console.log("applicationDidBecomeActive: " + application)
-    }
-}
-
-application.ios.delegate = MyDelegate;
-*/
-
 if (application.ios) {
     // Observe application notifications.
     application.ios.addNotificationObserver(UIApplicationDidFinishLaunchingNotification, (notification: NSNotification) => {
@@ -34,6 +16,18 @@ if (application.ios) {
 }
 
 // Common events for both Android and iOS.
+application.on(application.displayedEvent, function (args: application.ApplicationEventData) {
+    (<any>global).isDisplayedEventFired = true;
+
+    if (args.android) {
+        // For Android applications, args.android is an android activity class.
+        console.log("Activity: " + args.android);
+    } else if (args.ios) {
+        // For iOS applications, args.ios is UIApplication.
+        console.log("UIApplication: " + args.ios);
+    }
+});
+
 application.on(application.launchEvent, function (args: application.ApplicationEventData) {
     if (args.android) {
         // For Android applications, args.android is an android.content.Intent class.

--- a/tests/app/application/application-tests-common.ts
+++ b/tests/app/application/application-tests-common.ts
@@ -13,11 +13,16 @@ if (app.android) {
 
 import * as TKUnit from "../TKUnit";
 
-export var testInitialized = function () {
+export function testInitialized() {
     if (platform.device.os === platform.platformNames.android) {
         // we have the android defined
         TKUnit.assert(app.android, "Application module not properly intialized");
     } else if (platform.device.os === platform.platformNames.ios) {
         TKUnit.assert(app.ios, "Application module not properly intialized");
     }
-} 
+}
+
+export function testDisplayedEvent() {
+    // global.isDisplayedEventFired flag is set in app.ts application.displayedEvent handler
+    TKUnit.assert((<any>global).isDisplayedEventFired, "application.displayedEvent not fired");
+}

--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -19,7 +19,7 @@ import { createViewFromEntry } from "../ui/builder";
 import { ios as iosView, View } from "../ui/core/view";
 import { Frame, NavigationEntry } from "../ui/frame";
 import * as utils from "../utils/utils";
-import { profile, level as profilingLevel, Level } from "../profiling";
+import { profile } from "../profiling";
 
 // NOTE: UIResponder with implementation of window - related to https://github.com/NativeScript/ios-runtime/issues/430
 // TODO: Refactor the UIResponder to use Typescript extends when this issue is resolved:
@@ -131,7 +131,7 @@ class IOSApplication implements IOSApplicationDefinition {
 
     @profile
     private didFinishLaunchingWithOptions(notification: NSNotification) {
-        if (!displayedOnce && profilingLevel() >= Level.lifecycle) {
+        if (!displayedOnce) {
             displayedLinkTarget = CADisplayLinkTarget.new();
             displayedLink = CADisplayLink.displayLinkWithTargetSelector(displayedLinkTarget, "onDisplayed");
             displayedLink.addToRunLoopForMode(NSRunLoop.mainRunLoop, NSDefaultRunLoopMode);


### PR DESCRIPTION
Seems we started raising application.displayedEvent only for profiling with https://github.com/NativeScript/NativeScript/pull/5344 but as it is a [public and documented event](https://docs.nativescript.org/core-concepts/application-lifecycle) I've removed the profiling condition now 

Fixes: https://github.com/NativeScript/NativeScript/issues/5572