### PR TITLE
fix(observable-array): splice(...) to return correct amount of added items

### DIFF
--- a/tests/app/data/observable-array-tests.ts
+++ b/tests/app/data/observable-array-tests.ts
@@ -410,7 +410,7 @@ export const test_ObservableArray_spliceShouldRemoveAndInertSpecifiedNumberOfEle
         // args.action is "splice".
         // args.index is the start index.
         // args.removed.length is equal to the number of deleted items.
-        // args.addedCount is equal to the delta between number of inserted items and number of deleted items but not less than 0.
+        // args.addedCount is equal to the amount of added and replaced items.
 
         // >> (hide)
         result = args;
@@ -421,7 +421,7 @@ export const test_ObservableArray_spliceShouldRemoveAndInertSpecifiedNumberOfEle
     // << observable-array-splice-args-change
 
     TKUnit.assert(result.eventName === ObservableArray.changeEvent && result.action === ChangeType.Splice &&
-        result.removed.length === 2 && result.index === 1 && result.addedCount === 1, "ObservableArray splice() should raise 'change' event with correct args!");
+        result.removed.length === 2 && result.index === 1 && result.addedCount === 3, "ObservableArray splice() should raise 'change' event with correct args!");
 };
 
 export const test_ObservableArray_unshiftShouldInsertNewElementsFromTheStart = function () {

--- a/tns-core-modules/data/observable-array/observable-array.ts
+++ b/tns-core-modules/data/observable-array/observable-array.ts
@@ -207,7 +207,7 @@ export class ObservableArray<T> extends observable.Observable implements observa
             action: ChangeType.Splice,
             index: start,
             removed: result,
-            addedCount: this._array.length > length ? this._array.length - length : 0
+            addedCount: this._array.length + result.length - length
         });
         if (this._array.length !== length) {
             this._notifyLengthChange();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
ObservableArray `splice` does not notify the number of updated items and it can't be inferred from the passed arguments.

## What is the new behavior?
ObservableArray `splice` adds all updated items to `addedCount`, using a logic of "x items removed, y items added in their place"

The amount of change in the length of the array can be always inferred by `addedCount - removed.length`.

This fixes a bug that would cause `FormattedString.spans.splice` to keep removing spans and never adding any back.

Fixes #7425.


BREAKING CHANGES:

The `addedCount` variable from ObservableArray's `splice` change event is always the amount of added items.

Migration steps:
Ideally, developers should handle the case where items are replaced by `splice`. The old `addedCount` can be obtained by

`const addedCount = event.addedCount - event.removed.length`

