### PR TITLE
[WIP] fix(android): empty frame stack after suspend/resume of application

### DIFF
--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -17,12 +17,7 @@
             ]
         }
     },
-    "include": [
-        "../tns-core-modules",
-        "**/*"
-    ],
     "exclude": [
-        "../tns-core-modules/node_modules",
         "node_modules",
         "platforms"
     ]

--- a/e2e/nested-frame-navigation/app/home/home-page.ts
+++ b/e2e/nested-frame-navigation/app/home/home-page.ts
@@ -1,6 +1,7 @@
 import * as application from "tns-core-modules/application";
-import { EventData } from "tns-core-modules/ui/core/view";
 import { Button } from "tns-core-modules/ui/button";
+import { EventData } from "tns-core-modules/ui/core/view";
+import { topmost } from "tns-core-modules/ui/frame/frame";
 
 export function onNavigateToLayoutFrame(args: EventData) {
     application._resetRootView({ moduleName: "layout-root/layout-frame-root" });
@@ -66,8 +67,9 @@ export function onNavigateToTabsBottomRoot(args: EventData) {
 }
 
 export function onNavigateToSomePage(args: EventData) {
-    const button = <Button>args.object;
-    button.page.frame.navigate("some-page/some-page");
+    // Use `topmost()` in order to verify:
+    // https://github.com/NativeScript/NativeScript/issues/7594
+    topmost().navigate("some-page/some-page");
 }
 
 export function onFrameToNestedFrame(args: EventData) {

--- a/e2e/nested-frame-navigation/app/home/home-page.xml
+++ b/e2e/nested-frame-navigation/app/home/home-page.xml
@@ -20,7 +20,7 @@
             <Button text="Page w/ tabs (bottom)" tap="onNavigateToTabsBottomPage" />
             <Button text="Root tabs (top)" tap="onNavigateToTabsTopRoot" />
             <Button text="Root tabs (bottom)" tap="onNavigateToTabsBottomRoot" />
-            <Button text="Some page" automationText="somePage" tap="onNavigateToSomePage" />
+            <Button text="Some page" tap="onNavigateToSomePage" />
             <Button text="Frame to NestedFrame (non-default transition)" tap="onFrameToNestedFrame" />
         </StackLayout>
     </GridLayout>

--- a/e2e/nested-frame-navigation/app/home/home-page.xml
+++ b/e2e/nested-frame-navigation/app/home/home-page.xml
@@ -20,7 +20,7 @@
             <Button text="Page w/ tabs (bottom)" tap="onNavigateToTabsBottomPage" />
             <Button text="Root tabs (top)" tap="onNavigateToTabsTopRoot" />
             <Button text="Root tabs (bottom)" tap="onNavigateToTabsBottomRoot" />
-            <Button text="Some page on root" automationText="somePageOnRoot" tap="onNavigateToSomePage" />
+            <Button text="Some page" automationText="somePage" tap="onNavigateToSomePage" />
             <Button text="Frame to NestedFrame (non-default transition)" tap="onFrameToNestedFrame" />
         </StackLayout>
     </GridLayout>

--- a/e2e/nested-frame-navigation/e2e/issues.e2e-spec.ts
+++ b/e2e/nested-frame-navigation/e2e/issues.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { AppiumDriver, createDriver, nsCapabilities } from "nativescript-dev-appium";
-import { Screen } from "./screen";
+
 import { suspendTime, dontKeepActivities } from "./config";
+import { Screen, somePage } from "./screen";
 
 describe("issues", async function () {
     let driver: AppiumDriver;
@@ -30,27 +31,27 @@ describe("issues", async function () {
         }
     });
 
-    it("issue-6488", async function () {
-        await screen.loadedHome();
-        const showSomePage = async function () {
-            const somePageBtn = await driver.waitForElement("somePageOnRoot");
+    it("issues: 6488, 7594", async function () {
+        const navigateToSomePage = async function () {
+            const somePageBtn = await driver.waitForElement(somePage);
             await somePageBtn.tap();
             await screen.loadedSomePage();
         };
 
-        await showSomePage();
+        await screen.loadedHome();
+        await navigateToSomePage();
 
         await driver.navBack();
         await screen.loadedHome();
 
         await driver.backgroundApp(suspendTime);
 
-        await showSomePage();
+        await navigateToSomePage();
         await driver.navBack();
+        await screen.loadedHome();
 
-        await showSomePage();
+        await navigateToSomePage();
         await driver.navBack();
-
         await screen.loadedHome();
     });
 });

--- a/e2e/nested-frame-navigation/e2e/screen.ts
+++ b/e2e/nested-frame-navigation/e2e/screen.ts
@@ -43,7 +43,6 @@ const players = "Players";
 const teams = "Teams";
 const playersTab = "playersTabNavigation";
 const teamsTab = "teamsTabNavigation";
-const dummyTab = "dummyTabNavigation";
 const playerBack = "playerBack";
 const stillOtherPageBack = "stillOtherPageBack";
 const somePageBack = "somePageBack";
@@ -392,7 +391,7 @@ export class Screen {
     loadedBottomNavigationRootWithFrames = async () => {
         await this.loadedPage(bottomNavigationRootHome);
     }
-    
+
     loadedStillOtherPage = async () => {
         await this.loadedPage(stillOtherPage);
     }

--- a/e2e/nested-frame-navigation/nsconfig.json
+++ b/e2e/nested-frame-navigation/nsconfig.json
@@ -1,3 +1,0 @@
-{
-	"useLegacyWorkflow": false
-}

--- a/e2e/nested-frame-navigation/package.json
+++ b/e2e/nested-frame-navigation/package.json
@@ -14,11 +14,12 @@
   },
   "dependencies": {
     "nativescript-theme-core": "~1.0.4",
-    "tns-core-modules": "next"
+    "tns-core-modules": "file:../../tns-core-modules"
   },
   "devDependencies": {
     "@types/chai": "~4.1.7",
     "@types/mocha": "~5.2.5",
+    "@types/node": "~12.6.9",
     "mocha": "~5.2.0",
     "mochawesome": "~3.1.2",
     "nativescript-dev-appium": "next",

--- a/e2e/nested-frame-navigation/tsconfig.json
+++ b/e2e/nested-frame-navigation/tsconfig.json
@@ -21,7 +21,12 @@
             ]
         }
     },
+    "include": [
+        "../../tns-core-modules",
+        "**/*"
+    ],
     "exclude": [
+        "../../tns-core-modules/node_modules",
         "node_modules",
         "platforms",
         "e2e"

--- a/e2e/nested-frame-navigation/tsconfig.json
+++ b/e2e/nested-frame-navigation/tsconfig.json
@@ -21,12 +21,7 @@
             ]
         }
     },
