### PR TITLE
fix: clear the `resolvedPage` when entry is being cleared, change the passed `View` to be a weak reference

### DIFF
--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -483,52 +483,54 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
 
             if (changed) {
                 const view = this.viewRef.get();
-                if (reset) {
-                    delete this[key];
-                    if (valueChanged) {
-                        valueChanged(this, oldValue, value);
-                    }
-
-                    if (view[setNative]) {
-                        if (view._suspendNativeUpdatesCount) {
-                            if (view._suspendedUpdates) {
-                                view._suspendedUpdates[propertyName] = property;
-                            }
-                        } else {
-                            if (defaultValueKey in this) {
-                                view[setNative](this[defaultValueKey]);
-                                delete this[defaultValueKey];
+                if (view) {
+                    if (reset) {
+                        delete this[key];
+                        if (valueChanged) {
+                            valueChanged(this, oldValue, value);
+                        }
+    
+                        if (view[setNative]) {
+                            if (view._suspendNativeUpdatesCount) {
+                                if (view._suspendedUpdates) {
+                                    view._suspendedUpdates[propertyName] = property;
+                                }
                             } else {
-                                view[setNative](defaultValue);
+                                if (defaultValueKey in this) {
+                                    view[setNative](this[defaultValueKey]);
+                                    delete this[defaultValueKey];
+                                } else {
+                                    view[setNative](defaultValue);
+                                }
+                            }
+                        }
+                    } else {
+                        this[key] = value;
+                        if (valueChanged) {
+                            valueChanged(this, oldValue, value);
+                        }
+    
+                        if (view[setNative]) {
+                            if (view._suspendNativeUpdatesCount) {
+                                if (view._suspendedUpdates) {
+                                    view._suspendedUpdates[propertyName] = property;
+                                }
+                            } else {
+                                if (!(defaultValueKey in this)) {
+                                    this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
+                                }
+                                view[setNative](value);
                             }
                         }
                     }
-                } else {
-                    this[key] = value;
-                    if (valueChanged) {
-                        valueChanged(this, oldValue, value);
+    
+                    if (this.hasListeners(eventName)) {
+                        this.notify<PropertyChangeData>({ object: this, eventName, propertyName, value, oldValue });
                     }
-
-                    if (view[setNative]) {
-                        if (view._suspendNativeUpdatesCount) {
-                            if (view._suspendedUpdates) {
-                                view._suspendedUpdates[propertyName] = property;
-                            }
-                        } else {
-                            if (!(defaultValueKey in this)) {
-                                this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-                            }
-                            view[setNative](value);
-                        }
+    
+                    if (affectsLayout) {
+                        view.requestLayout();
                     }
-                }
-
-                if (this.hasListeners(eventName)) {
-                    this.notify<PropertyChangeData>({ object: this, eventName, propertyName, value, oldValue });
-                }
-
-                if (affectsLayout) {
-                    view.requestLayout();
                 }
             }
         }
@@ -558,52 +560,54 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
 
             if (changed) {
                 const view = this.viewRef.get();
-                if (reset) {
-                    delete this[key];
-                    if (valueChanged) {
-                        valueChanged(this, oldValue, value);
-                    }
-
-                    if (view[setNative]) {
-                        if (view._suspendNativeUpdatesCount) {
-                            if (view._suspendedUpdates) {
-                                view._suspendedUpdates[propertyName] = property;
-                            }
-                        } else {
-                            if (defaultValueKey in this) {
-                                view[setNative](this[defaultValueKey]);
-                                delete this[defaultValueKey];
+                if (view) {
+                    if (reset) {
+                        delete this[key];
+                        if (valueChanged) {
+                            valueChanged(this, oldValue, value);
+                        }
+    
+                        if (view[setNative]) {
+                            if (view._suspendNativeUpdatesCount) {
+                                if (view._suspendedUpdates) {
+                                    view._suspendedUpdates[propertyName] = property;
+                                }
                             } else {
-                                view[setNative](defaultValue);
+                                if (defaultValueKey in this) {
+                                    view[setNative](this[defaultValueKey]);
+                                    delete this[defaultValueKey];
+                                } else {
+                                    view[setNative](defaultValue);
+                                }
+                            }
+                        }
+                    } else {
+                        this[key] = value;
+                        if (valueChanged) {
+                            valueChanged(this, oldValue, value);
+                        }
+    
+                        if (view[setNative]) {
+                            if (view._suspendNativeUpdatesCount) {
+                                if (view._suspendedUpdates) {
+                                    view._suspendedUpdates[propertyName] = property;
+                                }
+                            } else {
+                                if (!(defaultValueKey in this)) {
+                                    this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
+                                }
+                                view[setNative](value);
                             }
                         }
                     }
-                } else {
-                    this[key] = value;
-                    if (valueChanged) {
-                        valueChanged(this, oldValue, value);
+    
+                    if (this.hasListeners(eventName)) {
+                        this.notify<PropertyChangeData>({ object: this, eventName, propertyName, value, oldValue });
                     }
-
-                    if (view[setNative]) {
-                        if (view._suspendNativeUpdatesCount) {
-                            if (view._suspendedUpdates) {
-                                view._suspendedUpdates[propertyName] = property;
-                            }
-                        } else {
-                            if (!(defaultValueKey in this)) {
-                                this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-                            }
-                            view[setNative](value);
-                        }
+    
+                    if (affectsLayout) {
+                        view.requestLayout();
                     }
-                }
-
-                if (this.hasListeners(eventName)) {
-                    this.notify<PropertyChangeData>({ object: this, eventName, propertyName, value, oldValue });
-                }
-
-                if (affectsLayout) {
-                    view.requestLayout();
                 }
             }
         }
@@ -761,7 +765,7 @@ export class CssAnimationProperty<T extends Style, U> implements definitions.Css
                     }
 
                     const view = this.viewRef.get();
-                    if (view[setNative] && (computedValueChanged || isSet !== wasSet)) {
+                    if (view && view[setNative] && (computedValueChanged || isSet !== wasSet)) {
                         if (view._suspendNativeUpdatesCount) {
                             if (view._suspendedUpdates) {
                                 view._suspendedUpdates[propertyName] = property;
@@ -879,7 +883,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
             const view = this.viewRef.get();
             let value: U;
             let unsetNativeValue = false;
-            if (reset) {
+            if (reset && view) {
                 // If unsetValue - we want to reset this property.
                 let parent = view.parent;
                 let style = parent ? parent.style : null;
@@ -908,55 +912,57 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 
             if (changed) {
                 const view = this.viewRef.get();
-                if (valueChanged) {
-                    valueChanged(this, oldValue, value);
-                }
-
-                if (view[setNative]) {
-                    if (view._suspendNativeUpdatesCount) {
-                        if (view._suspendedUpdates) {
-                            view._suspendedUpdates[propertyName] = property;
-                        }
-                    } else {
-                        if (unsetNativeValue) {
-                            if (defaultValueKey in this) {
-                                view[setNative](this[defaultValueKey]);
-                                delete this[defaultValueKey];
-                            } else {
-                                view[setNative](defaultValue);
+                if (view) {
+                    if (valueChanged) {
+                        valueChanged(this, oldValue, value);
+                    }
+    
+                    if (view[setNative]) {
+                        if (view._suspendNativeUpdatesCount) {
+                            if (view._suspendedUpdates) {
+                                view._suspendedUpdates[propertyName] = property;
                             }
                         } else {
-                            if (!(defaultValueKey in this)) {
-                                this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
+                            if (unsetNativeValue) {
+                                if (defaultValueKey in this) {
+                                    view[setNative](this[defaultValueKey]);
+                                    delete this[defaultValueKey];
+                                } else {
+                                    view[setNative](defaultValue);
+                                }
+                            } else {
+                                if (!(defaultValueKey in this)) {
+                                    this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
+                                }
+    
+                                view[setNative](value);
                             }
-
-                            view[setNative](value);
                         }
                     }
-                }
-
-                if (this.hasListeners(eventName)) {
-                    this.notify<PropertyChangeData>({ object: this, eventName, propertyName, value, oldValue });
-                }
-
-                if (affectsLayout) {
-                    view.requestLayout();
-                }
-
-                view.eachChild((child) => {
-                    const childStyle = child.style;
-                    const childValueSource = childStyle[sourceKey] || ValueSource.Default;
-                    if (reset) {
-                        if (childValueSource === ValueSource.Inherited) {
-                            setDefaultFunc.call(childStyle, unsetValue);
-                        }
-                    } else {
-                        if (childValueSource <= ValueSource.Inherited) {
-                            setInheritedFunc.call(childStyle, value);
-                        }
+    
+                    if (this.hasListeners(eventName)) {
+                        this.notify<PropertyChangeData>({ object: this, eventName, propertyName, value, oldValue });
                     }
-                    return true;
-                });
+    
+                    if (affectsLayout) {
+                        view.requestLayout();
+                    }
+    
+                    view.eachChild((child) => {
+                        const childStyle = child.style;
+                        const childValueSource = childStyle[sourceKey] || ValueSource.Default;
+                        if (reset) {
+                            if (childValueSource === ValueSource.Inherited) {
+                                setDefaultFunc.call(childStyle, unsetValue);
+                            }
+                        } else {
+                            if (childValueSource <= ValueSource.Inherited) {
+                                setInheritedFunc.call(childStyle, value);
+                            }
+                        }
+                        return true;
+                    });
+                }
             }
         };
 
@@ -997,19 +1003,25 @@ export class ShorthandProperty<T extends Style, P> implements definitions.Shorth
         const converter = options.converter;
 
         function setLocalValue(this: T, value: string | P): void {
-            this.viewRef.get()._batchUpdate(() => {
-                for (let [p, v] of converter(value)) {
-                    this[p.name] = v;
-                }
-            });
+            let view = this.viewRef.get()
+            if (view) {
+                view._batchUpdate(() => {
+                    for (let [p, v] of converter(value)) {
+                        this[p.name] = v;
+                    }
+                });
+            }
         }
 
         function setCssValue(this: T, value: string): void {
-            this.viewRef.get()._batchUpdate(() => {
-                for (let [p, v] of converter(value)) {
-                    this[p.cssName] = v;
-                }
-            });
+            let view = this.viewRef.get()
+            if (view) {
+                view._batchUpdate(() => {
+                    for (let [p, v] of converter(value)) {
+                        this[p.cssName] = v;
+                    }
+                });
+            }
         }
 
         this.cssValueDescriptor = {

--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -914,7 +914,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
             const oldValue: U = key in this ? this[key] : defaultValue;
             let value: U;
             let unsetNativeValue = false;
-            if (reset && view) {
+            if (reset) {
                 // If unsetValue - we want to reset this property.
                 let parent = view.parent;
                 let style = parent ? parent.style : null;
@@ -1031,25 +1031,33 @@ export class ShorthandProperty<T extends Style, P> implements definitions.Shorth
         const converter = options.converter;
 
         function setLocalValue(this: T, value: string | P): void {
-            let view = this.viewRef.get()
-            if (view) {
-                view._batchUpdate(() => {
-                    for (let [p, v] of converter(value)) {
-                        this[p.name] = v;
-                    }
-                });
+            const view = this.viewRef.get();
+            if (!view) {
+                traceWrite(`setLocalValue not executed to view because ".viewRef" is cleared`, traceCategories.Animation, traceMessageType.warn);
+    
+                return;
             }
+
+            view._batchUpdate(() => {
+                for (let [p, v] of converter(value)) {
+                    this[p.name] = v;
+                }
+            });
         }
 
         function setCssValue(this: T, value: string): void {
-            let view = this.viewRef.get()
-            if (view) {
-                view._batchUpdate(() => {
-                    for (let [p, v] of converter(value)) {
-                        this[p.cssName] = v;
-                    }
-                });
+            const view = this.viewRef.get();
+            if (!view) {
+                traceWrite(`setCssValue not executed to view because ".viewRef" is cleared`, traceCategories.Animation, traceMessageType.warn);
+    
+                return;
             }
+
+            view._batchUpdate(() => {
+                for (let [p, v] of converter(value)) {
+                    this[p.cssName] = v;
+                }
+            });
         }
 
         this.cssValueDescriptor = {

--- a/tns-core-modules/ui/core/properties/properties.ts
+++ b/tns-core-modules/ui/core/properties/properties.ts
@@ -482,7 +482,7 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
             const changed: boolean = equalityComparer ? !equalityComparer(oldValue, value) : oldValue !== value;
 
             if (changed) {
-                const view = this.view;
+                const view = this.viewRef.get();
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {
@@ -557,7 +557,7 @@ export class CssProperty<T extends Style, U> implements definitions.CssProperty<
             const changed: boolean = equalityComparer ? !equalityComparer(oldValue, value) : oldValue !== value;
 
             if (changed) {
-                const view = this.view;
+                const view = this.viewRef.get();
                 if (reset) {
                     delete this[key];
                     if (valueChanged) {
@@ -760,7 +760,7 @@ export class CssAnimationProperty<T extends Style, U> implements definitions.Css
                         valueChanged(this, oldValue, value);
                     }
 
-                    const view = this.view;
+                    const view = this.viewRef.get();
                     if (view[setNative] && (computedValueChanged || isSet !== wasSet)) {
                         if (view._suspendNativeUpdatesCount) {
                             if (view._suspendedUpdates) {
@@ -819,7 +819,7 @@ export class CssAnimationProperty<T extends Style, U> implements definitions.Css
         const defaultValueKey = this.defaultValueKey;
 
         if (!(defaultValueKey in target)) {
-            const view = target.view;
+            const view = target.viewRef.get();
             const getDefault = this.getDefault;
             target[defaultValueKey] = view[getDefault] ? view[getDefault]() : this.defaultValue;
         }
@@ -876,7 +876,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
             }
 
             const oldValue: U = key in this ? this[key] : defaultValue;
-            const view = this.view;
+            const view = this.viewRef.get();
             let value: U;
             let unsetNativeValue = false;
             if (reset) {
@@ -907,7 +907,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
             const changed: boolean = equalityComparer ? !equalityComparer(oldValue, value) : oldValue !== value;
 
             if (changed) {
-                const view = this.view;
+                const view = this.viewRef.get();
                 if (valueChanged) {
                     valueChanged(this, oldValue, value);
                 }
@@ -997,7 +997,7 @@ export class ShorthandProperty<T extends Style, P> implements definitions.Shorth
         const converter = options.converter;
 
         function setLocalValue(this: T, value: string | P): void {
-            this.view._batchUpdate(() => {
+            this.viewRef.get()._batchUpdate(() => {
                 for (let [p, v] of converter(value)) {
                     this[p.name] = v;
                 }
@@ -1005,7 +1005,7 @@ export class ShorthandProperty<T extends Style, P> implements definitions.Shorth
         }
 
         function setCssValue(this: T, value: string): void {
-            this.view._batchUpdate(() => {
+            this.viewRef.get()._batchUpdate(() => {
                 for (let [p, v] of converter(value)) {
                     this[p.cssName] = v;
                 }

--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -192,7 +192,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     public _domId: number;
     public _context: any;
     public _isAddedToNativeVisualTree: boolean;
-    public _cssState: ssm.CssState = new ssm.CssState(this);
+    public _cssState: ssm.CssState = new ssm.CssState(new WeakRef(this));
     public _styleScope: ssm.StyleScope;
     public _suspendedUpdates: { [propertyName: string]: Property<ViewBase, any> | CssProperty<Style, any> | CssAnimationProperty<Style, any> };
     public _suspendNativeUpdatesCount: SuspendType;
@@ -249,7 +249,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
     constructor() {
         super();
         this._domId = viewIdCounter++;
-        this._style = new Style(this);
+        this._style = new Style(new WeakRef(this));
     }
 
     // Used in Angular.

--- a/tns-core-modules/ui/frame/frame-common.ts
+++ b/tns-core-modules/ui/frame/frame-common.ts
@@ -154,6 +154,8 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
         } else {
             page._tearDownUI(true);
         }
+        
+        removed.resolvedPage = null;
     }
 
     // Attempts to implement https://github.com/NativeScript/NativeScript/issues/1311

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -443,6 +443,7 @@ export class Frame extends FrameBase {
 
         removed.fragment = null;
         removed.viewSavedState = null;
+        removed.resolvedPage = null;
     }
 
     public createNativeView() {

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -443,7 +443,6 @@ export class Frame extends FrameBase {
 
         removed.fragment = null;
         removed.viewSavedState = null;
-        removed.resolvedPage = null;
     }
 
     public createNativeView() {

--- a/tns-core-modules/ui/styling/style-properties.ts
+++ b/tns-core-modules/ui/styling/style-properties.ts
@@ -175,7 +175,7 @@ export const zeroLength: Length = { value: 0, unit: "px" };
 export const minWidthProperty = new CssProperty<Style, Length>({
     name: "minWidth", cssName: "min-width", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.view.effectiveMinWidth = Length.toDevicePixels(newValue, 0);
+        target.viewRef.get().effectiveMinWidth = Length.toDevicePixels(newValue, 0);
     }, valueConverter: Length.parse
 });
 minWidthProperty.register(Style);
@@ -183,7 +183,7 @@ minWidthProperty.register(Style);
 export const minHeightProperty = new CssProperty<Style, Length>({
     name: "minHeight", cssName: "min-height", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.view.effectiveMinHeight = Length.toDevicePixels(newValue, 0);
+        target.viewRef.get().effectiveMinHeight = Length.toDevicePixels(newValue, 0);
     }, valueConverter: Length.parse
 });
 minHeightProperty.register(Style);
@@ -237,7 +237,7 @@ paddingProperty.register(Style);
 export const paddingLeftProperty = new CssProperty<Style, Length>({
     name: "paddingLeft", cssName: "padding-left", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.view.effectivePaddingLeft = Length.toDevicePixels(newValue, 0);
+        target.viewRef.get().effectivePaddingLeft = Length.toDevicePixels(newValue, 0);
     }, valueConverter: Length.parse
 });
 paddingLeftProperty.register(Style);
@@ -245,7 +245,7 @@ paddingLeftProperty.register(Style);
 export const paddingRightProperty = new CssProperty<Style, Length>({
     name: "paddingRight", cssName: "padding-right", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.view.effectivePaddingRight = Length.toDevicePixels(newValue, 0);
+        target.viewRef.get().effectivePaddingRight = Length.toDevicePixels(newValue, 0);
     }, valueConverter: Length.parse
 });
 paddingRightProperty.register(Style);
@@ -253,7 +253,7 @@ paddingRightProperty.register(Style);
 export const paddingTopProperty = new CssProperty<Style, Length>({
     name: "paddingTop", cssName: "padding-top", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.view.effectivePaddingTop = Length.toDevicePixels(newValue, 0);
+        target.viewRef.get().effectivePaddingTop = Length.toDevicePixels(newValue, 0);
     }, valueConverter: Length.parse
 });
 paddingTopProperty.register(Style);
@@ -261,7 +261,7 @@ paddingTopProperty.register(Style);
 export const paddingBottomProperty = new CssProperty<Style, Length>({
     name: "paddingBottom", cssName: "padding-bottom", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.view.effectivePaddingBottom = Length.toDevicePixels(newValue, 0);
+        target.viewRef.get().effectivePaddingBottom = Length.toDevicePixels(newValue, 0);
     }, valueConverter: Length.parse
 });
 paddingBottomProperty.register(Style);
@@ -822,7 +822,7 @@ export const borderTopWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-top-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.view.effectiveBorderTopWidth = value;
+        target.viewRef.get().effectiveBorderTopWidth = value;
         const background = target.backgroundInternal.withBorderTopWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -837,7 +837,7 @@ export const borderRightWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-right-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.view.effectiveBorderRightWidth = value;
+        target.viewRef.get().effectiveBorderRightWidth = value;
         const background = target.backgroundInternal.withBorderRightWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -852,7 +852,7 @@ export const borderBottomWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-bottom-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.view.effectiveBorderBottomWidth = value;
+        target.viewRef.get().effectiveBorderBottomWidth = value;
         const background = target.backgroundInternal.withBorderBottomWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -867,7 +867,7 @@ export const borderLeftWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-left-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.view.effectiveBorderLeftWidth = value;
+        target.viewRef.get().effectiveBorderLeftWidth = value;
         const background = target.backgroundInternal.withBorderLeftWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -1095,7 +1095,7 @@ export namespace Visibility {
 
 export const visibilityProperty = new CssProperty<Style, Visibility>({
     name: "visibility", cssName: "visibility", defaultValue: Visibility.VISIBLE, affectsLayout: isIOS, valueConverter: Visibility.parse, valueChanged: (target, oldValue, newValue) => {
-        target.view.isCollapsed = (newValue === Visibility.COLLAPSE);
+        target.viewRef.get().isCollapsed = (newValue === Visibility.COLLAPSE);
     }
 });
 visibilityProperty.register(Style);

--- a/tns-core-modules/ui/styling/style-properties.ts
+++ b/tns-core-modules/ui/styling/style-properties.ts
@@ -180,7 +180,7 @@ export const zeroLength: Length = { value: 0, unit: "px" };
 export const minWidthProperty = new CssProperty<Style, Length>({
     name: "minWidth", cssName: "min-width", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectiveMinWidth = Length.toDevicePixels(newValue, 0);
         } else {
@@ -193,7 +193,7 @@ minWidthProperty.register(Style);
 export const minHeightProperty = new CssProperty<Style, Length>({
     name: "minHeight", cssName: "min-height", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectiveMinHeight = Length.toDevicePixels(newValue, 0);
         } else {
@@ -252,7 +252,7 @@ paddingProperty.register(Style);
 export const paddingLeftProperty = new CssProperty<Style, Length>({
     name: "paddingLeft", cssName: "padding-left", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectivePaddingLeft = Length.toDevicePixels(newValue, 0);
         } else {
@@ -265,7 +265,7 @@ paddingLeftProperty.register(Style);
 export const paddingRightProperty = new CssProperty<Style, Length>({
     name: "paddingRight", cssName: "padding-right", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectivePaddingRight = Length.toDevicePixels(newValue, 0);
         } else {
@@ -278,7 +278,7 @@ paddingRightProperty.register(Style);
 export const paddingTopProperty = new CssProperty<Style, Length>({
     name: "paddingTop", cssName: "padding-top", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectivePaddingTop = Length.toDevicePixels(newValue, 0);
         } else {
@@ -291,7 +291,7 @@ paddingTopProperty.register(Style);
 export const paddingBottomProperty = new CssProperty<Style, Length>({
     name: "paddingBottom", cssName: "padding-bottom", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectivePaddingBottom = Length.toDevicePixels(newValue, 0);
         } else {
@@ -857,7 +857,7 @@ export const borderTopWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-top-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectiveBorderTopWidth = value;
         } else {
@@ -877,7 +877,7 @@ export const borderRightWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-right-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectiveBorderRightWidth = value;
         } else {
@@ -897,7 +897,7 @@ export const borderBottomWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-bottom-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectiveBorderBottomWidth = value;
         } else {
@@ -917,7 +917,7 @@ export const borderLeftWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-left-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.effectiveBorderLeftWidth = value;
         } else {
@@ -1150,7 +1150,7 @@ export namespace Visibility {
 
 export const visibilityProperty = new CssProperty<Style, Visibility>({
     name: "visibility", cssName: "visibility", defaultValue: Visibility.VISIBLE, affectsLayout: isIOS, valueConverter: Visibility.parse, valueChanged: (target, oldValue, newValue) => {
-        let view = target.viewRef.get();
+        const view = target.viewRef.get();
         if (view) {
             view.isCollapsed = (newValue === Visibility.COLLAPSE);
         } else {

--- a/tns-core-modules/ui/styling/style-properties.ts
+++ b/tns-core-modules/ui/styling/style-properties.ts
@@ -25,6 +25,11 @@ import {
     matrixArrayToCssMatrix,
     multiplyAffine2d,
 } from "../../matrix";
+import {
+    write as traceWrite,
+    categories as traceCategories,
+    messageType as traceMessageType,
+} from "../../trace";
 
 import * as parser from "../../css/parser";
 import { LinearGradient } from "./linear-gradient";
@@ -175,7 +180,12 @@ export const zeroLength: Length = { value: 0, unit: "px" };
 export const minWidthProperty = new CssProperty<Style, Length>({
     name: "minWidth", cssName: "min-width", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().effectiveMinWidth = Length.toDevicePixels(newValue, 0);
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectiveMinWidth = Length.toDevicePixels(newValue, 0);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }, valueConverter: Length.parse
 });
 minWidthProperty.register(Style);
@@ -183,7 +193,12 @@ minWidthProperty.register(Style);
 export const minHeightProperty = new CssProperty<Style, Length>({
     name: "minHeight", cssName: "min-height", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().effectiveMinHeight = Length.toDevicePixels(newValue, 0);
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectiveMinHeight = Length.toDevicePixels(newValue, 0);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }, valueConverter: Length.parse
 });
 minHeightProperty.register(Style);
@@ -237,7 +252,12 @@ paddingProperty.register(Style);
 export const paddingLeftProperty = new CssProperty<Style, Length>({
     name: "paddingLeft", cssName: "padding-left", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().effectivePaddingLeft = Length.toDevicePixels(newValue, 0);
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectivePaddingLeft = Length.toDevicePixels(newValue, 0);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }, valueConverter: Length.parse
 });
 paddingLeftProperty.register(Style);
@@ -245,7 +265,12 @@ paddingLeftProperty.register(Style);
 export const paddingRightProperty = new CssProperty<Style, Length>({
     name: "paddingRight", cssName: "padding-right", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().effectivePaddingRight = Length.toDevicePixels(newValue, 0);
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectivePaddingRight = Length.toDevicePixels(newValue, 0);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }, valueConverter: Length.parse
 });
 paddingRightProperty.register(Style);
@@ -253,7 +278,12 @@ paddingRightProperty.register(Style);
 export const paddingTopProperty = new CssProperty<Style, Length>({
     name: "paddingTop", cssName: "padding-top", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().effectivePaddingTop = Length.toDevicePixels(newValue, 0);
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectivePaddingTop = Length.toDevicePixels(newValue, 0);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }, valueConverter: Length.parse
 });
 paddingTopProperty.register(Style);
@@ -261,7 +291,12 @@ paddingTopProperty.register(Style);
 export const paddingBottomProperty = new CssProperty<Style, Length>({
     name: "paddingBottom", cssName: "padding-bottom", defaultValue: zeroLength, affectsLayout: isIOS, equalityComparer: Length.equals,
     valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().effectivePaddingBottom = Length.toDevicePixels(newValue, 0);
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectivePaddingBottom = Length.toDevicePixels(newValue, 0);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }, valueConverter: Length.parse
 });
 paddingBottomProperty.register(Style);
@@ -822,7 +857,12 @@ export const borderTopWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-top-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.viewRef.get().effectiveBorderTopWidth = value;
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectiveBorderTopWidth = value;
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
         const background = target.backgroundInternal.withBorderTopWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -837,7 +877,12 @@ export const borderRightWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-right-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.viewRef.get().effectiveBorderRightWidth = value;
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectiveBorderRightWidth = value;
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
         const background = target.backgroundInternal.withBorderRightWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -852,7 +897,12 @@ export const borderBottomWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-bottom-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.viewRef.get().effectiveBorderBottomWidth = value;
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectiveBorderBottomWidth = value;
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
         const background = target.backgroundInternal.withBorderBottomWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -867,7 +917,12 @@ export const borderLeftWidthProperty = new CssProperty<Style, Length>({
             throw new Error(`border-left-width should be Non-Negative Finite number. Value: ${value}`);
         }
 
-        target.viewRef.get().effectiveBorderLeftWidth = value;
+        let view = target.viewRef.get();
+        if (view) {
+            view.effectiveBorderLeftWidth = value;
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
         const background = target.backgroundInternal.withBorderLeftWidth(value);
         target.backgroundInternal = background;
     }, valueConverter: Length.parse
@@ -1095,7 +1150,12 @@ export namespace Visibility {
 
 export const visibilityProperty = new CssProperty<Style, Visibility>({
     name: "visibility", cssName: "visibility", defaultValue: Visibility.VISIBLE, affectsLayout: isIOS, valueConverter: Visibility.parse, valueChanged: (target, oldValue, newValue) => {
-        target.viewRef.get().isCollapsed = (newValue === Visibility.COLLAPSE);
+        let view = target.viewRef.get();
+        if (view) {
+            view.isCollapsed = (newValue === Visibility.COLLAPSE);
+        } else {
+            traceWrite(`${newValue} not set to view's property because ".viewRef" is cleared`, traceCategories.Style, traceMessageType.warn);
+        }
     }
 });
 visibilityProperty.register(Style);

--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -350,7 +350,7 @@ export class CssState {
     _matchInvalid: boolean;
     _playsKeyframeAnimations: boolean;
 
-    constructor(private view: ViewBase) {
+    constructor(private viewRef: WeakRef<ViewBase>) {
         this._onDynamicStateChangeHandler = () => this.updateDynamicState();
     }
 
@@ -359,7 +359,8 @@ export class CssState {
      * As a result, at some point in time, the selectors matched have to be requerried from the style scope and applied to the view.
      */
     public onChange(): void {
-        if (this.view && this.view.isLoaded) {
+        let view = this.viewRef.get();
+        if (view && view.isLoaded) {
             this.unsubscribeFromDynamicUpdates();
             this.updateMatch();
             this.subscribeForDynamicUpdates();
@@ -370,7 +371,7 @@ export class CssState {
     }
 
     public isSelectorsLatestVersionApplied(): boolean {
-        return this.view._styleScope._getSelectorsVersion() === this._appliedSelectorsVersion;
+        return this.viewRef.get()._styleScope._getSelectorsVersion() === this._appliedSelectorsVersion;
     }
 
     public onLoaded(): void {
@@ -387,9 +388,10 @@ export class CssState {
 
     @profile
     private updateMatch() {
-        if (this.view._styleScope) {
-            this._appliedSelectorsVersion = this.view._styleScope._getSelectorsVersion();
-            this._match = this.view._styleScope.matchSelectors(this.view);
+        let view = this.viewRef.get();
+        if (view._styleScope) {
+            this._appliedSelectorsVersion = view._styleScope._getSelectorsVersion();
+            this._match = view._styleScope.matchSelectors(view);
         } else {
             this._match = CssState.emptyMatch;
         }
@@ -398,9 +400,10 @@ export class CssState {
 
     @profile
     private updateDynamicState(): void {
-        const matchingSelectors = this._match.selectors.filter(sel => sel.dynamic ? sel.match(this.view) : true);
+        let view = this.viewRef.get();
 
-        this.view._batchUpdate(() => {
+        const matchingSelectors = this._match.selectors.filter(sel => sel.dynamic ? sel.match(view) : true);
+        view._batchUpdate(() => {
             this.stopKeyframeAnimations();
             this.setPropertyValues(matchingSelectors);
             this.playKeyframeAnimations(matchingSelectors);
@@ -424,7 +427,7 @@ export class CssState {
         });
 
         if (this._playsKeyframeAnimations = animations.length > 0) {
-            animations.map(animation => animation.play(<View>this.view));
+            animations.map(animation => animation.play(<View>this.viewRef.get()));
             Object.freeze(animations);
             this._appliedAnimations = animations;
         }
@@ -440,13 +443,15 @@ export class CssState {
             .forEach(animation => animation.cancel());
         this._appliedAnimations = CssState.emptyAnimationArray;
 
-        this.view.style["keyframe:rotate"] = unsetValue;
-        this.view.style["keyframe:scaleX"] = unsetValue;
-        this.view.style["keyframe:scaleY"] = unsetValue;
-        this.view.style["keyframe:translateX"] = unsetValue;
-        this.view.style["keyframe:translateY"] = unsetValue;
-        this.view.style["keyframe:backgroundColor"] = unsetValue;
-        this.view.style["keyframe:opacity"] = unsetValue;
+        let view = this.viewRef.get();
+
+        view.style["keyframe:rotate"] = unsetValue;
+        view.style["keyframe:scaleX"] = unsetValue;
+        view.style["keyframe:scaleY"] = unsetValue;
+        view.style["keyframe:translateX"] = unsetValue;
+        view.style["keyframe:translateY"] = unsetValue;
+        view.style["keyframe:backgroundColor"] = unsetValue;
+        view.style["keyframe:opacity"] = unsetValue;
         this._playsKeyframeAnimations = false;
     }
 
@@ -457,7 +462,8 @@ export class CssState {
      * @param matchingSelectors
      */
     private setPropertyValues(matchingSelectors: SelectorCore[]): void {
-        const newPropertyValues = new this.view.style.PropertyBag();
+        let view = this.viewRef.get();
+        const newPropertyValues = new view.style.PropertyBag();
         matchingSelectors.forEach(selector =>
             selector.ruleset.declarations.forEach(declaration =>
                 newPropertyValues[declaration.property] = declaration.value));
@@ -466,8 +472,8 @@ export class CssState {
         const oldProperties = this._appliedPropertyValues;
         for (const key in oldProperties) {
             if (!(key in newPropertyValues)) {
-                if (key in this.view.style) {
-                    this.view.style[`css:${key}`] = unsetValue;
+                if (key in view.style) {
+                    view.style[`css:${key}`] = unsetValue;
                 } else {
                     // TRICKY: How do we unset local value?
                 }
@@ -479,14 +485,14 @@ export class CssState {
             }
             const value = newPropertyValues[property];
             try {
-                if (property in this.view.style) {
-                    this.view.style[`css:${property}`] = value;
+                if (property in view.style) {
+                    view.style[`css:${property}`] = value;
                 } else {
                     const camelCasedProperty = property.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
-                    this.view[camelCasedProperty] = value;
+                    view[camelCasedProperty] = value;
                 }
             } catch (e) {
-                traceWrite(`Failed to apply property [${property}] with value [${value}] to ${this.view}. ${e}`, traceCategories.Error, traceMessageType.error);
+                traceWrite(`Failed to apply property [${property}] with value [${value}] to ${view}. ${e}`, traceCategories.Error, traceMessageType.error);
             }
         }
 
@@ -535,7 +541,7 @@ export class CssState {
     }
 
     toString(): string {
-        return `${this.view}._cssState`;
+        return `${this.viewRef.get()}._cssState`;
     }
 }
 CssState.prototype._appliedChangeMap = CssState.emptyChangeMap;

--- a/tns-core-modules/ui/styling/style/style.d.ts
+++ b/tns-core-modules/ui/styling/style/style.d.ts
@@ -139,8 +139,8 @@ export class Style extends Observable {
     public statusBarStyle: "light" | "dark";
     public androidStatusBarBackground: Color;
 
-    constructor(ownerView: ViewBase);
-    public view: ViewBase;
+    constructor(ownerView: WeakRef<ViewBase>);
+    public viewRef: WeakRef<ViewBase>;
 
     //flexbox layout properties
     public flexDirection: FlexDirection;

--- a/tns-core-modules/ui/styling/style/style.d.ts
+++ b/tns-core-modules/ui/styling/style/style.d.ts
@@ -139,8 +139,15 @@ export class Style extends Observable {
     public statusBarStyle: "light" | "dark";
     public androidStatusBarBackground: Color;
 
-    constructor(ownerView: WeakRef<ViewBase>);
+    constructor(ownerView: ViewBase | WeakRef<ViewBase>);
     public viewRef: WeakRef<ViewBase>;
+
+    /**
+     * @deprecated use `viewRef` instead.
+     *
+     * The `ViewBase` object associated with the Style!
+     */
+    public view: ViewBase;
 
     //flexbox layout properties
     public flexDirection: FlexDirection;

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -21,10 +21,11 @@ export class Style extends Observable implements StyleDefinition {
     constructor(ownerView: ViewBase | WeakRef<ViewBase>) {
         super();
 
-        if (ownerView instanceof ViewBase) {
-            this.viewRef = new WeakRef(ownerView);
-        } else if (ownerView instanceof WeakRef) {
-            this.viewRef = ownerView;
+        // HACK: Could not find better way for cross platform WeakRef type checking.
+        if (ownerView.constructor.toString().indexOf("[native code]") !== -1) {
+            this.viewRef = <WeakRef<ViewBase>>ownerView;
+        } else  {
+            this.viewRef = new WeakRef(<ViewBase>ownerView);
         }
     }
 

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -10,7 +10,11 @@ import {
     FlexDirection, FlexWrap, JustifyContent, AlignItems, AlignContent,
     Order, FlexGrow, FlexShrink, FlexWrapBefore, AlignSelf
 } from "../../layouts/flexbox-layout";
-
+import {
+    write as traceWrite,
+    categories as traceCategories,
+    messageType as traceMessageType,
+} from "../../../trace";
 import { TextAlignment, TextDecoration, TextTransform, WhiteSpace } from "../../text-base";
 
 export class Style extends Observable implements StyleDefinition {
@@ -19,7 +23,13 @@ export class Style extends Observable implements StyleDefinition {
     }
 
     toString() {
-        return `${this.viewRef.get()}.style`;
+        let view = this.viewRef.get();
+        if (view) {
+            return `${view}.style`;
+
+        } else {
+            traceWrite(`toString() of Style cannot execute correctly because ".viewRef" is cleared`, traceCategories.Animation, traceMessageType.warn);
+        }
     }
 
     public fontInternal: Font;

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -29,13 +29,14 @@ export class Style extends Observable implements StyleDefinition {
     }
 
     toString() {
-        let view = this.viewRef.get();
-        if (view) {
-            return `${view}.style`;
-
-        } else {
+        const view = this.viewRef.get();
+        if (!view) {
             traceWrite(`toString() of Style cannot execute correctly because ".viewRef" is cleared`, traceCategories.Animation, traceMessageType.warn);
+
+            return "";
         }
+
+        return `${view}.style`;
     }
 
     public fontInternal: Font;

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -14,12 +14,12 @@ import {
 import { TextAlignment, TextDecoration, TextTransform, WhiteSpace } from "../../text-base";
 
 export class Style extends Observable implements StyleDefinition {
-    constructor(public view: ViewBase) {
+    constructor(public viewRef: WeakRef<ViewBase>) {
         super();
     }
 
     toString() {
-        return `${this.view}.style`;
+        return `${this.viewRef.get()}.style`;
     }
 
     public fontInternal: Font;

--- a/tns-core-modules/ui/styling/style/style.ts
+++ b/tns-core-modules/ui/styling/style/style.ts
@@ -18,8 +18,14 @@ import {
 import { TextAlignment, TextDecoration, TextTransform, WhiteSpace } from "../../text-base";
 
 export class Style extends Observable implements StyleDefinition {
-    constructor(public viewRef: WeakRef<ViewBase>) {
+    constructor(ownerView: ViewBase | WeakRef<ViewBase>) {
         super();
+
+        if (ownerView instanceof ViewBase) {
+            this.viewRef = new WeakRef(ownerView);
+        } else if (ownerView instanceof WeakRef) {
+            this.viewRef = ownerView;
+        }
     }
 
     toString() {
@@ -135,5 +141,15 @@ export class Style extends Observable implements StyleDefinition {
     public alignSelf: AlignSelf;
 
     public PropertyBag: { new(): { [property: string]: string }, prototype: { [property: string]: string } };
+
+    public viewRef: WeakRef<ViewBase>;
+
+    public get view(): ViewBase {
+        if (this.viewRef) {
+            return this.viewRef.get();
+        }
+
+        return undefined;
+    }
 }
 Style.prototype.PropertyBag = class { [property: string]: string; }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When navigating to a Page that contains any kind of elements (GridLayout, ListView, RadListView etc.), if you navigate back and trigger JS GC those elements and the Page itself are never collected and stay in the memory.
![Screenshot 2019-06-05 at 16 08 07](https://user-images.githubusercontent.com/4989411/59032620-6cd29c00-886f-11e9-8b0c-f96457926ec3.png)

## What is the new behavior?
When navigating to a Page that contains any kind of elements (GridLayout, ListView, RadListView etc.), if you navigate back and trigger JS GC those elements and the Page itself are collected and are removed from the memory.
![Screenshot 2019-06-06 at 15 26 31](https://user-images.githubusercontent.com/4989411/59032660-81af2f80-886f-11e9-9731-0da7b681d6b8.png)


Fixes/Implements/Closes #[Issue Number].


Here is a sample project that I created to test this case: 
[memory-test.zip](https://github.com/NativeScript/NativeScript/files/3261928/memory-test.zip)
