### PR TITLE
fix(text-base): update text color for ios

### DIFF
--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -141,13 +141,7 @@ export class TextBase extends TextBaseCommon {
     }
     [colorProperty.setNative](value: Color | UIColor) {
         const color = value instanceof Color ? value.ios : value;
-        const nativeView = this.nativeTextViewProtected;
-        if (nativeView instanceof UIButton) {
-            nativeView.setTitleColorForState(color, UIControlState.Normal);
-            nativeView.titleLabel.textColor = color;
-        } else {
-            nativeView.textColor = color;
-        }
+        this._setColor(color);
     }
 
     [fontInternalProperty.getDefault](): UIFont {
@@ -217,6 +211,16 @@ export class TextBase extends TextBaseCommon {
             this.setFormattedTextDecorationAndTransform();
         } else {
             this.setTextDecorationAndTransform();
+        }
+    }
+
+    _setColor(color: UIColor): void {
+        const nativeView = this.nativeTextViewProtected;
+        if (nativeView instanceof UIButton) {
+            nativeView.setTitleColorForState(color, UIControlState.Normal);
+            nativeView.titleLabel.textColor = color;
+        } else {
+            nativeView.textColor = color;
         }
     }
 
@@ -306,14 +310,6 @@ export class TextBase extends TextBaseCommon {
             dict.set(NSParagraphStyleAttributeName, paragraphStyle);
         }
 
-        if (dict.size > 0 || isTextView) {
-            if (style.color) {
-                dict.set(NSForegroundColorAttributeName, style.color.ios);
-            } else if (majorVersion >= 13 && UIColor.labelColor) {
-                dict.set(NSForegroundColorAttributeName, UIColor.labelColor);
-            }
-        }
-
         const text = this.text;
         const string = (text === undefined || text === null) ? "" : text.toString();
         const source = getTransformedText(string, this.textTransform);
@@ -340,6 +336,10 @@ export class TextBase extends TextBaseCommon {
                 this.nativeTextViewProtected.attributedText = undefined;
                 this.nativeTextViewProtected.text = source;
             }
+        }
+
+        if (!style.color && majorVersion >= 13 && UIColor.labelColor) {
+            this._setColor(UIColor.labelColor);
         }
     }
 


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla). -> Link does not work
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Updating the color property on a button in iOS does not change its text color.
Looks like the NSForegroundColorAttributeName takes precedence over any color later applied by setTitleColorForState.

## What is the new behavior?
Updating the color property on a button in iOS does change its text color.

Fixes/Implements/Closes https://github.com/NativeScript/nativescript-angular/issues/1453

