### PR TITLE
refactor: update access modifier

### DIFF
--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -570,8 +570,7 @@ export class StyleScope {
         this.appendCss(null, cssFileName);
     }
 
-    @profile
-    private changeCssFile(cssFileName: string): void {
+    public changeCssFile(cssFileName: string): void {
         if (!cssFileName) {
             return;
         }
@@ -777,15 +776,3 @@ function isParentDirectory(uriPart: string): boolean {
 function isKeyframe(node: CssNode): node is KeyframesDefinition {
     return node.type === "keyframes";
 }
-
-// class InlineSelector implements SelectorCore {
-//     constructor(ruleSet: RuleSet) {
-//         this.ruleset = ruleSet;
-//     }
-
-//     public specificity = 0x01000000;
-//     public rarity = 0;
-//     public dynamic: boolean = false;
-//     public ruleset: RuleSet;
-//     public match(node: Node): boolean { return true; }
-// }


### PR DESCRIPTION
We are no longer using StyleScope.changeCssFile() method internally but apparently there was a discrepancy where method implementation was private but d.ts listed it as public -- synced both to public now.