### PR TITLE
chore(widgets): Build TNSWidgets.framework.dSYM package

### DIFF
--- a/tns-core-modules-widgets/build.ios.sh
+++ b/tns-core-modules-widgets/build.ios.sh
@@ -17,7 +17,8 @@ mkdir dist/package/platforms/ios
 cd ios
 ./build.sh
 cd ..
-cp -r ios/TNSWidgets/build/TNSWidgets.framework dist/package/platforms/ios/TNSWidgets.framework
+echo "Copy TNSWidgets.framework and TNSWidgets.framework.dSYM.zip to dist/package/platforms/ios"
+cp -r ios/TNSWidgets/build/TNSWidgets.framework* dist/package/platforms/ios
 
 echo "Copy NPM artefacts"
 cp LICENSE dist/package/LICENSE

--- a/tns-core-modules-widgets/ios/build.sh
+++ b/tns-core-modules-widgets/ios/build.sh
@@ -19,3 +19,17 @@ cp -r TNSWidgets/build/Release-iphoneos/TNSWidgets.framework/Info.plist TNSWidge
 
 lipo -create TNSWidgets/build/Release-iphoneos/TNSWidgets.framework/TNSWidgets TNSWidgets/build/Release-iphonesimulator/TNSWidgets.framework/TNSWidgets -o TNSWidgets/build/TNSWidgets.framework/TNSWidgets
 file TNSWidgets/build/TNSWidgets.framework/TNSWidgets
+
+echo "Build fat dSYM at TNSWidgets/build/TNSWidgets.framework.dSYM"
+cp -r TNSWidgets/build/Release-iphoneos/TNSWidgets.framework.dSYM TNSWidgets/build
+rm "TNSWidgets/build/TNSWidgets.framework.dSYM/Contents/Resources/DWARF/TNSWidgets"
+lipo -create -output "TNSWidgets/build/TNSWidgets.framework.dSYM/Contents/Resources/DWARF/TNSWidgets" \
+    "TNSWidgets/build/Release-iphonesimulator/TNSWidgets.framework.dSYM/Contents/Resources/DWARF/TNSWidgets" \
+    "TNSWidgets/build/Release-iphoneos/TNSWidgets.framework.dSYM/Contents/Resources/DWARF/TNSWidgets"
+file TNSWidgets/build/TNSWidgets.framework.dSYM/Contents/Resources/DWARF/TNSWidgets
+
+echo "Archiving dSYM at TNSWidgets/build/TNSWidgets.framework.dSYM.zip"
+(cd TNSWidgets/build && zip -qr TNSWidgets.framework.dSYM.zip TNSWidgets.framework.dSYM)
+
+echo "Removing TNSWidgets/build/TNSWidgets.framework.dSYM"
+rm -rf TNSWidgets/build/TNSWidgets.framework.dSYM


### PR DESCRIPTION
We should provide debug symbols package so that users can upload it
to their crashlytics service provider.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

requested in support ticket 1410983