### PR TITLE
fix(android): a circular reexports

### DIFF
--- a/tns-core-modules/ui/animation/animation-common.ts
+++ b/tns-core-modules/ui/animation/animation-common.ts
@@ -14,7 +14,6 @@ import { isEnabled as traceEnabled, write as traceWrite, categories as traceCate
 import { PercentLength } from "../styling/style-properties";
 
 export { Color, traceEnabled, traceWrite, traceCategories, traceType };
-export { AnimationPromise } from ".";
 
 export module Properties {
     export const opacity = "opacity";
@@ -90,7 +89,7 @@ export abstract class AnimationBase implements AnimationBaseDefinition {
     protected _rejectAlreadyPlaying(): AnimationPromiseDefinition {
         const reason = "Animation is already playing.";
         traceWrite(reason, traceCategories.Animation, traceType.warn);
-        
+
         return <AnimationPromiseDefinition>new Promise<void>((resolve, reject) => {
             reject(reason);
         });

--- a/tns-core-modules/ui/animation/animation.android.ts
+++ b/tns-core-modules/ui/animation/animation.android.ts
@@ -1,8 +1,8 @@
 ﻿// Definitions.
-import { AnimationDefinition } from ".";
+import { AnimationDefinition, AnimationPromise } from ".";
 import { View } from "../core/view";
 
-import { AnimationBase, Properties, PropertyAnimation, CubicBezierAnimationCurve, AnimationPromise, Color, traceWrite, traceEnabled, traceCategories, traceType } from "./animation-common";
+import { AnimationBase, Properties, PropertyAnimation, CubicBezierAnimationCurve, Color, traceWrite, traceEnabled, traceCategories, traceType } from "./animation-common";
 import {
     opacityProperty, backgroundColorProperty, rotateProperty,
     translateXProperty, translateYProperty, scaleXProperty, scaleYProperty,

--- a/tns-core-modules/ui/animation/animation.ios.ts
+++ b/tns-core-modules/ui/animation/animation.ios.ts
@@ -1,7 +1,7 @@
-import { AnimationDefinition } from ".";
+import { AnimationDefinition, AnimationPromise } from ".";
 import { View } from "../core/view";
 
-import { AnimationBase, Properties, PropertyAnimation, CubicBezierAnimationCurve, AnimationPromise, traceWrite, traceEnabled, traceCategories, traceType } from "./animation-common";
+import { AnimationBase, Properties, PropertyAnimation, CubicBezierAnimationCurve, traceWrite, traceEnabled, traceCategories, traceType } from "./animation-common";
 import {
     opacityProperty, backgroundColorProperty, rotateProperty,
     translateXProperty, translateYProperty, scaleXProperty, scaleYProperty,
@@ -318,7 +318,7 @@ export class Animation extends AnimationBase {
                 }
                 break;
             case Properties.translate:
-                animation._originalValue = {x: animation.target.translateX, y: animation.target.translateY};
+                animation._originalValue = { x: animation.target.translateX, y: animation.target.translateY };
                 animation._propertyResetCallback = (value, valueSource) => {
                     animation.target.style[setLocal ? translateXProperty.name : translateXProperty.keyframe] = value.x;
                     animation.target.style[setLocal ? translateYProperty.name : translateYProperty.keyframe] = value.y;
@@ -334,7 +334,7 @@ export class Animation extends AnimationBase {
                 if (toValue.y === 0) {
                     toValue.y = 0.001;
                 }
-                animation._originalValue = {x: animation.target.scaleX, y: animation.target.scaleY};
+                animation._originalValue = { x: animation.target.scaleX, y: animation.target.scaleY };
                 animation._propertyResetCallback = (value, valueSource) => {
                     animation.target.style[setLocal ? scaleXProperty.name : scaleXProperty.keyframe] = value.x;
                     animation.target.style[setLocal ? scaleYProperty.name : scaleYProperty.keyframe] = value.y;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

Error:
```
ERROR in chunk bundle [initial]
bundle.js
/home/nsbuilduser/workspace/master-tns-core-modules-unittests-android/NativeScript/tests/node_modules/ts-loader/index.js??ref--11!/home/nsbuilduser/workspace/master-tns-core-modules-unittests-android/NativeScript/tns-core-modules/ui/animation/animation.ts ddf4f3bd9f31062f8eaa54b7a06b6e39
Circular reexports "/home/nsbuilduser/workspace/master-tns-core-modules-unittests-android/NativeScript/tns-core-modules/ui/animation/animation.ts".AnimationPromise --> "/home/nsbuilduser/workspace/master-tns-core-modules-unittests-android/NativeScript/tns-core-modules/ui/animation/animation-common.ts".AnimationPromise -(circular)-> "/home/nsbuilduser/workspace/master-tns-core-modules-unittests-android/NativeScript/tns-core-modules/ui/animation/animation.ts".AnimationPromise
```

