### PR TITLE
fix(ios/bottom-navigation): Changing tabs programatically messes up styles

### DIFF
--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -155,23 +155,6 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 
         const owner = this._owner.get();
         if (owner) {
-            if (tabBarController.viewControllers) {
-                const position = tabBarController.viewControllers.indexOfObject(viewController);
-                if (position !== NSNotFound) {
-                    const prevPosition = owner.selectedIndex;
-                    const tabStripItems = owner.tabStrip && owner.tabStrip.items;
-                    if (tabStripItems) {
-                        if (tabStripItems[position]) {
-                            tabStripItems[position]._emit(TabStripItem.selectEvent);
-                        }
-
-                        if (tabStripItems[prevPosition]) {
-                            tabStripItems[prevPosition]._emit(TabStripItem.unselectEvent);
-                        }
-                    }
-                }
-            }
-
             owner._onViewControllerShown(viewController);
         }
 
@@ -354,6 +337,17 @@ export class BottomNavigation extends TabNavigationBase {
 
             newItem.canBeLoaded = true;
             newItem.loadView(newItem.content);
+        }
+
+        const tabStripItems = this.tabStrip && this.tabStrip.items;
+        if (tabStripItems) {
+            if (tabStripItems[newIndex]) {
+                tabStripItems[newIndex]._emit(TabStripItem.selectEvent);
+            }
+
+            if (tabStripItems[oldIndex]) {
+                tabStripItems[oldIndex]._emit(TabStripItem.unselectEvent);
+            }
         }
 
         super.onSelectedIndexChanged(oldIndex, newIndex);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Currently, TabStrip items event emitting only when user click on UITabBar within processing `tabBarControllerDidSelectViewController` handler method of `UITabBarControllerDelegate` class. That is why when `selectedIndex` property changed programmatically TabStrip styling messed up.

## What is the new behavior?
Current fix, just move TabStrip items event emitting into `onSelectedIndexChanged` handler, which called on processing `tabBarControllerDidSelectViewController` handler method (within `_onViewControllerShown` method) and on processing `selectedIndex` property changed programmatically.

Fixes/Implements/Closes #7667.

