### PR TITLE
fix: the css parser should handle empty nodes

### DIFF
--- a/nativescript-core/css/css-tree-parser.ts
+++ b/nativescript-core/css/css-tree-parser.ts
@@ -39,7 +39,7 @@ function transformAst(node, css, type = null) {
         return {
             type: "stylesheet",
             stylesheet: {
-                rules: node.children.map(child => transformAst(child, css)).toArray(),
+                rules: node.children.map(child => transformAst(child, css)).filter(child => child !== null).toArray(),
                 parsingErrors: []
             }
         };
@@ -78,7 +78,7 @@ function transformAst(node, css, type = null) {
     }
 
     if (node.type === "Block") {
-        return node.children.map(child => transformAst(child, css, type)).toArray();
+        return node.children.map(child => transformAst(child, css, type)).filter(child => child !== null).toArray();
     }
 
     if (node.type === "Rule") {
@@ -114,6 +114,10 @@ function transformAst(node, css, type = null) {
             value: node.value.value ? node.value.value.trim() : "",
             position: mapPosition(node, css)
         };
+    }
+
+    if (node.type === "Raw") {
+        return null;
     }
 
     throw Error(`Unknown node type ${node.type}`);

--- a/unit-tests/css-tree-parser/css-tree-parser.ts
+++ b/unit-tests/css-tree-parser/css-tree-parser.ts
@@ -11,6 +11,16 @@ describe("css-tree parser compatible with rework ", () => {
         assert.deepEqual(cssTreeAST, reworkAST);
     });
 
+    it("empty rule", () => {
+        const css = `.test {
+            color: red;
+            ;
+        }`;
+        const reworkAST = reworkCssParse(css, { source: "file.css" });
+        const cssTreeAST = cssTreeParse(css, "file.css");
+        assert.deepEqual(cssTreeAST, reworkAST);
+    });
+
     it("@keyframes", () => {
         const testCase = ".test { animation-name: test; } @keyframes test { from { background-color: red; } to { background-color: blue; } } .test { color: red; }";
         const reworkAST = reworkCssParse(testCase, { source: "file.css" });


### PR DESCRIPTION
## PR Checklist

- [ x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ x ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ x ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

The CSS parser is failing for empty rules such as:

```css
Button.-primary {
    font-size: 18;
    ;
    color: red;
}
```
## What is the new behavior?

The CSS parser should ignore such empty rules without failing.