### PR TITLE
fix(android/button): possible incorrect button visual state

### DIFF
--- a/tns-core-modules/ui/button/button.android.ts
+++ b/tns-core-modules/ui/button/button.android.ts
@@ -91,6 +91,7 @@ export class Button extends ButtonBase {
             this._highlightedHandler = this._highlightedHandler || ((args: TouchGestureEventData) => {
                 switch (args.action) {
                     case TouchAction.up:
+                    case TouchAction.cancel:
                         this._goToVisualState("normal");
                         break;
                     case TouchAction.down:


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Currently, a button placed in ListView item does not restore its visual state to normal on cancel touch action which occurs when button received down touch action and then ListView scroll.

## What is the new behavior?
A button placed in ListView item restore its visual state to normal on cancel touch action.

## Difference visualisation (with animated gif)

* current version
![andriod-listview-button-err](https://user-images.githubusercontent.com/552025/57025847-ff649780-6c40-11e9-9ef7-b29c7da5ab0d.gif)

* fixed version
![andriod-listview-button-ok](https://user-images.githubusercontent.com/552025/57025863-08edff80-6c41-11e9-8aad-1464b040e6fc.gif)

