### PR TITLE
fix: do not clear androidView._cachedDrawable

### DIFF
--- a/nativescript-core/ui/styling/background.android.ts
+++ b/nativescript-core/ui/styling/background.android.ts
@@ -91,8 +91,6 @@ export module ad {
             }
 
             nativeView.setBackground(defaultDrawable);
-            // TODO: Do we need to clear the drawable here? Can't we just reuse it again?
-            androidView._cachedDrawable = undefined;
         }
 
         // TODO: Can we move BorderWidths as separate native setter?


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

It seems that keeping the cache solves the problem with `newDrawable(android.content.res.Resources) on null object`. However, it is not clear why we were clearing it from the cache. 

Fixes  #7954, #7867.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

