### PR TITLE
feat: flexbile font icon usage in tab navigation

### DIFF
--- a/e2e/ui-tests-app/app/bottom-navigation/color-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/color-page.css
@@ -17,3 +17,11 @@ TabStripItem.special {
 TabStripItem.special:active {
   color: yellowgreen;
 }
+
+TabStripItem.nested Label {
+  color: teal;
+}
+
+TabStripItem.nested:active Label {
+  color: yellowgreen;
+}

--- a/e2e/ui-tests-app/app/bottom-navigation/color-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/color-page.xml
@@ -3,10 +3,13 @@
   <ActionBar title="BottomNavigation color" icon="" class="action-bar">
   </ActionBar>
 
-  <BottomNavigation style="color: green;"  automationText="tabNavigation"  >
+  <BottomNavigation automationText="tabNavigation">
     <TabStrip>
-        <TabStripItem title="First" class="special"></TabStripItem>
-        <TabStripItem title="Second"></TabStripItem>
+        <TabStripItem title="first" class="special"></TabStripItem>
+        <TabStripItem title="second"></TabStripItem>
+        <TabStripItem class="nested">
+            <Label text="third" />
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
@@ -18,6 +21,12 @@
     <TabContentItem>
         <GridLayout>
           <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
         </GridLayout>
     </TabContentItem>
   </BottomNavigation>

--- a/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
@@ -33,3 +33,7 @@ TabStripItem.special Label {
 TabStripItem.special:active Label {
   color: darkgoldenrod;
 }
+
+TabStripItem:active .font-size {
+  font-size: 10;
+}

--- a/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
@@ -6,12 +6,20 @@
   font-size: 36;
 }
 
+TabStripItem {
+  color: skyblue;
+}
+
+TabStripItem:active {
+  color: darkblue;
+}
+
 TabStripItem.special Image {
-  color: teal;
+  color: lightgreen;
 }
 
 TabStripItem.special:active Image {
-  color: purple;
+  color: darkgreen;
 }
 
 TabStripItem.special Label {
@@ -19,5 +27,5 @@ TabStripItem.special Label {
 }
 
 TabStripItem.special:active Label {
-  color: olive;
+  color: darkgoldenrod;
 }

--- a/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
@@ -6,6 +6,10 @@
   font-size: 36;
 }
 
+TabStrip {
+  color: mediumvioletred;
+}
+
 TabStripItem {
   color: skyblue;
 }

--- a/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.css
@@ -6,6 +6,18 @@
   font-size: 36;
 }
 
-.color {
-  color: blue;
-} 
+TabStripItem.special Image {
+  color: teal;
+}
+
+TabStripItem.special:active Image {
+  color: purple;
+}
+
+TabStripItem.special Label {
+  color: gold;
+}
+
+TabStripItem.special:active Label {
+  color: olive;
+}

--- a/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.xml
@@ -5,40 +5,59 @@
 
   <BottomNavigation automationText="tabNavigation" >
     <TabStrip>
-        <!-- font family + font size + color -->
-        
-        <!-- <TabStripItem title="First" iconSource="font://&#xF10B;" class="special font-awesome font-size color">
-        </TabStripItem> -->
-        
-        <TabStripItem title="First" class="special">
-            <Label text="First" />
+        <!-- font family + font size + color -->        
+        <TabStripItem class="special">
+            <Label text="All Set"/>
             <Image src="font://&#xF10B;" class="font-awesome font-size" />
         </TabStripItem>
 
-
-
         <!-- default font + valid char code -->
-        <TabStripItem title="Second" iconSource="font://&#xF10B;"></TabStripItem>
+        <TabStripItem>
+            <Label text="Invalid Font" />
+            <Image src="font://&#xF10B;" />
+        </TabStripItem>
+
         <!-- font family + invalid char code -->
-        <TabStripItem title="Third" iconSource="font://&#xF556;" class="font-awesome font-size"></TabStripItem>
+        <TabStripItem>
+            <Label text="Invalid Char" />
+            <Image src="font://&#xF556;" class="font-awesome font-size"/>
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
-        <GridLayout>
-          <Label text="First View" />
-        </GridLayout>
+        <StackLayout>
+            <Label text="char code: phone" />
+            <Label text="font: Font Awesome" />
+            <Label text="font size: 36" />
+            <Label text="icon color inactive: lightgreen" />
+            <Label text="icon color active: darkgreen" />
+            <Label text="title color inactive: gold" />
+            <Label text="title color active: darkgoldenrod" />
+        </StackLayout>
     </TabContentItem>
 
     <TabContentItem>
-        <GridLayout>
-          <Label text="Second View" />
-        </GridLayout>
+        <StackLayout>
+            <Label text="char code: phone" />
+            <Label text="font: default/invalid" />
+            <Label text="font size: default" />
+            <Label text="icon color inactive: skyblue" />
+            <Label text="icon color active: darkblue" />
+            <Label text="title color inactive: skyblue" />
+            <Label text="title color active: darkblue" />
+        </StackLayout>
     </TabContentItem>
 
     <TabContentItem>
-        <GridLayout>
-          <Label text="Third View" />
-        </GridLayout>
+        <StackLayout>
+            <Label text="char code: invalid" />
+            <Label text="font: Font Awesome" />
+            <Label text="font size: 36" />
+            <Label text="icon color inactive: skyblue" />
+            <Label text="icon color active: darkblue" />
+            <Label text="title color inactive: skyblue" />
+            <Label text="title color active: darkblue" />
+        </StackLayout>
     </TabContentItem>
   </BottomNavigation>
 </Page>

--- a/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-icons-page.xml
@@ -3,10 +3,20 @@
   <ActionBar title="BottomNavigation font icons" icon="" class="action-bar">
   </ActionBar>
 
-  <BottomNavigation class="font-awesome" automationText="tabNavigation"  > <!-- TODO: The font-awesome class here should be removed -->
+  <BottomNavigation automationText="tabNavigation" >
     <TabStrip>
         <!-- font family + font size + color -->
-        <TabStripItem title="First" iconSource="font://&#xF10B;" class="special font-awesome font-size color"></TabStripItem>
+        
+        <!-- <TabStripItem title="First" iconSource="font://&#xF10B;" class="special font-awesome font-size color">
+        </TabStripItem> -->
+        
+        <TabStripItem title="First" class="special">
+            <Label text="First" />
+            <Image src="font://&#xF10B;" class="font-awesome font-size" />
+        </TabStripItem>
+
+
+
         <!-- default font + valid char code -->
         <TabStripItem title="Second" iconSource="font://&#xF10B;"></TabStripItem>
         <!-- font family + invalid char code -->

