### PR TITLE
fix(android/application-settings): possible uninitialized sharedPreferences variable usage

### DIFF
--- a/tns-core-modules/application-settings/application-settings.android.ts
+++ b/tns-core-modules/application-settings/application-settings.android.ts
@@ -86,6 +86,7 @@ export function clear(): void {
 
 export function flush(): boolean {
     ensureSharedPreferences();
+
     return sharedPreferences.edit().commit();
 }
 

--- a/tns-core-modules/application-settings/application-settings.android.ts
+++ b/tns-core-modules/application-settings/application-settings.android.ts
@@ -85,10 +85,12 @@ export function clear(): void {
 }
 
 export function flush(): boolean {
+    ensureSharedPreferences();
     return sharedPreferences.edit().commit();
 }
 
 export function getAllKeys(): Array<string> {
+    ensureSharedPreferences();
     const mappedPreferences = sharedPreferences.getAll();
     const iterator = mappedPreferences.keySet().iterator();
     const result = [];


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Currently, if `getAllKeys` (and `flush`) functions will be called before any other method of `application-settings` module next exception will be thrown
```
System.err: An uncaught Exception occurred on "main" thread.
System.err: Unable to create application com.tns.NativeScriptApplication: com.tns.NativeScriptException: Error calling module function
System.err: TypeError: Cannot read property 'getAll' of undefined
System.err: File: (file:///node_modules/tns-core-modules/application-settings/application-settings.js:85:0)
System.err:
System.err: StackTrace:
System.err: 	getAllKeys(file:///node_modules/tns-core-modules/application-settings/application-settings.js:85:0)
System.err: 	at myFunction(file:///app/common/helpers.ts:331:47)
System.err: 	at (file:///app/app.ts:111:10)
System.err: 	at ./app.ts(file:///data/data/com.abomic.mobile/files/app/bundle.js:388:30)
System.err: 	at __webpack_require__(file:///app/webpack/bootstrap:750:0)
System.err: 	at checkDeferredModules(file:///app/webpack/bootstrap:43:0)
System.err: 	at webpackJsonpCallback(file:///app/webpack/bootstrap:30:0)
System.err: 	at (file:///data/data/com.abomic.mobile/files/app/bundle.js:2:57)
System.err: 	at require(:1:266)
```

## What is the new behavior?
`getAllKeys` (and `flush`) functions work as expected regardless when they are calling.

## Test and alternative implemntation
As for tests, it is not simple to implement them correctly; that is why I decided to skim them and propose alternative implementation. What if instead of calling `ensureSharedPreferences` in each method call this function after its declaration?
```diff
diff --git a/tns-core-modules/application-settings/application-settings.android.ts b/tns-core-modules/application-settings/application-settings.android.ts
index e3774188a..454cd7a8a 100644
--- a/tns-core-modules/application-settings/application-settings.android.ts
+++ b/tns-core-modules/application-settings/application-settings.android.ts
@@ -7,10 +7,10 @@ function ensureSharedPreferences() {
         sharedPreferences = (<android.app.Application>getNativeApplication()).getApplicationContext().getSharedPreferences("prefs.db", 0);
     }
 }
+ensureSharedPreferences();
 
 function verify(key: string) {
     common.checkKey(key);
-    ensureSharedPreferences();
 }
 
 export function hasKey(key: string): boolean {
@@ -80,17 +80,14 @@ export function remove(key: string): void {
 }
 
 export function clear(): void {
-    ensureSharedPreferences();
     sharedPreferences.edit().clear().apply();
 }
 
 export function flush(): boolean {
-    ensureSharedPreferences();
     return sharedPreferences.edit().commit();
 }
 
 export function getAllKeys(): Array<string> {
-    ensureSharedPreferences();
     const mappedPreferences = sharedPreferences.getAll();
     const iterator = mappedPreferences.keySet().iterator();
     const result = [];
```
It this case `sharedPreferences` alway be initialized and if no method be called it will be the memory waste, but if someone includes this module, he definitely going to call some of its functions.