### PR TITLE
fix(android/action-bar): process Icon Fonts in NavigationButton the same way as in ActionItem

### DIFF
--- a/e2e/ui-tests-app/app/action-bar/font-icons-page.xml
+++ b/e2e/ui-tests-app/app/action-bar/font-icons-page.xml
@@ -1,6 +1,7 @@
 <Page>
   <Page.actionBar>
     <ActionBar automationText="actionBar">
+      <NavigationButton icon="font://&#xF137;" class="font-awesome font-size color"/>
       <ActionBar.actionItems>
         <!-- font family + font size + color -->
         <ActionItem icon="font://&#xF10B;" class="font-awesome font-size color" tap="navigate"/>

--- a/tns-core-modules/ui/action-bar/action-bar.android.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.android.ts
@@ -227,9 +227,21 @@ export class ActionBar extends ActionBarBase {
                 }
             }
             else if (navButton.icon) {
-                let drawableOrId = getDrawableOrResourceId(navButton.icon, appResources);
-                if (drawableOrId) {
-                    this.nativeViewProtected.setNavigationIcon(drawableOrId);
+                if (isFontIconURI(navButton.icon)) {
+                    const fontIconCode = navButton.icon.split("//")[1];
+                    const font = navButton.style.fontInternal;
+                    const color = navButton.style.color;
+                    const is = fromFontIconCode(fontIconCode, font, color);
+
+                    if (is && is.android) {
+                        const drawable = new android.graphics.drawable.BitmapDrawable(appResources, is.android);
+                        this.nativeViewProtected.setNavigationIcon(drawable);
+                    }
+                } else {
+                    let drawableOrId = getDrawableOrResourceId(navButton.icon, appResources);
+                    if (drawableOrId) {
+                        this.nativeViewProtected.setNavigationIcon(drawableOrId);
+                    }
                 }
             }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
`NavigationButton` does not process `font://` prefix in `icon` field.

## What is the new behavior?
`NavigationButton` processes `font://` prefix in `icon` field, the same way as `ActionItem` does.

Unfortunately, I could not found any test fro this functionality for `ActionItem`, that is why I could not implement the correct one for `NavigationButton`.
