### PR TITLE
fix(ios): potential memory leak with propertybag implementation

### DIFF
--- a/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets.xcodeproj/project.pbxproj
+++ b/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		8B7321D01D097ECD00884AC6 /* TNSLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B7321CE1D097ECD00884AC6 /* TNSLabel.m */; };
 		B8E76F52212C2DA2009CFCE2 /* NSObject+Swizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = B8E76F50212C2DA2009CFCE2 /* NSObject+Swizzling.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B8E76F53212C2DA2009CFCE2 /* NSObject+Swizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = B8E76F51212C2DA2009CFCE2 /* NSObject+Swizzling.m */; };
-		B8E76F5A212C2F4E009CFCE2 /* NSObject+PropertyBag.h in Headers */ = {isa = PBXBuildFile; fileRef = B8E76F58212C2F4E009CFCE2 /* NSObject+PropertyBag.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B8E76F5B212C2F4E009CFCE2 /* NSObject+PropertyBag.m in Sources */ = {isa = PBXBuildFile; fileRef = B8E76F59212C2F4E009CFCE2 /* NSObject+PropertyBag.m */; };
+		B8E76F5A212C2F4E009CFCE2 /* UIView+PropertyBag.h in Headers */ = {isa = PBXBuildFile; fileRef = B8E76F58212C2F4E009CFCE2 /* UIView+PropertyBag.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B8E76F5B212C2F4E009CFCE2 /* UIView+PropertyBag.m in Sources */ = {isa = PBXBuildFile; fileRef = B8E76F59212C2F4E009CFCE2 /* UIView+PropertyBag.m */; };
 		B8E76F5E212C3134009CFCE2 /* UIView+PassThroughParent.h in Headers */ = {isa = PBXBuildFile; fileRef = B8E76F5C212C3134009CFCE2 /* UIView+PassThroughParent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B8E76F5F212C3134009CFCE2 /* UIView+PassThroughParent.m in Sources */ = {isa = PBXBuildFile; fileRef = B8E76F5D212C3134009CFCE2 /* UIView+PassThroughParent.m */; };
 		F915D3551EC9EF5E00071914 /* TNSProcess.m in Sources */ = {isa = PBXBuildFile; fileRef = F915D3531EC9EF5E00071914 /* TNSProcess.m */; };
@@ -39,8 +39,8 @@
 		8B7321CE1D097ECD00884AC6 /* TNSLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNSLabel.m; sourceTree = "<group>"; };
 		B8E76F50212C2DA2009CFCE2 /* NSObject+Swizzling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+Swizzling.h"; sourceTree = "<group>"; };
 		B8E76F51212C2DA2009CFCE2 /* NSObject+Swizzling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+Swizzling.m"; sourceTree = "<group>"; };
-		B8E76F58212C2F4E009CFCE2 /* NSObject+PropertyBag.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+PropertyBag.h"; sourceTree = "<group>"; };
-		B8E76F59212C2F4E009CFCE2 /* NSObject+PropertyBag.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+PropertyBag.m"; sourceTree = "<group>"; };
+		B8E76F58212C2F4E009CFCE2 /* UIView+PropertyBag.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+PropertyBag.h"; sourceTree = "<group>"; };
+		B8E76F59212C2F4E009CFCE2 /* UIView+PropertyBag.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+PropertyBag.m"; sourceTree = "<group>"; };
 		B8E76F5C212C3134009CFCE2 /* UIView+PassThroughParent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+PassThroughParent.h"; sourceTree = "<group>"; };
 		B8E76F5D212C3134009CFCE2 /* UIView+PassThroughParent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+PassThroughParent.m"; sourceTree = "<group>"; };
 		F915D3531EC9EF5E00071914 /* TNSProcess.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TNSProcess.m; path = ../TNSProcess.m; sourceTree = "<group>"; };
@@ -105,8 +105,8 @@
 				F98F5CB41CD0EFEA00978308 /* Info.plist */,
 				B8E76F50212C2DA2009CFCE2 /* NSObject+Swizzling.h */,
 				B8E76F51212C2DA2009CFCE2 /* NSObject+Swizzling.m */,
-				B8E76F58212C2F4E009CFCE2 /* NSObject+PropertyBag.h */,
-				B8E76F59212C2F4E009CFCE2 /* NSObject+PropertyBag.m */,
+				B8E76F58212C2F4E009CFCE2 /* UIView+PropertyBag.h */,
+				B8E76F59212C2F4E009CFCE2 /* UIView+PropertyBag.m */,
 				B8E76F5C212C3134009CFCE2 /* UIView+PassThroughParent.h */,
 				B8E76F5D212C3134009CFCE2 /* UIView+PassThroughParent.m */,
 			);
@@ -134,7 +134,7 @@
 				B8E76F5E212C3134009CFCE2 /* UIView+PassThroughParent.h in Headers */,
 				F98F5CCB1CD0F09E00978308 /* UIImage+TNSBlocks.h in Headers */,
 				B8E76F52212C2DA2009CFCE2 /* NSObject+Swizzling.h in Headers */,
-				B8E76F5A212C2F4E009CFCE2 /* NSObject+PropertyBag.h in Headers */,
+				B8E76F5A212C2F4E009CFCE2 /* UIView+PropertyBag.h in Headers */,
 				8B7321CF1D097ECD00884AC6 /* TNSLabel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -239,7 +239,7 @@
 				F915D3551EC9EF5E00071914 /* TNSProcess.m in Sources */,
 				F98F5CCC1CD0F09E00978308 /* UIImage+TNSBlocks.m in Sources */,
 				B8E76F53212C2DA2009CFCE2 /* NSObject+Swizzling.m in Sources */,
-				B8E76F5B212C2F4E009CFCE2 /* NSObject+PropertyBag.m in Sources */,
+				B8E76F5B212C2F4E009CFCE2 /* UIView+PropertyBag.m in Sources */,
 				B8E76F5F212C3134009CFCE2 /* UIView+PassThroughParent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets/UIView+PassThroughParent.m
+++ b/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets/UIView+PassThroughParent.m
@@ -6,9 +6,9 @@
 //  Copyright © 2018 Telerik A D. All rights reserved.
 //
 
-#import "UIView+PassThroughParent.h"
 #import "NSObject+Swizzling.h"
-#import "NSObject+PropertyBag.h"
+#import "UIView+PassThroughParent.h"
+#import "UIView+PropertyBag.h"
 
 
 NSString * const TLKPassThroughParentKey = @"passThroughParent";

--- a/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets/UIView+PropertyBag.h
+++ b/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets/UIView+PropertyBag.h
@@ -1,5 +1,5 @@
 //
-//  NSObject+PropertyBag.h
+//  UIView+PropertyBag.h
 //  TNSWidgets
 //
 //  Created by Manol Donev on 21.08.18.
@@ -7,9 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
-@interface NSObject (PropertyBag)
+@interface UIView (PropertyBag)
 
 - (id) propertyValueForKey:(NSString*) key;
 - (void) setPropertyValue:(id) value forKey:(NSString*) key;

--- a/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets/UIView+PropertyBag.m
+++ b/tns-core-modules-widgets/ios/TNSWidgets/TNSWidgets/UIView+PropertyBag.m
@@ -1,22 +1,23 @@
 //
-//  NSObject+PropertyBag.m
+//  UIView+PropertyBag.m
 //  TNSWidgets
 //
 //  Created by Manol Donev on 21.08.18.
 //  Copyright © 2018 Telerik A D. All rights reserved.
 //
 
-#import "NSObject+PropertyBag.h"
 #import "NSObject+Swizzling.h"
+#import "UIView+PropertyBag.h"
+#import <UIKit/UIKit.h>
 
 
-@implementation NSObject (PropertyBag)
+@implementation UIView (PropertyBag)
 
-+ (void) load{
++ (void) load {
     [self loadPropertyBag];
 }
 
-+ (void) loadPropertyBag{
++ (void) loadPropertyBag {
     @autoreleasepool {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
@@ -36,7 +37,10 @@ __strong NSMutableDictionary *_propertyBagHolder; // Properties for every class 
 }
 
 - (NSMutableDictionary*) propertyBag {
-    if (_propertyBagHolder == nil) _propertyBagHolder = [[NSMutableDictionary alloc] initWithCapacity:100];
+    if (_propertyBagHolder == nil) {
+        _propertyBagHolder = [[NSMutableDictionary alloc] initWithCapacity:100];
+    }
+
     NSMutableDictionary *propBag = [_propertyBagHolder valueForKey:[[NSString alloc] initWithFormat:@"%p", self]];
     if (propBag == nil) {
         propBag = [NSMutableDictionary dictionary];
@@ -54,8 +58,14 @@ __strong NSMutableDictionary *_propertyBagHolder; // Properties for every class 
     [_propertyBagHolder setValue:propertyBag forKey:[[NSString alloc] initWithFormat:@"%p", self]];
 }
 
+- (void) removePropertyBag {
+    if (_propertyBagHolder != nil) {
+        [_propertyBagHolder removeObjectForKey:[[NSString alloc] initWithFormat:@"%p", self]];
+    }
+}
+
 - (void)propertyBag_dealloc {
-    [self setPropertyBag:nil];
+    [self removePropertyBag];
     [self propertyBag_dealloc]; // swizzled
 }
 


### PR DESCRIPTION
- Addresses potential memory leak with propertybag implementation storing nils on deallocation indefinitely.
- Restricts propertybag implementation to UIViews (not NSObjects)
- Might address obscure RadListView crash on dealloc.