### PR TITLE
feat: Provide way to center longer content for the SegmentedBarItem on Android

### DIFF
--- a/nativescript-core/ui/segmented-bar/segmented-bar-common.ts
+++ b/nativescript-core/ui/segmented-bar/segmented-bar-common.ts
@@ -1,8 +1,10 @@
 ﻿import { SegmentedBar as SegmentedBarDefinition, SegmentedBarItem as SegmentedBarItemDefinition, SelectedIndexChangedEventData } from ".";
 import {
     ViewBase, View, AddChildFromBuilder, AddArrayFromBuilder,
-    Property, CoercibleProperty, InheritedCssProperty, Color, Style, EventData, CSSType
+    Property, CoercibleProperty, InheritedCssProperty, Color, Style, EventData, CSSType,
+    makeParser, makeValidator
 } from "../core/view";
+import { SegmentedBarItemTextAlignment } from "./segmented-bar";
 
 export * from "../core/view";
 
@@ -13,11 +15,24 @@ export module knownCollections {
 @CSSType("SegmentedBarItem")
 export abstract class SegmentedBarItemBase extends ViewBase implements SegmentedBarItemDefinition {
     private _title: string = "";
+    private _textAlign: SegmentedBarItemTextAlignment = "initial";
 
     get title(): string {
         return this._title;
     }
     set title(value: string) {
+        let strValue = (value !== null && value !== undefined) ? value.toString() : "";
+        if (this._title !== strValue) {
+            this._title = strValue;
+            this._update();
+        }
+    }
+
+    get textAlignment() {
+        return this._textAlign;
+    }
+
+    set textAligment(value: string) {
         let strValue = (value !== null && value !== undefined) ? value.toString() : "";
         if (this._title !== strValue) {
             this._title = strValue;
@@ -136,3 +151,7 @@ itemsProperty.register(SegmentedBarBase);
 
 export const selectedBackgroundColorProperty = new InheritedCssProperty<Style, Color>({ name: "selectedBackgroundColor", cssName: "selected-background-color", equalityComparer: Color.equals, valueConverter: (v) => new Color(v) });
 selectedBackgroundColorProperty.register(Style);
+
+const textAlignmentConverter = makeParser<SegmentedBarItemTextAlignment>(makeValidator<SegmentedBarItemTextAlignment>("initial", "left", "center", "right"));
+export const textAlignmentProperty = new Property<SegmentedBarItemBase, SegmentedBarItemTextAlignment>({ name: "textAlignment", defaultValue: "initial", valueConverter: textAlignmentConverter });
+textAlignmentProperty.register(SegmentedBarItemBase);

--- a/nativescript-core/ui/segmented-bar/segmented-bar.android.ts
+++ b/nativescript-core/ui/segmented-bar/segmented-bar.android.ts
@@ -1,8 +1,9 @@
 import { Font } from "../styling/font";
 import {
     SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty,
-    colorProperty, fontInternalProperty, fontSizeProperty, Color, layout
+    colorProperty, fontInternalProperty, fontSizeProperty, Color, layout, textAlignmentProperty
 } from "./segmented-bar-common";
+import { SegmentedBarItemTextAlignment } from "./segmented-bar";
 
 export * from "./segmented-bar-common";
 
@@ -146,6 +147,25 @@ export class SegmentedBarItem extends SegmentedBarItemBase {
     }
     [fontInternalProperty.setNative](value: Font | android.graphics.Typeface) {
         this.nativeViewProtected.setTypeface(value instanceof Font ? value.getAndroidTypeface() : value);
+    }
+
+    [textAlignmentProperty.getDefault](): SegmentedBarItemTextAlignment {
+        return "initial";
+    }
+    [textAlignmentProperty.setNative](value: SegmentedBarItemTextAlignment) {
+        let verticalGravity = this.nativeViewProtected.getGravity() & android.view.Gravity.VERTICAL_GRAVITY_MASK;
+        switch (value) {
+            case "initial":
+            case "left":
+                this.nativeViewProtected.setGravity(android.view.Gravity.START | verticalGravity);
+                break;
+            case "center":
+                this.nativeViewProtected.setGravity(android.view.Gravity.CENTER_HORIZONTAL | verticalGravity);
+                break;
+            case "right":
+                this.nativeViewProtected.setGravity(android.view.Gravity.END | verticalGravity);
+                break;
+        }
     }
 
     [selectedBackgroundColorProperty.getDefault](): android.graphics.drawable.Drawable {

--- a/nativescript-core/ui/segmented-bar/segmented-bar.d.ts
+++ b/nativescript-core/ui/segmented-bar/segmented-bar.d.ts
@@ -17,6 +17,11 @@ export class SegmentedBarItem extends ViewBase {
      * Gets or sets the title of the SegmentedBarItem.
      */
     public title: string;
+
+    /**
+     * Gets or sets text-alignment style property.
+     */
+    public textAlignment: SegmentedBarItemTextAlignment;
 }
 
 /**
@@ -94,3 +99,5 @@ export const selectedBackgroundColorProperty: CssProperty<Style, Color>;
  * Gets or sets the items dependency property of the SegmentedBar.
  */
 export const itemsProperty: Property<SegmentedBar, SegmentedBarItem[]>;
+
+export type SegmentedBarItemTextAlignment = "initial" | "left" | "center" | "right";


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

Currently longer content is auto-aligned to left on Android - thus breaking the default centered alignment.

On iOS, all items will always be centered.

## What is the new behavior?
Providing a way to center a longer text content for SegmentedBarItem on Android.
Related to https://github.com/NativeScript/NativeScript/issues/6974

Fixes/Implements/Closes #[Issue Number].

 https://github.com/NativeScript/NativeScript/issues/6974


The PR covers the following scenariosni1:
```XML
<!-- As set via textAlignment -->
<SegmentedBar row="0"  class="m-5" selectedIndex="{{ sbSelectedIndex }}">
    <SegmentedBar.items>
        <SegmentedBarItem title="LONG TITLE HERE Left Item 1" textAlignment="left" />
        <SegmentedBarItem title="LONG TITLE HERE Center Item 2" textAlignment="center" />
        <SegmentedBarItem title="LONG TITLE HERE Right Item 3" textAlignment="right" />
    </SegmentedBar.items>
</SegmentedBar>
<!-- 
    Default for longer content (no textAlignment) as native (all on left on Android) - 
    leaviong this to prevent breaking change 
-->
<SegmentedBar row="1"  class="m-5" selectedIndex="{{ sbSelectedIndex }}">
    <SegmentedBar.items>
        <SegmentedBarItem title="LONG TITLE HERE Left Item 1" />
        <SegmentedBarItem title="LONG TITLE HERE Left Item 2" />
        <SegmentedBarItem title="LONG TITLE HERE Left Item 3" />
    </SegmentedBar.items>
</SegmentedBar>
<!-- All centered (as default on iOS)  -->
<SegmentedBar row="2"  class="m-5" selectedIndex="{{ sbSelectedIndex }}">
    <SegmentedBar.items>
        <SegmentedBarItem title="LONG TITLE HERE Center Item 1" textAlignment="center" />
        <SegmentedBarItem title="LONG TITLE HERE Left Item 2" textAlignment="center" />
        <SegmentedBarItem title="LONG TITLE HERE Right Item 3" textAlignment="center"  />
    </SegmentedBar.items>
</SegmentedBar>
<!-- Short content are always centered (as default on iOS) -->
<SegmentedBar row="3"  class="m-5" selectedIndex="{{ sbSelectedIndex }}">
    <SegmentedBar.items>
        <SegmentedBarItem title="Left" textAlignment="left" />
        <SegmentedBarItem title="Center" textAlignment="center" />
        <SegmentedBarItem title="Right" textAlignment="right" />
    </SegmentedBar.items>
</SegmentedBar>
```

![Screen Shot 2019-12-13 at 1 43 38 PM](https://user-images.githubusercontent.com/18008302/70798069-ac45ec00-1dae-11ea-8c43-f860ec5ce8d6.png)


