### PR TITLE
chore: update dev workflow for Angular app

### DIFF
--- a/DevelopmentWorkflow.md
+++ b/DevelopmentWorkflow.md
@@ -81,6 +81,47 @@ tns run ios
 tns run android
 ```
 
+### Running Another Angular App
+
+When linking within a Angular/TS project, `tns run` will grab the linked TS files in core modules and try to compile them without the references needed.  To work around this, from the root of your `NativeScript` clone do the following:
+
+1. Create a copy of `tns-core-modules` folder via:
+```bash
+mkdir dist && cp -r tns-core-modules dist/
+# Should look like this:
+NativeScript
+     |
+     +--> dist
+            |
+            +--> tns-core-modules
+                        |
+                        +--> ...
+                        +--> ...
+                        +--> ...
+```
+2. Delete all `.ts` files, keeping `d.ts` ones via:
+```bash
+find dist/tns-core-modules -name "*.ts" -not -name "*.d.ts" -delete
+```
+3. Add `--outDir dist` to the `tsc-w` script in `package.json`
+```
+"scripts": {
+...
+"tsc-w": "npm run tsc -- --skipLibCheck -w --outDir dist",
+...
+```
+4. Run `npm run tsc-w`
+5. In another terminal, go to the root of your NS Angular project and link the `dist/tns-core-modules` via:
+```bash
+npm install --save <path to dist/tns-core-modules>
+# Example: npm install --save ../NativeScript/dist/tns-core-modules
+```
+6. Run the app
+```bash
+tns run ios
+tns run android
+```
+
 ## Platform declarations
 To update the platform declarations (the ios.d.ts-es) you can run:
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

When trying to contribute to `tns-core*`, and using an external NS Angular to develop/test these contributions, the compile step fails when following the instructions currently outlined in [DevelopmentWorkflow.md](https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-another-app) (Running Another App).

@bundyo [discovered](https://github.com/NativeScript/nativescript-dev-webpack/issues/1044#issuecomment-533397897) this workaround, I'll paste his findings here:

> The problem with linking is that Angular/TS project tend to grab the linked TS files in core modules and try to compile them without the references needed. I've only managed to run it by compiling the core modules with outDir and linking that (.d.ts, package.json and other files, except TS ones should be copied over too). Maybe the team can consider moving to an outDir compilation. Another way would be dev-webpack to forbid Angular/ts-loader for traversing node_modules.

## What is the new behavior?

This PR contains a workaround for Angular that moves `tns-core*` to a new `dist` directory.

This workflow is obviously not ideal.  Would love the NativeScript team's thoughts on a cleaner solution.

Fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/1044 and https://github.com/NativeScript/NativeScript/issues/7745


