### PR TITLE
feat(android): fit tab resource icon size based on spec

### DIFF
--- a/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/tns-core-modules/ui/bottom-navigation/bottom-navigation.android.ts
@@ -540,23 +540,15 @@ export class BottomNavigation extends TabNavigationBase {
             // ICON
             const iconSource = tabStripItem.image && tabStripItem.image.src;
             if (iconSource) {
-                if (iconSource.indexOf(RESOURCE_PREFIX) === 0) {
-                    tabItemSpec.iconId = ad.resources.getDrawableId(iconSource.substr(RESOURCE_PREFIX.length));
-                    if (tabItemSpec.iconId === 0) {
-                        // TODO:
-                        // traceMissingIcon(iconSource);
-                    }
-                } else {
-                    const icon = this.getIcon(tabStripItem);
+                const icon = this.getIcon(tabStripItem);
 
-                    if (icon) {
-                        // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
-                        // tslint:disable-next-line:deprecation
-                        tabItemSpec.iconDrawable = icon;
-                    } else {
-                        // TODO:
-                        // traceMissingIcon(iconSource);
-                    }
+                if (icon) {
+                    // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
+                    // tslint:disable-next-line:deprecation
+                    tabItemSpec.iconDrawable = icon;
+                } else {
+                    // TODO:
+                    // traceMissingIcon(iconSource);
                 }
             }
         }

--- a/tns-core-modules/ui/tabs/tabs.android.ts
+++ b/tns-core-modules/ui/tabs/tabs.android.ts
@@ -615,23 +615,15 @@ export class Tabs extends TabsBase {
             // ICON
             const iconSource = tabStripItem.image && tabStripItem.image.src;
             if (iconSource) {
-                if (iconSource.indexOf(RESOURCE_PREFIX) === 0) {
-                    tabItemSpec.iconId = ad.resources.getDrawableId(iconSource.substr(RESOURCE_PREFIX.length));
-                    if (tabItemSpec.iconId === 0) {
-                        // TODO:
-                        // traceMissingIcon(iconSource);
-                    }
-                } else {
-                    const icon = this.getIcon(tabStripItem);
+                const icon = this.getIcon(tabStripItem);
 
-                    if (icon) {
-                        // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
-                        // tslint:disable-next-line:deprecation
-                        tabItemSpec.iconDrawable = icon;
-                    } else {
-                        // TODO:
-                        // traceMissingIcon(iconSource);
-                    }
+                if (icon) {
+                    // TODO: Make this native call that accepts string so that we don't load Bitmap in JS.
+                    // tslint:disable-next-line:deprecation
+                    tabItemSpec.iconDrawable = icon;
+                } else {
+                    // TODO:
+                    // traceMissingIcon(iconSource);
                 }
             }
         }


### PR DESCRIPTION
In order to have the fit to spec tab icons, we need to remove this optimization.

Fixes https://github.com/NativeScript/NativeScript/issues/7713