### PR TITLE
WIP: fix(text-base): apply letter spacing in ios text field

### DIFF
--- a/e2e/ui-tests-app/app/fonts-tests/text-field-page.xml
+++ b/e2e/ui-tests-app/app/fonts-tests/text-field-page.xml
@@ -6,6 +6,8 @@
     <TextField text="left"    style="text-align: left" />
     <TextField text="center"  style="text-align: center" />
     <TextField text="right"   style="text-align: right" />
+    <!-- Text must not be predefined in the letter spacing test -->
+    <TextField style="letter-spacing: 0.4em;" />
 
     <WrapLayout>
       <TextField text="normal" />


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
A text field without a predefined `text` value (or empty string) does not apply letter spacing on ios.

## What is the new behavior?


Fixes/Implements/Closes https://github.com/NativeScript/NativeScript/issues/4892
Previous PR: https://github.com/NativeScript/NativeScript/pull/8618
Playground demo with the issue: https://play.nativescript.org/?template=play-js&id=onwdD0

