### PR TITLE
chore: More forgiving version check hook

### DIFF
--- a/nativescript-core/cli-hooks/before-checkForChanges.js
+++ b/nativescript-core/cli-hooks/before-checkForChanges.js
@@ -54,8 +54,6 @@ function getMinWebpackVersion(projectData) {
         webpackMinVer = semver.parse(webpackVer);
     } else if (semver.validRange(webpackVer)) {
         webpackMinVer = semver.minVersion(webpackVer);
-    } else {
-        webpackMinVer = semver.coerce(webpackVer);
     }
 
     return webpackMinVer;


### PR DESCRIPTION
The CLI hook that check required versions for CLI and nativescript-dev-webpack made more forgiving.

It will now wont match versions like `file:../../nativescript-dev-webpack.tgz`.