### PR TITLE
fix(css-state): _appliedSelectorsVersion assignment

### DIFF
--- a/tns-core-modules/ui/styling/style-scope.ts
+++ b/tns-core-modules/ui/styling/style-scope.ts
@@ -397,8 +397,8 @@ export class CssState {
     private updateMatch() {
         const view = this.viewRef.get();
         if (view && view._styleScope) {
-            this._appliedSelectorsVersion = view._styleScope._getSelectorsVersion();
             this._match = view._styleScope.matchSelectors(view);
+            this._appliedSelectorsVersion = view._styleScope._getSelectorsVersion();
         } else {
             this._match = CssState.emptyMatch;
         }


### PR DESCRIPTION
Assign CSS state applied selectors version after ensuring and matching them.
This caused sync issues between the CSS state selectors and the style scope. 

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

