### PR TITLE
fix: change #aarrggbb to #rrggbbaa

### DIFF
--- a/nativescript-core/color/color-common.ts
+++ b/nativescript-core/color/color-common.ts
@@ -26,7 +26,9 @@ export class Color implements definition.Color {
                     const hex = knownColors.getKnownColor(arg);
                     this._name = arg;
                     this._argb = this._argbFromString(hex);
-                } else if (HEX_REGEX.test(arg)) {
+                } else if (arg[0].charAt(0) === SHARP && (arg.length === 4 || arg.length === 7 || arg.length === 9)) {
+                    //we dont use the regexp as it is quite slow. Instead we expect it to be a valid hex format
+                    //strange that it would not be. And if it is not a thrown error seems best
                     // The parameter is a "#RRGGBBAA" formatted string
                     const hex = this._normalizeHex(arg);
                     this._argb = this._argbFromString(hex);
@@ -148,7 +150,8 @@ export class Color implements definition.Color {
     }
 
     private _normalizeHex(hexStr: string): string {
-        if (hexStr.charAt(0) === SHARP && hexStr.length === 4) {
+        // we expect this to already has a # as first char as it is supposed to be tested before
+        if (hexStr.length === 4) {
             // Duplicate each char after the #, so "#123" becomes "#112233"
             hexStr = hexStr.charAt(0)
                 + hexStr.charAt(1) + hexStr.charAt(1)

--- a/nativescript-core/color/color-common.ts
+++ b/nativescript-core/color/color-common.ts
@@ -63,7 +63,7 @@ export class Color implements definition.Color {
         if (this.a === 0xFF) {
             return ("#" + this._componentToHex(this.r) + this._componentToHex(this.g) + this._componentToHex(this.b)).toUpperCase();
         } else {
-            return ("#" + this._componentToHex(this.a) + this._componentToHex(this.r) + this._componentToHex(this.g) + this._componentToHex(this.b)).toUpperCase();
+            return ("#" + this._componentToHex(this.r) + this._componentToHex(this.g) + this._componentToHex(this.b) + this._componentToHex(this.a)).toUpperCase();
         }
     }
 
@@ -93,7 +93,12 @@ export class Color implements definition.Color {
         let intVal = parseInt(hex, 16);
         if (hex.length === 6) {
             // add the alpha component since the provided string is RRGGBB
-            intVal = (intVal & 0xFFFFFF00) + 0x000000FF;
+            intVal = (intVal & 0x00FFFFFF) + 0xFF000000;
+        } else {
+            // the new format is #RRGGBBAA 
+            // we need to shift the alpha value to 0x01000000 position
+            const a = (intVal / 0x00000001) & 0xFF;
+            intVal = (intVal >>> 8)  + (a & 0xFF) * 0x01000000;
         }
 
         return intVal;

--- a/nativescript-core/color/color-common.ts
+++ b/nativescript-core/color/color-common.ts
@@ -27,7 +27,7 @@ export class Color implements definition.Color {
                     this._name = arg;
                     this._argb = this._argbFromString(hex);
                 } else if (HEX_REGEX.test(arg)) {
-                    // The parameter is a "#AARRGGBB" formatted string
+                    // The parameter is a "#RRGGBBAA" formatted string
                     const hex = this._normalizeHex(arg);
                     this._argb = this._argbFromString(hex);
                 } else {
@@ -93,7 +93,7 @@ export class Color implements definition.Color {
         let intVal = parseInt(hex, 16);
         if (hex.length === 6) {
             // add the alpha component since the provided string is RRGGBB
-            intVal = (intVal & 0x00FFFFFF) + 0xFF000000;
+            intVal = (intVal & 0xFFFFFF00) + 0x000000FF;
         }
 
         return intVal;

--- a/tests/app/color/color-tests.ts
+++ b/tests/app/color/color-tests.ts
@@ -39,7 +39,7 @@ export var test_Argb_Color = function () {
     TKUnit.assertEqual(color.r, 255, "Color.r not properly parsed");
     TKUnit.assertEqual(color.g, 100, "Color.g not properly parsed");
     TKUnit.assertEqual(color.b, 100, "Color.b not properly parsed");
-    TKUnit.assertEqual(color.hex, "#64FF6464", "Color.hex not properly parsed");
+    TKUnit.assertEqual(color.hex, "#FF646464", "Color.hex not properly parsed");
     TKUnit.assertEqual(color.argb, 0x64FF6464, "Color.argb not properly parsed");
 };
 
@@ -86,6 +86,6 @@ export var test_rgba_Color_CSS = function () {
     TKUnit.assertEqual(color.r, 255, "Color.r not properly parsed");
     TKUnit.assertEqual(color.g, 100, "Color.g not properly parsed");
     TKUnit.assertEqual(color.b, 100, "Color.b not properly parsed");
-    TKUnit.assertEqual(color.hex, "#80FF6464", "Color.hex not properly parsed");
+    TKUnit.assertEqual(color.hex, "#FF646480", "Color.hex not properly parsed");
     TKUnit.assertEqual(color.argb, 0x80FF6464, "Color.argb not properly parsed");
 };

--- a/tests/app/ui/button/button-tests.ts
+++ b/tests/app/ui/button/button-tests.ts
@@ -185,7 +185,7 @@ var _testNativeFontSizeFromLocal = function (views: Array<viewModule.View>) {
     helper.assertAreClose(actualResult, expectedFontSize, "FontSizeFromLocal");
 };
 
-var actualColorHex = "#ffff0000";
+var actualColorHex = "#ff0000ff";
 var expectedNormalizedColorHex = "#FF0000";
 var _testLocalColorFromCss = function (views: Array<viewModule.View>) {
     var button = <buttonModule.Button>views[0];
@@ -213,7 +213,7 @@ var _testNativeColorFromLocal = function (views: Array<viewModule.View>) {
     TKUnit.assert(actualResult === expectedNormalizedColorHex, "Actual: " + actualResult + "; Expected: " + expectedNormalizedColorHex);
 };
 
-var actualBackgroundColorHex = "#FF00FF00";
+var actualBackgroundColorHex = "#00FF00FF";
 var expectedNormalizedBackgroundColorHex = "#00FF00";
 var _testLocalBackgroundColorFromCss = function (views: Array<viewModule.View>) {
     var button = <buttonModule.Button>views[0];
@@ -272,7 +272,7 @@ export var test_StateHighlighted_also_fires_pressedState = function () {
     helper.buildUIAndRunTest(_createButtonFunc(), function (views: Array<viewModule.View>) {
         var view = <buttonModule.Button>views[0];
         var page = <pagesModule.Page>views[1];
-        var expectedColor = "#FFFF0000";
+        var expectedColor = "#FF0000FF";
         var expectedNormalizedColor = "#FF0000";
         page.css = "button:pressed { background-color: " + expectedColor + "; }";
 
@@ -289,7 +289,7 @@ export var test_StateHighlighted_also_fires_activeState = function () {
     helper.buildUIAndRunTest(_createButtonFunc(), function (views: Array<viewModule.View>) {
         var view = <buttonModule.Button>views[0];
         var page = <pagesModule.Page>views[1];
-        var expectedColor = "#FFFF0000";
+        var expectedColor = "#FF0000FF";
         var expectedNormalizedColor = "#FF0000";
         page.css = "button:active { background-color: " + expectedColor + "; }";
 
@@ -306,7 +306,7 @@ export var test_applying_disabled_visual_State_when_button_is_disable = function
     helper.buildUIAndRunTest(_createButtonFunc(), function (views: Array<viewModule.View>) {
         var view = <buttonModule.Button>views[0];
         var page = <pagesModule.Page>views[1];
-        var expectedColor = "#FFFF0000";
+        var expectedColor = "#FF0000FF";
         var expectedNormalizedColor = "#FF0000";
         page.css = "button:disabled { background-color: " + expectedColor + "; }";
 

--- a/tests/app/ui/label/label-tests.ts
+++ b/tests/app/ui/label/label-tests.ts
@@ -301,8 +301,8 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         const label = this.testView;
 
         const fontSize = 14;
-        const color = "#FFFF0000";
-        const backgroundColor = "#FF00FF00";
+        const color = "#FF0000FF";
+        const backgroundColor = "#00FF00FF";
         const testCss = [".title {background-color: ", backgroundColor, "; ",
             "color: ", color, "; ",
             "font-size: ", fontSize, ";}"].join("");
@@ -580,7 +580,7 @@ export class LabelTest extends testModule.UITest<LabelModule.Label> {
         let view = this.testView;
         let page = this.testPage;
         this.waitUntilTestElementIsLoaded();
-        let expectedColor = "#FFFF0000";
+        let expectedColor = "#FF0000FF";
         let expectedNormalizedColor = "#FF0000";
 
         page.css = "label:disabled { background-color: " + expectedColor + "; }";

--- a/tests/app/ui/page/page-tests-common.ts
+++ b/tests/app/ui/page/page-tests-common.ts
@@ -339,7 +339,7 @@ export function test_cssShouldBeAppliedToAllNestedElements() {
     const stackLayout = new StackLayout();
     stackLayout.addChild(label);
     testPage.content = stackLayout;
-    testPage.css = "stackLayout {background-color: #FFFF0000;} label {background-color: #FF00FF00;}";
+    testPage.css = "stackLayout {background-color: #FF0000FF;} label {background-color: #00FF00FF;}";
 
     const pageFactory = function () {
         return testPage;
@@ -361,7 +361,7 @@ export function test_cssShouldBeAppliedAfterChangeToAllNestedElements() {
     const stackLayout = new StackLayout();
     stackLayout.addChild(label);
     testPage.content = stackLayout;
-    testPage.css = "stackLayout {background-color: #FFFF0000;} label {background-color: #FF00FF00;}";
+    testPage.css = "stackLayout {background-color: #FF0000FF;} label {background-color: #00FF00FF;}";
 
     const pageFactory = function () {
         return testPage;
@@ -372,7 +372,7 @@ export function test_cssShouldBeAppliedAfterChangeToAllNestedElements() {
     TKUnit.assertEqual(label.style.backgroundColor.hex, "#00FF00");
     TKUnit.assertEqual(stackLayout.style.backgroundColor.hex, "#FF0000");
 
-    testPage.css = "stackLayout {background-color: #FF0000FF;} label {background-color: #FFFF0000;}";
+    testPage.css = "stackLayout {background-color: #0000FFFF;} label {background-color: #FF0000FF;}";
     TKUnit.assertEqual(label.style.backgroundColor.hex, "#FF0000");
     TKUnit.assertEqual(stackLayout.style.backgroundColor.hex, "#0000FF");
 }

--- a/tests/app/ui/page/test-declarative-css-page.css
+++ b/tests/app/ui/page/test-declarative-css-page.css
@@ -1,3 +1,3 @@
 Label {
-    background-color: #ff00ff00;
+    background-color: #00ff00ff;
 }

--- a/tests/app/ui/page/test-module-css-page.css
+++ b/tests/app/ui/page/test-module-css-page.css
@@ -1,3 +1,3 @@
 Label {
-    background-color: #ff00ff00;
+    background-color: #00ff00ff;
 }

--- a/tests/app/ui/text-field/text-field-tests.ts
+++ b/tests/app/ui/text-field/text-field-tests.ts
@@ -524,7 +524,7 @@ export var testNativeFontSizeFromLocal = function () {
     });
 };
 
-var expectedColorHex = "#FFFF0000";
+var expectedColorHex = "#FF0000FF";
 var expectedNormalizedColorHex = "#FF0000";
 export var testLocalColorFromCss = function () {
     helper.buildUIAndRunTest(_createTextFieldFunc(), function (views: Array<View>) {
@@ -558,7 +558,7 @@ export var testNativeColorFromLocal = function () {
     });
 };
 
-var expectedBackgroundColorHex = "#FF00FF00";
+var expectedBackgroundColorHex = "#00FF00FF";
 var expectedNormalizedBackgroundColorHex = "#00FF00";
 export var testLocalBackgroundColorFromCss = function () {
     helper.buildUIAndRunTest(_createTextFieldFunc(), function (views: Array<View>) {
@@ -701,7 +701,7 @@ export function test_IntegrationTest_Transform_Decoration_Spacing_WithFormattedT
 
 export function test_set_placeholder_color() {
     const view = new TextField();
-    const expectedColorHex = "#FFFF0000";
+    const expectedColorHex = "#FF0000FF";
     const expectedNormalizedColorHex = "#FF0000";
     helper.buildUIAndRunTest(view, function (views: Array<View>) {
         view.hint = "Some text for hint";
@@ -713,7 +713,7 @@ export function test_set_placeholder_color() {
 
 export function test_set_placeholder_color_when_hint_is_not_set() {
     const view = new TextField();
-    const expectedColorHex = "#FFFF0000";
+    const expectedColorHex = "#FF0000FF";
     const expectedNormalizedColorHex = "#FF0000";
     helper.buildUIAndRunTest(view, function (views: Array<View>) {
         view.setInlineStyle("placeholder-color: " + expectedColorHex + ";");

--- a/tests/app/ui/text-view/text-view-tests.ts
+++ b/tests/app/ui/text-view/text-view-tests.ts
@@ -270,11 +270,11 @@ export var testHintColoriOS = function () {
 
         actualValue = textViewTestsNative.getNativeColor(textView).hex;
 
-        TKUnit.assertEqual(actualValue, "#38FF0000", "Expected hint color to be a subtle transparent red: #38FF0000");
+        TKUnit.assertEqual(actualValue, "#FF000038", "Expected hint color to be a subtle transparent red: #FF000038");
 
         textView.text = "text";
 
-        expectedValue = "#FFFF0000"; // red
+        expectedValue = "#FF0000FF"; // red
         expectedNormalizedValue = "#FF0000";
         actualValue = textViewTestsNative.getNativeColor(textView).hex;
         TKUnit.assert(actualValue === expectedNormalizedValue, "Actual: " + actualValue + "; Expected: " + expectedNormalizedValue);
@@ -403,7 +403,7 @@ export var testLocalLineHeightFromCss = function () {
     });
 };
 
-var expectedColorHex = "#FFFF0000";
+var expectedColorHex = "#FF0000FF";
 var expectedNormalizedColorHex = "#FF0000";
 export var testLocalColorFromCss = function () {
     helper.buildUIAndRunTest(_createTextViewFunc(), function (views: Array<viewModule.View>) {
@@ -437,7 +437,7 @@ export var testNativeColorFromLocal = function () {
     });
 };
 
-var expectedBackgroundColorHex = "#FF00FF00";
+var expectedBackgroundColorHex = "#00FF00FF";
 var expectedNormalizedBackgroundColorHex = "#00FF00";
 export var testLocalBackgroundColorFromCss = function () {
     helper.buildUIAndRunTest(_createTextViewFunc(), function (views: Array<viewModule.View>) {

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
       "version": "next"
     },
     "tns-ios": {
-      "version": "next"
+      "version": "6.5.0-2020-03-12-133513-01"
     }
   },
   "main": "app.js",

--- a/unit-tests/css/parser.ts
+++ b/unit-tests/css/parser.ts
@@ -50,7 +50,7 @@ describe("css", () => {
             describe("color", () => {
                 test(parseColor, "  #369 ", { start: 0, end: 7, value: 0xFF336699 });
                 test(parseColor, "  #456789 ", { start: 0, end: 10, value: 0xFF456789 });
-                test(parseColor, "  #85456789 ", { start: 0, end: 12, value: 0x85456789 });
+                test(parseColor, "  #45678985 ", { start: 0, end: 12, value: 0x85456789 });
                 test(parseColor, "  rgb(255, 8, 128) ", { start: 0, end: 18, value: 0xFFFF0880 });
                 test(parseColor, "  rgba(255, 8, 128, 0.5) ", { start: 0, end: 24, value: 0x80FF0880 });
                 test(parseColor, "  hsl(330.9, 100%, 51.6%) ", { start: 0, end: 25, value: 0xFFFF0880 });


### PR DESCRIPTION
This makes {N} support the web standard ##rrggbbaa format
See https://github.com/NativeScript/NativeScript/issues/8517

Now are there some tests to update?