### PR TITLE
fix(gradient): import LinearGradient with alias

### DIFF
--- a/nativescript-core/ui/styling/gradient.d.ts
+++ b/nativescript-core/ui/styling/gradient.d.ts
@@ -4,15 +4,15 @@
 
 import { LengthPercentUnit } from "./style-properties";
 import { Color } from "../../color";
-import { LinearGradient } from "../../css/parser";
+import { LinearGradient as LinearGradientDefinition } from "../../css/parser";
 
 export class LinearGradient {
     public angle: number;
     public colorStops: ColorStop[];
 
-    public static parse(value: LinearGradient): LinearGradient;
+    public static parse(value: LinearGradientDefinition): LinearGradientDefinition;
 
-    public static equals(first: LinearGradient, second: LinearGradient): boolean;
+    public static equals(first: LinearGradientDefinition, second: LinearGradientDefinition): boolean;
 }
 
 export interface ColorStop {


### PR DESCRIPTION
With typescript@3.7.2 this import throws `Import declaration conflicts with local declaration of 'LinearGradient'.`

