### PR TITLE
fix(dev-tools): use app root in getDocument()

### DIFF
--- a/nativescript-core/debugger/devtools-elements.common.ts
+++ b/nativescript-core/debugger/devtools-elements.common.ts
@@ -4,6 +4,9 @@ import { getNodeById } from "./dom-node";
 import { ViewBase } from "../ui/core/view-base";
 import { mainThreadify } from "../utils/utils";
 
+// Use lazy requires for core modules
+const getAppRootView = () => require("../application").getRootView();
+
 let unsetValue;
 function unsetViewValue(view, name) {
     if (!unsetValue) {
@@ -24,19 +27,19 @@ function getViewById(nodeId: number): ViewBase {
 }
 
 export function getDocument() {
-    const topMostFrame = require("../ui/frame").Frame.topmost();
-    if (!topMostFrame) {
+    const appRoot = getAppRootView();
+    if (!appRoot) {
         return undefined;
     }
 
     try {
-        topMostFrame.ensureDomNode();
+        appRoot.ensureDomNode();
 
     } catch (e) {
         console.log("ERROR in getDocument(): " + e);
     }
 
-    return topMostFrame.domNode.toObject();
+    return appRoot.domNode.toObject();
 }
 
 export function getComputedStylesForNode(nodeId): Array<{ name: string, value: string }> {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
The element returned by `frame.topmost()` was used as the root of the app in chrome-devtools elements tab.

## What is the new behavior?
The element returned by `application.getRootView()` was used as the root of the app in chrome-devtools elements tab.


