### PR TITLE
fix(android/TextField): set focusable, clickable to false if not editable

### DIFF
--- a/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
@@ -227,9 +227,13 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
             this._keyListenerCache = listener;
         }
 
-        // clear the listener if editable is false
+        // clear these fields instead of clearing listener.
+        // this allows input Type to be changed even after editable is false.
         if (!this.editable) {
-            nativeView.setKeyListener(null);
+            nativeView.setFocusable(false);
+            nativeView.setFocusableInTouchMode(false);
+            nativeView.setLongClickable(false);
+            nativeView.setClickable(false);
         }
     }
 


### PR DESCRIPTION

Do not clear key listener when editable is false This prevents the input type to be changed.
Instead, we can set focusable, clickable to false.
This allows to change input Type i.e (secure) at run time when editable is false.

Reference issue: https://github.com/NativeScript/NativeScript/issues/8523

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
In android platform, In TextField if editable is set to false. We cannot change or toggle secure property. This occurs because we are setting KeyListener to false. Instead we can set Focusable, clickable to false.

## What is the new behavior?
Now, one can toggle between secure property, even if editable is set to false. 



