### PR TITLE
fix: change the way we import 'esprima' to avoid wrong path resolution in Angular projects

### DIFF
--- a/tns-core-modules/js-libs/polymer-expressions/polymer-expressions.js
+++ b/tns-core-modules/js-libs/polymer-expressions/polymer-expressions.js
@@ -5,7 +5,10 @@
 // Code distributed by Google as part of the polymer project is also
 // subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 
+// Hack to resolve https://github.com/webpack/enhanced-resolve/issues/197 . 
+// This issue causes an require like this (`../esprima`) to be resolved to (`esprima`) by the Angular webpack plugin
 var esprima = require("../../js-libs/esprima").esprima;
+
 var Path = require("./path-parser").Path;
 
 (function (global) {

--- a/tns-core-modules/js-libs/polymer-expressions/polymer-expressions.js
+++ b/tns-core-modules/js-libs/polymer-expressions/polymer-expressions.js
@@ -5,7 +5,7 @@
 // Code distributed by Google as part of the polymer project is also
 // subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 
-var esprima = require("../esprima").esprima;
+var esprima = require("../../js-libs/esprima").esprima;
 var Path = require("./path-parser").Path;
 
 (function (global) {


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Binding expressions in the HTML of an NativeScript + Angular app do not work and throw and non critical error.

This change https://github.com/NativeScript/NativeScript/commit/beffc5736a050f4f38eb051e7e1bfb77ed0f9576 caused and error and failing tests to occur in the `nativescript-angular` repo. The source of the issue is an actual issue in the `Angular > ngtools > Webpack > enhanced-resolve` packages. We have logged [this issue](https://github.com/webpack/enhanced-resolve/issues/197) here but it is already resolved in the beta tag of the `enhanced-resolve` package. Since this fixed package needs to be updated in the ngtools package and that can take a while I am proposing this fix.

## What is the new behavior?
Binding expressions in the HTML of an NativeScript + Angular app work.
