### PR TITLE
fix: snapshot build for android

### DIFF
--- a/tns-core-modules/module-name-resolver/non-bundle-workflow-compat.ts
+++ b/tns-core-modules/module-name-resolver/non-bundle-workflow-compat.ts
@@ -1,7 +1,6 @@
 import * as fs from "../file-system/file-system";
 import * as appCommonModule from "../application/application-common";
 
-const appFolder = fs.knownFolders.currentApp();
 const cache = new Set<string>();
 let initialized = false;
 
@@ -10,7 +9,7 @@ function register(name, loader) {
 }
 
 function processFile(file: fs.File) {
-    const filePathRelativeToApp = file.path.substr(appFolder.path.length + 1);
+    const filePathRelativeToApp = file.path.substr(fs.knownFolders.currentApp().path.length + 1);
     const loadContent = () => file.readTextSync();
 
     switch (file.extension.toLocaleLowerCase()) {


### PR DESCRIPTION
Fix broken snapshot because of `fs.knownFolders.currentApp()` call in the root scope of a module.