### PR TITLE
[Do Not Merge] fix(tabstrip-android): wrong color when change tabs with css class

### DIFF
--- a/e2e/ui-tests-app/app/bottom-navigation/css-color-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/css-color-page.css
@@ -1,0 +1,16 @@
+BottomNavigation {
+    color: gold;
+  }
+  
+  TabStrip {
+    color: skyblue;
+  }
+  
+  TabStripItem.special {
+    color: red;
+  }
+  
+  TabStripItem.special:active {
+    color: yellowgreen;
+  }
+  

--- a/e2e/ui-tests-app/app/bottom-navigation/css-color-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/css-color-page.xml
@@ -1,0 +1,30 @@
+<Page class="page">
+
+  <ActionBar title="BottomNavigation color" icon="" class="action-bar">
+  </ActionBar>
+
+  <BottomNavigation style="color: green;"  automationText="tabNavigation"  >
+    <TabStrip>
+        <TabStripItem title="First" class="special"></TabStripItem>
+        <TabStripItem title="Second" class="special"></TabStripItem>
+        <TabStripItem title="Third" class="special"></TabStripItem>
+    </TabStrip>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="First View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
+        </GridLayout>
+    </TabContentItem>
+  </BottomNavigation>
+</Page>

--- a/e2e/ui-tests-app/app/bottom-navigation/main-page.ts
+++ b/e2e/ui-tests-app/app/bottom-navigation/main-page.ts
@@ -23,6 +23,7 @@ export function loadExamples() {
     examples.set("font-icons", "bottom-navigation/font-icons-page");
     examples.set("fancy-fonts", "bottom-navigation/fancy-fonts-page");
     examples.set("css-text-transform", "bottom-navigation/bottom-navigation-css-page");
+    examples.set("css-color-active", "bottom-navigation/css-color-page");
 
     return examples;
 }

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
@@ -43,6 +43,7 @@ class TabStrip extends LinearLayout {
     private final int mDefaultBottomBorderColor;
 
     private int mSelectedPosition;
+    private int mPreviousSelectedPosition;
     private float mSelectionOffset;
 
     private TabLayout.TabColorizer mCustomTabColorizer;
@@ -121,14 +122,14 @@ class TabStrip extends LinearLayout {
     }
 
     private void updateTabsTextColor(){
-        final int childCount = getChildCount();
-        for (int i = 0; i < childCount; i++){
-            LinearLayout linearLayout = (LinearLayout)getChildAt(i);
+        if (getChildCount() > 0) {
+            LinearLayout linearLayout = (LinearLayout)getChildAt(mSelectedPosition);
             TextView textView = (TextView)linearLayout.getChildAt(1);
-            if (i == mSelectedPosition){
-                textView.setTextColor(mSelectedTabTextColor);
-            }
-            else {
+            textView.setTextColor(mSelectedTabTextColor);
+
+            if (mSelectedPosition != mPreviousSelectedPosition) {
+                linearLayout = (LinearLayout)getChildAt(mPreviousSelectedPosition);
+                textView = (TextView)linearLayout.getChildAt(1);
                 textView.setTextColor(mTabTextColor);
             }
         }
@@ -154,6 +155,7 @@ class TabStrip extends LinearLayout {
 
     // Used by TabLayout (the 'old' tab-view control)
     void onViewPagerPageChanged(int position, float positionOffset) {
+        mPreviousSelectedPosition = mSelectedPosition;
         mSelectedPosition = position;
         mSelectionOffset = positionOffset;
         invalidate();
@@ -162,19 +164,22 @@ class TabStrip extends LinearLayout {
 
     // Used by TabsBar
     void onTabsViewPagerPageChanged(int position, float positionOffset) {
+        mPreviousSelectedPosition = mSelectedPosition;
         mSelectedPosition = position;
         mSelectionOffset = positionOffset;
         invalidate();
     }
 
-    int getSelectedPosition(){
-        return mSelectedPosition;
-    }
-
+    // Used by BottomNavigation
     void setSelectedPosition(int position) {
+        mPreviousSelectedPosition = mSelectedPosition;
         mSelectedPosition = position;
         invalidate();
         updateTabsTextColor();
+    }
+
+    int getSelectedPosition(){
+        return mSelectedPosition;
     }
 
     @Override


### PR DESCRIPTION
Reapply 'normal' color only for the previously selected tabStripItem.

_This applies only to TabStripItems with color property set through css class for both normal and active state_

TO DO: _Added example (e2e/ui-tests-app/bottom-navigaiton/css-color-page) but e2e tests needed_

Fix https://github.com/NativeScript/NativeScript/issues/7623