### PR TITLE
fix(bottom-navigation): created dynamically does not show tabstrip

### DIFF
--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -1,10 +1,11 @@
 ﻿// Types
+import { TabStrip } from "../tab-navigation-base/tab-strip";
 import { TabContentItem } from "../tab-navigation-base/tab-content-item";
 import { TabStripItem } from "../tab-navigation-base/tab-strip-item";
 import { TextTransform } from "../text-base";
 
 //Requires
-import { TabNavigationBase, itemsProperty, selectedIndexProperty } from "../tab-navigation-base/tab-navigation-base";
+import { TabNavigationBase, itemsProperty, selectedIndexProperty, tabStripProperty } from "../tab-navigation-base/tab-navigation-base";
 import { Font } from "../styling/font";
 import { getTransformedText } from "../text-base";
 import { Frame } from "../frame";
@@ -137,7 +138,7 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
                         if (tabStripItems[position]) {
                             tabStripItems[position]._emit(TabStripItem.selectEvent);
                         }
-    
+
                         if (tabStripItems[prevPosition]) {
                             tabStripItems[prevPosition]._emit(TabStripItem.unselectEvent);
                         }
@@ -608,6 +609,15 @@ export class BottomNavigation extends TabNavigationBase {
     }
     [itemsProperty.setNative](value: TabContentItem[]) {
         this.setViewControllers(value);
+        selectedIndexProperty.coerce(this);
+    }
+
+    [tabStripProperty.getDefault](): TabStrip {
+        return null;
+    }
+
+    [tabStripProperty.setNative](value: TabStrip) {
+        this.setViewControllers(this.items);
         selectedIndexProperty.coerce(this);
     }
 }

--- a/tns-core-modules/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
@@ -37,8 +37,8 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
             this._addView(value);
             // selectedIndexProperty.coerce(this);
         } else if (name === "TabStrip") {
+            // Setting tabStrip will trigger onTabStripChanged
             this.tabStrip = value;
-            this._addView(value);
         }
     }
 
@@ -94,14 +94,12 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
     }
 
     public onTabStripChanged(oldTabStrip: TabStrip, newTabStrip: TabStrip) {
-        if (oldTabStrip && oldTabStrip.items && oldTabStrip.items.length) {
-            oldTabStrip.items.forEach(item => this._removeView(item));
+        if (oldTabStrip && oldTabStrip.parent) {
+            this._removeView(oldTabStrip);
         }
 
-        if (newTabStrip && newTabStrip.items && newTabStrip.items.length) {
-            newTabStrip.items.forEach(item => {
-                this._addView(item);
-            });
+        if (newTabStrip) {
+            this._addView(newTabStrip);
         }
     }
 


### PR DESCRIPTION
[iOS]: execute `setViewControllers` when setting `.tabStrip` property to populate all tabStrip and tabContent items. Thus, there is no need to worry with property (items/tabStrip) is set first.

[Android]: `onTabStripChanged` was adding TabStripItem child views in BottomNavigation directly, instead of just adding the new TabStrip as a child view.

Fix: https://github.com/NativeScript/NativeScript/issues/7433