### PR TITLE
refactor(dev-tools): replace topmost() usage

### DIFF
--- a/nativescript-core/debugger/devtools-elements.common.ts
+++ b/nativescript-core/debugger/devtools-elements.common.ts
@@ -4,9 +4,6 @@ import { getNodeById } from "./dom-node";
 import { ViewBase } from "../ui/core/view-base";
 import { mainThreadify } from "../utils/utils";
 
-// Use lazy requires for core modules
-const frameTopmost = () => require("../ui/frame").topmost();
-
 let unsetValue;
 function unsetViewValue(view, name) {
     if (!unsetValue) {
@@ -27,7 +24,7 @@ function getViewById(nodeId: number): ViewBase {
 }
 
 export function getDocument() {
-    const topMostFrame = frameTopmost();
+    const topMostFrame = require("../ui/frame").Frame.topmost();
     if (!topMostFrame) {
         return undefined;
     }


### PR DESCRIPTION
Replace `topmost()` usage in dev tools.

```
topmost() is deprecated. Use Frame.topmost() instead.
topmost(file:///app/vendor.js:22230:18)
at frameTopmost(file:///app/vendor.js:4162:124)
at getDocument(file:///app/vendor.js:4179:36)
at getDocument(file:///app/vendor.js:4606:48)
at onTap(file:///app/bundle.js:283:9)
at notify(file:///app/vendor.js:3620:37)
at _emit(file:///app/vendor.js:3640:24)
at tap(file:///app/vendor.js:15523:24)
at UIApplicationMain([native code])
at _start(file:///app/vendor.js:492:26)
at run(file:///app/vendor.js:534:11)
at file:///app/bundle.js:155:16
at ./app.js(file:///app/bundle.js:172:34)
at __webpack_require__(file:///app/runtime.js:751:34)
at checkDeferredModules(file:///app/runtime.js:44:42)
at webpackJsonpCallback(file:///app/runtime.js:31:39)
at anonymous(file:///app/bundle.js:2:61)
at evaluate([native code])
at moduleEvaluation
at promiseReactionJob
```