### PR TITLE
fix: invoke done callback in image cache unit test for API Level < 20

### DIFF
--- a/tests/app/ui/image-cache/image-cache-tests.ts
+++ b/tests/app/ui/image-cache/image-cache-tests.ts
@@ -8,6 +8,8 @@ const sdkVersion = lazy(() => parseInt(device.sdkVersion));
 export const test_ImageCache_ValidUrl = function (done: (err: Error, res?: string) => void) {
     // see https://github.com/NativeScript/NativeScript/issues/6643
     if (isAndroid && sdkVersion() < 20) {
+        done(null);
+
         return;
     }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

The `[IMAGE-CACHE.test_ImageCache_ValidUrl]` unit test is failing on API levels < 20

## What is the new behavior?

The `[IMAGE-CACHE.test_ImageCache_ValidUrl]` unit test is passing on API levels < 20