### PR TITLE
fix: bot nav android crash when change tab and suspend

### DIFF
--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -380,9 +380,7 @@ export class BottomNavigation extends TabNavigationBase {
             this._bottomNavigationBar.setVisibility(android.view.View.GONE);
         }
 
-        if (this._attachedToWindow) {
-            this.changeTab(this.selectedIndex);
-        }
+        this.changeTab(this.selectedIndex);
     }
 
     _onAttachedToWindow(): void {
@@ -467,8 +465,9 @@ export class BottomNavigation extends TabNavigationBase {
     // TODO: Should we extract adapter-like class?
     // TODO: Rename this?
     public changeTab(index: number) {
-        // this is the case when there are no items
-        if (index === -1) {
+        // index is -1 when there are no items
+        // bot nav is not attached if you change the tab too early
+        if (index === -1 || !this._attachedToWindow) {
             return;
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
This issue was originally reported by the PNP team. Can be reproduced with [Archive.zip](https://github.com/NativeScript/NativeScript/files/3771918/Archive.zip). There is a crash when you change tabs fast and suspend/resume the app.

## What is the new behavior?
The app doesn't crash anymore.
