### PR TITLE
test: execute api-extractor on CI properly

### DIFF
--- a/api-reports/NativeScript.api.md
+++ b/api-reports/NativeScript.api.md
@@ -219,7 +219,7 @@ export class Animation {
     // (undocumented)
     public isPlaying: boolean;
     // Warning: (ae-forgotten-export) The symbol "AnimationPromise" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public play: (resetOnFinish?: boolean) => AnimationPromise;
     // (undocumented)
@@ -432,7 +432,7 @@ export interface CommonLayoutParams {
     // (undocumented)
     heightPercent: number;
     // Warning: (ae-forgotten-export) The symbol "HorizontalAlignment" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     horizontalAlignment: HorizontalAlignment;
     // (undocumented)
@@ -448,7 +448,7 @@ export interface CommonLayoutParams {
     // (undocumented)
     topMarginPercent: number;
     // Warning: (ae-forgotten-export) The symbol "VerticalAlignment" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     verticalAlignment: VerticalAlignment;
     // (undocumented)
@@ -466,7 +466,7 @@ export const Connectivity: {
 };
 
 // Warning: (ae-forgotten-export) The symbol "AddChildFromBuilder" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class ContentView extends View implements AddChildFromBuilder {
     // (undocumented)
@@ -524,7 +524,7 @@ export class DefaultErrorHandler implements ErrorHandler {
 }
 
 // Warning: (ae-forgotten-export) The symbol "Device" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export const Device: Device_2;
 
@@ -668,19 +668,19 @@ export class FileSystemEntity {
 // @public (undocumented)
 export class FlexboxLayout extends LayoutBase {
     // Warning: (ae-forgotten-export) The symbol "AlignContent" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public alignContent: AlignContent;
     // Warning: (ae-forgotten-export) The symbol "AlignItems" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public alignItems: AlignItems;
     // Warning: (ae-forgotten-export) The symbol "FlexDirection" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public flexDirection: FlexDirection;
     // Warning: (ae-forgotten-export) The symbol "FlexWrap" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public flexWrap: FlexWrap;
     // (undocumented)
@@ -694,11 +694,11 @@ export class FlexboxLayout extends LayoutBase {
     // (undocumented)
     public static getOrder(view: View): number;
     // Warning: (ae-forgotten-export) The symbol "JustifyContent" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public justifyContent: JustifyContent;
     // Warning: (ae-forgotten-export) The symbol "AlignSelf" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public static setAlignSelf(view: View, align: AlignSelf);
     // (undocumented)
@@ -845,7 +845,7 @@ export class Frame extends View {
     _removeFromFrameStack();
 
     // Warning: (ae-forgotten-export) The symbol "NavigationType" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     setCurrent(entry: BackstackEntry, navigationType: NavigationType): void;
 
@@ -1309,7 +1309,7 @@ export interface LaunchEventData extends ApplicationEventData {
 }
 
 // Warning: (ae-forgotten-export) The symbol "CustomLayoutView" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class LayoutBase extends CustomLayoutView {
     addChild(view: View): void;
@@ -1832,7 +1832,7 @@ export class SearchBar extends View {
 }
 
 // Warning: (ae-forgotten-export) The symbol "AddArrayFromBuilder" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class SegmentedBar extends View implements AddChildFromBuilder, AddArrayFromBuilder {
     // (undocumented)
@@ -1874,6 +1874,8 @@ export interface ShowModalOptions {
     }
 
     animated?: boolean;
+
+    cancelable?: boolean
 
     closeCallback: Function;
 
@@ -1962,17 +1964,17 @@ export class Style extends Observable {
     // (undocumented)
     public backgroundColor: Color;
     // Warning: (ae-forgotten-export) The symbol "LinearGradient" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public backgroundImage: string | LinearGradient;
     // Warning: (ae-forgotten-export) The symbol "Background" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public backgroundInternal: Background;
     // (undocumented)
     public backgroundPosition: string;
     // Warning: (ae-forgotten-export) The symbol "BackgroundRepeat" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public backgroundRepeat: BackgroundRepeat;
     // (undocumented)
@@ -2014,17 +2016,17 @@ export class Style extends Observable {
     // (undocumented)
     public flexDirection: FlexDirection;
     // Warning: (ae-forgotten-export) The symbol "FlexGrow" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public flexGrow: FlexGrow;
     // Warning: (ae-forgotten-export) The symbol "FlexShrink" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public flexShrink: FlexShrink;
     // (undocumented)
     public flexWrap: FlexWrap;
     // Warning: (ae-forgotten-export) The symbol "FlexWrapBefore" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public flexWrapBefore: FlexWrapBefore;
     // (undocumented)
@@ -2067,7 +2069,7 @@ export class Style extends Observable {
     // (undocumented)
     public opacity: number;
     // Warning: (ae-forgotten-export) The symbol "Order" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public order: Order;
     // (undocumented)
@@ -2109,19 +2111,19 @@ export class Style extends Observable {
     // (undocumented)
     public tabTextFontSize: number;
     // Warning: (ae-forgotten-export) The symbol "TextAlignment" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public textAlignment: TextAlignment;
     // (undocumented)
     public textDecoration: TextDecoration;
     // Warning: (ae-forgotten-export) The symbol "TextTransform" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public textTransform: TextTransform;
     // (undocumented)
     public tintColor: Color;
     // Warning: (ae-forgotten-export) The symbol "dip" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public translateX: dip;
     // (undocumented)
@@ -2133,11 +2135,11 @@ export class Style extends Observable {
     // (undocumented)
     public viewRef: WeakRef<ViewBase>;
     // Warning: (ae-forgotten-export) The symbol "Visibility" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public visibility: Visibility;
     // Warning: (ae-forgotten-export) The symbol "WhiteSpace" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public whiteSpace: WhiteSpace;
     // (undocumented)
@@ -2749,7 +2751,7 @@ export abstract class ViewBase extends Observable {
     public _automaticallyAdjustsScrollViewInsets: boolean;
     public _batchUpdate<T>(callback: () => T): T;
     // Warning: (ae-forgotten-export) The symbol "BindingOptions" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     public bind(options: BindingOptions, source?: Object): void;
     // (undocumented)
@@ -2793,7 +2795,7 @@ export abstract class ViewBase extends Observable {
     // (undocumented)
     _domId: number;
     // Warning: (ae-forgotten-export) The symbol "DOMNode" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     domNode: DOMNode;
     public eachChild(callback: (child: ViewBase) => boolean): void;
@@ -2987,7 +2989,7 @@ export class XmlParser {
 
 
 // Warnings were encountered during analysis:
-// 
+//
 // nativescript-core/index.d.ts:15:5 - (ae-forgotten-export) The symbol "getMainEntry" needs to be exported by the entry point index.d.ts
 // nativescript-core/index.d.ts:16:5 - (ae-forgotten-export) The symbol "getRootView" needs to be exported by the entry point index.d.ts
 // nativescript-core/index.d.ts:17:5 - (ae-forgotten-export) The symbol "setResources" needs to be exported by the entry point index.d.ts
@@ -3061,9 +3063,9 @@ export class XmlParser {
 // nativescript-core/index.d.ts:117:5 - (ae-forgotten-export) The symbol "layout" needs to be exported by the entry point index.d.ts
 // nativescript-core/index.d.ts:118:5 - (ae-forgotten-export) The symbol "ad" needs to be exported by the entry point index.d.ts
 // nativescript-core/index.d.ts:119:5 - (ae-forgotten-export) The symbol "ios" needs to be exported by the entry point index.d.ts
-// nativescript-core/ui/core/view-base/view-base.d.ts:166:26 - (ae-forgotten-export) The symbol "Property" needs to be exported by the entry point index.d.ts
-// nativescript-core/ui/core/view-base/view-base.d.ts:166:26 - (ae-forgotten-export) The symbol "CssProperty" needs to be exported by the entry point index.d.ts
-// nativescript-core/ui/core/view-base/view-base.d.ts:166:26 - (ae-forgotten-export) The symbol "CssAnimationProperty" needs to be exported by the entry point index.d.ts
+// nativescript-core/ui/core/view-base/view-base.d.ts:171:26 - (ae-forgotten-export) The symbol "Property" needs to be exported by the entry point index.d.ts
+// nativescript-core/ui/core/view-base/view-base.d.ts:171:26 - (ae-forgotten-export) The symbol "CssProperty" needs to be exported by the entry point index.d.ts
+// nativescript-core/ui/core/view-base/view-base.d.ts:171:26 - (ae-forgotten-export) The symbol "CssAnimationProperty" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/build/prepare-core.sh
+++ b/build/prepare-core.sh
@@ -51,7 +51,7 @@ mkdir -p "$DIST"
     npx rimraf "$DIST/$PACKAGE"
     npx rimraf "$DIST/$PACKAGE*.tgz"
 
-    npm run api-extractor
+    npm run api-extractor-ci
 
     echo "Copying $PACKAGE $DIST/$PACKAGE..."
     npx ncp "$PACKAGE" "$DIST/$PACKAGE"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.5.0",
+    "@microsoft/api-extractor": "7.6.1",
     "@nativescript/tslint-rules": "0.0.5",
     "@types/chai": "^4.0.4",
     "@types/mocha": "^2.2.42",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
The `npm run setup` script was generating the api-report file each time. Executing `npm run api-extractor-ci` after that will always succeed as it will check to the newly generated api-report.  

## What is the new behavior?
The setup script will not re-generate the api-report and use the one coming from git. 

