### PR TITLE
fix(android): BottomNavigation TabStripItem compat with prettier

### DIFF
--- a/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/tns-core-modules/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -172,14 +172,15 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
     }
 
     public _addChildFromBuilder(name: string, value: any): void {
-        if (name === "Image") {
+        // ensure compat with .prettier formatters
+        if (name && name.toLowerCase() === "image") {
             this.image = <Image>value;
             this.iconSource = (<Image>value).src;
             this._addView(value);
             // selectedIndexProperty.coerce(this);
         }
 
-        if (name === "Label") {
+        if (name && name.toLowerCase() === "label") {
             this.label = <Label>value;
             this.title = (<Label>value).text;
             this._addView(value);


### PR DESCRIPTION
- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?

Using `.prettierrc` for auto codebase formatting will often lowercase `Image` and `Label` component tag names and hence break `BottomNavigation`'s `TabStripItem`.

## What is the new behavior?

It now works with both cases (with or without prettier).

## Notes

Caught me by surprise. Was working in codebase that used prettier to format entire codebase including .html templates and BottomNavigation was just not showing anything in the TabStrip. Was related to this.