### PR TITLE
Bottom nav color ios fix

### DIFF
--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -377,7 +377,7 @@ export class BottomNavigation extends TabNavigationBase {
 
     public setTabBarItemColor(tabStripItem: TabStripItem, value: UIColor | Color): void {
         const states = getTitleAttributesForStates(tabStripItem.label);
-        applyStatesToItem(tabStripItem.nativeView, states);
+        applyStatesToItem(tabStripItem.nativeView, states, this.viewController.tabBar);
     }
 
     public setTabBarIconColor(tabStripItem: TabStripItem, value: UIColor | Color): void {
@@ -389,7 +389,7 @@ export class BottomNavigation extends TabNavigationBase {
 
     public setTabBarItemFontInternal(tabStripItem: TabStripItem, value: Font): void {
         const states = getTitleAttributesForStates(tabStripItem.label);
-        applyStatesToItem(tabStripItem.nativeView, states);
+        applyStatesToItem(tabStripItem.nativeView, states, this.viewController.tabBar);
     }
 
     public setTabBarItemTextTransform(tabStripItem: TabStripItem, value: TextTransform): void {
@@ -519,7 +519,7 @@ export class BottomNavigation extends TabNavigationBase {
                 updateTitleAndIconPositions(tabStripItem, tabBarItem, controller);
 
                 const states = getTitleAttributesForStates(tabStripItem.label);
-                applyStatesToItem(tabBarItem, states);
+                applyStatesToItem(tabBarItem, states, this.viewController.tabBar);
 
                 controller.tabBarItem = tabBarItem;
                 tabStripItem._index = i;
@@ -719,11 +719,16 @@ function getTitleAttributesForStates(view: View): TabStates {
     return result;
 }
 
-function applyStatesToItem(item: UITabBarItem, states: TabStates) {
+function applyStatesToItem(item: UITabBarItem, states: TabStates, tabBar: UITabBar) {
     if (!states) {
         return;
     }
 
     item.setTitleTextAttributesForState(states.normalState, UIControlState.Normal);
     item.setTitleTextAttributesForState(states.selectedState, UIControlState.Selected);
+
+    // fix for the following issue https://books.google.bg/books?id=99_BDwAAQBAJ&q=tabBar.unselectedItemTintColor
+    if (states.normalState[UITextAttributeTextColor] && (majorVersion > 9)) {
+        tabBar.unselectedItemTintColor = states.normalState[UITextAttributeTextColor];
+    }
 }

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -727,9 +727,9 @@ function applyStatesToItem(item: UITabBarItem, states: TabStates, tabBar: UITabB
     item.setTitleTextAttributesForState(states.normalState, UIControlState.Normal);
     item.setTitleTextAttributesForState(states.selectedState, UIControlState.Selected);
 
-    // there's a bug when setting the item color on ios 13 if there's no backround set to the tabstrip
+    // there's a bug when setting the item color on ios 13 if there's no background set to the tabstrip
     // https://books.google.bg/books?id=99_BDwAAQBAJ&q=tabBar.unselectedItemTintColor
-    // to fix the above issue we are applying the selected fix only for the case when there is no background set
+    // to fix the above issue we are applying the selected fix only for the case, when there is no background set
     // in that case we have the following known issue:
     // the color to all unselected items, so you won't be able to set different colors for the different not selected items
     if ((!tabBar.barTintColor) && (states.normalState[UITextAttributeTextColor] && (majorVersion > 9))) {

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -727,8 +727,12 @@ function applyStatesToItem(item: UITabBarItem, states: TabStates, tabBar: UITabB
     item.setTitleTextAttributesForState(states.normalState, UIControlState.Normal);
     item.setTitleTextAttributesForState(states.selectedState, UIControlState.Selected);
 
-    // fix for the following issue https://books.google.bg/books?id=99_BDwAAQBAJ&q=tabBar.unselectedItemTintColor
-    if (states.normalState[UITextAttributeTextColor] && (majorVersion > 9)) {
+    // there's a bug when setting the item color on ios 13 if there's no backround set to the tabstrip
+    // https://books.google.bg/books?id=99_BDwAAQBAJ&q=tabBar.unselectedItemTintColor
+    // to fix the above issue we are applying the selected fix only for the case when there is no background set
+    // in that case we have the following known issue:
+    // the color to all unselected items, so you won't be able to set different colors for the different not selected items
+    if ((!tabBar.barTintColor) && (states.normalState[UITextAttributeTextColor] && (majorVersion > 9))) {
         tabBar.unselectedItemTintColor = states.normalState[UITextAttributeTextColor];
     }
 }

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -732,7 +732,7 @@ function applyStatesToItem(item: UITabBarItem, states: TabStates, tabBar: UITabB
     // to fix the above issue we are applying the selected fix only for the case, when there is no background set
     // in that case we have the following known issue:
     // we will set the color to all unselected items, so you won't be able to set different colors for the different not selected items
-    if ((!tabBar.barTintColor) && (states.normalState[UITextAttributeTextColor] && (majorVersion > 9))) {
+    if (!tabBar.barTintColor && states.normalState[UITextAttributeTextColor] && (majorVersion > 9)) {
         tabBar.unselectedItemTintColor = states.normalState[UITextAttributeTextColor];
     }
 }

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.ios.ts
@@ -731,7 +731,7 @@ function applyStatesToItem(item: UITabBarItem, states: TabStates, tabBar: UITabB
     // https://books.google.bg/books?id=99_BDwAAQBAJ&q=tabBar.unselectedItemTintColor
     // to fix the above issue we are applying the selected fix only for the case, when there is no background set
     // in that case we have the following known issue:
-    // the color to all unselected items, so you won't be able to set different colors for the different not selected items
+    // we will set the color to all unselected items, so you won't be able to set different colors for the different not selected items
     if ((!tabBar.barTintColor) && (states.normalState[UITextAttributeTextColor] && (majorVersion > 9))) {
         tabBar.unselectedItemTintColor = states.normalState[UITextAttributeTextColor];
     }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

There's a bug when setting the item color on ios 13 if there's no background set to the tabstrip -  https://books.google.bg/books?id=99_BDwAAQBAJ&q=tabBar.unselectedItemTintColor 
To fix the above issue we are applying the selected fix only for the case when there is no background set. In that case, we have the following known issue:
    -  we will set the same color to all unselected items, so you won't be able to set different colors for the different not selected items

Fixes #8309.

BREAKING CHANGES:

iOS: You cannot set different text colors for different not selected items in the TabStrip if there is no background set to the tabs. 
The above background cannot be achieved in iOS 13 because of a bug, and to avoid different behavior on different versions we've added the above restriction.

Migration steps:

Make sure you either have set the TabStrip background or you don't use different text colors for non-selected tabs. 