### PR TITLE
fix: remove duplicate snippet

### DIFF
--- a/tests/app/ui/text-field/text-field-tests.ts
+++ b/tests/app/ui/text-field/text-field-tests.ts
@@ -463,10 +463,7 @@ export var testCloseOnReturn = function () {
             return;
         }
         var textField = <TextField>views[0];
-
-        // >> setting-closeOnReturn-property
         textField.closeOnReturn = true;
-        // << setting-closeOnReturn-property
 
         typeTextNativelyWithReturn(textField, "Should close textfield");
 


### PR DESCRIPTION
A duplicate snippet (for markdown generation) was crashing the DOCS build.

Related to [this PR here](https://github.com/NativeScript/NativeScript/pull/8347/files)