### PR TITLE
fix(hmr): quick fade upon replace navigation

### DIFF
--- a/tests/app/livesync/livesync-tests.ts
+++ b/tests/app/livesync/livesync-tests.ts
@@ -146,9 +146,5 @@ function _test_onLiveSync_ModuleContext_TypeStyle(context: { type, path }) {
 }
 
 function waitUntilLivesyncComplete(frame: Frame) {
-    if (isAndroid) {
-        TKUnit.waitUntilReady(() => frame._executingEntry === null);
-    } else {
-        TKUnit.waitUntilReady(() => frame.currentPage.isLoaded);
-    }
+    TKUnit.waitUntilReady(() => frame._executingEntry === null);
 }

--- a/tns-core-modules/ui/core/view/view-common.ts
+++ b/tns-core-modules/ui/core/view/view-common.ts
@@ -5,7 +5,7 @@ import {
 } from ".";
 
 import {
-    ViewBase, Property, booleanConverter, eachDescendant, EventData, layout,
+    ViewBase, Property, booleanConverter, EventData, layout,
     getEventOrGestureName, traceEnabled, traceWrite, traceCategories,
     InheritedProperty, ShowModalOptions
 } from "../view-base";

--- a/tns-core-modules/ui/frame/fragment.transitions.android.ts
+++ b/tns-core-modules/ui/frame/fragment.transitions.android.ts
@@ -169,8 +169,11 @@ export function _setAndroidFragmentTransitions(
 
     // Having transition means we have custom animation
     if (transition) {
-        // we do not use Android backstack so setting popEnter / popExit is meaningless (3rd and 4th optional args)
-        fragmentTransaction.setCustomAnimations(AnimationType.enterFakeResourceId, AnimationType.exitFakeResourceId);
+        if (fragmentTransaction) {
+            // we do not use Android backstack so setting popEnter / popExit is meaningless (3rd and 4th optional args)
+            fragmentTransaction.setCustomAnimations(AnimationType.enterFakeResourceId, AnimationType.exitFakeResourceId);
+        }
+        
         setupAllAnimation(newEntry, transition);
         if (currentFragmentNeedsDifferentAnimation) {
             setupExitAndPopEnterAnimation(currentEntry, transition);
@@ -502,6 +505,8 @@ function clearEntry(entry: ExpandedEntry, removeListener: boolean): void {
         clearAnimationListener(entry.exitAnimator, listener);
         clearAnimationListener(entry.popEnterAnimator, listener);
         clearAnimationListener(entry.popExitAnimator, listener);
+        clearAnimationListener(entry.defaultEnterAnimator, listener);
+        clearAnimationListener(entry.defaultExitAnimator, listener);
     }
 }
 

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -7,12 +7,11 @@ import { profile } from "../../profiling";
 
 //Types.
 import {
-    FrameBase, View, isCategorySet, layout, NavigationContext,
+    FrameBase, View, isCategorySet, layout,
     NavigationType, traceCategories, traceEnabled, traceWrite
 } from "./frame-common";
 import { _createIOSAnimatedTransitioning } from "./fragment.transitions";
 
-import { createViewFromEntry } from "../builder";
 import * as utils from "../../utils/utils";
 
 export * from "./frame-common";
@@ -24,6 +23,7 @@ const DELEGATE = "_delegate";
 const NAV_DEPTH = "_navDepth";
 const TRANSITION = "_transition";
 const NON_ANIMATED_TRANSITION = "non-animated";
+const HMR_REPLACE_TRANSITION = "fade";
 
 let navDepth = -1;
 
@@ -88,7 +88,10 @@ export class Frame extends FrameBase {
 
         let navigationTransition: NavigationTransition;
         let animated = this.currentPage ? this._getIsAnimatedNavigation(backstackEntry.entry) : false;
-        if (animated) {
+        if (isReplace) {
+            navigationTransition = { name: HMR_REPLACE_TRANSITION, duration: 100 }
+            viewController[TRANSITION] = navigationTransition;
+        } else if (animated) {
             navigationTransition = this._getNavigationTransition(backstackEntry.entry);
             if (navigationTransition) {
                 viewController[TRANSITION] = navigationTransition;

--- a/tns-core-modules/ui/frame/frame.ios.ts
+++ b/tns-core-modules/ui/frame/frame.ios.ts
@@ -89,6 +89,7 @@ export class Frame extends FrameBase {
         let navigationTransition: NavigationTransition;
         let animated = this.currentPage ? this._getIsAnimatedNavigation(backstackEntry.entry) : false;
         if (isReplace) {
+            animated = true;
             navigationTransition = { name: HMR_REPLACE_TRANSITION, duration: 100 }
             viewController[TRANSITION] = navigationTransition;
         } else if (animated) {
@@ -96,8 +97,7 @@ export class Frame extends FrameBase {
             if (navigationTransition) {
                 viewController[TRANSITION] = navigationTransition;
             }
-        }
-        else {
+        } else {
             //https://github.com/NativeScript/NativeScript/issues/1787
             viewController[TRANSITION] = { name: NON_ANIMATED_TRANSITION };
         }

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -1,5 +1,5 @@
 ﻿// Definitions.
-import { Frame } from "../frame";
+import { Frame, BackstackEntry } from "../frame";
 import { NavigationType } from "../frame/frame-common";
 
 // Types.
@@ -16,6 +16,7 @@ export * from "./page-common";
 const ENTRY = "_entry";
 const DELEGATE = "_delegate";
 const TRANSITION = "_transition";
+const NON_ANIMATED_TRANSITION = "non-animated";
 
 const majorVersion = iosUtils.MajorVersion;
 
@@ -131,7 +132,7 @@ class UIViewControllerImpl extends UIViewController {
         const frame = navigationController ? (<any>navigationController).owner : null;
         // Skip navigation events if modal page is shown.
         if (!owner._presentedViewController && frame) {
-            const newEntry = this[ENTRY];
+            const newEntry: BackstackEntry = this[ENTRY];
 
             let isBack: boolean;
             let navType = frame.navigationType;
@@ -151,7 +152,11 @@ class UIViewControllerImpl extends UIViewController {
             if (frame.navigationType === NavigationType.replace) {
                 let controller = newEntry.resolvedPage.ios;
                 if (controller) {
-                    controller[TRANSITION] = frame._getNavigationTransition(newEntry.entry);
+                    if (newEntry.entry.animated) {
+                        controller[TRANSITION] = frame._getNavigationTransition(newEntry.entry);
+                    } else {
+                        controller[TRANSITION] = { name: NON_ANIMATED_TRANSITION };
+                    }
                 }
             }
 

--- a/tns-core-modules/ui/page/page.ios.ts
+++ b/tns-core-modules/ui/page/page.ios.ts
@@ -15,6 +15,7 @@ export * from "./page-common";
 
 const ENTRY = "_entry";
 const DELEGATE = "_delegate";
+const TRANSITION = "_transition";
 
 const majorVersion = iosUtils.MajorVersion;
 
@@ -146,6 +147,14 @@ class UIViewControllerImpl extends UIViewController {
             }
 
             frame.setCurrent(newEntry, navType);
+            
+            if (frame.navigationType === NavigationType.replace) {
+                let controller = newEntry.resolvedPage.ios;
+                if (controller) {
+                    controller[TRANSITION] = frame._getNavigationTransition(newEntry.entry);
+                }
+            }
+
             frame.navigationType = isBack ? NavigationType.back : NavigationType.forward;
 
             // If page was shown with custom animation - we need to set the navigationController.delegate to the animatedDelegate.


### PR DESCRIPTION
Apply quick(100ms) fade transition upon hot module replacement on both platforms as a visual indication that hmr occurred.

Closes: https://github.com/NativeScript/NativeScript/issues/7256