### PR TITLE
fix: remove the password type for Integer-type keyboard in TextField

### DIFF
--- a/nativescript-core/ui/text-field/text-field.android.ts
+++ b/nativescript-core/ui/text-field/text-field.android.ts
@@ -78,7 +78,7 @@ export class TextField extends TextFieldBase {
                     inputType = android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
                     break;
                 case "integer":
-                    inputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD;
+                    inputType = android.text.InputType.TYPE_CLASS_NUMBER;
                     break;
                 default:
                     break;


### PR DESCRIPTION
Related to https://github.com/NativeScript/NativeScript/issues/8285

Updating the TextField code as well.