### PR TITLE
fix(android-label): Match iOS default vertical alignment

### DIFF
--- a/nativescript-core/ui/label/label.android.ts
+++ b/nativescript-core/ui/label/label.android.ts
@@ -36,6 +36,7 @@ export class Label extends TextBase implements LabelDefinition {
         const textView = this.nativeTextViewProtected;
         textView.setSingleLine(true);
         textView.setEllipsize(android.text.TextUtils.TruncateAt.END);
+        textView.setGravity(android.view.Gravity.CENTER_VERTICAL);
     }
 
     [whiteSpaceProperty.setNative](value: WhiteSpace) {


### PR DESCRIPTION
Set gravity to CENTER_VERTICAL on android to match iOS labels which default to vertically centered

Fixes issue #3829

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## Playground
[This playground displays the issue](https://play.nativescript.org/?template=play-js&id=GdUADF&v=4)

## What is the current behavior?
Labels on iOS are by default vertically aligned center in all layouts. On Android they are aligned top.  Reference issue #3829.
![Screen Shot 2019-12-27 at 11 28 33 AM](https://user-images.githubusercontent.com/2379994/71524545-0a3cfe00-289c-11ea-9bd2-e5b939d29e40.png)

## What is the new behavior?
Labels on Android are now vertically aligned center by default
![Screen Shot 2019-12-27 at 11 29 20 AM](https://user-images.githubusercontent.com/2379994/71524567-2345af00-289c-11ea-89b7-4fa9f68514db.png)

Fixes #3829.

