### PR TITLE
fix: prevent plugin podfile platform version clash

### DIFF
--- a/tns-core-modules/platforms/ios/Podfile
+++ b/tns-core-modules/platforms/ios/Podfile
@@ -1,1 +1,4 @@
+platform :ios, '9.0'
+use_frameworks!
+
 pod 'MaterialComponents/Tabs', '~> 84.4'


### PR DESCRIPTION
Currently, if a plugin has a podfile with platform version of `8.0`, the build will fail with:
```Specs satisfying the `MaterialComponents/Tabs (~> 84.4)` dependency were found, but they required a higher minimum deployment target.
'pod install' command failed.```