### PR TITLE
feat: add integer only keyboard type for text-field

### DIFF
--- a/nativescript-core/ui/editable-text-base/editable-text-base-common.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base-common.ts
@@ -38,7 +38,7 @@ export abstract class EditableTextBase extends TextBase implements EditableTextB
 export const placeholderColorProperty = new CssProperty<Style, Color>({ name: "placeholderColor", cssName: "placeholder-color", equalityComparer: Color.equals, valueConverter: (v) => new Color(v) });
 placeholderColorProperty.register(Style);
 
-const keyboardTypeConverter = makeParser<KeyboardType>(makeValidator<KeyboardType>("datetime", "phone", "number", "url", "email"));
+const keyboardTypeConverter = makeParser<KeyboardType>(makeValidator<KeyboardType>("datetime", "phone", "number", "url", "email", "integer"));
 
 export const keyboardTypeProperty = new Property<EditableTextBase, KeyboardType>({ name: "keyboardType", valueConverter: keyboardTypeConverter });
 keyboardTypeProperty.register(EditableTextBase);

--- a/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
@@ -248,8 +248,9 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
     [keyboardTypeProperty.getDefault](): number {
         return this.nativeTextViewProtected.getInputType();
     }
-    [keyboardTypeProperty.setNative](value: "datetime" | "phone" | "number" | "url" | "email" | number) {
+    [keyboardTypeProperty.setNative](value: "datetime" | "phone" | "number" | "url" | "email" | "integer" | number) {
         let newInputType;
+
         switch (value) {
             case "datetime":
                 newInputType = android.text.InputType.TYPE_CLASS_DATETIME | android.text.InputType.TYPE_DATETIME_VARIATION_NORMAL;
@@ -269,6 +270,10 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
             case "email":
                 newInputType = android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
+                break;
+
+            case "integer":
+                newInputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD;
                 break;
 
             default:

--- a/nativescript-core/ui/editable-text-base/editable-text-base.d.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base.d.ts
@@ -65,7 +65,7 @@ export class EditableTextBase extends TextBase {
     //@endprivate
 }
 
-export type KeyboardType = "datetime" | "phone" | "number" | "url" | "email";
+export type KeyboardType = "datetime" | "phone" | "number" | "url" | "email" | "integer";
 export type ReturnKeyType = "done" | "next" | "go" | "search" | "send";
 export type UpdateTextTrigger = "focusLost" | "textChanged";
 export type AutocapitalizationType = "none" | "words" | "sentences" | "allcharacters";

--- a/nativescript-core/ui/editable-text-base/editable-text-base.ios.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base.ios.ts
@@ -13,7 +13,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
         this.notify({ eventName: EditableTextBase.blurEvent, object: this });
     }
 
-    [keyboardTypeProperty.getDefault](): "datetime" | "phone" | "number" | "url" | "email" | string {
+    [keyboardTypeProperty.getDefault](): "datetime" | "phone" | "number" | "url" | "email" | "integer" | string {
         let keyboardType = this.nativeTextViewProtected.keyboardType;
         switch (keyboardType) {
             case UIKeyboardType.NumbersAndPunctuation:
@@ -28,11 +28,14 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
             case UIKeyboardType.EmailAddress:
                 return "email";
 
+            case UIKeyboardType.NumberPad:
+                return "integer";
+
             default:
                 return keyboardType.toString();
         }
     }
-    [keyboardTypeProperty.setNative](value: "datetime" | "phone" | "number" | "url" | "email" | string) {
+    [keyboardTypeProperty.setNative](value: "datetime" | "phone" | "number" | "url" | "email" | "integer" | string) {
         let newKeyboardType: UIKeyboardType;
         switch (value) {
             case "datetime":
@@ -53,6 +56,10 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 ;
             case "email":
                 newKeyboardType = UIKeyboardType.EmailAddress;
+                break;
+
+            case "integer":
+                newKeyboardType = UIKeyboardType.NumberPad;
                 break;
 
             default:

--- a/nativescript-core/ui/enums/enums.d.ts
+++ b/nativescript-core/ui/enums/enums.d.ts
@@ -73,6 +73,12 @@ export module KeyboardType {
      * iOS:  [UIKeyboardTypeEmailAddress](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
      */
     export const email: BaseKeyboardType
+
+    /**
+     * Android: [TYPE_CLASS_NUMBER](http://developer.android.com/reference/android/text/InputType.html#TYPE_CLASS_NUMBER | [TYPE_NUMBER_VARIATION_PASSWORD](android type_text_variation_password)) 
+     * iOS:  [UIKeyboardTypeNumberPad](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType)
+     */
+    export const integer: BaseKeyboardType
 }
 
 /**

--- a/nativescript-core/ui/enums/enums.ts
+++ b/nativescript-core/ui/enums/enums.ts
@@ -7,6 +7,7 @@ export module KeyboardType {
     export const number = "number";
     export const url = "url";
     export const email = "email";
+    export const integer = "integer";
 }
 
 export module ReturnKeyType {

--- a/nativescript-core/ui/text-field/text-field.android.ts
+++ b/nativescript-core/ui/text-field/text-field.android.ts
@@ -77,6 +77,9 @@ export class TextField extends TextFieldBase {
                 case "email":
                     inputType = android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
                     break;
+                case "integer":
+                    inputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD;
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.


## What is the new behavior?

Adding integer only keyboard type for text-field and for all editable text components. This type has no additional options (which is different from the **number** type)

```XML
<TextField keyboardType="integer"/>
```

Results an integer only keyboard types (Android and iOS):
![Screen Shot 2019-12-12 at 10 55 09 AM](https://user-images.githubusercontent.com/18008302/70697393-1a66b200-1cce-11ea-9b94-92320289c74a.png)


Related to feature request https://github.com/NativeScript/NativeScript/issues/3303
