### PR TITLE
fix(ios-tabs): handle nesting proxy view container

### DIFF
--- a/tns-core-modules/ui/tabs/tabs.ios.ts
+++ b/tns-core-modules/ui/tabs/tabs.ios.ts
@@ -150,10 +150,17 @@ class UIPageViewControllerImpl extends UIPageViewController {
                 scrollViewHeight = this.view.frame.size.height - safeAreaInsetsBottom;
             }
 
-            const parent = owner.parent;
+            let parent = owner.parent;
+
+            // Handle Angular scenario where Tabs is in a ProxyViewContainer
+            // It is possible to wrap components in ProxyViewContainers indefinitely
+            while (parent && !parent.nativeViewProtected) {
+                parent = parent.parent;
+            }
+
             if (parent && majorVersion > 10) {
                 // TODO: Figure out a better way to handle ViewController nesting/Safe Area nesting
-                tabBarTop = Math.max(tabBarTop, owner.parent.nativeView.safeAreaInsets.top);
+                tabBarTop = Math.max(tabBarTop, parent.nativeView.safeAreaInsets.top);
             }
 
             this.tabBar.frame = CGRectMake(0, tabBarTop, this.tabBar.frame.size.width, tabBarHeight);


### PR DESCRIPTION
This handles the most common scenario in Angular, when `Tabs` is used as a root of a navigate component. In this case ns-ng wraps the component in a proxy view container which doesn't have a native view.