### PR TITLE
chore(hook): Check for min required webpack version

### DIFF
--- a/nativescript-core/cli-hooks/before-checkForChanges.js
+++ b/nativescript-core/cli-hooks/before-checkForChanges.js
@@ -1,13 +1,62 @@
 const semver = require("semver");
 
+const webpackPackageName = "nativescript-dev-webpack";
+
 module.exports = function ($staticConfig, hookArgs) {
     const cliVersion = semver.parse($staticConfig.version);
-    const majorVersion = cliVersion && cliVersion.major;
-    const minorVersion = cliVersion && cliVersion.minor;
     const platfrom = hookArgs.prepareData.platform;
+    const projectData = hookArgs.projectData;
 
+    // Required CLI version for building IOS: 6.2.0
     if (platfrom.toLowerCase() === "ios" &&
-        (majorVersion < 6 || (majorVersion === 6 && minorVersion < 2))) {
+        !satisfiesRequriredVersion(cliVersion, 6, 2)) {
         throw new Error(`Building @nativescript/core for iOS requires NativeScript CLI with version at least 6.2.0. Please upgrade your NativeScript CLI version (npm i -g nativescript).`);
     }
+
+    // Required webpack version for angular projects: 1.3.0
+    if (projectData.projectType === "Angular") {
+        const webpackMinVer = getMinWebpackVersion(projectData);
+
+        if (webpackMinVer && !satisfiesRequriredVersion(webpackMinVer, 1, 3)) {
+            throw new Error(`Building @nativescript/core for Angular requires ${webpackPackageName} with version at least 1.3.0. Please upgrade: npm i ${webpackPackageName} --save-dev.`);
+        }
+    }
 };
+
+/**
+ * Checks if semver object satisifies a major/minor requirement. Pre-release versions are OK too!
+ */
+function satisfiesRequriredVersion(actualVersion, requiredMajor, requiredMinor) {
+    // Return true for null version to handle tags (ex. "next", "rc")
+    if (!actualVersion) {
+        return true;
+    }
+
+    if (actualVersion.major < requiredMajor) {
+        return false;
+    }
+
+    if (actualVersion.major === requiredMajor && actualVersion.minor < requiredMinor) {
+        return false;
+    }
+
+    return true;
+}
+
+function getMinWebpackVersion(projectData) {
+    const devDependencies = projectData.devDependencies || {};
+    const dependencies = projectData.dependencies || {};
+    const webpackVer = dependencies[webpackPackageName] || devDependencies[webpackPackageName];
+
+    let webpackMinVer = null;
+
+    if (semver.valid(webpackVer)) {
+        webpackMinVer = semver.parse(webpackVer);
+    } else if (semver.validRange(webpackVer)) {
+        webpackMinVer = semver.minVersion(webpackVer);
+    } else {
+        webpackMinVer = semver.coerce(webpackVer);
+    }
+
+    return webpackMinVer;
+}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the new behavior?
Add a hook that will throw an error if building Angular project without the required version fo `nativescript-dev-webpack` (1.3.0)
