### PR TITLE
fix(ios): add null check to TouchGestureRecognizer

### DIFF
--- a/tns-core-modules/ui/gestures/gestures.ios.ts
+++ b/tns-core-modules/ui/gestures/gestures.ios.ts
@@ -351,22 +351,30 @@ class TouchGestureRecognizer extends UIGestureRecognizer {
 
     touchesBeganWithEvent(touches: NSSet<any>, event: any): void {
         this.executeCallback(TouchAction.down, touches, event);
-        this.view.touchesBeganWithEvent(touches, event);
+        if (this.view) {
+            this.view.touchesBeganWithEvent(touches, event);
+        }
     }
 
     touchesMovedWithEvent(touches: NSSet<any>, event: any): void {
         this.executeCallback(TouchAction.move, touches, event);
-        this.view.touchesMovedWithEvent(touches, event);
+        if (this.view) {
+            this.view.touchesMovedWithEvent(touches, event);
+        }
     }
 
     touchesEndedWithEvent(touches: NSSet<any>, event: any): void {
         this.executeCallback(TouchAction.up, touches, event);
-        this.view.touchesEndedWithEvent(touches, event);
+        if (this.view) {
+            this.view.touchesEndedWithEvent(touches, event);
+        }
     }
 
     touchesCancelledWithEvent(touches: NSSet<any>, event: any): void {
         this.executeCallback(TouchAction.cancel, touches, event);
-        this.view.touchesCancelledWithEvent(touches, event);
+        if (this.view) {
+            this.view.touchesCancelledWithEvent(touches, event);
+        }
     }
 
     private executeCallback(action: string, touches: NSSet<any>, event: any): void {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We tracked 80+ of these crashes the past week in production:
```text
TypeError: null is not an object (evaluating 'this.view.touchesEndedWithEvent')
```

## What is the new behavior?
<!-- Describe the changes. -->
Adds a null check to `TouchGestureRecognizer` to avoid crash on iOS.

fixes: #7181 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

