### PR TITLE
fix(text-base): apply letter spacing in ios text field

### DIFF
--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -281,7 +281,11 @@ export class TextBase extends TextBaseCommon {
         }
 
         if (style.letterSpacing !== 0) {
-            dict.set(NSKernAttributeName, style.letterSpacing * this.nativeTextViewProtected.font.pointSize);
+            const kern = style.letterSpacing * this.nativeTextViewProtected.font.pointSize
+            dict.set(NSKernAttributeName, kern);
+            if (this.nativeTextViewProtected instanceof UITextField) {
+                this.nativeTextViewProtected.defaultTextAttributes.setObjectForKey(kern, NSKernAttributeName);
+            }
         }
 
         const isTextView = this.nativeTextViewProtected instanceof UITextView;


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla)
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
If the value of the text field is changed at runtime, the configured letter spacing is not respected.

## What is the new behavior?
Letter spacing is respected if text in text field is changed at runtime.

Fixes/Implements/Closes https://github.com/NativeScript/NativeScript/issues/4892

