### PR TITLE
feat: setProperty on Observable

### DIFF
--- a/api-reports/NativeScript.api.md
+++ b/api-reports/NativeScript.api.md
@@ -1503,6 +1503,8 @@ export class Observable {
     removeEventListener(eventNames: string, callback?: any, thisArg?: any);
 
     set(name: string, value: any): void;
+
+    setProperty(name: string, value: any): void;
     //@endprivate
 }
 
@@ -2425,10 +2427,11 @@ export class TabViewItem extends ViewBase {
 
 // @public
 export interface TapGestureEventData extends GestureEventData {
-    getPointerCount(): number;
+   getPointerCount(): number;
     getX(): number;
     getY(): number;
-}
+
+ }
 
 // @public
 export interface Template {

--- a/nativescript-core/data/observable/observable.d.ts
+++ b/nativescript-core/data/observable/observable.d.ts
@@ -130,6 +130,11 @@ export class Observable {
     set(name: string, value: any): void;
 
     /**
+     * Updates the specified property with the provided value and raises a property change event and a specific change event based on the property name.
+     */
+    setProperty(name: string, value: any): void;
+
+    /**
      * Gets the value of the specified property.
      */
     get(name: string): any;

--- a/nativescript-core/data/observable/observable.ts
+++ b/nativescript-core/data/observable/observable.ts
@@ -66,7 +66,7 @@ export class Observable implements ObservableDefinition {
         this.notifyPropertyChange(name, value, oldValue);
 
         const specificPropertyChangeEventName = name + "Change";
-        if(this.hasListeners(specificPropertyChangeEventName)) {
+        if (this.hasListeners(specificPropertyChangeEventName)) {
             const eventData = this._createPropertyChangeData(name, value, oldValue);
             eventData.eventName = specificPropertyChangeEventName;
             this.notify(eventData);

--- a/nativescript-core/data/observable/observable.ts
+++ b/nativescript-core/data/observable/observable.ts
@@ -57,6 +57,22 @@ export class Observable implements ObservableDefinition {
         this.notifyPropertyChange(name, newValue, oldValue);
     }
 
+    public setProperty(name: string, value: any) {
+        const oldValue = this[name];
+        if (this[name] === value) {
+            return;
+        }
+        this[name] = value;
+        this.notifyPropertyChange(name, value, oldValue);
+
+        const specificPropertyChangeEventName = name + "Change";
+        if(this.hasListeners(specificPropertyChangeEventName)) {
+            const eventData = this._createPropertyChangeData(name, value, oldValue);
+            eventData.eventName = specificPropertyChangeEventName;
+            this.notify(eventData);
+        }
+    }
+
     public on(eventNames: string, callback: (data: EventData) => void, thisArg?: any) {
         this.addEventListener(eventNames, callback, thisArg);
     }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Right now when unknown properties are added/set on a View, css attribute selectors do not update the styling.

## What is the new behavior?
<!-- Describe the changes. -->
A new `setProperty` method has been added to Observable that will fire a `propertyChange` and a `${propertyName}Change` event - which will get picked up by the css runtime and styles will update.

The reason I've opted for a new method is because the `set` method of the Observable is overwritten in Views - adding a new method allows triggering the correct events.

Ref: #6122, #7914

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

