### PR TITLE
fix(frame-android): IllegalStateException: The specified child already has a parent

### DIFF
--- a/tns-core-modules/ui/frame/frame.android.ts
+++ b/tns-core-modules/ui/frame/frame.android.ts
@@ -902,7 +902,7 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
                     parentView.addViewInLayout(nativeView, -1, new org.nativescript.widgets.CommonLayoutParams());
                 }
 
-                parentView.removeView(nativeView);
+                parentView.removeAllViews();
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/NativeScript/NativeScript/issues/7901

However, note that while this change fixes this specific issue we have only verified NativeScript works with androidx@1.0.0 package versions at this point.