### PR TITLE
feat: update material components dependency to 92.3

### DIFF
--- a/tns-core-modules/platforms/ios/Podfile
+++ b/tns-core-modules/platforms/ios/Podfile
@@ -1,4 +1,4 @@
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'MaterialComponents/Tabs', '~> 84.4'
+pod 'MaterialComponents/Tabs', '~> 92.3'


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
The core modules had a dependency to Material Components v84.4. There is a fix in v91.0 that resolves problems with app publishing to iOS.

## What is the new behavior?
Update MC to latest.

Closes https://github.com/NativeScript/NativeScript/issues/7928
