### PR TITLE
fix: make integer type visible

### DIFF
--- a/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
@@ -273,7 +273,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
                 break;
 
             case "integer":
-                newInputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD;
+                newInputType = android.text.InputType.TYPE_CLASS_NUMBER;
                 break;
 
             default:


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Integer type on Android is always hidden (password type)

## What is the new behavior?
<!-- Describe the changes. -->

Removed the password flag to make integer type keyboard input visible. Tested with visible_palssword flag (to create even simpler number pad) but it is not working as expected from native development.

Fixes/Implements/Closes #[Issue Number].

https://github.com/NativeScript/NativeScript/issues/8248#issuecomment-574638734

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

