### PR TITLE
fix(tabstrip-android):fix selection highlight not visible

### DIFF
--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
@@ -170,7 +170,9 @@ class TabStrip extends LinearLayout {
     }
 
     @Override
-    protected void onDraw(Canvas canvas) {
+    protected void dispatchDraw(Canvas canvas) {
+        super.dispatchDraw(canvas);
+
         final int height = getHeight();
         final int childCount = getChildCount();
         final TabLayout.TabColorizer tabColorizer = mCustomTabColorizer != null


### PR DESCRIPTION
Fix https://github.com/NativeScript/NativeScript/issues/7494

More stackoverflow info about `dispatchDraw` [here](https://stackoverflow.com/questions/4827848/ondraw-on-view-draws-behind-the-layout) and [here](https://stackoverflow.com/questions/11928570/use-of-dispatchdrawcanvas-canvas)