### PR TITLE
feat: Make css-tree the default parser

### DIFF
--- a/nativescript-core/ui/styling/style-scope.ts
+++ b/nativescript-core/ui/styling/style-scope.ts
@@ -53,12 +53,12 @@ function ensureCssAnimationParserModule() {
     }
 }
 
-let parser: "rework" | "nativescript" | "css-tree" = "rework";
+let parser: "rework" | "nativescript" | "css-tree" = "css-tree";
 try {
     const appConfig = require("~/package.json");
     if (appConfig) {
-        if (appConfig.cssParser === "css-tree") {
-            parser = "css-tree";
+        if (appConfig.cssParser === "rework") {
+            parser = "rework";
         } else if (appConfig.cssParser === "nativescript") {
             parser = "nativescript";
         }


### PR DESCRIPTION
#PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

Rework is the current default CSS parser

## What is the new behavior?

css-tree is the new default CSS parser

The old parser is still available and can be enabled by setting the `cssParser` property in `package.json`:

```json
{
    "main": "bundle",
    "cssParser": "rework",
    "android": {
        "v8Flags": "--expose_gc",
        "markingMode": "none"
    }
}
```