### PR TITLE
fix(iOS): check for iOS 13 APIs

### DIFF
--- a/nativescript-core/application/application.ios.ts
+++ b/nativescript-core/application/application.ios.ts
@@ -89,7 +89,7 @@ class CADisplayLinkTarget extends NSObject {
 }
 
 class IOSApplication implements IOSApplicationDefinition {
-    private _backgroundColor = majorVersion <= 12 ? UIColor.whiteColor : UIColor.systemBackgroundColor;
+    private _backgroundColor = (majorVersion <= 12 || !UIColor.systemBackgroundColor) ? UIColor.whiteColor : UIColor.systemBackgroundColor;
     private _delegate: typeof UIApplicationDelegate;
     private _window: UIWindow;
     private _observers: Array<NotificationObserver>;
@@ -121,7 +121,6 @@ class IOSApplication implements IOSApplicationDefinition {
     }
 
     get systemAppearance(): "light" | "dark" | null {
-
         // userInterfaceStyle is available on UITraitCollection since iOS 12.
         if (majorVersion <= 11) {
             return null;

--- a/nativescript-core/ui/activity-indicator/activity-indicator.ios.ts
+++ b/nativescript-core/ui/activity-indicator/activity-indicator.ios.ts
@@ -9,7 +9,7 @@ const majorVersion = ios.MajorVersion;
 export class ActivityIndicator extends ActivityIndicatorBase {
     nativeViewProtected: UIActivityIndicatorView;
 
-    private _activityIndicatorViewStyle = majorVersion <= 12 ? UIActivityIndicatorViewStyle.Gray : UIActivityIndicatorViewStyle.Medium;
+    private _activityIndicatorViewStyle = (majorVersion <= 12 || !UIActivityIndicatorViewStyle.Medium) ? UIActivityIndicatorViewStyle.Gray : UIActivityIndicatorViewStyle.Medium;
 
     createNativeView() {
         const viewStyle = this._activityIndicatorViewStyle;

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -93,7 +93,9 @@ class UITabBarControllerImpl extends UITabBarController {
 
         if (majorVersion >= 13) {
             const owner = this._owner.get();
-            if (owner && this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
+            if (owner &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
                 owner.notify({ eventName: iosView.traitCollectionColorAppearanceChangedEvent, object: owner });
             }
         }

--- a/nativescript-core/ui/core/view/view.ios.ts
+++ b/nativescript-core/ui/core/view/view.ios.ts
@@ -1012,7 +1012,9 @@ export namespace ios {
 
             if (majorVersion >= 13) {
                 const owner = this.owner.get();
-                if (owner && this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
+                if (owner &&
+                    this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection &&
+                    this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
                     owner.notify({ eventName: traitCollectionColorAppearanceChangedEvent, object: owner });
                 }
             }

--- a/nativescript-core/ui/frame/frame.ios.ts
+++ b/nativescript-core/ui/frame/frame.ios.ts
@@ -540,7 +540,9 @@ class UINavigationControllerImpl extends UINavigationController {
 
         if (majorVersion >= 13) {
             const owner = this._owner.get();
-            if (owner && this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
+            if (owner &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
                 owner.notify({ eventName: iosView.traitCollectionColorAppearanceChangedEvent, object: owner });
             }
         }

--- a/nativescript-core/ui/html-view/html-view.ios.ts
+++ b/nativescript-core/ui/html-view/html-view.ios.ts
@@ -59,7 +59,7 @@ export class HtmlView extends HtmlViewBase {
             null
         );
 
-        if (majorVersion >= 13) {
+        if (majorVersion >= 13 && UIColor.labelColor) {
             this.nativeViewProtected.textColor = UIColor.labelColor;
         }
     }

--- a/nativescript-core/ui/page/page.ios.ts
+++ b/nativescript-core/ui/page/page.ios.ts
@@ -300,7 +300,7 @@ export class Page extends PageBase {
     nativeViewProtected: UIView;
     viewController: UIViewControllerImpl;
 
-    private _backgroundColor = majorVersion <= 12 ? UIColor.whiteColor : UIColor.systemBackgroundColor;
+    private _backgroundColor = (majorVersion <= 12 && !UIColor.systemBackgroundColor) ? UIColor.whiteColor : UIColor.systemBackgroundColor;
     private _ios: UIViewControllerImpl;
     public _presentedViewController: UIViewController; // used when our page present native viewController without going through our abstraction.
 

--- a/nativescript-core/ui/page/page.ios.ts
+++ b/nativescript-core/ui/page/page.ios.ts
@@ -287,7 +287,9 @@ class UIViewControllerImpl extends UIViewController {
 
         if (majorVersion >= 13) {
             const owner = this._owner.get();
-            if (owner && this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
+            if (owner &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
                 owner.notify({ eventName: iosView.traitCollectionColorAppearanceChangedEvent, object: owner });
             }
         }

--- a/nativescript-core/ui/tab-view/tab-view.ios.ts
+++ b/nativescript-core/ui/tab-view/tab-view.ios.ts
@@ -78,7 +78,9 @@ class UITabBarControllerImpl extends UITabBarController {
 
         if (majorVersion >= 13) {
             const owner = this._owner.get();
-            if (owner && this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
+            if (owner &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
                 owner.notify({ eventName: iosView.traitCollectionColorAppearanceChangedEvent, object: owner });
             }
         }

--- a/nativescript-core/ui/tabs/tabs.ios.ts
+++ b/nativescript-core/ui/tabs/tabs.ios.ts
@@ -100,7 +100,7 @@ class UIPageViewControllerImpl extends UIPageViewController {
 
         tabBar.delegate = this.tabBarDelegate = MDCTabBarDelegateImpl.initWithOwner(new WeakRef(owner));
 
-        if (majorVersion <= 12) {
+        if (majorVersion <= 12 || !UIColor.labelColor) {
             tabBar.tintColor = UIColor.blueColor;
             tabBar.barTintColor = UIColor.whiteColor;
             tabBar.setTitleColorForState(UIColor.blackColor, MDCTabBarItemState.Normal);

--- a/nativescript-core/ui/tabs/tabs.ios.ts
+++ b/nativescript-core/ui/tabs/tabs.ios.ts
@@ -24,7 +24,7 @@ export * from "./tabs-common";
 const majorVersion = iosUtils.MajorVersion;
 
 // Equivalent to dispatch_async(dispatch_get_main_queue(...)) call
-const invokeOnRunLoop = (function() {
+const invokeOnRunLoop = (function () {
     const runloop = CFRunLoopGetMain();
 
     return (action: () => any) => {
@@ -216,7 +216,9 @@ class UIPageViewControllerImpl extends UIPageViewController {
 
         if (majorVersion >= 13) {
             const owner = this._owner.get();
-            if (owner && this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
+            if (owner &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection &&
+                this.traitCollection.hasDifferentColorAppearanceComparedToTraitCollection(previousTraitCollection)) {
                 owner.notify({ eventName: iosView.traitCollectionColorAppearanceChangedEvent, object: owner });
             }
         }
@@ -1087,7 +1089,7 @@ export class Tabs extends TabsBase {
                         // HACK: UIPageViewController fix; see https://stackoverflow.com/a/17330606
                         invokeOnRunLoop(() => this.viewController.setViewControllersDirectionAnimatedCompletion(controllers, navigationDirection, false, null));
                     }
-                    
+
                     this._canSelectItem = true;
                     this._setCanBeLoaded(value);
                     this._loadUnloadTabItems(value);

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -153,7 +153,7 @@ export class TextBase extends TextBaseCommon {
             this.nativeTextViewProtected.setAttributedTitleForState(attrText, UIControlState.Normal);
         }
         else {
-            if (majorVersion >= 13) {
+            if (majorVersion >= 13 && UIColor.labelColor) {
                 this.nativeTextViewProtected.textColor = UIColor.labelColor;
             }
 
@@ -205,7 +205,7 @@ export class TextBase extends TextBaseCommon {
         if (dict.size > 0 || isTextView) {
             if (style.color) {
                 dict.set(NSForegroundColorAttributeName, style.color.ios);
-            } else if (majorVersion >= 13) {
+            } else if (majorVersion >= 13 && UIColor.labelColor) {
                 dict.set(NSForegroundColorAttributeName, UIColor.labelColor);
             }
         }

--- a/nativescript-core/ui/text-view/text-view.ios.ts
+++ b/nativescript-core/ui/text-view/text-view.ios.ts
@@ -116,8 +116,8 @@ export class TextView extends EditableTextBase implements TextViewDefinition {
     private _isShowingHint: boolean;
     public _isEditing: boolean;
 
-    private _hintColor = majorVersion <= 12 ? UIColor.blackColor.colorWithAlphaComponent(0.22) : UIColor.placeholderTextColor;
-    private _textColor = majorVersion <= 12 ? null : UIColor.labelColor;
+    private _hintColor = (majorVersion <= 12 || !UIColor.placeholderTextColor) ? UIColor.blackColor.colorWithAlphaComponent(0.22) : UIColor.placeholderTextColor;
+    private _textColor = (majorVersion <= 12 || !UIColor.labelColor) ? null : UIColor.labelColor;
 
     createNativeView() {
         const textView = NoScrollAnimationUITextView.new();

--- a/tests/app/ui/page/page-tests-common.ts
+++ b/tests/app/ui/page/page-tests-common.ts
@@ -385,7 +385,7 @@ export function test_page_backgroundColor() {
     helper.navigate(factory);
 
     if (isIOS) {
-        const backgroundColor = ios.MajorVersion <= 12 ? UIColor.whiteColor : UIColor.systemBackgroundColor;
+        const backgroundColor = (ios.MajorVersion <= 12 || !UIColor.systemBackgroundColor) ? UIColor.whiteColor : UIColor.systemBackgroundColor;
         TKUnit.assertEqual(page.nativeView.backgroundColor, backgroundColor, "page backgroundColor is wrong");
     } else {
         const whiteColor = new Color("white");


### PR DESCRIPTION
### Scenario

Build the application with Xcode 10 (no iOS 13 APIs available) and deploy it to iOS 13.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The application crashes.

## What is the new behavior?
<!-- Describe the changes. -->

The application runs and fallbacks to APIs < 13.