### PR TITLE
fix(8104): BottomNavigation crash on resume

### DIFF
--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -275,8 +275,8 @@ export class Frame extends FrameBase {
             fragmentExitTransition.setResetOnTransitionEnd(true);
         }
 
-        transaction.remove(fragment);
         transaction.commitNowAllowingStateLoss();
+        transaction.remove(fragment);
     }
 
     private createFragment(backstackEntry: BackstackEntry, fragmentTag: string): androidx.fragment.app.Fragment {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using BottomNavigation caused a crash on Android 10 when the app resumed, with an error like this:

```bash
Error: java.lang.IllegalArgumentException: No view found for id 0x2 (unknown) for fragment FragmentBase_vendor_15352_26_TabFragmentImplementation{54a9e51 #1 id=0x2 android:bottomnavigation:2:1}
```

## What is the new behavior?
<!-- Describe the changes. -->
Not crashing anymore.

Fixes #8104.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->