### PR TITLE
fix: xml parsing when input value is reported as object instead of string

### DIFF
--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -252,9 +252,7 @@ namespace xml2ui {
 
             if (isString(value)) {
                 xmlParser.parse(<string>value);
-            }
-
-            if (isObject(value) && isString(value.default)) {
+            } else if (isObject(value) && isString(value.default)) {
                 xmlParser.parse(value.default);
             }
         }

--- a/tns-core-modules/ui/builder/builder.ts
+++ b/tns-core-modules/ui/builder/builder.ts
@@ -6,7 +6,7 @@ import { ViewEntry } from "../frame";
 // Types.
 import { debug, ScopeError, SourceError, Source } from "../../utils/debug";
 import * as xml from "../../xml";
-import { isString, isDefined } from "../../utils/types";
+import { isString, isObject, isDefined } from "../../utils/types";
 import { ComponentModule, setPropertyValue, getComponentModule } from "./component-builder";
 import { platformNames, device } from "../../platform";
 import { profile } from "../../profiling";
@@ -215,6 +215,10 @@ namespace xml2ui {
         parse(args: xml.ParserEvent);
     }
 
+    interface ParseInputData extends String {
+        default?: string;
+    }
+
     export class XmlProducerBase implements XmlProducer {
         private _next: XmlConsumer;
         public pipe<Next extends XmlConsumer>(next: Next) {
@@ -235,7 +239,7 @@ namespace xml2ui {
             this.error = error || PositionErrorFormat;
         }
 
-        public parse(value: string) {
+        public parse(value: ParseInputData) {
             const xmlParser = new xml.XmlParser((args: xml.ParserEvent) => {
                 try {
                     this.next(args);
@@ -247,7 +251,11 @@ namespace xml2ui {
             }, true);
 
             if (isString(value)) {
-                xmlParser.parse(value);
+                xmlParser.parse(<string>value);
+            }
+
+            if (isObject(value) && isString(value.default)) {
+                xmlParser.parse(value.default);
             }
         }
     }


### PR DESCRIPTION
The [raw-loader](https://github.com/webpack-contrib/raw-loader/blob/6cf76b8947d34fcbe2c11fabc0a995cbf246615f/src/index.js#L18) changed the way the modules are exported e.g they've already used ES Module export instead of CommonJS. This way, the format of modules inside `bundle.js` or `vendor.js` is changed:

Previous:
```
module.exports = "<Frame defaultPage=\"bundle-main-page\" id=\"root-frame\">\n</Frame>\n"; 
```

Current:
```
 __webpack_exports__["default"] = ("<Frame defaultPage=\"bundle-main-page\" id=\"root-frame1\">\n</Frame>\n");
```

On the other side, angular updated `raw-loader` to v3.1.0 in their latest minor release e.g in v8.3.0. As a result, `tns test` command doesn't work for newly created code shared applications.

This PR adds support for parsing xml modules exported via ES module export syntax.

Rel to: https://github.com/NativeScript/NativeScript/issues/7915

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

