### PR TITLE
fix: full Unicode support in xml

### DIFF
--- a/tests/app/xml-parser-tests/xml-parser-tests.ts
+++ b/tests/app/xml-parser-tests/xml-parser-tests.ts
@@ -54,6 +54,32 @@ export var test_XmlParser_EntityReferencesInAttributeValuesAreDecoded = function
     TKUnit.assert(data === "<>\"&'", "Expected result: <>\"&'; Actual result: " + data + ";");
 };
 
+export var test_XmlParser_UnicodeEntitiesAreDecoded = function () {
+    var data;
+    var xmlParser = new xmlModule.XmlParser(function (event: xmlModule.ParserEvent) {
+        switch (event.eventType) {
+            case xmlModule.ParserEventType.Text:
+                data = event.data;
+                break;
+        }
+    });
+    xmlParser.parse("<element>&#x1f923;&#x2713;</element>");
+    TKUnit.assert(data === "\uD83E\uDD23\u2713", "Expected result: \uD83E\uDD23\u2713; Actual result: " + data + ";");
+};
+
+export var test_XmlParser_UnicodeEntitiesInAttributeValuesAreDecoded = function () {
+    var data;
+    var xmlParser = new xmlModule.XmlParser(function (event: xmlModule.ParserEvent) {
+        switch (event.eventType) {
+            case xmlModule.ParserEventType.StartElement:
+                data = event.attributes["text"];
+                break;
+        }
+    });
+    xmlParser.parse("<Label text=\"&#x1f923;&#x2713;\"/>");
+    TKUnit.assert(data === "\uD83E\uDD23\u2713", "Expected result: \uD83E\uDD23\u2713; Actual result: " + data + ";");
+};
+
 export var test_XmlParser_OnErrorIsCalledWhenAnErrorOccurs = function () {
     var e;
     var xmlParser = new xmlModule.XmlParser(

--- a/tns-core-modules/js-libs/easysax/easysax.js
+++ b/tns-core-modules/js-libs/easysax/easysax.js
@@ -188,10 +188,10 @@ function rpEntities(s, d, x, z) {
     };
 
     if (d) {
-        return String.fromCharCode(d);
+        return String.fromCodePoint(d);
     };
 
-    return String.fromCharCode(parseInt(x, 16));
+    return String.fromCodePoint(parseInt(x, 16));
 };
 
 function unEntities(s, i) {

--- a/tns-core-modules/xml/xml.ts
+++ b/tns-core-modules/xml/xml.ts
@@ -100,17 +100,17 @@ function _HandleAmpEntities(found: string, decimalValue: string, hexValue: strin
         }
         const res = _ampCodes.get(wordValue);
         if (res) {
-            return String.fromCharCode(res);
+            return String.fromCodePoint(res);
         }
 
         // Invalid word; so we just return it
         return found;
     }
     if (decimalValue) {
-        return String.fromCharCode(parseInt(decimalValue, 10));
+        return String.fromCodePoint(parseInt(decimalValue, 10));
     }
 
-    return String.fromCharCode(parseInt(hexValue, 16));
+    return String.fromCodePoint(parseInt(hexValue, 16));
 }
 
 export class XmlParser implements definition.XmlParser {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Full unicode can have up to 21 bits, but the current decoding method ( `String.fromCharCode`) can only handle 16 bits. HTML entities like `&#x1f923;` (17 bits) will fail to render properly as `&#xf923;` (highest-order bits are stripped).

## What is the new behavior?
 `&#x1f923;` is correcly rendered as the byte sequence `f0 9f a4 a3` instead of `ef a4 a3` by using `String.fromCodePoint`, which generates a string/char from any number of bytes

