### PR TITLE
feat(text-base): Add Span vertical-align support

### DIFF
--- a/nativescript-core/ui/styling/style-properties.ts
+++ b/nativescript-core/ui/styling/style-properties.ts
@@ -358,13 +358,18 @@ export namespace HorizontalAlignment {
 export const horizontalAlignmentProperty = new CssProperty<Style, HorizontalAlignment>({ name: "horizontalAlignment", cssName: "horizontal-align", defaultValue: HorizontalAlignment.STRETCH, affectsLayout: isIOS, valueConverter: HorizontalAlignment.parse });
 horizontalAlignmentProperty.register(Style);
 
-export type VerticalAlignment = "top" | "middle" | "bottom" | "stretch";
+export type VerticalAlignment = "top" | "middle" | "bottom" | "stretch" | "text-top" | "text-bottom" | "super" | "sub" | "baseline";
 export namespace VerticalAlignment {
     export const TOP: "top" = "top";
     export const MIDDLE: "middle" = "middle";
     export const BOTTOM: "bottom" = "bottom";
     export const STRETCH: "stretch" = "stretch";
-    export const isValid = makeValidator<VerticalAlignment>(TOP, MIDDLE, BOTTOM, STRETCH);
+    export const TEXTTOP: "text-top" = "text-top";
+    export const TEXTBOTTOM: "text-bottom" = "text-bottom";
+    export const SUPER: "super" = "super";
+    export const SUB: "sub" = "sub";
+    export const BASELINE: "baseline" = "baseline";
+    export const isValid = makeValidator<VerticalAlignment>(TOP, MIDDLE, BOTTOM, STRETCH, TEXTTOP, TEXTBOTTOM, SUPER, SUB, BASELINE);
     export const parse = (value: string) => value.toLowerCase() === "center" ? MIDDLE : parseStrict(value);
     const parseStrict = makeParser<VerticalAlignment>(isValid);
 }

--- a/nativescript-core/ui/text-base/span.ts
+++ b/nativescript-core/ui/text-base/span.ts
@@ -65,7 +65,7 @@ export class Span extends ViewBase implements SpanDefinition {
     }
     set text(value: string) {
         if (this._text !== value) {
-            this._text = value.replace("\\n", "\n").replace("\\t", "\t");
+            this._text = value && value.replace("\\n", "\n").replace("\\t", "\t");
             this.notifyPropertyChange("text", value);
         }
     }

--- a/nativescript-core/ui/text-base/span.ts
+++ b/nativescript-core/ui/text-base/span.ts
@@ -65,7 +65,7 @@ export class Span extends ViewBase implements SpanDefinition {
     }
     set text(value: string) {
         if (this._text !== value) {
-            this._text = value;
+            this._text = value.replace("\\n", "\n").replace("\\t", "\t");
             this.notifyPropertyChange("text", value);
         }
     }

--- a/nativescript-core/ui/text-base/text-base-common.ts
+++ b/nativescript-core/ui/text-base/text-base-common.ts
@@ -217,10 +217,10 @@ const textDecorationConverter = makeParser<TextDecoration>(makeValidator<TextDec
 export const textDecorationProperty = new CssProperty<Style, TextDecoration>({ name: "textDecoration", cssName: "text-decoration", defaultValue: "none", valueConverter: textDecorationConverter });
 textDecorationProperty.register(Style);
 
-export const letterSpacingProperty = new CssProperty<Style, number>({ name: "letterSpacing", cssName: "letter-spacing", defaultValue: 0, affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
+export const letterSpacingProperty = new InheritedCssProperty<Style, number>({ name: "letterSpacing", cssName: "letter-spacing", defaultValue: 0, affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 letterSpacingProperty.register(Style);
 
-export const lineHeightProperty = new CssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
+export const lineHeightProperty = new InheritedCssProperty<Style, number>({ name: "lineHeight", cssName: "line-height", affectsLayout: isIOS, valueConverter: v => parseFloat(v) });
 lineHeightProperty.register(Style);
 
 export const resetSymbol = Symbol("textPropertyDefault");

--- a/nativescript-core/ui/text-base/text-base-common.ts
+++ b/nativescript-core/ui/text-base/text-base-common.ts
@@ -201,6 +201,18 @@ function onFormattedTextPropertyChanged(textBase: TextBaseCommon, oldValue: Form
     }
 }
 
+export function getClosestPropertyValue<T>(property: CssProperty<any, T>, span: Span): T {
+  if (property.isSet(span.style)) {
+      return span.style[property.name];
+  } else if (property.isSet(span.parent.style)) {
+      // parent is FormattedString
+      return span.parent.style[property.name];
+  } else if (property.isSet(span.parent.parent.style)) {
+      // parent.parent is TextBase
+      return span.parent.parent.style[property.name];
+  }
+}
+
 const textAlignmentConverter = makeParser<TextAlignment>(makeValidator<TextAlignment>("initial", "left", "center", "right"));
 export const textAlignmentProperty = new InheritedCssProperty<Style, TextAlignment>({ name: "textAlignment", cssName: "text-align", defaultValue: "initial", valueConverter: textAlignmentConverter });
 textAlignmentProperty.register(Style);

--- a/nativescript-core/ui/text-base/text-base.android.ts
+++ b/nativescript-core/ui/text-base/text-base.android.ts
@@ -11,7 +11,7 @@ import {
     whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold, resetSymbol
 } from "./text-base-common";
 import { isString } from "../../utils/types";
-import { Property } from "tns-core-modules/ui/core/properties/properties";
+import { Property } from "../core/properties/properties";
 
 export * from "./text-base-common";
 

--- a/nativescript-core/ui/text-base/text-base.android.ts
+++ b/nativescript-core/ui/text-base/text-base.android.ts
@@ -532,13 +532,13 @@ function setSpanModifiers(ssb: android.text.SpannableStringBuilder, span: Span, 
         ssb.setSpan(new android.text.style.ForegroundColorSpan(color.android), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
-    let backgroundColor: Color = getClosestPropertyValue(backgroundColorProperty, span);
+    const backgroundColor: Color = getClosestPropertyValue(backgroundColorProperty, span);
 
     if (backgroundColor) {
         ssb.setSpan(new android.text.style.BackgroundColorSpan(backgroundColor.android), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
-    let textDecoration: TextDecoration = getClosestPropertyValue(textDecorationProperty, span);
+    const textDecoration: TextDecoration = getClosestPropertyValue(textDecorationProperty, span);
 
     if (textDecoration) {
         const underline = textDecoration.indexOf("underline") !== -1;

--- a/nativescript-core/ui/text-base/text-base.android.ts
+++ b/nativescript-core/ui/text-base/text-base.android.ts
@@ -1,5 +1,5 @@
 // Types
-import { TextTransformation, TextDecoration, TextAlignment, TextTransform, WhiteSpace } from "./text-base-common";
+import { TextTransformation, TextDecoration, TextAlignment, TextTransform, WhiteSpace, getClosestPropertyValue } from "./text-base-common";
 
 // Requires
 import { Font } from "../styling/font";
@@ -496,18 +496,6 @@ class BaselineAdjustedSpan extends android.text.style.MetricAffectingSpan {
         if (this.align === "sub") {
             return paint.baselineShift = (metrics.descent - metrics.ascent) * .4;
         }
-    }
-}
-
-function getClosestPropertyValue(property: any, span: Span) {
-    if ((<Property<any, any>>property).isSet(span.style)) {
-        return span.style[property.name];
-    } else if ((<Property<any, any>>property).isSet(span.parent.style)) {
-        // parent is FormattedString
-        return span.parent.style[property.name];
-    } else if ((<Property<any, any>>property).isSet(span.parent.parent.style)) {
-        // parent.parent is TextBase
-        return span.parent.parent.style[property.name];
     }
 }
 

--- a/nativescript-core/ui/text-base/text-base.android.ts
+++ b/nativescript-core/ui/text-base/text-base.android.ts
@@ -11,7 +11,6 @@ import {
     whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold, resetSymbol
 } from "./text-base-common";
 import { isString } from "../../utils/types";
-import { Property } from "../core/properties/properties";
 
 export * from "./text-base-common";
 

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -371,7 +371,7 @@ export class TextBase extends TextBaseCommon {
         return mas;
     }
 
-    getBaselineOffset(font: UIFont, align?: string | number) : number {
+    getBaselineOffset(font: UIFont, align?: string | number): number {
         if (!align || align === "baseline") {
             return 0;
         }

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -371,38 +371,38 @@ export class TextBase extends TextBaseCommon {
         return mas;
     }
 
-    getBaselineOffset(font: UIFont, defaultFontSize: number, align?: string | number) : number {
-        console.log(font.pointSize, font.lineHeight, font.ascender, font.descender, font.leading);
+    getBaselineOffset(font: UIFont, align?: string | number) : number {
+        if (!align || align === "baseline") {
+            return 0;
+        }
 
         if (align === "top") {
-            return defaultFontSize - font.descender - font.ascender + font.leading / 2;
+            return -this.fontSize - font.descender - font.ascender - font.leading / 2;
         }
 
         if (align === "bottom") {
-            return -defaultFontSize / 2;
+            return font.descender + font.leading / 2;
         }
 
         if (align === "text-top") {
-            return defaultFontSize - font.descender - font.ascender;
+            return -this.fontSize - font.descender - font.ascender;
         }
 
         if (align === "text-bottom") {
-            return font.descender / font.pointSize * defaultFontSize;
+            return font.descender;
         }
 
         if (align === "middle") {
-            return -font.lineHeight / 2 - font.descender;
+            return (font.descender - font.ascender) / 2 - font.descender;
         }
 
         if (align === "super") {
-            return defaultFontSize * .4;
+            return -this.fontSize * .4;
         }
 
         if (align === "sub") {
-            return (font.descender - font.ascender) / font.pointSize * font.lineHeight * .4;
+            return (font.descender - font.ascender) * .4;
         }
-
-        return 0;
     }
 
     createMutableStringForSpan(span: Span, text: string): NSMutableAttributedString {
@@ -411,7 +411,7 @@ export class TextBase extends TextBaseCommon {
         const style = span.style;
         const align = style.verticalAlignment;
 
-        let font = new Font(style.fontFamily, style.fontSize || 12, style.fontStyle, style.fontWeight);
+        let font = new Font(style.fontFamily, style.fontSize, style.fontStyle, style.fontWeight);
         let iosFont = font.getUIFont(viewFont);
 
         attrDict[NSFontAttributeName] = iosFont;
@@ -444,12 +444,7 @@ export class TextBase extends TextBaseCommon {
         }
 
         if (align) {
-            attrDict[NSBaselineOffsetAttributeName] =
-                this.getBaselineOffset(
-                    iosFont,
-                    (<TextBase>span.parent.parent).fontSize * layout.getDisplayDensity(),
-                    align
-                );
+            attrDict[NSBaselineOffsetAttributeName] = this.getBaselineOffset(iosFont, align);
         }
 
         return NSMutableAttributedString.alloc().initWithStringAttributes(text, <any>attrDict);

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -1,5 +1,5 @@
 // Types
-import { TextDecoration, TextAlignment, TextTransform, layout } from "./text-base-common";
+import { TextDecoration, TextAlignment, TextTransform, layout, getClosestPropertyValue } from "./text-base-common";
 
 // Requires
 import { Font } from "../styling/font";
@@ -407,18 +407,17 @@ export class TextBase extends TextBaseCommon {
 
     createMutableStringForSpan(span: Span, text: string): NSMutableAttributedString {
         const viewFont = this.nativeTextViewProtected.font;
-        let attrDict = <{ key: string, value: any }>{};
+        const attrDict = <{ key: string, value: any }>{};
         const style = span.style;
         const align = style.verticalAlignment;
 
-        let font = new Font(style.fontFamily, style.fontSize, style.fontStyle, style.fontWeight);
-        let iosFont = font.getUIFont(viewFont);
+        const font = new Font(style.fontFamily, style.fontSize, style.fontStyle, style.fontWeight);
+        const iosFont = font.getUIFont(viewFont);
 
         attrDict[NSFontAttributeName] = iosFont;
 
-        const color = span.color;
-        if (color) {
-            attrDict[NSForegroundColorAttributeName] = color.ios;
+        if (span.color) {
+            attrDict[NSForegroundColorAttributeName] = span.color.ios;
         }
 
         // We don't use isSet function here because defaultValue for backgroundColor is null.
@@ -429,7 +428,7 @@ export class TextBase extends TextBaseCommon {
             attrDict[NSBackgroundColorAttributeName] = backgroundColor.ios;
         }
 
-        let textDecoration: TextDecoration = getClosestPropertyValue(textDecorationProperty, span);
+        const textDecoration: TextDecoration = getClosestPropertyValue(textDecorationProperty, span);
 
         if (textDecoration) {
             const underline = textDecoration.indexOf("underline") !== -1;
@@ -448,18 +447,6 @@ export class TextBase extends TextBaseCommon {
         }
 
         return NSMutableAttributedString.alloc().initWithStringAttributes(text, <any>attrDict);
-    }
-}
-
-function getClosestPropertyValue(property: any, span: Span) {
-    if ((<Property<any, any>>property).isSet(span.style)) {
-        return span.style[property.name];
-    } else if ((<Property<any, any>>property).isSet(span.parent.style)) {
-        // parent is FormattedString
-        return span.parent.style[property.name];
-    } else if ((<Property<any, any>>property).isSet(span.parent.parent.style)) {
-        // parent.parent is TextBase
-        return span.parent.parent.style[property.name];
     }
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Currently there's no way to align vertically the Spans in a FormattedString

## What is the new behavior?
Spans in FormattedString support the vertical-align CSS property.

Implements #4795.
