### PR TITLE
fix(platform-declarations-ios): Change 2^64-1 enum values to -1

### DIFF
--- a/tns-platform-declarations/ios/objc-x86_64/objc!MediaPlayer.d.ts
+++ b/tns-platform-declarations/ios/objc-x86_64/objc!MediaPlayer.d.ts
@@ -743,7 +743,7 @@ declare const enum MPMediaType {
 
 	AnyVideo = 65280,
 
-	Any = 18446744073709551615
+	Any = -1
 }
 
 declare class MPMovieAccessLog extends NSObject implements NSCopying {

--- a/tns-platform-declarations/ios/objc-x86_64/objc!PassKit.d.ts
+++ b/tns-platform-declarations/ios/objc-x86_64/objc!PassKit.d.ts
@@ -375,7 +375,7 @@ declare const enum PKPassType {
 
 	Payment = 1,
 
-	Any = 18446744073709551615
+	Any = -1
 }
 
 declare class PKPayment extends NSObject {

--- a/tns-platform-declarations/ios/objc-x86_64/objc!SceneKit.d.ts
+++ b/tns-platform-declarations/ios/objc-x86_64/objc!SceneKit.d.ts
@@ -2939,7 +2939,7 @@ declare const enum SCNPhysicsCollisionCategory {
 
 	Static = 2,
 
-	All = 18446744073709551615
+	All = -1
 }
 
 declare class SCNPhysicsConeTwistJoint extends SCNPhysicsBehavior {

--- a/tns-platform-declarations/ios/objc-x86_64/objc!UIKit.d.ts
+++ b/tns-platform-declarations/ios/objc-x86_64/objc!UIKit.d.ts
@@ -4354,7 +4354,7 @@ declare const enum UICollisionBehaviorMode {
 
 	Boundaries = 2,
 
-	Everything = 18446744073709551615
+	Everything = -1
 }
 
 declare class UIColor extends NSObject implements NSCopying, NSItemProviderReading, NSItemProviderWriting, NSSecureCoding {
@@ -4831,7 +4831,7 @@ declare const enum UIDataDetectorTypes {
 
 	None = 0,
 
-	All = 18446744073709551615
+	All = -1
 }
 
 interface UIDataSourceModelAssociation {
@@ -9348,7 +9348,7 @@ declare const enum UIPopoverArrowDirection {
 
 	Any = 15,
 
-	Unknown = 18446744073709551615
+	Unknown = -1
 }
 
 declare class UIPopoverBackgroundView extends UIView implements UIPopoverBackgroundViewMethods {
@@ -10286,7 +10286,7 @@ declare const enum UIRectCorner {
 
 	BottomRight = 8,
 
-	AllCorners = 18446744073709551615
+	AllCorners = -1
 }
 
 declare const enum UIRectEdge {

--- a/tns-platform-declarations/ios/objc-x86_64/objc!WebKit.d.ts
+++ b/tns-platform-declarations/ios/objc-x86_64/objc!WebKit.d.ts
@@ -7,7 +7,7 @@ declare const enum WKAudiovisualMediaTypes {
 
 	Video = 2,
 
-	All = 18446744073709551615
+	All = -1
 }
 
 declare class WKBackForwardList extends NSObject {
@@ -88,7 +88,7 @@ declare const enum WKDataDetectorTypes {
 
 	LookupSuggestion = 64,
 
-	All = 18446744073709551615,
+	All = -1,
 
 	SpotlightSuggestion = 64
 }


### PR DESCRIPTION
`18446744073709551615` (`0xFFFFFFFFFFFFFFFF`) is an overflow to the JS
numerical system and therefore incorrect. Integer values from `-(2^53-1)` to `(2^53-1)`
only can be safely represented in JS (`Number​.MIN_SAFE_INTEGER` to
`Number​.MAX_SAFE_INTEGER`)

There's a fix in iOS Runtime's metadata generator which now automatically
converts such values to signed. (https://github.com/NativeScript/ios-runtime/pull/1151)

refs https://github.com/NativeScript/ios-runtime/issues/1150

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

