### PR TITLE
fix(text-base): letter spacing for textfield

### DIFF
--- a/e2e/ui-tests-app/app/fonts-tests/text-field-page.xml
+++ b/e2e/ui-tests-app/app/fonts-tests/text-field-page.xml
@@ -6,6 +6,8 @@
     <TextField text="left"    style="text-align: left" />
     <TextField text="center"  style="text-align: center" />
     <TextField text="right"   style="text-align: right" />
+    <!-- Text must not be predefined in the letter spacing test -->
+    <TextField style="letter-spacing: 0.9em;" />
 
     <WrapLayout>
       <TextField text="normal" />

--- a/e2e/ui-tests-app/package.json
+++ b/e2e/ui-tests-app/package.json
@@ -35,6 +35,7 @@
   "gitHead": "8ab7726d1ee9991706069c1359c552e67ee0d1a4",
   "readme": "NativeScript Application",
   "scripts": {
+    "clean": "npx rimraf hooks node_modules platforms package-lock.json",
     "e2e": "tsc -p e2e && mocha --opts ../config/mocha.opts --recursive e2e --appiumCapsLocation ../config/appium.capabilities.json",
     "e2e-debug": "./node_modules/.bin/ns-dev-appium --startSession",
     "e2e-watch": "tsc -p e2e --watch",

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -288,6 +288,9 @@ export class TextBase extends TextBaseCommon {
         if (style.letterSpacing !== 0 && this.nativeTextViewProtected.font) {
             const kern = style.letterSpacing * this.nativeTextViewProtected.font.pointSize;
             dict.set(NSKernAttributeName, kern);
+            if (this.nativeTextViewProtected instanceof UITextField) {
+              this.nativeTextViewProtected.defaultTextAttributes.setValueForKey(kern, NSKernAttributeName);
+            }
         }
 
         if (style.color) {


### PR DESCRIPTION
closes https://github.com/NativeScript/NativeScript/pull/8626
closes https://github.com/NativeScript/NativeScript/issues/4892

@dosomder `setValueForKey` as well as `setObjectForKey` do fix the issue, nice work on the original PR. Sticking with `setValueForKey` since it's typesafe and works same 👍 

![textfield-letter-spacing](https://user-images.githubusercontent.com/457187/84231096-3e028d80-aaa2-11ea-8ebb-023bf871e59b.gif)

