### PR TITLE
fix(android): Bugs in tab strip items when changing styles dynamically

### DIFF
--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -614,6 +614,9 @@ export class BottomNavigation extends TabNavigationBase {
 
     private getIcon(tabStripItem: TabStripItem): android.graphics.drawable.BitmapDrawable {
         const iconSource = tabStripItem.image && tabStripItem.image.src;
+        if (!iconSource) {
+            return null;
+        }
 
         let is: ImageSource;
         if (isFontIconURI(iconSource)) {

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -391,7 +391,7 @@ export class BottomNavigation extends TabNavigationBase {
         if (this._manager && this._manager.isDestroyed()) {
             return;
         }
-        
+
         this._attachedToWindow = true;
         this.changeTab(this.selectedIndex);
     }
@@ -705,7 +705,10 @@ export class BottomNavigation extends TabNavigationBase {
     }
 
     public setTabBarItemFontInternal(tabStripItem: TabStripItem, value: Font): void {
-        tabStripItem.nativeViewProtected.setTextSize(value.fontSize);
+        if (value.fontSize) {
+            tabStripItem.nativeViewProtected.setTextSize(value.fontSize);
+        }
+
         tabStripItem.nativeViewProtected.setTypeface(value.getAndroidTypeface());
     }
 

--- a/nativescript-core/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
+++ b/nativescript-core/ui/tab-navigation-base/tab-strip-item/tab-strip-item.ts
@@ -127,7 +127,7 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
             const parent = <TabStrip>this.parent;
             const tabStripParent = parent && <TabNavigationBase>parent.parent;
 
-            return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
+            return tabStripParent && tabStripParent.setTabBarIconColor(this, args.value);
         });
         this.image.style.on("colorChange", this._imageColorHandler);
 
@@ -135,7 +135,7 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
             const parent = <TabStrip>this.parent;
             const tabStripParent = parent && <TabNavigationBase>parent.parent;
 
-            return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
+            return tabStripParent && tabStripParent.setTabBarIconColor(this, args.value);
         });
         this.image.style.on("fontInternalChange", this._imageFontHandler);
 
@@ -143,7 +143,7 @@ export class TabStripItem extends View implements TabStripItemDefinition, AddChi
             const parent = <TabStrip>this.parent;
             const tabStripParent = parent && <TabNavigationBase>parent.parent;
 
-            return tabStripParent && (<any>tabStripParent).setTabBarIconColor(this, args.value);
+            return tabStripParent && tabStripParent.setTabBarIconColor(this, args.value);
         });
         this.image.on("srcChange", this._imageSrcHandler);
     }

--- a/nativescript-core/ui/tabs/tabs.android.ts
+++ b/nativescript-core/ui/tabs/tabs.android.ts
@@ -689,6 +689,9 @@ export class Tabs extends TabsBase {
 
     private getIcon(tabStripItem: TabStripItem): android.graphics.drawable.BitmapDrawable {
         const iconSource = tabStripItem.image && tabStripItem.image.src;
+        if (!iconSource) {
+            return null;
+        }
 
         let is: ImageSource;
         if (isFontIconURI(iconSource)) {
@@ -814,7 +817,7 @@ export class Tabs extends TabsBase {
         const tabBarItem = this._tabsBar.getViewForItemAt(index);
         const imgView = <android.widget.ImageView>tabBarItem.getChildAt(0);
         const drawable = this.getIcon(tabStripItem);
-
+        
         imgView.setImageDrawable(drawable);
     }
 

--- a/nativescript-core/ui/tabs/tabs.android.ts
+++ b/nativescript-core/ui/tabs/tabs.android.ts
@@ -819,7 +819,9 @@ export class Tabs extends TabsBase {
     }
 
     public setTabBarItemFontInternal(tabStripItem: TabStripItem, value: Font): void {
-        tabStripItem.nativeViewProtected.setTextSize(value.fontSize);
+        if (value.fontSize) {
+            tabStripItem.nativeViewProtected.setTextSize(value.fontSize);
+        }
         tabStripItem.nativeViewProtected.setTypeface(value.getAndroidTypeface());
     }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When changing fonts for tab strip items (ex. with `:active`) style dynamically there are cases when the title disappears(#8310) or app crashes(#8311).

## What is the new behavior?
Titles no longer disappear and switching tabs no longer causes crashes

Fixes #8310 
Fixes #8311