### PR TITLE
fix(android-tabs): tab backgroundColor cache can be wrong - DO NOT MERGE

### DIFF
--- a/nativescript-core/ui/tab-view/tab-view.android.ts
+++ b/nativescript-core/ui/tab-view/tab-view.android.ts
@@ -698,7 +698,9 @@ export class TabView extends TabViewBase {
     }
 
     public updateAndroidItemAt(index: number, spec: org.nativescript.widgets.TabItemSpec) {
-        this._tabLayout.updateItemAt(index, spec);
+        if (index < this._tabLayout.getItemCount()) {
+            this._tabLayout.updateItemAt(index, spec);
+        }
     }
 
     [androidOffscreenTabLimitProperty.getDefault](): number {

--- a/nativescript-core/ui/tab-view/tab-view.android.ts
+++ b/nativescript-core/ui/tab-view/tab-view.android.ts
@@ -734,6 +734,7 @@ export class TabView extends TabViewBase {
 
         if (value instanceof Color) {
             this._tabLayout.setBackgroundColor(value.android);
+            this.nativeViewProtected.viewPager.setBackgroundColor(value.android);
         } else {
             this._tabLayout.setBackground(tryCloneDrawable(value, this.nativeViewProtected.getResources()));
         }

--- a/nativescript-core/ui/tab-view/tab-view.android.ts
+++ b/nativescript-core/ui/tab-view/tab-view.android.ts
@@ -736,7 +736,7 @@ export class TabView extends TabViewBase {
 
         if (value instanceof Color) {
             this._tabLayout.setBackgroundColor(value.android);
-            this.nativeViewProtected.viewPager.setBackgroundColor(value.android);
+            this._viewPager.setBackgroundColor(value.android);
         } else {
             this._tabLayout.setBackground(tryCloneDrawable(value, this.nativeViewProtected.getResources()));
         }

--- a/nativescript-core/ui/tab-view/tab-view.android.ts
+++ b/nativescript-core/ui/tab-view/tab-view.android.ts
@@ -730,6 +730,8 @@ export class TabView extends TabViewBase {
         return this._tabLayout.getBackground();
     }
     [tabBackgroundColorProperty.setNative](value: android.graphics.drawable.Drawable | Color) {
+        this._originalBackground = null;
+
         if (value instanceof Color) {
             this._tabLayout.setBackgroundColor(value.android);
         } else {

--- a/nativescript-core/ui/tabs/tabs.android.ts
+++ b/nativescript-core/ui/tabs/tabs.android.ts
@@ -783,7 +783,9 @@ export class Tabs extends TabsBase {
     // }
 
     public updateAndroidItemAt(index: number, spec: org.nativescript.widgets.TabItemSpec) {
-        this._tabsBar.updateItemAt(index, spec);
+        if (index < this._tabsBar.getItemCount()) {
+            this._tabsBar.updateItemAt(index, spec);
+        }
     }
 
     public getTabBarBackgroundColor(): android.graphics.drawable.Drawable {
@@ -791,6 +793,8 @@ export class Tabs extends TabsBase {
     }
 
     public setTabBarBackgroundColor(value: android.graphics.drawable.Drawable | Color): void {
+        this._originalBackground = null;
+
         if (value instanceof Color) {
             this._tabsBar.setBackgroundColor(value.android);
         } else {


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?
1. Currently on android if you set the Tab & TabView's background color; it cache's the color when you leave the page and resets it when you return to the page.  (Good behavior so far).   However, if you navigate away; and then change the global CSS from say light theme to a dark theme, then return back to the page with a tab/tab-view the tab attempts to use the old cached color, despite the CSS system passing a new backgroundColor into the control on refresh. 

2. On tab-views; the ViewPager can cache the background color; so we need to force it to change the color also.

3. Crashing issue with `updateAndroidItemAt` during startup of control.   

## What is the new behavior?
1. This clears the `_originalBackground` cached value if a new backgroundColor is set.

2. sets the viewPagers color also

3. Adds a safety check to make sure updateAndroidItemAt can't update something that doesn't exist.


Fixes/Implements/Closes #
Fixes two issues repoted in NativeScript-Themes repo with the "tabs" and "tab-view" controls.

