### PR TITLE
chore: update modal-navigation app to use local modules via symlink

### DIFF
--- a/e2e/modal-navigation/package.json
+++ b/e2e/modal-navigation/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "nativescript-theme-core": "~1.0.6",
-    "tns-core-modules": "next"
+    "tns-core-modules": "file:../../tns-core-modules"
   },
   "devDependencies": {
     "@types/chai": "~4.1.7",

--- a/e2e/modal-navigation/tsconfig.json
+++ b/e2e/modal-navigation/tsconfig.json
@@ -21,7 +21,12 @@
             ]
         }
     },
+    "include": [
+        "../tns-core-modules",
+        "**/*"
+    ],
     "exclude": [
+        "../tns-core-modules/node_modules",
         "node_modules",
         "platforms",
         "e2e"

--- a/e2e/modal-navigation/tsconfig.json
+++ b/e2e/modal-navigation/tsconfig.json
@@ -26,7 +26,6 @@
         "**/*"
     ],
     "exclude": [
-        "../tns-core-modules/node_modules",
         "node_modules",
         "platforms",
         "e2e"


### PR DESCRIPTION
Update the e2e/modal-navigation` application to work with local `tns-core-modules`