### PR TITLE
chore(android): disable test_ImageCache_ValidUrl on api19

### DIFF
--- a/tests/app/ui/image-cache/image-cache-tests.ts
+++ b/tests/app/ui/image-cache/image-cache-tests.ts
@@ -1,9 +1,19 @@
 ﻿import * as imageCacheModule from "tns-core-modules/ui/image-cache";
 import * as imageSource from "tns-core-modules/image-source";
 import * as types from "tns-core-modules/utils/types";
+import { device } from "tns-core-modules/platform";
+import lazy from "tns-core-modules/utils/lazy";
+
 import * as TKUnit from "../../TKUnit";
 
+const sdkVersion = lazy(() => parseInt(device.sdkVersion));
+
 export const test_ImageCache_ValidUrl = function() {
+    // see https://github.com/NativeScript/NativeScript/issues/6643
+    if (sdkVersion() < 20) {
+        return;
+    }
+
     const cache = new imageCacheModule.Cache();
     cache.maxRequests = 5;
 


### PR DESCRIPTION
See https://github.com/NativeScript/NativeScript/issues/6643