### PR TITLE
fix(ios): undefined is not an object (evaluating 'measureSpec.setColumn')

### DIFF
--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout-common.ts
@@ -5,7 +5,7 @@ export * from "../layout-base";
 
 function validateArgs(element: View): View {
     if (!element) {
-        throw new Error("element cannot be null or undefinied.");
+        throw new Error("element cannot be null or undefined.");
     }
     return element;
 }
@@ -291,7 +291,7 @@ export class GridLayoutBase extends LayoutBase implements GridLayoutDefinition {
     }
 
     protected invalidate(): void {
-        // handled natively in android and overriden in ios.
+        // handled natively in android and overridden in ios.
     }
 
     set rows(value: string) {

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
@@ -137,8 +137,7 @@ export class GridLayout extends GridLayoutBase {
         this.eachLayoutChild((child, last) => {
             let measureSpecs = this.map.get(child);
             if (!measureSpecs) {
-                this._registerLayoutChild(child);
-                measureSpecs = this.map.get(child);
+                return;
             }
 
             this.updateMeasureSpecs(child, measureSpecs);

--- a/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
+++ b/tns-core-modules/ui/layouts/grid-layout/grid-layout.ios.ts
@@ -136,6 +136,11 @@ export class GridLayout extends GridLayoutBase {
 
         this.eachLayoutChild((child, last) => {
             let measureSpecs = this.map.get(child);
+            if (!measureSpecs) {
+                this._registerLayoutChild(child);
+                measureSpecs = this.map.get(child);
+            }
+
             this.updateMeasureSpecs(child, measureSpecs);
             this.helper.addMeasureSpec(measureSpecs);
         });

--- a/tns-core-modules/ui/proxy-view-container/proxy-view-container.ts
+++ b/tns-core-modules/ui/proxy-view-container/proxy-view-container.ts
@@ -131,12 +131,12 @@ export class ProxyViewContainer extends LayoutBase implements ProxyViewContainer
         const oldLayout = <LayoutBase>oldParent;
 
         if (addingToParent && newLayout instanceof LayoutBase) {
-            this.eachChildView((child) => {
+            this.eachLayoutChild((child) => {
                 newLayout._registerLayoutChild(child);
                 return true;
             });
         } else if (oldLayout instanceof LayoutBase) {
-            this.eachChildView((child) => {
+            this.eachLayoutChild((child) => {
                 oldLayout._unregisterLayoutChild(child);
                 return true;
             });


### PR DESCRIPTION

We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- ~[ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md~

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the past month we've tracked 20+ crashes with this error:
```
TypeError: undefined is not an object (evaluating 'measureSpec.setColumn')
```

We haven't been able to consistently reproduce the crash locally, but I think it is clear where it does wrong.

## What is the new behavior?
<!-- Describe the changes. -->

`GridLayout(ios).onMeasure(...)` will create `MeasureSpecs` if missing the for `child` view when it calls `this.eachLayoutChild(...)`

Fixes: #7226 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

