### PR TITLE
test: fix private nativescript-dev-webpack API usage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -69,6 +69,16 @@
             "stopOnEntry": true,
             "watch": true,
         },
+        {
+            "name": "Debug tests on iOS",
+            "type": "nativescript",
+            "request": "launch",
+            "platform": "ios",
+            "appRoot": "${workspaceRoot}/tests",
+            "sourceMaps": true,
+            "stopOnEntry": true,
+            "watch": true,
+        },
         // {
         //     "name": "Test on Android",
         //     "type": "nativescript",

--- a/tests/app/livesync/livesync-tests.ts
+++ b/tests/app/livesync/livesync-tests.ts
@@ -249,7 +249,7 @@ function _test_onLiveSync_ModalViewClosed(context: ModuleContext) {
 }
 
 function livesync(context: ModuleContext) {
-    const ls = (<any>global).__hmrSyncBackup || global.__onLiveSync;
+    const ls = (<any>global).__coreModulesLiveSync || global.__onLiveSync;
     ls(context);
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

The `__hmrSyncBackup` is renamed to `__coreModulesLiveSync` starting from this PR: https://github.com/NativeScript/nativescript-dev-webpack/pull/1081/files