### PR TITLE
chore: pin tslib@~1.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "shelljs": "^0.7.0",
     "source-map-support": "^0.4.17",
     "time-grunt": "1.3.0",
-    "tslib": "^1.9.3",
+    "tslib": "~1.9.3",
     "tslint": "^5.4.3",
     "typedoc": "^0.13.0",
     "typedoc-plugin-external-module-name": "git://github.com/PanayotCankov/typedoc-plugin-external-module-name.git#with-js",

--- a/tns-core-modules/package.json
+++ b/tns-core-modules/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "reduce-css-calc": "^2.1.6",
     "tns-core-modules-widgets": "next",
-    "tslib": "^1.9.3"
+    "tslib": "~1.9.3"
   },
   "devDependencies": {
     "@types/node": "~7.0.5",


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

The `master-detail-kinvey-ts` template fails with:
```
CONSOLE ERROR file:///node_modules/tns-core-modules/trace/trace.js:174:0 Error: Css styling failed: ReferenceError: Can't find variable: __spreadArrays
```

caused by a mismatch of the `tslib` versions as follows:
- the `tns-core-modules` package transpiles with `tslib@1.10.0`
- the `kinvey-js-sdk@4.2.3` references `tslib@1.9.3`.

The `tslib@1.10.0` version [introduces](https://github.com/microsoft/tslib/releases) a new `__spreadArrays` helper.

Currently, stick to `tslib@1.9.3` for `tns-core-modules` and mind to upgrade with the next release of `kinvey-js-sdk` where `tslib@1.10.0` has been already referenced.