### PR TITLE
fix(ios-modal): closeCallback not being called with popover presentation style

### DIFF
--- a/e2e/modal-navigation/app/home/home-page.ts
+++ b/e2e/modal-navigation/app/home/home-page.ts
@@ -1,7 +1,7 @@
 import * as application from "tns-core-modules/application";
 import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
 import { NavigatedData, Page } from "tns-core-modules/ui/page";
-import { View, EventData } from "tns-core-modules/ui/core/view";
+import { View, EventData, ShowModalOptions } from "tns-core-modules/ui/core/view";
 import { Frame } from "tns-core-modules/ui/frame";
 
 export function onNavigatingTo(args: NavigatedData) {
@@ -27,6 +27,20 @@ export function onModalNoPage(args: EventData) {
         "context",
         () => console.log("home-page modal frame closed"),
         false);
+}
+
+export function onPopoverModal(args: EventData) {
+    const view = args.object as View;
+    let options: ShowModalOptions = {
+        context: "context",
+        closeCallback: () => console.log("home-page modal popover frame closed"),
+        animated: false,
+        ios: {
+            presentationStyle: UIModalPresentationStyle.Popover
+        }
+    }
+
+    view.showModal("modal-no-page/modal-no-page", options);
 }
 
 export function onModalFrame(args: EventData) {

--- a/e2e/modal-navigation/app/home/home-page.xml
+++ b/e2e/modal-navigation/app/home/home-page.xml
@@ -20,6 +20,7 @@
             <Button text="Show Modal Without Page" tap="onModalNoPage" textAlignment="left" />
             <Button text="Show Modal Page With Frame" tap="onModalFrame" textAlignment="left" />
             <Button text="Show Modal Page" tap="onModalPage" textAlignment="left" />
+            <Button text="Show 'popover' modal" tap="onPopoverModal" textAlignment="left" />
             <Button text="Show Modal Layout" tap="onModalLayout" textAlignment="left" />
             <Button text="Show Modal TabView" tap="onModalTabView" textAlignment="left" />
             <Button text="Android Back Btn Events" tap="onAndroidBackEvents" textAlignment="left" />

--- a/e2e/modal-navigation/app/modal-no-page/modal-no-page.ts
+++ b/e2e/modal-navigation/app/modal-no-page/modal-no-page.ts
@@ -3,7 +3,7 @@ import { NavigatedData, Page } from "tns-core-modules/ui/page";
 import { View, EventData } from "tns-core-modules/ui/core/view";
 import { Frame, ShownModallyData } from "tns-core-modules/ui/frame";
 import { fromObject } from "tns-core-modules/data/observable";
-import { confirm } from "ui/dialogs";
+import { confirm } from "tns-core-modules/ui/dialogs";
 
 export function onLoaded(args) {
     console.log("modal-no-page loaded");

--- a/e2e/modal-navigation/app/modal/modal-page.ts
+++ b/e2e/modal-navigation/app/modal/modal-page.ts
@@ -3,7 +3,7 @@ import { NavigatedData, Page } from "tns-core-modules/ui/page";
 import { View, EventData } from "tns-core-modules/ui/core/view";
 import { Frame, ShownModallyData } from "tns-core-modules/ui/frame";
 import { fromObject } from "tns-core-modules/data/observable";
-import { confirm } from "ui/dialogs";
+import { confirm } from "tns-core-modules/ui/dialogs";
 
 export function onShowingModally(args: ShownModallyData) {
     console.log("modal-page showingModally");

--- a/e2e/modal-navigation/package.json
+++ b/e2e/modal-navigation/package.json
@@ -26,6 +26,7 @@
     "nativescript-dev-appium": "next",
     "nativescript-dev-typescript": "next",
     "nativescript-dev-webpack": "next",
+    "tns-platform-declarations": "next",
     "rimraf": "^2.6.2",
     "typescript": "^3.1.6"
   },

--- a/e2e/modal-navigation/references.d.ts
+++ b/e2e/modal-navigation/references.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -22,6 +22,7 @@ import {
 } from "../../gestures";
 
 import { createViewFromEntry } from "../../builder";
+import { isAndroid } from "../../../platform";
 import { StyleScope } from "../../styling/style-scope";
 import { LinearGradient } from "../../styling/linear-gradient";
 import { BackgroundRepeat } from "../../styling/style-properties";
@@ -324,7 +325,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
                     }
                 }
 
-                if (parent.viewController && parent.viewController.presentedViewController) {
+                if (isAndroid || (parent.viewController && parent.viewController.presentedViewController)) {
                     that._hideNativeModalView(parent, whenClosedCallback);
                 } else {
                     whenClosedCallback();

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -324,7 +324,11 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
                     }
                 }
 
-                that._hideNativeModalView(parent, whenClosedCallback);
+                if (parent.viewController.presentedViewController) {
+                    that._hideNativeModalView(parent, whenClosedCallback);
+                } else {
+                    whenClosedCallback();
+                }
             }
         };
     }

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -324,7 +324,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
                     }
                 }
 
-                if (parent.viewController.presentedViewController) {
+                if (parent.viewController && parent.viewController.presentedViewController) {
                     that._hideNativeModalView(parent, whenClosedCallback);
                 } else {
                     whenClosedCallback();


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].
Fixes https://github.com/NativeScript/NativeScript/issues/7050

## Developer notes
This PR introduces a new event `popoverClosed` to the `View` class. This event is raised when a modal using the `presentationStyle: UIModalPresentationStyle.Popover` is closed by tapping outside of the popup area.
