### PR TITLE
chore: fix typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tslint": "^5.4.3",
     "typedoc": "^0.13.0",
     "typedoc-plugin-external-module-name": "git://github.com/PanayotCankov/typedoc-plugin-external-module-name.git#with-js",
-    "typescript": "^3.7.5"
+    "typescript": "~3.8.3"
   },
   "scripts": {
     "setup": "npm run build-core && npm run build-compat && npm run setup-link",


### PR DESCRIPTION
Fix typescript version with `~`.
It looks we have issues with 3.9.* versions.