### PR TITLE
feat(css): add attribute scoped css without global refresh (#7907)

### DIFF
--- a/tns-core-modules/application/application.android.ts
+++ b/tns-core-modules/application/application.android.ts
@@ -177,11 +177,13 @@ export function run(entry?: NavigationEntry | string) {
     _start(entry);
 }
 
-export function addCss(cssText: string): void {
+export function addCss(cssText: string, attributeScoped?: boolean): void {
     notify(<CssChangedEventData>{ eventName: "cssChanged", object: androidApp, cssText: cssText });
-    const rootView = getRootView();
-    if (rootView) {
-        rootView._onCssStateChange();
+    if (!attributeScoped) {
+        const rootView = getRootView();
+        if (rootView) {
+            rootView._onCssStateChange();
+        }
     }
 }
 

--- a/tns-core-modules/application/application.d.ts
+++ b/tns-core-modules/application/application.d.ts
@@ -171,8 +171,9 @@ export function loadAppCss();
 /**
 * Adds new values to the application styles.
 * @param cssText - A valid styles which will be added to the current application styles.
+* @param attributeScoped - Whether the styles are attribute scoped. Adding attribute scoped styles will not perform a full application styling refresh.
 */
-export function addCss(cssText: string): void;
+export function addCss(cssText: string, attributeScoped?: boolean): void;
 
 /**
  * This event is raised when application css is changed.

--- a/tns-core-modules/application/application.ios.ts
+++ b/tns-core-modules/application/application.ios.ts
@@ -370,11 +370,13 @@ export function run(entry?: string | NavigationEntry) {
     _start(entry);
 }
 
-export function addCss(cssText: string): void {
+export function addCss(cssText: string, attributeScoped?: boolean): void {
     notify(<CssChangedEventData>{ eventName: "cssChanged", object: <any>iosApp, cssText: cssText });
-    const rootView = getRootView();
-    if (rootView) {
-        rootView._onCssStateChange();
+    if (!attributeScoped) {
+        const rootView = getRootView();
+        if (rootView) {
+            rootView._onCssStateChange();
+        }
     }
 }
 


### PR DESCRIPTION
This is a patch PR for https://github.com/NativeScript/NativeScript/pull/7907