### PR TITLE
chore: restore temporarily deprecated apis

### DIFF
--- a/tns-core-modules/ui/core/view-base/view-base.ts
+++ b/tns-core-modules/ui/core/view-base/view-base.ts
@@ -865,6 +865,24 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
         this.addPseudoClass(state);
     }
 
+    /**
+     * @deprecated
+     * 
+     * This used to be the way to set attribute values in early {N} versions.
+     * Now attributes are expected to be set as plain properties on the view instances.
+     */
+    public _applyXmlAttribute(attribute: string, value: string): boolean {
+        console.log("ViewBase._applyXmlAttribute(...) is deprecated; set attributes as plain properties instead");
+
+        if (attribute === "style" || attribute === "rows" || attribute === "columns" || attribute === "fontAttributes") {
+            this[attribute] = value;
+
+            return true;
+        }
+
+        return false;
+    }
+
     public setInlineStyle(style: string): void {
         if (typeof style !== "string") {
             throw new Error("Parameter should be valid CSS string!");

--- a/tns-core-modules/utils/utils.ios.ts
+++ b/tns-core-modules/utils/utils.ios.ts
@@ -50,7 +50,8 @@ Object.assign(layout, layoutCommon);
 
 export module ios {
     // TODO: remove for NativeScript 7.0
-    export function _getter<T>(_this: any, property: T | { (): T }): T {
+    export function getter<T>(_this: any, property: T | { (): T }): T {
+        console.log("utils.ios.getter() is deprecated; use the respective native property instead");
         if (typeof property === "function") {
             return (<{ (): T }>property).call(_this);
         } else {


### PR DESCRIPTION
Temporarily restore utils.ios.getter(...) and ViewBase._applyXmlAttribute(...) (but do not expose them in d.ts)