### PR TITLE
refactor(ios): Chrome DevTools Runtime domain

### DIFF
--- a/nativescript-core/debugger/webinspector-network.ios.ts
+++ b/nativescript-core/debugger/webinspector-network.ios.ts
@@ -247,14 +247,3 @@ export class NetworkDomainDebugger implements inspectorCommandTypes.NetworkDomai
         return resourceData;
     }
 }
-
-@inspectorCommands.DomainDispatcher("Runtime")
-export class RuntimeDomainDebugger {
-    constructor() {
-        __inspectorSendEvent(`{"method":"Runtime.executionContextCreated","params":{"context":{"id":1,"origin":"http://main.xml","name":"","auxData":{"isDefault":true,"frameId":"${frameId}"}}}}`);
-    }
-
-    compileScript(): { scriptId?: string, exceptionDetails?: Object } {
-        return {};
-    }
-}


### PR DESCRIPTION
Move the logic from core modules to iOS runtime. This way watches
and expressions evaluation in console will work for apps which
do not use the core modules (e.g. TestRunner of iOS runtime)

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

Merge along with https://github.com/NativeScript/ios-runtime/pull/1222
refs https://github.com/NativeScript/ios-runtime/issues/905