### PR TITLE
feat(EditableTextBase) Add support for :focus pseudo class in TextField/TextView

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base-common.ts
@@ -1,5 +1,5 @@
 ﻿import { EditableTextBase as EditableTextBaseDefinition, KeyboardType, ReturnKeyType, UpdateTextTrigger, AutocapitalizationType } from ".";
-import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser } from "../text-base";
+import { TextBase, Property, CssProperty, Style, Color, booleanConverter, makeValidator, makeParser, PseudoClassHandler } from "../text-base";
 
 export * from "../text-base";
 
@@ -18,6 +18,17 @@ export abstract class EditableTextBase extends TextBase implements EditableTextB
 
     public abstract dismissSoftInput();
     public abstract _setInputType(inputType: number): void;
+
+    private _focusHandler = () => this._goToVisualState("focus");
+    private _blurHandler = () => this._goToVisualState("blur");
+
+    @PseudoClassHandler("focus", "blur")
+    _updateHandler(subscribe) {
+        const method = subscribe ? "on" : "off";
+
+        this[method]("focus", this._focusHandler);
+        this[method]("blur", this._blurHandler);
+    };
 }
 
 // TODO: Why not name it - hintColor property??


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
TextField/TextView doesn't have focus states.
There should be a way to style the TextField/TextView focus states in CSS without the manual need to attach events and set classes.

## What is the new behavior?
:focus pseudo class is applied whenever a field gets focused.

Fixes/Implements/Closes #7395.