### PR TITLE
fix(core): pin typescript to 3.8.3 to avoid __exportStar issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tslint": "^5.4.3",
     "typedoc": "^0.13.0",
     "typedoc-plugin-external-module-name": "git://github.com/PanayotCankov/typedoc-plugin-external-module-name.git#with-js",
-    "typescript": "^3.7.5"
+    "typescript": "~3.8.3"
   },
   "scripts": {
     "setup": "npm run build-core && npm run build-compat && npm run setup-link",


### PR DESCRIPTION
We need to do a bit more testing with #8591 before we merge it - as there may be other side effects of typescript 3.9.3.