### PR TITLE
fix(android): handle fake attach

### DIFF
--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -385,14 +385,14 @@ export class BottomNavigation extends TabNavigationBase {
 
     _onAttachedToWindow(): void {
         super._onAttachedToWindow();
-        this._attachedToWindow = true;
 
         // _onAttachedToWindow called from OS again after it was detach
         // TODO: Consider testing and removing it when update to androidx.fragment:1.2.0
         if (this._manager && this._manager.isDestroyed()) {
             return;
         }
-
+        
+        this._attachedToWindow = true;
         this.changeTab(this.selectedIndex);
     }
 

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -150,14 +150,14 @@ export class Frame extends FrameBase {
 
     _onAttachedToWindow(): void {
         super._onAttachedToWindow();
-        this._attachedToWindow = true;
-
+        
         // _onAttachedToWindow called from OS again after it was detach
         // TODO: Consider testing and removing it when update to androidx.fragment:1.2.0
         if (this._manager && this._manager.isDestroyed()) {
             return;
         }
-
+        
+        this._attachedToWindow = true;
         this._processNextNavigationEntry();
     }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Sometimes `_onAttachedToWindow` is called by Android after the app has suspended. Usually there is another call to `_onDetachFromWindow` immediately after, but on some version of android (reproduced on Oxygen 10 / OnePls 7T) there isn't. Which cause fragment manager calls too early in the lifecycle after the app is resumed and leads to crashes.

## What is the new behavior?
Set the `_attachedToWindow` after the `this._manager.isDestroyed()` check to make sure it is not raised falsely.

Fixes #8104