### PR TITLE
fix(android): remove the hack for nested fragments

### DIFF
--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -251,11 +251,6 @@ export class Frame extends FrameBase {
 
     onUnloaded() {
         super.onUnloaded();
-
-        // calling dispose fragment after super.onUnloaded() means we are not relying on the built-in Android logic
-        // to automatically remove child fragments when parent fragment is removed;
-        // this fixes issue with missing nested fragment on app suspend / resume;
-        this.disposeCurrentFragment();
     }
 
     private disposeCurrentFragment(): void {


### PR DESCRIPTION
As explained here https://github.com/NativeScript/NativeScript/issues/6659
That hack has bad consequences.
Also i actually cant see any wrong behavior using the sample provided in the issue and upgrading to latest N.