### PR TITLE
feat: adding support for the new selectedSegmentTintColor property

### DIFF
--- a/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
@@ -3,6 +3,7 @@ import {
     SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty,
     colorProperty, fontInternalProperty, Color
 } from "./segmented-bar-common";
+import { ios as iosUtils } from "../../utils/utils";
 export * from "./segmented-bar-common";
 
 export class SegmentedBarItem extends SegmentedBarItemBase {
@@ -67,12 +68,12 @@ export class SegmentedBar extends SegmentedBarBase {
     }
 
     [selectedBackgroundColorProperty.getDefault](): UIColor {
-        const currentOsVersion = parseFloat(UIDevice.currentDevice.systemVersion);
+        const currentOsVersion = iosUtils.MajorVersion;
 
         return currentOsVersion < 13 ? this.ios.tintColor : this.ios.selectedSegmentTintColor;
     }
     [selectedBackgroundColorProperty.setNative](value: UIColor | Color) {
-        const currentOsVersion = parseFloat(UIDevice.currentDevice.systemVersion);
+        const currentOsVersion = iosUtils.MajorVersion;
         let color = value instanceof Color ? value.ios : value;
         if (currentOsVersion < 13) {
             this.ios.tintColor = color;

--- a/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
+++ b/tns-core-modules/ui/segmented-bar/segmented-bar.ios.ts
@@ -3,7 +3,6 @@ import {
     SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty,
     colorProperty, fontInternalProperty, Color
 } from "./segmented-bar-common";
-
 export * from "./segmented-bar-common";
 
 export class SegmentedBarItem extends SegmentedBarItemBase {
@@ -68,11 +67,19 @@ export class SegmentedBar extends SegmentedBarBase {
     }
 
     [selectedBackgroundColorProperty.getDefault](): UIColor {
-        return this.ios.tintColor;
+        const currentOsVersion = parseFloat(UIDevice.currentDevice.systemVersion);
+
+        return currentOsVersion < 13 ? this.ios.tintColor : this.ios.selectedSegmentTintColor;
     }
     [selectedBackgroundColorProperty.setNative](value: UIColor | Color) {
+        const currentOsVersion = parseFloat(UIDevice.currentDevice.systemVersion);
         let color = value instanceof Color ? value.ios : value;
-        this.ios.tintColor = color;
+        if (currentOsVersion < 13) {
+            this.ios.tintColor = color;
+        } else {
+            this.ios.selectedSegmentTintColor = color;
+        }
+        
     }
 
     [colorProperty.getDefault](): UIColor {


### PR DESCRIPTION
Adding support for the new SegmentedControl's selectedSegmentTintColor property. Introduced with iOS 13.