### PR TITLE
fix(css): parse css selectors with escape sequences (for real)

### DIFF
--- a/nativescript-core/css/parser.ts
+++ b/nativescript-core/css/parser.ts
@@ -804,10 +804,16 @@ export function parseUniversalSelector(text: string, start: number = 0): Parsed<
     return { start, end, value: { type: "*" } };
 }
 
-const simpleIdentifierSelectorRegEx = /(#|\.|:|\b)([_-\w][_-\w\d\\/]*)/gy;
+const simpleIdentifierSelectorRegEx = /(#|\.|:|\b)((?:[\w_-]|\\.)(?:[\w\d_-]|\\.)*)/gyu;
+const unicodeEscapeRegEx = /\\([0-9a-fA-F]{1,5}\s|[0-9a-fA-F]{6})/g
 export function parseSimpleIdentifierSelector(text: string, start: number = 0): Parsed<TypeSelector | ClassSelector | IdSelector | PseudoClassSelector> {
     simpleIdentifierSelectorRegEx.lastIndex = start;
-    const result = simpleIdentifierSelectorRegEx.exec(text);
+    const result = simpleIdentifierSelectorRegEx.exec(
+        text.replace(
+            unicodeEscapeRegEx,
+            (_, c) => "\\" + String.fromCodePoint(parseInt(c.trim(), 16))
+        )
+    );
     if (!result) {
         return null;
     }

--- a/nativescript-core/css/parser.ts
+++ b/nativescript-core/css/parser.ts
@@ -805,7 +805,7 @@ export function parseUniversalSelector(text: string, start: number = 0): Parsed<
 }
 
 const simpleIdentifierSelectorRegEx = /(#|\.|:|\b)((?:[\w_-]|\\.)(?:[\w\d_-]|\\.)*)/gyu;
-const unicodeEscapeRegEx = /\\([0-9a-fA-F]{1,5}\s|[0-9a-fA-F]{6})/g
+const unicodeEscapeRegEx = /\\([0-9a-fA-F]{1,5}\s|[0-9a-fA-F]{6})/g;
 export function parseSimpleIdentifierSelector(text: string, start: number = 0): Parsed<TypeSelector | ClassSelector | IdSelector | PseudoClassSelector> {
     simpleIdentifierSelectorRegEx.lastIndex = start;
     const result = simpleIdentifierSelectorRegEx.exec(

--- a/tests/app/ui/styling/style-tests.ts
+++ b/tests/app/ui/styling/style-tests.ts
@@ -200,25 +200,32 @@ export function test_class_selector() {
 
 export function test_class_selector_with_escape_characters() {
     let page = helper.getClearCurrentPage();
-    let btnWithClass1: buttonModule.Button;
-    let btnWithClass2: buttonModule.Button;
-
-    page.css = ".test-1 { color: red; } .test-1\\/2 { color: blue }";
-
-    //// Will be styled
-    btnWithClass1 = new buttonModule.Button();
-    btnWithClass1.className = "test-1";
-
-    btnWithClass2 = new buttonModule.Button();
-    btnWithClass2.className = "test-1/2";
+    page.css = `
+        .test-1 { color: red; }
+        .test-1\\/2, .test-1\\:2, .\\61 f, .\\1F642 { color: blue }
+    `;
 
     const stack = new stackModule.StackLayout();
     page.content = stack;
-    stack.addChild(btnWithClass1);
-    stack.addChild(btnWithClass2);
 
-    helper.assertViewColor(btnWithClass1, "#FF0000");
-    helper.assertViewColor(btnWithClass2, "#0000FF");
+    let btn: buttonModule.Button = new buttonModule.Button();
+    stack.addChild(btn);
+
+    //// Will be styled
+    btn.className = "test-1";
+    helper.assertViewColor(btn, "#FF0000");
+
+    btn.className = "test-1/2";
+    helper.assertViewColor(btn, "#0000FF");
+
+    btn.className = "test-1:2";
+    helper.assertViewColor(btn, "#0000FF");
+
+    btn.className = "af";
+    helper.assertViewColor(btn, "#0000FF");
+
+    btn.className = "\u{1F642}";
+    helper.assertViewColor(btn, "#0000FF");
 }
 
 export function test_multiple_class_selector() {


### PR DESCRIPTION
Currently NativeScript doesn't correctly parse escape sequences in CSS selectors. There was an issue and PR (#7688, #7689) about this problem previously but only escaping a slash was implemented. My PR fully supports escape sequence from the [spec](https://www.w3.org/TR/CSS21/syndata.html#characters). This includes escaping any character or Unicode sequence.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

