### PR TITLE
fix: throw if failed to load component

### DIFF
--- a/tests/app/ui/builder/builder-tests.ts
+++ b/tests/app/ui/builder/builder-tests.ts
@@ -1,26 +1,32 @@
 import { path } from "tns-core-modules/file-system";
 import { loadPage } from "tns-core-modules/ui/builder";
-import { assertEqual, assertNull } from "../../TKUnit";
+import { assertEqual, assertNull, assertThrows } from "../../TKUnit";
 
 const COMPONENT_MODULE = "component-module";
+const MISSING_MODULE = "missing-module";
 const LABEL = "label";
 
-function getViewComponent() {
-    const moduleNamePath = path.join(__dirname, COMPONENT_MODULE);
-    const fileName = path.join(__dirname, `${COMPONENT_MODULE}.xml`);
+function getViewComponent(componentModule: string) {
+    const moduleNamePath = path.join(__dirname, componentModule);
+    const fileName = path.join(__dirname, `${componentModule}.xml`);
     const view = loadPage(moduleNamePath, fileName);
     return view;
 }
 
 export function test_view_is_module_root_component() {
-    const view = getViewComponent();
+    const view = getViewComponent(COMPONENT_MODULE);
     const actualModule = view._moduleName;
     assertEqual(actualModule, COMPONENT_MODULE, `View<${view}> is NOT root component of module <${COMPONENT_MODULE}>.`);
 }
 
 export function test_view_is_NOT_module_root_component() {
-    const view = getViewComponent();
+    const view = getViewComponent(COMPONENT_MODULE);
     const nestedView = view.getViewById(`${LABEL}`);
     const undefinedModule = nestedView._moduleName;
     assertNull(undefinedModule, `View<${nestedView}> should NOT be a root component of a module.`);
+}
+
+export function test_load_component_from_missing_module_throws() {
+    assertThrows(() => getViewComponent(MISSING_MODULE),
+        "Loading component from a missing module SHOULD throw an error.")
 }

--- a/tests/app/xml-declaration/xml-declaration-tests.ts
+++ b/tests/app/xml-declaration/xml-declaration-tests.ts
@@ -35,9 +35,10 @@ export function test_parse_IsDefined() {
     TKUnit.assertTrue(types.isFunction(builder.parse), "ui/builder should have parse method!");
 };
 
-export function test_load_ShouldNotCrashWithInvalidFileName() {
-    var v = builder.load(fs.path.join(__dirname, "mainPage1.xml"));
-    TKUnit.assertTrue(types.isUndefined(v), "Expected result: undefined; Actual result: " + v + ";");
+export function test_load_ShouldThrowWithInvalidFileName() {
+    let fileName = fs.path.join(__dirname, "invalid-page.xml");
+    TKUnit.assertThrows(() => builder.load(fileName),
+        "Loading component from a missing module SHOULD throw an error.");
 };
 
 export function test_load_ShouldNotCrashWithoutExports() {
@@ -300,7 +301,7 @@ export function test_parse_ShouldSetCanvasAttachedProperties() {
     var child = absLayout.getChildAt(0);
 
     var left = absoluteLayoutModule.AbsoluteLayout.getLeft(child);
-    
+
     TKUnit.assert(Length.equals(left, Length.parse("1")), `Expected result for canvas left: 1; Actual result: ${(<any>left).value};`)
 
     var top = absoluteLayoutModule.AbsoluteLayout.getTop(child);

--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -60,7 +60,9 @@ export function load(pathOrOptions: string | LoadOptions, context?: any): View {
 export function loadPage(moduleNamePath: string, fileName: string, context?: any): View {
     const componentModule = loadInternal(fileName, context, moduleNamePath);
     const componentView = componentModule && componentModule.component;
-    markAsModuleRoot(componentView, moduleNamePath);
+    if (componentView && moduleNamePath) {
+        markAsModuleRoot(componentView, moduleNamePath);
+    }
     return componentView;
 }
 
@@ -162,6 +164,10 @@ function loadInternal(fileName: string, context?: any, moduleNamePath?: string):
     if (componentModule && componentModule.component) {
         // Save exports to root component (will be used for templates).
         (<any>componentModule.component).exports = context;
+    }
+
+    if (!componentModule) {
+        throw new Error("Failed to load component from module: " + filePathRelativeToApp + " or file: " + fileName);
     }
 
     return componentModule;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If loading a component from a module fails (for example, when there is no such module/it is missing), the application crashes at runtime with:
```
JavaScript error:
file:///app/vendor.js:19492:18: JS ERROR TypeError: undefined is not an object (evaluating 'componentView._moduleName = moduleName')
```

## What is the new behavior?
<!-- Describe the changes. -->

In the same scenario, a descriptive error is thrown referring the module/file to load from: 
```
JavaScript error:
file:///app/vendor.js:19513:116: JS ERROR Error: Failed to load component from module: ./details-page.xml or file: null
```

## Additional

This error could (not only) be experienced in `webpack` workflow when navigating to a module, which did not get to the application's bundle.

<!-- Fixes/Implements/Closes #[Issue Number]. -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

