### PR TITLE
fix-next(css-classes): increase application CSS selector version at runtime

### DIFF
--- a/nativescript-core/application/application-common.ts
+++ b/nativescript-core/application/application-common.ts
@@ -142,6 +142,13 @@ function removeCssClass(rootView: View, cssClass: string) {
     rootView.cssClasses.delete(cssClass);
 }
 
+function increaseStyleScopeApplicationCssSelectorVersion(rootView: View) {
+    const styleScope = rootView._styleScope || (<any>rootView).currentPage._styleScope;
+    if (styleScope) {
+        styleScope._increaseApplicationCssSelectorVersion();
+    }
+}
+
 export function orientationChanged(rootView: View, newOrientation: "portrait" | "landscape" | "unknown"): void {
     if (!rootView) {
         return;
@@ -151,6 +158,7 @@ export function orientationChanged(rootView: View, newOrientation: "portrait" | 
     if (!rootView.cssClasses.has(newOrientationCssClass)) {
         ORIENTATION_CSS_CLASSES.forEach(cssClass => removeCssClass(rootView, cssClass));
         applyCssClass(rootView, newOrientationCssClass);
+        increaseStyleScopeApplicationCssSelectorVersion(rootView);
         rootView._onCssStateChange();
     }
 }
@@ -164,6 +172,7 @@ export function systemAppearanceChanged(rootView: View, newSystemAppearance: "da
     if (!rootView.cssClasses.has(newSystemAppearanceCssClass)) {
         SYSTEM_APPEARANCE_CSS_CLASSES.forEach(cssClass => removeCssClass(rootView, cssClass));
         applyCssClass(rootView, newSystemAppearanceCssClass);
+        increaseStyleScopeApplicationCssSelectorVersion(rootView);
         rootView._onCssStateChange();
     }
 }

--- a/nativescript-core/application/application-common.ts
+++ b/nativescript-core/application/application-common.ts
@@ -143,7 +143,8 @@ function removeCssClass(rootView: View, cssClass: string) {
 }
 
 function increaseStyleScopeApplicationCssSelectorVersion(rootView: View) {
-    const styleScope = rootView._styleScope || (<any>rootView).currentPage._styleScope;
+    const styleScope = rootView._styleScope || ((<any>rootView).currentPage && (<any>rootView).currentPage._styleScope);
+
     if (styleScope) {
         styleScope._increaseApplicationCssSelectorVersion();
     }

--- a/nativescript-core/ui/styling/style-scope.d.ts
+++ b/nativescript-core/ui/styling/style-scope.d.ts
@@ -39,7 +39,7 @@ export class StyleScope {
     /**
      * Increase the application CSS selector version.
      */
-    public _increaseApplicationCssSelectorVersion(): number;
+    public _increaseApplicationCssSelectorVersion(): void;
     public isApplicationCssSelectorsLatestVersionApplied(): boolean;
     public isLocalCssSelectorsLatestVersionApplied(): boolean;
 

--- a/nativescript-core/ui/styling/style-scope.d.ts
+++ b/nativescript-core/ui/styling/style-scope.d.ts
@@ -36,6 +36,10 @@ export class StyleScope {
     public static createSelectorsFromImports(tree: SyntaxTree, keyframes: Object): RuleSet[];
     public ensureSelectors(): number;
 
+    /**
+     * Increase the application CSS selector version.
+     */
+    public _increaseApplicationCssSelectorVersion(): number;
     public isApplicationCssSelectorsLatestVersionApplied(): boolean;
     public isLocalCssSelectorsLatestVersionApplied(): boolean;
 

--- a/nativescript-core/ui/styling/style-scope.ts
+++ b/nativescript-core/ui/styling/style-scope.ts
@@ -760,8 +760,8 @@ export class StyleScope {
         return this._getSelectorsVersion();
     }
 
-    public _increaseApplicationCssSelectorVersion(): number {
-        return applicationCssSelectorVersion++;
+    public _increaseApplicationCssSelectorVersion(): void {
+        applicationCssSelectorVersion++;
     }
 
     public isApplicationCssSelectorsLatestVersionApplied(): boolean {

--- a/nativescript-core/ui/styling/style-scope.ts
+++ b/nativescript-core/ui/styling/style-scope.ts
@@ -760,6 +760,10 @@ export class StyleScope {
         return this._getSelectorsVersion();
     }
 
+    public _increaseApplicationCssSelectorVersion(): number {
+        return applicationCssSelectorVersion++;
+    }
+
     public isApplicationCssSelectorsLatestVersionApplied(): boolean {
         return this._applicationCssSelectorsAppliedVersion === applicationCssSelectorVersion;
     }


### PR DESCRIPTION
On a runtime change of orientation or system appearance,
the respective root view CSS class updates to reflect the changes.

At the same time, increase the application CSS selector version,
so that to update styles on back navigation.

The check for back navigation is in `onNavigatingTo` method:
https://github.com/NativeScript/NativeScript/blob/6.1.0/tns-core-modules/ui/page/page-common.ts#L108-L113

Relates to #7800.