--- a/e2e/ui-tests-app/app/bottom-navigation/font-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-page.css
@@ -17,3 +17,11 @@ TabStripItem.special {
 TabStripItem.special:active {
   font: 16 monospace;
 }
+
+TabStripItem.nested Label {
+  font: 12 monospace;
+}
+
+TabStripItem.nested:active Label {
+  font: 16 monospace;
+}

--- a/e2e/ui-tests-app/app/bottom-navigation/font-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/font-page.xml
@@ -1,12 +1,15 @@
 <Page class="page">
 
-  <ActionBar title="BottomNavigation FONT" icon="" class="action-bar">
+  <ActionBar title="BottomNavigation font" class="action-bar">
   </ActionBar>
 
-  <BottomNavigation automationText="tabNavigation"  >
+  <BottomNavigation automationText="tabNavigation">
     <TabStrip>
-        <TabStripItem title="First" class="special"></TabStripItem>
-        <TabStripItem title="Second"></TabStripItem>
+        <TabStripItem title="first" class="special"></TabStripItem>
+        <TabStripItem title="second"></TabStripItem>
+        <TabStripItem class="nested">
+            <Label text="third" />
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
@@ -18,6 +21,12 @@
     <TabContentItem>
         <GridLayout>
           <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
         </GridLayout>
     </TabContentItem>
   </BottomNavigation>

--- a/e2e/ui-tests-app/app/bottom-navigation/icon-change-page.ts
+++ b/e2e/ui-tests-app/app/bottom-navigation/icon-change-page.ts
@@ -6,10 +6,12 @@ export function onSelectedIndexChanged(args: SelectedIndexChangedEventData) {
     const newItem = bottomNav.tabStrip.items[args.newIndex];
     if (newItem) {
         newItem.iconSource = "res://icon";
+        newItem.title = "selected";
     }
 
     const oldItem = bottomNav.tabStrip.items[args.oldIndex];
     if (oldItem) {
         oldItem.iconSource = "res://testlogo";
+        oldItem.title = "unselected";
     }
 }

--- a/e2e/ui-tests-app/app/bottom-navigation/icon-change-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/icon-change-page.xml
@@ -4,8 +4,8 @@
 
     <BottomNavigation id="tab-view" selectedIndexChanged="onSelectedIndexChanged" automationText="tabNavigation"  >
         <TabStrip>
-            <TabStripItem iconSource="res://icon"></TabStripItem>
-            <TabStripItem iconSource="res://testlogo"></TabStripItem>
+            <TabStripItem iconSource="res://icon" title="selected"></TabStripItem>
+            <TabStripItem iconSource="res://testlogo" title="unselected"></TabStripItem>
         </TabStrip>
 
         <TabContentItem>

--- a/e2e/ui-tests-app/app/bottom-navigation/text-transform-page.css
+++ b/e2e/ui-tests-app/app/bottom-navigation/text-transform-page.css
@@ -17,3 +17,11 @@ TabStripItem.special {
 TabStripItem.special:active {
   text-transform: uppercase;
 }
+
+TabStripItem.nested Label {
+  text-transform: lowercase;
+}
+
+TabStripItem.nested:active Label {
+  text-transform: uppercase;
+}

--- a/e2e/ui-tests-app/app/bottom-navigation/text-transform-page.xml
+++ b/e2e/ui-tests-app/app/bottom-navigation/text-transform-page.xml
@@ -1,12 +1,15 @@
 <Page class="page">
 
-  <ActionBar title="BottomNavigation Text Transform" icon="" class="action-bar">
+  <ActionBar title="BottomNavigation text-transform" class="action-bar">
   </ActionBar>
 
-  <BottomNavigation automationText="tabNavigation"  >
+  <BottomNavigation automationText="tabNavigation">
     <TabStrip>
         <TabStripItem title="first" class="special"></TabStripItem>
         <TabStripItem title="second"></TabStripItem>
+        <TabStripItem class="nested">
+            <Label text="third" />
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
@@ -18,6 +21,12 @@
     <TabContentItem>
         <GridLayout>
           <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
         </GridLayout>
     </TabContentItem>
   </BottomNavigation>

--- a/e2e/ui-tests-app/app/tabs/color-page.css
+++ b/e2e/ui-tests-app/app/tabs/color-page.css
@@ -17,3 +17,11 @@ TabStripItem.special {
 TabStripItem.special:active {
   color: yellowgreen;
 }
+
+TabStripItem.nested Label {
+  color: teal;
+}
+
+TabStripItem.nested:active Label {
+  color: yellowgreen;
+}

--- a/e2e/ui-tests-app/app/tabs/color-page.xml
+++ b/e2e/ui-tests-app/app/tabs/color-page.xml
@@ -1,12 +1,15 @@
 <Page class="page">
 
-  <ActionBar title="Tabs color" icon="" class="action-bar">
+  <ActionBar title="Tabs color" class="action-bar">
   </ActionBar>
 
-  <Tabs automationText="tabNavigation"  >
+  <Tabs automationText="tabNavigation">
     <TabStrip>
-        <TabStripItem title="First" class="special"></TabStripItem>
-        <TabStripItem title="Second"></TabStripItem>
+        <TabStripItem title="first" class="special"></TabStripItem>
+        <TabStripItem title="second"></TabStripItem>
+        <TabStripItem class="nested">
+            <Label text="third" />
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
@@ -18,6 +21,12 @@
     <TabContentItem>
         <GridLayout>
           <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
         </GridLayout>
     </TabContentItem>
   </Tabs>

--- a/e2e/ui-tests-app/app/tabs/font-icons-page.css
+++ b/e2e/ui-tests-app/app/tabs/font-icons-page.css
@@ -33,3 +33,7 @@ TabStripItem.special Label {
 TabStripItem.special:active Label {
   color: darkgoldenrod;
 }
+
+TabStripItem:active .font-size {
+  font-size: 10;
+}

--- a/e2e/ui-tests-app/app/tabs/font-icons-page.css
+++ b/e2e/ui-tests-app/app/tabs/font-icons-page.css
@@ -6,6 +6,30 @@
   font-size: 36;
 }
 
-.color {
-  color: blue;
-} 
+TabStrip {
+  color: mediumvioletred;
+}
+
+TabStripItem {
+  color: skyblue;
+}
+
+TabStripItem:active {
+  color: darkblue;
+}
+
+TabStripItem.special Image {
+  color: lightgreen;
+}
+
+TabStripItem.special:active Image {
+  color: darkgreen;
+}
+
+TabStripItem.special Label {
+  color: gold;
+}
+
+TabStripItem.special:active Label {
+  color: darkgoldenrod;
+}

--- a/e2e/ui-tests-app/app/tabs/font-icons-page.xml
+++ b/e2e/ui-tests-app/app/tabs/font-icons-page.xml
@@ -3,32 +3,61 @@
   <ActionBar title="Tabs font icons" icon="" class="action-bar">
   </ActionBar>
 
-  <Tabs class="font-awesome" automationText="tabNavigation"  > <!-- TODO: The font-awesome class here should be removed -->
+  <Tabs automationText="tabNavigation">
     <TabStrip>
-        <!-- font family + font size + color -->
-        <TabStripItem title="First" iconSource="font://&#xF10B;" class="special font-awesome font-size color"></TabStripItem>
+        <!-- font family + font size + color -->        
+        <TabStripItem class="special">
+            <Label text="All Set"/>
+            <Image src="font://&#xF10B;" class="font-awesome font-size" />
+        </TabStripItem>
+
         <!-- default font + valid char code -->
-        <TabStripItem title="Second" iconSource="font://&#xF10B;"></TabStripItem>
+        <TabStripItem>
+            <Label text="Invalid Font" />
+            <Image src="font://&#xF10B;" />
+        </TabStripItem>
+
         <!-- font family + invalid char code -->
-        <TabStripItem title="Third" iconSource="font://&#xF556;" class="font-awesome font-size"></TabStripItem>
+        <TabStripItem>
+            <Label text="Invalid Char" />
+            <Image src="font://&#xF556;" class="font-awesome font-size"/>
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
-        <GridLayout>
-          <Label text="First View" />
-        </GridLayout>
+        <StackLayout>
+            <Label text="char code: phone" />
+            <Label text="font: Font Awesome" />
+            <Label text="font size: 36" />
+            <Label text="icon color inactive: lightgreen" />
+            <Label text="icon color active: darkgreen" />
+            <Label text="title color inactive: gold" />
+            <Label text="title color active: darkgoldenrod" />
+        </StackLayout>
     </TabContentItem>
 
     <TabContentItem>
-        <GridLayout>
-          <Label text="Second View" />
-        </GridLayout>
+        <StackLayout>
+            <Label text="char code: phone" />
+            <Label text="font: default/invalid" />
+            <Label text="font size: default" />
+            <Label text="icon color inactive: skyblue" />
+            <Label text="icon color active: darkblue" />
+            <Label text="title color inactive: skyblue" />
+            <Label text="title color active: darkblue" />
+        </StackLayout>
     </TabContentItem>
 
     <TabContentItem>
-        <GridLayout>
-          <Label text="Third View" />
-        </GridLayout>
+        <StackLayout>
+            <Label text="char code: invalid" />
+            <Label text="font: Font Awesome" />
+            <Label text="font size: 36" />
+            <Label text="icon color inactive: skyblue" />
+            <Label text="icon color active: darkblue" />
+            <Label text="title color inactive: skyblue" />
+            <Label text="title color active: darkblue" />
+        </StackLayout>
     </TabContentItem>
   </Tabs>
 </Page>

--- a/e2e/ui-tests-app/app/tabs/font-page.css
+++ b/e2e/ui-tests-app/app/tabs/font-page.css
@@ -17,3 +17,11 @@ TabStripItem.special {
 TabStripItem.special:active {
   font: 16 monospace;
 }
+
+TabStripItem.nested Label {
+  font: 12 monospace;
+}
+
+TabStripItem.nested:active Label {
+  font: 16 monospace;
+}

--- a/e2e/ui-tests-app/app/tabs/font-page.xml
+++ b/e2e/ui-tests-app/app/tabs/font-page.xml
@@ -1,12 +1,15 @@
 <Page class="page">
 
-  <ActionBar title="Tabs font" icon="" class="action-bar">
+  <ActionBar title="Tabs font" class="action-bar">
   </ActionBar>
 
   <Tabs automationText="tabNavigation"  >
     <TabStrip>
-        <TabStripItem title="First" class="special"></TabStripItem>
-        <TabStripItem title="Second"></TabStripItem>
+        <TabStripItem title="first" class="special"></TabStripItem>
+        <TabStripItem title="second"></TabStripItem>
+        <TabStripItem class="nested">
+            <Label text="third" />
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
@@ -18,6 +21,12 @@
     <TabContentItem>
         <GridLayout>
           <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
         </GridLayout>
     </TabContentItem>
   </Tabs>

--- a/e2e/ui-tests-app/app/tabs/icon-change-page.ts
+++ b/e2e/ui-tests-app/app/tabs/icon-change-page.ts
@@ -6,10 +6,12 @@ export function onSelectedIndexChanged(args: SelectedIndexChangedEventData) {
     const newItem = tabsNav.tabStrip.items[args.newIndex];
     if (newItem) {
         newItem.iconSource = "res://icon";
+        newItem.title = "selected";
     }
 
     const oldItem = tabsNav.tabStrip.items[args.oldIndex];
     if (oldItem) {
         oldItem.iconSource = "res://testlogo";
+        oldItem.title = "unselected";
     }
 }

--- a/e2e/ui-tests-app/app/tabs/icon-change-page.xml
+++ b/e2e/ui-tests-app/app/tabs/icon-change-page.xml
@@ -4,8 +4,8 @@
 
     <Tabs id="tab-view" selectedIndexChanged="onSelectedIndexChanged" automationText="tabNavigation"  >
         <TabStrip>
-            <TabStripItem iconSource="res://icon"></TabStripItem>
-            <TabStripItem iconSource="res://testlogo"></TabStripItem>
+            <TabStripItem iconSource="res://icon" title="selected"></TabStripItem>
+            <TabStripItem iconSource="res://testlogo" title="unselected"></TabStripItem>
         </TabStrip>
 
         <TabContentItem>

--- a/e2e/ui-tests-app/app/tabs/text-transform-page.css
+++ b/e2e/ui-tests-app/app/tabs/text-transform-page.css
@@ -17,3 +17,11 @@ TabStripItem.special {
 TabStripItem.special:active {
   text-transform: uppercase;
 }
+
+TabStripItem.nested Label {
+  text-transform: lowercase;
+}
+
+TabStripItem.nested:active Label {
+  text-transform: uppercase;
+}

--- a/e2e/ui-tests-app/app/tabs/text-transform-page.xml
+++ b/e2e/ui-tests-app/app/tabs/text-transform-page.xml
@@ -1,12 +1,15 @@
 <Page class="page">
 
-  <ActionBar title="Tabs text-transform" icon="" class="action-bar">
+  <ActionBar title="Tabs text-transform" class="action-bar">
   </ActionBar>
 
-  <Tabs automationText="tabNavigation"  >
+  <Tabs automationText="tabNavigation">
     <TabStrip>
         <TabStripItem title="first" class="special"></TabStripItem>
         <TabStripItem title="second"></TabStripItem>
+        <TabStripItem class="nested">
+            <Label text="third" />
+        </TabStripItem>
     </TabStrip>
 
     <TabContentItem class="special">
@@ -18,6 +21,12 @@
     <TabContentItem>
         <GridLayout>
           <Label text="Second View" />
+        </GridLayout>
+    </TabContentItem>
+
+    <TabContentItem>
+        <GridLayout>
+          <Label text="Third View" />
         </GridLayout>
     </TabContentItem>
   </Tabs>

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,10 +2,10 @@
   "nativescript": {
     "id": "org.nativescript.UnitTestApp",
     "tns-android": {
-      "version": "next"
+      "version": "6.1.0-2019-07-29-182447-01"
     },
     "tns-ios": {
-      "version": "next"
+      "version": "6.1.0-2019-08-01-122621-01"
     }
   },
   "main": "app.js",

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,10 +2,10 @@
   "nativescript": {
     "id": "org.nativescript.UnitTestApp",
     "tns-android": {
-      "version": "6.1.0-2019-07-29-182447-01"
+      "version": "next"
     },
     "tns-ios": {
-      "version": "6.1.0-2019-08-01-122621-01"
+      "version": "next"
     }
   },
   "main": "app.js",

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/BottomNavigationBar.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/BottomNavigationBar.java
@@ -205,6 +205,10 @@ public class BottomNavigationBar extends LinearLayout {
             textView.setVisibility(GONE);
         }
 
+        if (tabItem.color != 0) {
+            textView.setTextColor(tabItem.color);            
+        }
+
         if (tabItem.backgroundColor != 0) {
             ll.setBackgroundColor(tabItem.backgroundColor);
         }

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/BottomNavigationBar.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/BottomNavigationBar.java
@@ -205,8 +205,17 @@ public class BottomNavigationBar extends LinearLayout {
             textView.setVisibility(GONE);
         }
 
+        if (tabItem.typeFace != null) {
+            textView.setTypeface(tabItem.typeFace);
+        }
+
+        if (tabItem.fontSize != 0) {
+            textView.setTextSize(tabItem.fontSize);
+        }
+
         if (tabItem.color != 0) {
-            textView.setTextColor(tabItem.color);            
+            textView.setTextColor(tabItem.color);
+            mTabStrip.setShouldUpdateTabsTextColor(false);          
         }
 
         if (tabItem.backgroundColor != 0) {

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/BottomNavigationBar.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/BottomNavigationBar.java
@@ -201,21 +201,21 @@ public class BottomNavigationBar extends LinearLayout {
         if (tabItem.title != null && !tabItem.title.isEmpty()) {
             textView.setText(tabItem.title);
             textView.setVisibility(VISIBLE);
+
+            if (tabItem.typeFace != null) {
+                textView.setTypeface(tabItem.typeFace);
+            }
+    
+            if (tabItem.fontSize != 0) {
+                textView.setTextSize(tabItem.fontSize);
+            }
+    
+            if (tabItem.color != 0) {
+                textView.setTextColor(tabItem.color);
+                mTabStrip.setShouldUpdateTabsTextColor(false);          
+            }
         } else {
             textView.setVisibility(GONE);
-        }
-
-        if (tabItem.typeFace != null) {
-            textView.setTypeface(tabItem.typeFace);
-        }
-
-        if (tabItem.fontSize != 0) {
-            textView.setTextSize(tabItem.fontSize);
-        }
-
-        if (tabItem.color != 0) {
-            textView.setTextColor(tabItem.color);
-            mTabStrip.setShouldUpdateTabsTextColor(false);          
         }
 
         if (tabItem.backgroundColor != 0) {

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabItemSpec.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabItemSpec.java
@@ -1,9 +1,12 @@
 package org.nativescript.widgets;
 
 import android.graphics.drawable.Drawable;
+import android.graphics.Typeface;
 
 public class TabItemSpec {
     public String title;
+    public int fontSize;
+    public Typeface typeFace;
     public int iconId;
     public Drawable iconDrawable;
     public int backgroundColor;

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabItemSpec.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabItemSpec.java
@@ -7,4 +7,5 @@ public class TabItemSpec {
     public int iconId;
     public Drawable iconDrawable;
     public int backgroundColor;
+    public int color;
 }

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabStrip.java
@@ -52,6 +52,8 @@ class TabStrip extends LinearLayout {
     private int mSelectedTabTextColor;
     private float mTabTextFontSize;
 
+    private boolean mShouldUpdateTabsTextColor;
+
     TabStrip(Context context) {
         this(context, null);
     }
@@ -87,6 +89,8 @@ class TabStrip extends LinearLayout {
         // Default selected color is the same as mTabTextColor
         mSelectedTabTextColor = mTabTextColor;
 
+        mShouldUpdateTabsTextColor = true;
+
         setMeasureWithLargestChildEnabled(true);
     }
 
@@ -120,16 +124,22 @@ class TabStrip extends LinearLayout {
         return mSelectedTabTextColor;
     }
 
+    void setShouldUpdateTabsTextColor(boolean value) {
+        mShouldUpdateTabsTextColor = value;
+    }
+
     private void updateTabsTextColor(){
-        final int childCount = getChildCount();
-        for (int i = 0; i < childCount; i++){
-            LinearLayout linearLayout = (LinearLayout)getChildAt(i);
-            TextView textView = (TextView)linearLayout.getChildAt(1);
-            if (i == mSelectedPosition){
-                textView.setTextColor(mSelectedTabTextColor);
-            }
-            else {
-                textView.setTextColor(mTabTextColor);
+        if (mShouldUpdateTabsTextColor) {
+            final int childCount = getChildCount();
+            for (int i = 0; i < childCount; i++){
+                LinearLayout linearLayout = (LinearLayout)getChildAt(i);
+                TextView textView = (TextView)linearLayout.getChildAt(1);
+                if (i == mSelectedPosition){
+                    textView.setTextColor(mSelectedTabTextColor);
+                }
+                else {
+                    textView.setTextColor(mTabTextColor);
+                }
             }
         }
     }

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabsBar.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabsBar.java
@@ -252,7 +252,6 @@ public class TabsBar extends HorizontalScrollView {
         textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, TAB_VIEW_TEXT_SIZE_SP);
         textView.setTypeface(Typeface.DEFAULT_BOLD);
         textView.setEllipsize(TextUtils.TruncateAt.END);
-        textView.setAllCaps(true);
         textView.setMaxLines(2);
         textView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         textView.setPadding(padding, 0, padding, 0);
@@ -286,6 +285,19 @@ public class TabsBar extends HorizontalScrollView {
 
         if (tabItem.backgroundColor != 0) {
             ll.setBackgroundColor(tabItem.backgroundColor);
+        }
+
+        if (tabItem.typeFace != null) {
+            textView.setTypeface(tabItem.typeFace);
+        }
+
+        if (tabItem.fontSize != 0) {
+            textView.setTextSize(tabItem.fontSize);
+        }
+
+        if (tabItem.color != 0) {
+            textView.setTextColor(tabItem.color);
+            mTabStrip.setShouldUpdateTabsTextColor(false);          
         }
 
         if (imgView.getVisibility() == VISIBLE && textView.getVisibility() == VISIBLE) {

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabsBar.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabsBar.java
@@ -279,25 +279,25 @@ public class TabsBar extends HorizontalScrollView {
         if (tabItem.title != null && !tabItem.title.isEmpty()) {
             textView.setText(tabItem.title);
             textView.setVisibility(VISIBLE);
+
+            if (tabItem.typeFace != null) {
+                textView.setTypeface(tabItem.typeFace);
+            }
+    
+            if (tabItem.fontSize != 0) {
+                textView.setTextSize(tabItem.fontSize);
+            }
+    
+            if (tabItem.color != 0) {
+                textView.setTextColor(tabItem.color);
+                mTabStrip.setShouldUpdateTabsTextColor(false);          
+            }
         } else {
             textView.setVisibility(GONE);
         }
 
         if (tabItem.backgroundColor != 0) {
             ll.setBackgroundColor(tabItem.backgroundColor);
-        }
-
-        if (tabItem.typeFace != null) {
-            textView.setTypeface(tabItem.typeFace);
-        }
-
-        if (tabItem.fontSize != 0) {
-            textView.setTextSize(tabItem.fontSize);
-        }
-
-        if (tabItem.color != 0) {
-            textView.setTextColor(tabItem.color);
-            mTabStrip.setShouldUpdateTabsTextColor(false);          
         }
 
         if (imgView.getVisibility() == VISIBLE && textView.getVisibility() == VISIBLE) {

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
-    "tns-core-modules-widgets": "file:../tns-core-modules-widgets/dist/package",
+    "tns-core-modules-widgets": "next",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "typings": "tns-core-modules.d.ts",
   "dependencies": {
-    "tns-core-modules-widgets": "next",
+    "tns-core-modules-widgets": "file:../tns-core-modules-widgets/dist/package",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
@@ -170,15 +170,17 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
     let iconSource;
     const tabItemSpec = new org.nativescript.widgets.TabItemSpec();
 
-    // Image and Label children of TabStripItem
-    // take priority over its `iconSource` and `title` properties
-    iconSource = tabStripItem.image ? tabStripItem.image.src : tabStripItem.iconSource;
-    tabItemSpec.title = tabStripItem.label ? tabStripItem.label.text : tabStripItem.title;
-
+    tabItemSpec.title = tabStripItem.label && tabStripItem.label.text;
+    
     if (tabStripItem.backgroundColor instanceof Color) {
         tabItemSpec.backgroundColor = tabStripItem.backgroundColor.android;
     }
-
+    
+    if (tabStripItem.label && tabStripItem.label.style.color instanceof Color) {
+        tabItemSpec.color = tabStripItem.label.style.color.android;
+    }
+    
+    iconSource = tabStripItem.image && tabStripItem.image.src;
     if (iconSource) {
         if (iconSource.indexOf(RESOURCE_PREFIX) === 0) {
             tabItemSpec.iconId = ad.resources.getDrawableId(iconSource.substr(RESOURCE_PREFIX.length));
@@ -187,21 +189,12 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
                 // traceMissingIcon(iconSource);
             }
         } else {
-            let is = new ImageSource();
-            if (isFontIconURI(iconSource)) {
-                const fontIconCode = iconSource.split("//")[1];
-                const target = tabStripItem.image ? tabStripItem.image : tabStripItem;
-                const font = target.style.fontInternal;
-                const color = target.style.color;
-                is = fromFontIconCode(fontIconCode, font, color);
-            } else {
-                is = fromFileOrResource(iconSource);
-            }
+            const icon = _getIcon(tabStripItem);
 
-            if (is) {
+            if (icon) {
                 // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
                 // tslint:disable-next-line:deprecation
-                tabItemSpec.iconDrawable = new android.graphics.drawable.BitmapDrawable(application.android.context.getResources(), is.android);
+                tabItemSpec.iconDrawable = icon;
             } else {
                 // TODO:
                 // traceMissingIcon(iconSource);
@@ -210,6 +203,25 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
     }
 
     return tabItemSpec;
+}
+
+function _getIcon(tabStripItem: TabStripItem): android.graphics.drawable.BitmapDrawable {
+    const iconSource = tabStripItem.image && tabStripItem.image.src;
+
+    let is = new ImageSource();
+    if (isFontIconURI(iconSource)) {
+        const fontIconCode = iconSource.split("//")[1];
+        const target = tabStripItem.image ? tabStripItem.image : tabStripItem;
+        const font = target.style.fontInternal;
+        const color = target.style.color;
+        is = fromFontIconCode(fontIconCode, font, color);
+    } else {
+        is = fromFileOrResource(iconSource);
+    }
+
+    const image = new android.graphics.drawable.BitmapDrawable(application.android.context.getResources(), is.android);
+    
+    return image;
 }
 
 function setElevation(bottomNavigationBar: org.nativescript.widgets.BottomNavigationBar) {
@@ -562,20 +574,6 @@ export class BottomNavigation extends TabNavigationBase {
         }
     }
 
-    public getTabBarColor(): number {
-        return this._bottomNavigationBar.getTabTextColor();
-    }
-
-    public setTabBarColor(value: number | Color): void {
-        if (value instanceof Color) {
-            this._bottomNavigationBar.setTabTextColor(value.android);
-            this._bottomNavigationBar.setSelectedTabTextColor(value.android);
-        } else {
-            this._bottomNavigationBar.setTabTextColor(value);
-            this._bottomNavigationBar.setSelectedTabTextColor(value);
-        }
-    }
-
     public setTabBarItemBackgroundColor(tabStripItem: TabStripItem, value: android.graphics.drawable.Drawable | Color): void {
         // TODO: Should figure out a way to do it directly with the the nativeView
         const tabStripItemIndex = this.tabStrip.items.indexOf(tabStripItem);
@@ -593,6 +591,15 @@ export class BottomNavigation extends TabNavigationBase {
         } else {
             tabStripItem.nativeViewProtected.setTextColor(value.android);
         }
+    }
+
+    public setTabBarIconColor(tabStripItem: TabStripItem, value: number | Color): void {
+        const index = (<any>tabStripItem).index;
+        const tabBarItem = this._bottomNavigationBar.getViewForItemAt(index);
+        const imgView = <android.widget.ImageView>tabBarItem.getChildAt(0);
+        const drawable = _getIcon(tabStripItem);
+
+        imgView.setImageDrawable(drawable);
     }
 
     public getTabBarItemFontSize(tabStripItem: TabStripItem): { nativeSize: number } {

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
@@ -170,11 +170,11 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
     const tabItemSpec = new org.nativescript.widgets.TabItemSpec();
 
     if (tabStripItem.isLoaded) {
-        const nestedLabel = tabStripItem.label;
-        let title = nestedLabel.text;
+        const titleLabel = tabStripItem.label;
+        let title = titleLabel.text;
 
         // TEXT-TRANSFORM
-        const textTransform = nestedLabel.style.textTransform;
+        const textTransform = titleLabel.style.textTransform;
         if (textTransform) {
             title = getTransformedText(title, textTransform);
         }
@@ -187,13 +187,13 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
         }
 
         // COLOR
-        const color = nestedLabel.style.color;
+        const color = titleLabel.style.color;
         if (color) {
             tabItemSpec.color = color.android;
         }
 
         // FONT
-        const fontInternal = nestedLabel.style.fontInternal;
+        const fontInternal = titleLabel.style.fontInternal;
         if (fontInternal) {
             tabItemSpec.fontSize = fontInternal.fontSize;
             tabItemSpec.typeFace = fontInternal.getAndroidTypeface();
@@ -229,7 +229,7 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
 function _getIcon(tabStripItem: TabStripItem): android.graphics.drawable.BitmapDrawable {
     const iconSource = tabStripItem.image && tabStripItem.image.src;
 
-    let is = new ImageSource();
+    let is: ImageSource;
     if (isFontIconURI(iconSource)) {
         const fontIconCode = iconSource.split("//")[1];
         const target = tabStripItem.image ? tabStripItem.image : tabStripItem;
@@ -632,8 +632,8 @@ export class BottomNavigation extends TabNavigationBase {
     }
 
     public setTabBarItemTextTransform(tabStripItem: TabStripItem, value: TextTransform): void {
-        const nestedLabel = tabStripItem.label;    
-        const title = getTransformedText(nestedLabel.text, value);
+        const titleLabel = tabStripItem.label;    
+        const title = getTransformedText(titleLabel.text, value);
         tabStripItem.nativeViewProtected.setText(title);
     }
 

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
@@ -595,6 +595,13 @@ export class BottomNavigation extends TabNavigationBase {
         }
     }
 
+    public setTabBarItemTitle(tabStripItem: TabStripItem, value: string): void {
+        // TODO: Should figure out a way to do it directly with the the nativeView
+        const tabStripItemIndex = this.tabStrip.items.indexOf(tabStripItem);
+        const tabItemSpec = createTabItemSpec(tabStripItem);
+        this.updateAndroidItemAt(tabStripItemIndex, tabItemSpec);
+    }
+
     public setTabBarItemBackgroundColor(tabStripItem: TabStripItem, value: android.graphics.drawable.Drawable | Color): void {
         // TODO: Should figure out a way to do it directly with the the nativeView
         const tabStripItemIndex = this.tabStrip.items.indexOf(tabStripItem);

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
@@ -188,13 +188,14 @@ function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets
             }
         } else {
             let is = new ImageSource();
-            if (isFontIconURI(tabStripItem.iconSource)) {
-                const fontIconCode = tabStripItem.iconSource.split("//")[1];
-                const font = tabStripItem.style.fontInternal;
-                const color = tabStripItem.style.color;
+            if (isFontIconURI(iconSource)) {
+                const fontIconCode = iconSource.split("//")[1];
+                const target = tabStripItem.image ? tabStripItem.image : tabStripItem;
+                const font = target.style.fontInternal;
+                const color = target.style.color;
                 is = fromFontIconCode(fontIconCode, font, color);
             } else {
-                is = fromFileOrResource(tabStripItem.iconSource);
+                is = fromFileOrResource(iconSource);
             }
 
             if (is) {

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -340,10 +340,6 @@ export class BottomNavigation extends TabNavigationBase {
         bgView.backgroundColor = value instanceof Color ? value.ios : value;
     }
 
-    public getTabBarItemColor(tabStripItem: TabStripItem): UIColor {
-        return this._ios.tabBar.tintColor;
-    }
-
     public setTabBarItemColor(tabStripItem: TabStripItem, value: UIColor | Color): void {
         const states = getTitleAttributesForStates(tabStripItem.label);
         applyStatesToItem(tabStripItem.nativeView, states);
@@ -356,30 +352,13 @@ export class BottomNavigation extends TabNavigationBase {
         tabStripItem.nativeView.selectedImage = image;
     }
 
-    public getTabBarItemFontSize(tabStripItem: TabStripItem): number {
-        return null;
-    }
-
-    public setTabBarItemFontSize(tabStripItem: TabStripItem, value: number | { nativeSize: number }): void {
-        const states = getTitleAttributesForStates(tabStripItem);
-        applyStatesToItem(tabStripItem.nativeView, states);
-    }
-
-    public getTabBarItemFontInternal(tabStripItem: TabStripItem): Font {
-        return null;
-    }
-
     public setTabBarItemFontInternal(tabStripItem: TabStripItem, value: Font): void {
-        const states = getTitleAttributesForStates(tabStripItem);
+        const states = getTitleAttributesForStates(tabStripItem.label);
         applyStatesToItem(tabStripItem.nativeView, states);
-    }
-
-    public getTabBarItemTextTransform(tabStripItem: TabStripItem): TextTransform {
-        return null;
     }
 
     public setTabBarItemTextTransform(tabStripItem: TabStripItem, value: TextTransform): void {
-        const title = getTransformedText(tabStripItem.title, value);
+        const title = getTransformedText(tabStripItem.label.text, value);
         tabStripItem.nativeView.title = title;
     }
 
@@ -526,8 +505,15 @@ export class BottomNavigation extends TabNavigationBase {
         let image: UIImage;
         let title: string;
 
-        image = item.isLoaded && this._getIcon(item);
-        title = item.label && item.label.text;
+        if (item.isLoaded) {
+            image = this._getIcon(item);
+            title = item.label.text;
+
+            const textTransform = item.label.style.textTransform;
+            if (textTransform) {
+                title = getTransformedText(title, textTransform);
+            }
+        }
 
         const tabBarItem = UITabBarItem.alloc().initWithTitleImageTag(title, image, index);
 

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -259,6 +259,8 @@ export class BottomNavigation extends TabNavigationBase {
     public onLoaded() {
         super.onLoaded();
 
+        this.setViewControllers(this.items);
+
         const selectedIndex = this.selectedIndex;
         const selectedView = this.items && this.items[selectedIndex] && this.items[selectedIndex].content;
         if (selectedView instanceof Frame) {
@@ -554,13 +556,16 @@ export class BottomNavigation extends TabNavigationBase {
             return null;
         }
 
-        let image: UIImage = this._iconsCache[iconSource];
+        const target = tabStripItem.image ? tabStripItem.image : tabStripItem;
+        const font = target.style.fontInternal;
+        const color = target.style.color;
+        const iconTag = [iconSource, font.fontStyle, font.fontWeight, font.fontSize, font.fontFamily, color].join(";");
+
+        let image: UIImage = this._iconsCache[iconTag];
         if (!image) {
             let is = new ImageSource;
             if (isFontIconURI(iconSource)) {
                 const fontIconCode = iconSource.split("//")[1];
-                const font = tabStripItem.style.fontInternal;
-                const color = tabStripItem.style.color;
                 is = fromFontIconCode(fontIconCode, font, color);
             } else {
                 is = fromFileOrResource(iconSource);
@@ -615,6 +620,12 @@ export class BottomNavigation extends TabNavigationBase {
         return null;
     }
     [itemsProperty.setNative](value: TabContentItem[]) {
+        if (value) {
+            value.forEach((item: TabContentItem, i) => {
+                (<any>item).index = i;
+            });
+        }
+
         this.setViewControllers(value);
         selectedIndexProperty.coerce(this);
     }

--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -322,6 +322,10 @@ export class BottomNavigation extends TabNavigationBase {
         this._ios.tabBar.barTintColor = value instanceof Color ? value.ios : value;
     }
 
+    public setTabBarItemTitle(tabStripItem: TabStripItem, value: string): void {
+        tabStripItem.nativeView.title = value;
+    }
+
     public setTabBarItemBackgroundColor(tabStripItem: TabStripItem, value: UIColor | Color): void {
         if (!this.tabStrip) {
             return;

--- a/tns-core-modules/ui/tab-navigation-base/tab-content-item/tab-content-item.android.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-content-item/tab-content-item.android.ts
@@ -27,7 +27,6 @@ export class TabContentItem extends TabContentItemBase {
 
     public initNativeView(): void {
         super.initNativeView();
-        this.nativeViewProtected.setBackgroundColor(-1); // White color.
     }
 
     public _addViewToNativeVisualTree(child: View, atIndex?: number): boolean {

--- a/tns-core-modules/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.d.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.d.ts
@@ -148,6 +148,12 @@ export class TabNavigationBase extends View {
      * @private
      * Method is intended to be overridden by inheritors and used as "protected"
      */
+    setTabBarItemTitle(tabStripItem: TabStripItem, value: any): any
+
+    /**
+     * @private
+     * Method is intended to be overridden by inheritors and used as "protected"
+     */
     getTabBarItemBackgroundColor(tabStripItem: TabStripItem): any
 
     /**
@@ -167,6 +173,12 @@ export class TabNavigationBase extends View {
      * Method is intended to be overridden by inheritors and used as "protected"
      */
     setTabBarItemColor(tabStripItem: TabStripItem, value: any): void
+
+    /**
+     * @private
+     * Method is intended to be overridden by inheritors and used as "protected"
+     */
+    setTabBarIconColor(tabStripItem: TabStripItem, value: any): void
 
     /**
      * @private

--- a/tns-core-modules/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
@@ -152,6 +152,10 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
         // overridden by inheritors
     }
 
+    public setTabBarItemTitle(tabStripItem: TabStripItem, value: any): void {
+        // overridden by inheritors        
+    }
+
     public getTabBarItemBackgroundColor(tabStripItem: TabStripItem): any {
         // overridden by inheritors
         return null;
@@ -167,6 +171,10 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
     }
 
     public setTabBarItemColor(tabStripItem: TabStripItem, value: any): void {
+        // overridden by inheritors
+    }
+
+    public setTabBarIconColor(tabStripItem: TabStripItem, value: any): void {
         // overridden by inheritors
     }
 

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -24,10 +24,11 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
     public static selectEvent = "select";
     public static unselectEvent = "unselect";
 
-    public title: string;
-    public iconSource: string;
     public image: Image;
     public label: Label;
+
+    private _title: string;
+    private _iconSource: string;
 
     private _highlightedHandler: () => void;
     private _normalHandler: () => void;
@@ -35,8 +36,43 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
     private _labelColorHandler: (args: PropertyChangeData) => void;
     private _labelFontHandler: (args: PropertyChangeData) => void;
     private _labelTextTransformHandler: (args: PropertyChangeData) => void;
+    private _labelTextHandler: (args: PropertyChangeData) => void;
     
     private _imageColorHandler: (args: PropertyChangeData) => void;
+    private _imageFontHandler: (args: PropertyChangeData) => void;
+    private _imageSrcHandler: (args: PropertyChangeData) => void;
+
+    get title(): string {
+        if (this.isLoaded) {
+            return this.label.text;
+        }
+
+        return this._title;
+    }
+
+    set title(value: string) {
+        this._title = value;
+        
+        if (this.isLoaded) {
+            this.label.text = value;
+        }
+    }
+
+    get iconSource(): string {
+        if (this.isLoaded) {
+            return this.image.src;
+        }
+
+        return this._iconSource;
+    }
+
+    set iconSource(value: string) {
+        this._iconSource = value;
+        
+        if (this.isLoaded) {
+            this.image.src = value;
+        }
+    }
 
     public onLoaded() {
         if (!this.image) {
@@ -79,6 +115,14 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
         });
         this.label.style.on("textTransformChange", this._labelTextTransformHandler);
 
+        this._labelTextHandler = this._labelTextHandler || ((args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && tabStripParent.setTabBarItemTitle(this, args.value);
+        });
+        this.label.on("textChange", this._labelTextHandler);
+
         this._imageColorHandler = this._imageColorHandler || ((args: PropertyChangeData) => {
             const parent = <TabStrip>this.parent;
             const tabStripParent = parent && <TabNavigationBase>parent.parent;
@@ -86,6 +130,22 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
             return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
         });
         this.image.style.on("colorChange", this._imageColorHandler);
+
+        this._imageFontHandler = this._imageFontHandler || ((args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
+        });
+        this.image.style.on("fontInternalChange", this._imageFontHandler);
+
+        this._imageSrcHandler = this._imageSrcHandler || ((args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
+        });
+        this.image.on("srcChange", this._imageSrcHandler);
     }
 
     public onUnloaded() {

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -154,8 +154,11 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
         this.label.style.off("colorChange", this._labelColorHandler);
         this.label.style.off("fontInternalChange", this._labelFontHandler);
         this.label.style.off("textTransformChange", this._labelTextTransformHandler);
+        this.label.style.off("textChange", this._labelTextHandler);
         
         this.image.style.off("colorChange", this._imageColorHandler);
+        this.image.style.off("fontInternalChange", this._imageFontHandler);
+        this.image.style.off("srcChange", this._imageSrcHandler);
     }
 
     public eachChild(callback: (child: ViewBase) => boolean) {

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -1,5 +1,6 @@
 ﻿// Types
 import { TabStripItem as TabStripItemDefinition } from ".";
+import { PropertyChangeData } from "../../../data/observable";
 import { TabNavigationBase } from "../tab-navigation-base";
 import { TabStrip } from "../tab-strip";
 import { Image } from "../../image/image";
@@ -30,6 +31,38 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
 
     private _highlightedHandler: () => void;
     private _normalHandler: () => void;
+
+    public onLoaded() {
+        if (!this.image) {
+            const image = new Image();
+            image.src = this.iconSource;
+            this.image = image;
+            this._addView(this.image);
+        }
+
+        if (!this.label) {
+            const label = new Label();
+            label.text = this.title;
+            this.label = label;
+            this._addView(this.label);
+        }
+
+        super.onLoaded();
+
+        this.label.style.addEventListener("colorChange", (args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && tabStripParent.setTabBarItemColor(this, args.value);
+        });
+
+        this.image.style.addEventListener("colorChange", (args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
+        });
+    }
 
     public eachChild(callback: (child: ViewBase) => boolean) {
         if (this.label) {
@@ -108,19 +141,6 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
     }
     [backgroundInternalProperty.setNative](value: any) {
         // disable the background CSS properties
-    }
-
-    [colorProperty.getDefault](): Color {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-
-        return tabStripParent && tabStripParent.getTabBarItemColor(this);
-    }
-    [colorProperty.setNative](value: Color) {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-        
-        return tabStripParent && tabStripParent.setTabBarItemColor(this, value);
     }
 
     [fontSizeProperty.getDefault](): { nativeSize: number } {

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -10,10 +10,8 @@ import { AddChildFromBuilder } from "../../core/view";
 
 // Requires
 import { 
-    View, ViewBase, CSSType, backgroundColorProperty, backgroundInternalProperty, colorProperty, 
-    fontSizeProperty, fontInternalProperty, PseudoClassHandler
+    View, ViewBase, CSSType, backgroundColorProperty, backgroundInternalProperty, PseudoClassHandler
 } from "../../core/view";
-import { textTransformProperty, TextTransform } from "../../text-base";
 
 export * from "../../core/view";
 export const traceCategory = "TabView";

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -32,6 +32,12 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
     private _highlightedHandler: () => void;
     private _normalHandler: () => void;
 
+    private _labelColorHandler: (args: PropertyChangeData) => void;
+    private _labelFontHandler: (args: PropertyChangeData) => void;
+    private _labelTextTransformHandler: (args: PropertyChangeData) => void;
+    
+    private _imageColorHandler: (args: PropertyChangeData) => void;
+
     public onLoaded() {
         if (!this.image) {
             const image = new Image();
@@ -49,19 +55,47 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
 
         super.onLoaded();
 
-        this.label.style.addEventListener("colorChange", (args: PropertyChangeData) => {
+        this._labelColorHandler = this._labelColorHandler || ((args: PropertyChangeData) => {
             const parent = <TabStrip>this.parent;
             const tabStripParent = parent && <TabNavigationBase>parent.parent;
             
             return tabStripParent && tabStripParent.setTabBarItemColor(this, args.value);
         });
+        this.label.style.on("colorChange", this._labelColorHandler);
 
-        this.image.style.addEventListener("colorChange", (args: PropertyChangeData) => {
+        this._labelFontHandler = this._labelFontHandler || ((args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && tabStripParent.setTabBarItemFontInternal(this, args.value);
+        });
+        this.label.style.on("fontInternalChange", this._labelFontHandler);
+
+        this._labelTextTransformHandler = this._labelTextTransformHandler || ((args: PropertyChangeData) => {
+            const parent = <TabStrip>this.parent;
+            const tabStripParent = parent && <TabNavigationBase>parent.parent;
+            
+            return tabStripParent && tabStripParent.setTabBarItemTextTransform(this, args.value);
+        });
+        this.label.style.on("textTransformChange", this._labelTextTransformHandler);
+
+        this._imageColorHandler = this._imageColorHandler || ((args: PropertyChangeData) => {
             const parent = <TabStrip>this.parent;
             const tabStripParent = parent && <TabNavigationBase>parent.parent;
             
             return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
         });
+        this.image.style.on("colorChange", this._imageColorHandler);
+    }
+
+    public onUnloaded() {
+        super.onUnloaded();
+
+        this.label.style.off("colorChange", this._labelColorHandler);
+        this.label.style.off("fontInternalChange", this._labelFontHandler);
+        this.label.style.off("textTransformChange", this._labelTextTransformHandler);
+        
+        this.image.style.off("colorChange", this._imageColorHandler);
     }
 
     public eachChild(callback: (child: ViewBase) => boolean) {
@@ -141,44 +175,5 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
     }
     [backgroundInternalProperty.setNative](value: any) {
         // disable the background CSS properties
-    }
-
-    [fontSizeProperty.getDefault](): { nativeSize: number } {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-
-        return tabStripParent && tabStripParent.getTabBarItemFontSize(this);
-    }
-    [fontSizeProperty.setNative](value: number | { nativeSize: number }) {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-        
-        return tabStripParent && tabStripParent.setTabBarItemFontSize(this, value);
-    }
-
-    [fontInternalProperty.getDefault](): any {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-
-        return tabStripParent && tabStripParent.getTabBarItemFontInternal(this);
-    }
-    [fontInternalProperty.setNative](value: any) {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-        
-        return tabStripParent && tabStripParent.setTabBarItemFontInternal(this, value);
-    }
-
-    [textTransformProperty.getDefault](): any {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-
-        return tabStripParent && tabStripParent.getTabBarItemTextTransform(this);
-    }
-    [textTransformProperty.setNative](value: any) {
-        const parent = <TabStrip>this.parent;
-        const tabStripParent = parent && <TabNavigationBase>parent.parent;
-        
-        return tabStripParent && tabStripParent.setTabBarItemTextTransform(this, value);
     }
 }

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -9,7 +9,7 @@ import { AddChildFromBuilder } from "../../core/view";
 
 // Requires
 import { 
-    View, CSSType, backgroundColorProperty, backgroundInternalProperty, colorProperty, 
+    View, ViewBase, CSSType, backgroundColorProperty, backgroundInternalProperty, colorProperty, 
     fontSizeProperty, fontInternalProperty, PseudoClassHandler
 } from "../../core/view";
 import { textTransformProperty, TextTransform } from "../../text-base";
@@ -30,6 +30,16 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
 
     private _highlightedHandler: () => void;
     private _normalHandler: () => void;
+
+    public eachChild(callback: (child: ViewBase) => boolean) {
+        if (this.label) {
+            callback(this.label);
+        }
+
+        if (this.image) {
+            callback(this.image);
+        }
+    }
 
     public _addChildFromBuilder(name: string, value: any): void {
         if (name === "Image") {

--- a/tns-core-modules/ui/tab-navigation-base/tab-strip/tab-strip.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip/tab-strip.ts
@@ -51,6 +51,18 @@ export class TabStrip extends View implements TabStripDefinition, AddChildFromBu
         }
     }
 
+    public onItemsChanged(oldItems: TabStripItem[], newItems: TabStripItem[]): void {
+        if (oldItems) {
+            oldItems.forEach(item => this._removeView(item));
+        }
+
+        if (newItems) {
+            newItems.forEach(item => {
+                this._addView(item);
+            });
+        }
+    }
+
     [backgroundColorProperty.getDefault](): Color {
         const parent = <TabNavigationBase>this.parent;
 
@@ -112,7 +124,14 @@ export class TabStrip extends View implements TabStripDefinition, AddChildFromBu
         
         return parent && parent.setTabBarHighlightColor(value);
     }
-} 
+}
+
+export const itemsProperty = new Property<TabStrip, TabStripItem[]>({
+    name: "items", valueChanged: (target, oldValue, newValue) => {
+        target.onItemsChanged(oldValue, newValue);
+    }
+});
+itemsProperty.register(TabStrip);
 
 export const iosIconRenderingModeProperty = new Property<TabStrip, "automatic" | "alwaysOriginal" | "alwaysTemplate">({ name: "iosIconRenderingMode", defaultValue: "automatic" });
 iosIconRenderingModeProperty.register(TabStrip);

--- a/tns-core-modules/ui/tabs/tabs.android.ts
+++ b/tns-core-modules/ui/tabs/tabs.android.ts
@@ -284,37 +284,58 @@ function initializeNativeClasses() {
 }
 
 function createTabItemSpec(tabStripItem: TabStripItem): org.nativescript.widgets.TabItemSpec {
-    let iconSource;
     const tabItemSpec = new org.nativescript.widgets.TabItemSpec();
 
-    tabItemSpec.title = tabStripItem.label && tabStripItem.label.text;
-    
-    if (tabStripItem.backgroundColor instanceof Color) {
-        tabItemSpec.backgroundColor = tabStripItem.backgroundColor.android;
-    }
-    
-    if (tabStripItem.label && tabStripItem.label.style.color instanceof Color) {
-        tabItemSpec.color = tabStripItem.label.style.color.android;
-    }
-    
-    iconSource = tabStripItem.image && tabStripItem.image.src;
-    if (iconSource) {
-        if (iconSource.indexOf(RESOURCE_PREFIX) === 0) {
-            tabItemSpec.iconId = ad.resources.getDrawableId(iconSource.substr(RESOURCE_PREFIX.length));
-            if (tabItemSpec.iconId === 0) {
-                // TODO:
-                // traceMissingIcon(iconSource);
-            }
-        } else {
-            const icon = _getIcon(tabStripItem);
+    if (tabStripItem.isLoaded) {
+        const nestedLabel = tabStripItem.label;
+        let title = nestedLabel.text;
 
-            if (icon) {
-                // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
-                // tslint:disable-next-line:deprecation
-                tabItemSpec.iconDrawable = icon;
+        // TEXT-TRANSFORM
+        const textTransform = nestedLabel.style.textTransform;
+        if (textTransform) {
+            title = getTransformedText(title, textTransform);
+        }
+        tabItemSpec.title = title;
+
+        // BACKGROUND-COLOR
+        const backgroundColor = tabStripItem.style.backgroundColor;
+        if (backgroundColor) {
+            tabItemSpec.backgroundColor = backgroundColor.android;
+        }
+
+        // COLOR
+        const color = nestedLabel.style.color;
+        if (color) {
+            tabItemSpec.color = color.android;
+        }
+
+        // FONT
+        const fontInternal = nestedLabel.style.fontInternal;
+        if (fontInternal) {
+            tabItemSpec.fontSize = fontInternal.fontSize;
+            tabItemSpec.typeFace = fontInternal.getAndroidTypeface();
+        }
+
+        // ICON
+        const iconSource = tabStripItem.image && tabStripItem.image.src;
+        if (iconSource) {
+            if (iconSource.indexOf(RESOURCE_PREFIX) === 0) {
+                tabItemSpec.iconId = ad.resources.getDrawableId(iconSource.substr(RESOURCE_PREFIX.length));
+                if (tabItemSpec.iconId === 0) {
+                    // TODO:
+                    // traceMissingIcon(iconSource);
+                }
             } else {
-                // TODO:
-                // traceMissingIcon(iconSource);
+                const icon = _getIcon(tabStripItem);
+
+                if (icon) {
+                    // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
+                    // tslint:disable-next-line:deprecation
+                    tabItemSpec.iconDrawable = icon;
+                } else {
+                    // TODO:
+                    // traceMissingIcon(iconSource);
+                }
             }
         }
     }
@@ -679,20 +700,6 @@ export class Tabs extends TabsBase {
         }
     }
 
-    public getTabBarColor(): number {
-        return this._tabsBar.getTabTextColor();
-    }
-
-    public setTabBarColor(value: number | Color): void {
-        if (value instanceof Color) {
-            this._tabsBar.setTabTextColor(value.android);
-            this._tabsBar.setSelectedTabTextColor(value.android);
-        } else {
-            this._tabsBar.setTabTextColor(value);
-            this._tabsBar.setSelectedTabTextColor(value);
-        }
-    }
-
     public getTabBarHighlightColor(): number {
         return getDefaultAccentColor(this._context);
     }
@@ -707,10 +714,6 @@ export class Tabs extends TabsBase {
         const tabStripItemIndex = this.tabStrip.items.indexOf(tabStripItem);
         const tabItemSpec = createTabItemSpec(tabStripItem);
         this.updateAndroidItemAt(tabStripItemIndex, tabItemSpec);
-    }
-
-    public getTabBarItemColor(tabStripItem: TabStripItem): number {
-        return tabStripItem.nativeViewProtected.getCurrentTextColor();
     }
 
     public setTabBarItemColor(tabStripItem: TabStripItem, value: number | Color): void {
@@ -730,45 +733,15 @@ export class Tabs extends TabsBase {
         imgView.setImageDrawable(drawable);
     }
 
-    public getTabBarItemFontSize(tabStripItem: TabStripItem): { nativeSize: number } {
-        return { nativeSize: tabStripItem.nativeViewProtected.getTextSize() };
+    public setTabBarItemFontInternal(tabStripItem: TabStripItem, value: Font): void {
+        tabStripItem.nativeViewProtected.setTextSize(value.fontSize);
+        tabStripItem.nativeViewProtected.setTypeface(value.getAndroidTypeface());
     }
 
-    public setTabBarItemFontSize(tabStripItem: TabStripItem, value: number | { nativeSize: number }): void {
-        if (typeof value === "number") {
-            tabStripItem.nativeViewProtected.setTextSize(value);
-        } else {
-            tabStripItem.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
-        }
-    }
-
-    public getTabBarItemFontInternal(tabStripItem: TabStripItem): android.graphics.Typeface {
-        return tabStripItem.nativeViewProtected.getTypeface();
-    }
-
-    public setTabBarItemFontInternal(tabStripItem: TabStripItem, value: Font | android.graphics.Typeface): void {
-        tabStripItem.nativeViewProtected.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
-    }
-
-    private _defaultTransformationMethod: android.text.method.TransformationMethod;
-
-    public getTabBarItemTextTransform(tabStripItem: TabStripItem): "default" {
-        return "default";
-    }
-
-    public setTabBarItemTextTransform(tabStripItem: TabStripItem, value: TextTransform | "default"): void {
-        const tv = tabStripItem.nativeViewProtected;
-
-        this._defaultTransformationMethod = this._defaultTransformationMethod || tv.getTransformationMethod();
-
-        if (value === "default") {
-            tv.setTransformationMethod(this._defaultTransformationMethod);
-            tv.setText(tabStripItem.title);
-        } else {
-            const result = getTransformedText(tabStripItem.title, value);
-            tv.setText(result);
-            tv.setTransformationMethod(null);
-        }
+    public setTabBarItemTextTransform(tabStripItem: TabStripItem, value: TextTransform): void {
+        const nestedLabel = tabStripItem.label;    
+        const title = getTransformedText(nestedLabel.text, value);
+        tabStripItem.nativeViewProtected.setText(title);
     }
 
     [selectedIndexProperty.setNative](value: number) {

--- a/tns-core-modules/ui/tabs/tabs.android.ts
+++ b/tns-core-modules/ui/tabs/tabs.android.ts
@@ -709,6 +709,13 @@ export class Tabs extends TabsBase {
         this._tabsBar.setSelectedIndicatorColors([color]);
     }
 
+    public setTabBarItemTitle(tabStripItem: TabStripItem, value: string): void {
+        // TODO: Should figure out a way to do it directly with the the nativeView
+        const tabStripItemIndex = this.tabStrip.items.indexOf(tabStripItem);
+        const tabItemSpec = createTabItemSpec(tabStripItem);
+        this.updateAndroidItemAt(tabStripItemIndex, tabItemSpec);
+    }
+
     public setTabBarItemBackgroundColor(tabStripItem: TabStripItem, value: android.graphics.drawable.Drawable | Color): void {
         // TODO: Should figure out a way to do it directly with the the nativeView
         const tabStripItemIndex = this.tabStrip.items.indexOf(tabStripItem);

--- a/tns-core-modules/ui/tabs/tabs.android.ts
+++ b/tns-core-modules/ui/tabs/tabs.android.ts
@@ -723,7 +723,7 @@ export class Tabs extends TabsBase {
 
     public setTabBarIconColor(tabStripItem: TabStripItem, value: number | Color): void {
         const index = (<any>tabStripItem).index;
-        const tabBarItem = this._tabLayout.getViewForItemAt(index);
+        const tabBarItem = this._tabsBar.getViewForItemAt(index);
         const imgView = <android.widget.ImageView>tabBarItem.getChildAt(0);
         const drawable = _getIcon(tabStripItem);
 

--- a/tns-platform-declarations/android/org.nativescript.widgets.d.ts
+++ b/tns-platform-declarations/android/org.nativescript.widgets.d.ts
@@ -452,6 +452,8 @@
 
             export class TabItemSpec {
                 title: string;
+                fontSize: number;
+                typeFace: android.graphics.Typeface;
                 iconId: number;
                 iconDrawable: android.graphics.drawable.Drawable;
                 backgroundColor: number;

--- a/tns-platform-declarations/android/org.nativescript.widgets.d.ts
+++ b/tns-platform-declarations/android/org.nativescript.widgets.d.ts
@@ -455,6 +455,7 @@
                 iconId: number;
                 iconDrawable: android.graphics.drawable.Drawable;
                 backgroundColor: number;
+                color: number;
             }
 
             export namespace image {


### PR DESCRIPTION
Enables more flexible declaration and manipulation of font icons as tab bar icons. Utilizes the nested Image and Label elements better.

Part of the 6.1 release for the Tab Navigation story - https://github.com/NativeScript/NativeScript/issues/6967

Fixes https://github.com/NativeScript/NativeScript/issues/7623
Fixes https://github.com/NativeScript/NativeScript/issues/7506
Fixes https://github.com/NativeScript/NativeScript/issues/7470
Fixes https://github.com/NativeScript/NativeScript/issues/7547