### PR TITLE
feat: add longPress state argument w/ UILongPressGestureRecognizer (iOS)

### DIFF
--- a/nativescript-core/ui/gestures/gestures.android.ts
+++ b/nativescript-core/ui/gestures/gestures.android.ts
@@ -1,5 +1,5 @@
 // Definitions.
-import { GestureEventData, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData } from ".";
+import { GestureEventData, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData, GestureEventDataWithState } from ".";
 import { View, EventData } from "../core/view";
 
 // Types.
@@ -62,7 +62,7 @@ function initializeTapAndDoubleTapGestureListener() {
 
         public onLongPress(motionEvent: android.view.MotionEvent): void {
             if (this._type & GestureTypes.longPress) {
-                const args = _getArgs(GestureTypes.longPress, this._target, motionEvent);
+                const args = _getLongPressArgs(GestureTypes.longPress, this._target, GestureStateTypes.began, motionEvent);
                 _executeCallback(this._observer, args);
             }
         }
@@ -380,6 +380,18 @@ function _getArgs(type: GestureTypes, view: View, e: android.view.MotionEvent): 
         ios: undefined,
         object: view,
         eventName: toString(type),
+    };
+}
+
+function _getLongPressArgs(type: GestureTypes, view: View, state: GestureStateTypes, e: android.view.MotionEvent): GestureEventDataWithState {
+    return <GestureEventDataWithState>{
+        type: type,
+        view: view,
+        android: e,
+        ios: undefined,
+        object: view,
+        eventName: toString(type),
+        state: state
     };
 }
 

--- a/nativescript-core/ui/gestures/gestures.ios.ts
+++ b/nativescript-core/ui/gestures/gestures.ios.ts
@@ -1,5 +1,5 @@
 // Definitions.
-import { GestureEventData, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData, PinchGestureEventData } from ".";
+import { GestureEventData, GestureEventDataWithState, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData, PinchGestureEventData } from ".";
 import { View, EventData } from "../core/view";
 
 // Types.
@@ -167,7 +167,9 @@ export class GesturesObserver extends GesturesObserverBase {
             }
 
             if (type & GestureTypes.longPress) {
-                nativeView.addGestureRecognizer(this._createRecognizer(GestureTypes.longPress));
+                nativeView.addGestureRecognizer(this._createRecognizer(GestureTypes.longPress, args => {
+                    this._executeCallback(_getLongPressData(args));
+                }));
             }
 
             if (type & GestureTypes.touch) {
@@ -353,6 +355,20 @@ function _getRotationData(args: GestureEventData): RotationGestureEventData {
         ios: args.ios,
         android: undefined,
         rotation: recognizer.rotation * (180.0 / Math.PI),
+        object: args.view,
+        eventName: toString(args.type),
+        state: getState(recognizer)
+    };
+}
+
+function _getLongPressData(args: GestureEventData): GestureEventDataWithState {
+    const recognizer = <UILongPressGestureRecognizer>args.ios;
+
+    return <GestureEventDataWithState>{
+        type: args.type,
+        view: args.view,
+        ios: args.ios,
+        android: undefined,
         object: args.view,
         eventName: toString(args.type),
         state: getState(recognizer)


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
No state for longPress on iOS which leads to [this](https://github.com/NativeScript/NativeScript/issues/3573#issuecomment-514950219)

## What is the new behavior?

Adding a `state` argument for the iOS long press event. Android doesn't support states so it would always return state = 1 (began) when longPress is triggered.

Fixes/Implements/Closes #[Issue Number].

Related to [https://github.com/NativeScript/NativeScript/issues/3573#issuecomment-514950219](https://github.com/NativeScript/NativeScript/issues/3573#issuecomment-514950219)