-    "include": [
-        "../../tns-core-modules",
-        "**/*"
-    ],
     "exclude": [
-        "../../tns-core-modules/node_modules",
         "node_modules",
         "platforms",
         "e2e"

--- a/e2e/ui-tests-app/tsconfig.json
+++ b/e2e/ui-tests-app/tsconfig.json
@@ -17,12 +17,7 @@
             ]
         }
     },
-    "include": [
-        "../tns-core-modules",
-        "**/*"
-    ],
     "exclude": [
-        "../tns-core-modules/node_modules",
         "node_modules",
         "platforms",
         "e2e"

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -17,12 +17,7 @@
             ]
         }
     },
-    "include": [
-        "../tns-core-modules",
-        "**/*"
-    ],
     "exclude": [
-        "../tns-core-modules/node_modules",
         "node_modules",
         "platforms"
     ]

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -164,6 +164,7 @@ export class Frame extends FrameBase {
         // In this case call _navigateCore in order to recreate the current fragment.
         // Don't call navigate because it will fire navigation events.
         // As JS instances are alive it is already done for the current page.
+        // This requires explicitly to add the frame to the stack.
         if (!this.isLoaded || this._executingContext || !this._attachedToWindow) {
             return;
         }
@@ -191,6 +192,7 @@ export class Frame extends FrameBase {
             // NOTE: we are restoring the animation settings in Frame.setCurrent(...) as navigation completes asynchronously
             this._cachedAnimatorState = getAnimatorState(this._currentEntry);
 
+            this._pushInFrameStack();
             this._currentEntry = null;
             // NavigateCore will eventually call _processNextNavigationEntry again.
             this._navigateCore(entry);

--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -164,7 +164,6 @@ export class Frame extends FrameBase {
         // In this case call _navigateCore in order to recreate the current fragment.
         // Don't call navigate because it will fire navigation events.
         // As JS instances are alive it is already done for the current page.
-        // This requires explicitly to add the frame to the stack.
         if (!this.isLoaded || this._executingContext || !this._attachedToWindow) {
             return;
         }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
In the suspend/resume scenario, when the activity is destroyed and the application restores, navigation does not execute as the *JavaScript* instance of the current page is still alive. 
Therefore, the frame stack is `undefined`.

## What is the new behavior?
In this case, explicitly add the frame to the stack.

Fixes https://github.com/NativeScript/NativeScript/issues/7594.