### PR TITLE
fix(android): crash on setting elevation on API21

### DIFF
--- a/nativescript-core/ui/core/view/view.android.ts
+++ b/nativescript-core/ui/core/view/view.android.ts
@@ -829,6 +829,11 @@ export class View extends ViewCommon {
         stateListAnimator.addState([statePressed, stateEnabled], pressedSet);
         stateListAnimator.addState([stateEnabled], notPressedSet);
         stateListAnimator.addState([], defaultSet);
+
+        const currentAnimator = nativeView.getStateListAnimator();
+        if (currentAnimator) {
+            currentAnimator.jumpToCurrentState();
+        }
         nativeView.setStateListAnimator(stateListAnimator);
     }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Crash when setting android button properties that set `StateListAnimator`

## What is the new behavior?
The current `StateListAnimator` is flashed (using `jumpToCurrentState`) before setting the new one

Fixes #7886
Fixes #7532
Fixes #4256


