### PR TITLE
fix(ios): ActionBar style wrong after cancelled swipe back navigation

### DIFF
--- a/nativescript-core/ui/page/page.ios.ts
+++ b/nativescript-core/ui/page/page.ios.ts
@@ -93,6 +93,7 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
 
+        // console.log("---> viewWillAppear", owner);
         const frame = this.navigationController ? (<any>this.navigationController).owner : null;
         const newEntry = this[ENTRY];
 
@@ -124,6 +125,9 @@ class UIViewControllerImpl extends UIViewController {
         // Pages in backstack are unloaded so raise loaded here.
         if (!owner.isLoaded) {
             owner.callLoaded();
+        } else {
+            // console.log(" ------>  MANUAL UPDATE!")
+            owner.actionBar.update();
         }
     }
 
@@ -136,6 +140,7 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
 
+        // console.log("---> viewDidAppear", owner);
         const navigationController = this.navigationController;
         const frame: Frame = navigationController ? (<any>navigationController).owner : null;
         // Skip navigation events if modal page is shown.
@@ -192,7 +197,8 @@ class UIViewControllerImpl extends UIViewController {
         if (!owner) {
             return;
         }
-
+        
+        console.log("---> viewWillDisappear", owner);
         // Cache presentedViewController if any. We don't want to raise
         // navigation events in case of presenting view controller.
         if (!owner._presentedViewController) {
@@ -223,7 +229,8 @@ class UIViewControllerImpl extends UIViewController {
         if (!page || page.modal || page._presentedViewController) {
             return;
         }
-
+        
+        console.log("---> viewDidDisappear", page);
         // Forward navigation does not remove page from frame so we raise unloaded manually.
         if (page.isLoaded) {
             page.callUnloaded();
@@ -343,6 +350,7 @@ export class Page extends PageBase {
     }
 
     public onLoaded(): void {
+        // console.log(this, " onLoaded");
         super.onLoaded();
         if (this.hasActionBar) {
             this.actionBar.update();

--- a/nativescript-core/ui/page/page.ios.ts
+++ b/nativescript-core/ui/page/page.ios.ts
@@ -93,7 +93,6 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
 
-        // console.log("---> viewWillAppear", owner);
         const frame = this.navigationController ? (<any>this.navigationController).owner : null;
         const newEntry = this[ENTRY];
 
@@ -126,7 +125,11 @@ class UIViewControllerImpl extends UIViewController {
         if (!owner.isLoaded) {
             owner.callLoaded();
         } else {
-            // console.log(" ------>  MANUAL UPDATE!")
+            // Note: Handle the case of canceled backstack navigation. (https://github.com/NativeScript/NativeScript/issues/7430)
+            // In this case viewWillAppear will be executed for the previous page and it will change the ActionBar
+            // because changes happen in an interactive transition - IOS will animate between the the states.
+            // If canceled - viewWillAppear will be called for the current page(which is already loaded) and we need to
+            // update the action bar explicitly, so that it is not left styles as the previous page.
             owner.actionBar.update();
         }
     }
@@ -140,7 +143,6 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
 
-        // console.log("---> viewDidAppear", owner);
         const navigationController = this.navigationController;
         const frame: Frame = navigationController ? (<any>navigationController).owner : null;
         // Skip navigation events if modal page is shown.
@@ -198,7 +200,6 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
         
-        console.log("---> viewWillDisappear", owner);
         // Cache presentedViewController if any. We don't want to raise
         // navigation events in case of presenting view controller.
         if (!owner._presentedViewController) {
@@ -230,7 +231,6 @@ class UIViewControllerImpl extends UIViewController {
             return;
         }
         
-        console.log("---> viewDidDisappear", page);
         // Forward navigation does not remove page from frame so we raise unloaded manually.
         if (page.isLoaded) {
             page.callUnloaded();

--- a/nativescript-core/ui/page/page.ios.ts
+++ b/nativescript-core/ui/page/page.ios.ts
@@ -350,7 +350,6 @@ export class Page extends PageBase {
     }
 
     public onLoaded(): void {
-        // console.log(this, " onLoaded");
         super.onLoaded();
         if (this.hasActionBar) {
             this.actionBar.update();


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
If swipe back navigation is cancelled - the current page ActionBar gets the style from the previous page in the nav-stack (the one that we were swiping back to).

## What is the new behavior?
If the swipe back navigation is cancelled - the current style of the ActionBar is preserved.

Fixes: #7430
