### PR TITLE
fix: return default tab background color when the background color is not explicitely set through css

### DIFF
--- a/api-reports/NativeScript.api.md
+++ b/api-reports/NativeScript.api.md
@@ -2197,6 +2197,8 @@ export class TabContentItem extends ContentView {
 export class TabNavigationBase extends View {
     android: any /* android.view.View */;
 
+    getTabBarBackgroundArgbColor(): any
+
     getTabBarBackgroundColor(): any
 
     getTabBarColor(): any

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -578,9 +578,7 @@ export class BottomNavigation extends TabNavigationBase {
 
             // BACKGROUND-COLOR
             const backgroundColor = tabStripItem.style.backgroundColor;
-            if (backgroundColor) {
-                tabItemSpec.backgroundColor = backgroundColor.android;
-            }
+            tabItemSpec.backgroundColor = backgroundColor ? backgroundColor.android : this.getTabBarBackgroundArgbColor();
 
             // COLOR
             const color = titleLabel.style.color;

--- a/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.d.ts
+++ b/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.d.ts
@@ -94,6 +94,12 @@ export class TabNavigationBase extends View {
      * @private
      * Method is intended to be overridden by inheritors and used as "protected"
      */
+    getTabBarBackgroundArgbColor(): any
+
+    /**
+     * @private
+     * Method is intended to be overridden by inheritors and used as "protected"
+     */
     setTabBarBackgroundColor(value: any): void
 
     /**

--- a/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
+++ b/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
@@ -114,9 +114,10 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
     }
 
     public getTabBarBackgroundArgbColor(): any {
+        // This method is implemented only for Android
         const colorDrawable = this.getTabBarBackgroundColor();
 
-        return colorDrawable && colorDrawable.getColor();
+        return colorDrawable && colorDrawable.getColor && colorDrawable.getColor();
     }
 
     public setTabBarBackgroundColor(value: any): void {

--- a/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
+++ b/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
@@ -113,6 +113,12 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
         return null;
     }
 
+    public getTabBarBackgroundArgbColor(): any {
+        const colorDrawable = this.getTabBarBackgroundColor() as android.graphics.drawable.ColorDrawable;
+
+        return colorDrawable && colorDrawable.getColor();
+    }
+
     public setTabBarBackgroundColor(value: any): void {
         // overridden by inheritors
     }

--- a/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
+++ b/nativescript-core/ui/tab-navigation-base/tab-navigation-base/tab-navigation-base.ts
@@ -114,7 +114,7 @@ export class TabNavigationBase extends View implements TabNavigationBaseDefiniti
     }
 
     public getTabBarBackgroundArgbColor(): any {
-        const colorDrawable = this.getTabBarBackgroundColor() as android.graphics.drawable.ColorDrawable;
+        const colorDrawable = this.getTabBarBackgroundColor();
 
         return colorDrawable && colorDrawable.getColor();
     }

--- a/nativescript-core/ui/tabs/tabs.android.ts
+++ b/nativescript-core/ui/tabs/tabs.android.ts
@@ -653,9 +653,7 @@ export class Tabs extends TabsBase {
 
             // BACKGROUND-COLOR
             const backgroundColor = tabStripItem.style.backgroundColor;
-            if (backgroundColor) {
-                tabItemSpec.backgroundColor = backgroundColor.android;
-            }
+            tabItemSpec.backgroundColor = backgroundColor ? backgroundColor.android : this.getTabBarBackgroundArgbColor();
 
             // COLOR
             const color = nestedLabel.style.color;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When a tab's in tabs/bottom-navigation is activated and its background-color is changed it does not return to its default background-color after deactivating it.

## What is the new behavior?
When a tab's in tabs/bottom-navigation is activated and its background-color is changed it returns to its default background-color after deactivating it.

Fixes #8235.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

