### PR TITLE
fix: '__exportStar undefined'

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tslint": "^5.4.3",
     "typedoc": "^0.13.0",
     "typedoc-plugin-external-module-name": "git://github.com/PanayotCankov/typedoc-plugin-external-module-name.git#with-js",
-    "typescript": "^3.7.5"
+    "typescript": "^3.9.3"
   },
   "scripts": {
     "setup": "npm run build-core && npm run build-compat && npm run setup-link",

--- a/tns-core-modules-package/application/application.js
+++ b/tns-core-modules-package/application/application.js
@@ -1,0 +1,4 @@
+// use precompiled js file to make sure we require the ts-helpers to register __exportStar function
+Object.defineProperty(exports, "__esModule", { value: true });
+require("@nativescript/core/globals/ts-helpers");
+__exportStar(require("@nativescript/core/application/application"), exports);

--- a/tns-core-modules-package/tsconfig.json
+++ b/tns-core-modules-package/tsconfig.json
@@ -20,6 +20,7 @@
         "**/*.ts"
     ],
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "application/application.ts"
     ]
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When using typescript version 3.9.3 the generated files in the tns-core-modules package look like:
```JavaScript
Object.defineProperty(exports, “__esModule”, { value: true });
__exportStar(require(“@nativescript/core/application/application”), exports);
```
and for the older versions it looks like:
```JavaScript
function __export(m) {
    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
}
Object.defineProperty(exports, "__esModule", { value: true });
__export(require("@nativescript/core/application/application"));

```
The problem is that if we register **__exportStar** function in the ts-helpers.ts file which is called inside the application module, but if we load the application through the **tns-core-modules** package like this:
```TypeScript
import * as application from "tns-core-modules/application";
```
this will call the code in the beginning and there will be no __exportStar yet.

## What is the new behavior?
To fix that I've added the compiled js content inside the **tns-core-modules-package/application/** folder and ignored the **application/application.ts** in package's **tsconfig.json** file as I have the js file already. In that js file, I'm requiring the **ts-hepers** module which will register the needed __exportStar function.

Fixes #8590.