### PR TITLE
chore: add no android.R tslint rule

### DIFF
--- a/build/lint-rules/noAndroidResourceRule.ts
+++ b/build/lint-rules/noAndroidResourceRule.ts
@@ -1,0 +1,20 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    static FAILURE_STRING = "Use of android.R is forbidden, because of performance reasons. Use a constant instead.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new Walk(sourceFile, this.getOptions()));
+    }
+}
+
+class Walk extends Lint.RuleWalker {
+    protected visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {
+        if (node.name.getText() === "R" && node.expression.getText() === "android") {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        }
+
+        super.visitPropertyAccessExpression(node);
+    }
+}

--- a/build/lint-rules/tsconfig.json
+++ b/build/lint-rules/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "sourceMap": true,        /* Generates corresponding '.map' file. */
+    "strict": true,           /* Enable all strict type-checking options. */
+    "esModuleInterop": true,   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "diagnostics": true,
+    "skipLibCheck": true
+  }
+}

--- a/build/tslint.json
+++ b/build/tslint.json
@@ -1,4 +1,5 @@
 {
+    "rulesDirectory": ["./lint-rules/"],
     "rules": {
         "arrow-return-shorthand": true,
         "class-name": true,
@@ -9,6 +10,7 @@
         "jsdoc-format": false,
         "max-line-length": [false, 120],
         "newline-before-return": true,
+        "no-android-resource": true,
         "no-arg": true,
         "no-bitwise": false,
         "no-consecutive-blank-lines": true,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "setup-link": "(cd nativescript-core && npm link) && (cd dist/tns-core-modules && npm uninstall @nativescript/core -S)",
     "setup-widgets": "(cd tns-core-modules-widgets && sh build.sh) && npm run dev-link-tns-core-modules-widgets",
     "tsc-core-watch": "tsc -p nativescript-core/tsconfig.json -w",
-    "tslint": "tslint --project tsconfig.tslint.json --config build/tslint.json",
+    "tslint": "tsc -p build/lint-rules/ && tslint --project tsconfig.tslint.json --config build/tslint.json",
     "unit-test": "tsc -p unit-tests/tsconfig.json && mocha --opts unit-tests/mocha.opts",
     "unit-test-watch": "mocha-typescript-watch -p unit-tests/tsconfig.json --opts unit-tests/mocha.opts",
     "dev-link-tns-core-modules-widgets": "(cd tns-core-modules-widgets/dist/package && npm link) && (cd nativescript-core && npm i ../tns-core-modules-widgets/dist/package --save)",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the new behavior?
Add a custom `tslint` rule that checks there are no `android.R.xxx` property access in the codebase as they cause performance issues.

>**Note**: Build currently failing as they are `android.R` usages. Should be OK after fixes are merged from `release` branch

