### PR TITLE
fix(ios): Ensure ObserverClass is initialized

### DIFF
--- a/nativescript-core/ui/core/control-state-change/control-state-change.ios.ts
+++ b/nativescript-core/ui/core/control-state-change/control-state-change.ios.ts
@@ -22,7 +22,7 @@ export class ControlStateChangeListener implements ControlStateChangeListenerDef
     private _callback: (state: string) => void;
 
     constructor(control: UIControl, callback: (state: string) => void) {
-        this._observer = ObserverClass.alloc();
+        this._observer = ObserverClass.alloc().init();
         this._observer["_owner"] = this;
         this._control = control;
         this._callback = callback;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

The extended `ObserverClass` is only allocated but never initialized. The iOS runtime applies some heuristics to such objects trying to automatically initialize them when used. The [new iOS V8 based runtime](https://github.com/NativeScript/ns-v8ios-runtime) no longer does that and the application will crash if we try to use such objects.

## What is the new behavior?

Ensure that the allocated instance is initialized.

