### PR TITLE
fix(android): check is disposed fragment is in the FragmentManager

### DIFF
--- a/nativescript-core/ui/core/view/view.android.ts
+++ b/nativescript-core/ui/core/view/view.android.ts
@@ -155,6 +155,8 @@ function initializeDialogFragment() {
             const ownerId = this.getArguments().getInt(DOMID);
             const options = getModalOptions(ownerId);
             this.owner = options.owner;
+            // Set owner._dialogFragment to this in case the DialogFragment was recreated after app suspend
+            this.owner._dialogFragment = this;
             this._fullscreen = options.fullscreen;
             this._animated = options.animated;
             this._cancelable = options.cancelable;

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -264,13 +264,13 @@ export class Frame extends FrameBase {
             !this._currentEntry.fragment.isAdded()) {
             return;
         }
+        const fragment: androidx.fragment.app.Fragment = this._currentEntry.fragment;
+        const fragmentManager: androidx.fragment.app.FragmentManager = fragment.getFragmentManager();
 
-        const manager: androidx.fragment.app.FragmentManager = this._getFragmentManager();
-        const transaction = manager.beginTransaction();
-        const fragment = this._currentEntry.fragment;
+        const transaction = fragmentManager.beginTransaction();
         const fragmentExitTransition = fragment.getExitTransition();
 
-        // Reset animation to its initial state to prevent mirrorered effect when restore current fragment transitions
+        // Reset animation to its initial state to prevent mirrored effect when restore current fragment transitions
         if (fragmentExitTransition && fragmentExitTransition instanceof org.nativescript.widgets.CustomTransition) {
             fragmentExitTransition.setResetOnTransitionEnd(true);
         }
@@ -637,7 +637,7 @@ function clearEntry(entry: BackstackEntry): void {
     entry.recreated = false;
     entry.fragment = null;
     const page = entry.resolvedPage;
-    if (page._context) {
+    if (page && page._context) {
         entry.resolvedPage._tearDownUI(true);
     }
 }
@@ -1032,6 +1032,12 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
     }
 
     private loadBitmapFromView(view: android.view.View): android.graphics.Bitmap {
+        // Don't try to creat bitmaps with no dimensions as this causes a crash
+        // This might happen when showing and closing dialogs fast.  
+        if (!(view && view.getWidth() > 0 && view.getHeight() > 0)) {
+            return undefined;
+        }
+
         // Another way to get view bitmap. Test performance vs setDrawingCacheEnabled
         // const width = view.getWidth();
         // const height = view.getHeight();
@@ -1041,7 +1047,8 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
         // view.draw(canvas);
 
         view.setDrawingCacheEnabled(true);
-        const bitmap = android.graphics.Bitmap.createBitmap(view.getDrawingCache());
+        const drawCache = view.getDrawingCache();
+        const bitmap = android.graphics.Bitmap.createBitmap(drawCache);
         view.setDrawingCacheEnabled(false);
 
         return bitmap;

--- a/nativescript-core/utils/utils.ios.ts
+++ b/nativescript-core/utils/utils.ios.ts
@@ -6,8 +6,6 @@ import {
 export { ios };
 export * from "./utils-common";
 
-let mainScreenScale;
-
 export function openFile(filePath: string): boolean {
     try {
         const appPath = ios.getCurrentAppPath();
@@ -47,5 +45,3 @@ export function openUrl(location: string): boolean {
 
     return false;
 }
-
-mainScreenScale = UIScreen.mainScreen.scale;


### PR DESCRIPTION
_Same as #8166 but based on release branch._

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Fragment is always removed from the fragment manager in the `Frame.disposeCurrentFragment()` method. Different versions of androidX behave differently if you try to remove a fragment from a fragment manager.

## What is the new behavior?
Added a check if the current fragment is actually contained in the fragment manager returned by the `_getFragmentManager()`

Fixes #8037


