### PR TITLE
fix(ios-text-base): button textAlignment on IOS (UIButton)

### DIFF
--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -139,7 +139,12 @@ export class TextBase extends TextBaseCommon {
             const paragraphStyle = NSMutableParagraphStyle.alloc().init();
             paragraphStyle.lineSpacing = this.lineHeight;
             // make sure a possible previously set text alignment setting is not lost when line height is specified
-            paragraphStyle.alignment = (<UITextField | UITextView | UILabel>this.nativeTextViewProtected).textAlignment;
+            if (this.nativeTextViewProtected instanceof UIButton) {
+                paragraphStyle.alignment = (<UIButton>this.nativeTextViewProtected).titleLabel.textAlignment;
+            } else {
+                paragraphStyle.alignment = (<UITextField | UITextView | UILabel>this.nativeTextViewProtected).textAlignment;
+            }
+
             if (this.nativeTextViewProtected instanceof UILabel) {
                 // make sure a possible previously set line break mode is not lost when line height is specified
                 paragraphStyle.lineBreakMode = this.nativeTextViewProtected.lineBreakMode;
@@ -192,7 +197,12 @@ export class TextBase extends TextBaseCommon {
             const paragraphStyle = NSMutableParagraphStyle.alloc().init();
             paragraphStyle.lineSpacing = style.lineHeight;
             // make sure a possible previously set text alignment setting is not lost when line height is specified
-            paragraphStyle.alignment = (<UITextField | UITextView | UILabel>this.nativeTextViewProtected).textAlignment;
+            if (this.nativeTextViewProtected instanceof UIButton) {
+                paragraphStyle.alignment = (<UIButton>this.nativeTextViewProtected).titleLabel.textAlignment;
+            } else {
+                paragraphStyle.alignment = (<UITextField | UITextView | UILabel>this.nativeTextViewProtected).textAlignment;
+            }
+
             if (this.nativeTextViewProtected instanceof UILabel) {
                 // make sure a possible previously set line break mode is not lost when line height is specified
                 paragraphStyle.lineBreakMode = this.nativeTextViewProtected.lineBreakMode;


### PR DESCRIPTION
## Introduction
When setting the format of a "text view", we need to recover existing values for properties that will get default values otherwise.

## What is the current behavior?
The "textAlignment" of a UIButton is available through a "titleLabel" object instead of directly on itself (see IOS documentation fo UIButton).
Currently, when setting a new format on a UIButton, the recovered value for textAlignment would always be `undefined`, and therefore the default value for textAlignment would always be applied when instantiating a new paragraphStyling.

## What is the new behavior?
After this commit, the previously set textAlignment (if any) is properly recovered and reused.

fixes pr #8151 