### PR TITLE
fix(text): crash when removing FormattedText

### DIFF
--- a/tests/app/ui/label/label-tests.ts
+++ b/tests/app/ui/label/label-tests.ts
@@ -162,10 +162,10 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         const span = new Span();
         span.text = "long label";
         span.fontWeight = "bold";
-    
+
         const span2 = new Span();
         span2.text = "long label";
-    
+
         const formattedString = new FormattedString();
         formattedString.spans.push(span);
         formattedString.spans.push(span2);
@@ -176,7 +176,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         const span3 = new Span();
         span3.text = "short label";
         span3.fontWeight = "bold";
-    
+
         const formattedString2 = new FormattedString();
         formattedString2.spans.push(span3);
         label.formattedText = formattedString2;
@@ -210,7 +210,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         const span = new Span();
         span.text = "short label";
         span.fontWeight = "bold";
-    
+
         const formattedString = new FormattedString();
         formattedString.spans.push(span);
         label.formattedText = formattedString;
@@ -220,10 +220,10 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         const span2 = new Span();
         span2.text = "long label";
         span2.fontWeight = "bold";
-    
+
         const span3 = new Span();
         span3.text = "long label";
-    
+
         const formattedString2 = new FormattedString();
         formattedString2.spans.push(span2);
         formattedString2.spans.push(span3);
@@ -733,6 +733,21 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
             return host;
         });
     }
+    
+    public test_FormattedText_ShouldNotCrash_WheRemovedFromSpan() {
+        const label = this.testView;
+        label.color = new colorModule.Color("red");
+        this.waitUntilTestElementIsLoaded();
+
+        const span = new Span();
+        span.text = "test";
+        
+        const formattedString = new FormattedString();
+        formattedString.spans.push(span);
+
+        label._addChildFromBuilder("FormattedString", formattedString);
+        label._removeView(formattedString);
+    };
 }
 
 export function createTestCase(): LabelTest {

--- a/tns-core-modules/ui/text-base/text-base.android.ts
+++ b/tns-core-modules/ui/text-base/text-base.android.ts
@@ -12,7 +12,7 @@ import { isString } from "../../utils/types";
 export * from "./text-base-common";
 
 interface TextTransformation {
-    new (owner: TextBase): android.text.method.TransformationMethod;
+    new(owner: TextBase): android.text.method.TransformationMethod;
 }
 
 let TextTransformation: TextTransformation;
@@ -344,7 +344,7 @@ export function getTransformedText(text: string, textTransform: TextTransform): 
 }
 
 function createSpannableStringBuilder(formattedString: FormattedString): android.text.SpannableStringBuilder {
-    if (!formattedString) {
+    if (!formattedString || !formattedString.parent) {
         return null;
     }
 

--- a/tns-core-modules/ui/text-base/text-base.ios.ts
+++ b/tns-core-modules/ui/text-base/text-base.ios.ts
@@ -231,7 +231,7 @@ export class TextBase extends TextBaseCommon {
 
     createNSMutableAttributedString(formattedString: FormattedString): NSMutableAttributedString {
         let mas = NSMutableAttributedString.alloc().init();
-        if (formattedString) {
+        if (formattedString && formattedString.parent) {
             for (let i = 0, spanStart = 0, length = formattedString.spans.length; i < length; i++) {
                 const span = formattedString.spans.getItem(i);
                 const text = span.text;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
See https://github.com/NativeScript/nativescript-angular/issues/1818

## What is the new behavior?
App no longer crashes 

Fixes https://github.com/NativeScript/nativescript-angular/issues/1818

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

