### PR TITLE
feat: Implementing 'onBackPressed' for frame-root. Useful for meddling with tab-navigated apps

### DIFF
--- a/nativescript-core/ui/core/view/view.android.ts
+++ b/nativescript-core/ui/core/view/view.android.ts
@@ -401,18 +401,7 @@ export class View extends ViewCommon {
         // Delegate back navigation handling to the topmost Frame
         // when it's a child of the current View.
         if (topmostFrame && topmostFrame._hasAncestorView(this)) {
-            if (topmostFrame.canGoBack()) {
-                topmostFrame.goBack();
-                return true;
-            }
-
-            if (!topmostFrame.navigationQueueIsEmpty()) {
-                const manager = topmostFrame._getFragmentManager();
-                if (manager) {
-                    manager.executePendingTransactions();
-                    return true;
-                }
-            }
+            return topmostFrame.onBackPressed();
         }
 
         return false;

--- a/nativescript-core/ui/core/view/view.android.ts
+++ b/nativescript-core/ui/core/view/view.android.ts
@@ -401,7 +401,18 @@ export class View extends ViewCommon {
         // Delegate back navigation handling to the topmost Frame
         // when it's a child of the current View.
         if (topmostFrame && topmostFrame._hasAncestorView(this)) {
-            return topmostFrame.onBackPressed();
+            if (topmostFrame.canGoBack()) {
+                topmostFrame.goBack();
+                return true;
+            }
+
+            if (!topmostFrame.navigationQueueIsEmpty()) {
+                const manager = topmostFrame._getFragmentManager();
+                if (manager) {
+                    manager.executePendingTransactions();
+                    return true;
+                }
+            }
         }
 
         return false;

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -1231,7 +1231,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
         view.notify(viewArgs);
 
         // In the case of Frame, use this callback only if it was overridden, since the original will cause navigation issues
-        if (!viewArgs.cancel && (view.onBackPressed === Frame.prototype.onBackPressed || !view.onBackPressed()) {
+        if (!viewArgs.cancel && (view.onBackPressed === Frame.prototype.onBackPressed || !view.onBackPressed())) {
             callSuper = view instanceof Frame ? !FrameBase.goBack() : true;
         }
 

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -361,6 +361,25 @@ export class Frame extends FrameBase {
         }
     }
 
+    public onBackPressed(): boolean {
+        if (this.canGoBack()) {
+            this.goBack();
+
+            return true;
+        }
+
+        if (!this.navigationQueueIsEmpty()) {
+            const manager = this._getFragmentManager();
+            if (manager) {
+                manager.executePendingTransactions();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // HACK: This @profile decorator creates a circular dependency
     // HACK: because the function parameter type is evaluated with 'typeof'
     @profile

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -361,25 +361,6 @@ export class Frame extends FrameBase {
         }
     }
 
-    public onBackPressed(): boolean {
-        if (this.canGoBack()) {
-            this.goBack();
-
-            return true;
-        }
-
-        if (!this.navigationQueueIsEmpty()) {
-            const manager = this._getFragmentManager();
-            if (manager) {
-                manager.executePendingTransactions();
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     // HACK: This @profile decorator creates a circular dependency
     // HACK: because the function parameter type is evaluated with 'typeof'
     @profile

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -1229,8 +1229,9 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
             cancel: false,
         };
         view.notify(viewArgs);
-        
-        if (!viewArgs.cancel && !view.onBackPressed()) {
+
+        // In the case of Frame, use this callback only if it was overridden, since the original will cause navigation issues
+        if (view.onBackPressed === Frame.prototype.onBackPressed || !viewArgs.cancel && !view.onBackPressed()) {
             callSuper = view instanceof Frame ? !FrameBase.goBack() : true;
         }
 

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -1231,7 +1231,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
         view.notify(viewArgs);
 
         // In the case of Frame, use this callback only if it was overridden, since the original will cause navigation issues
-        if (view.onBackPressed === Frame.prototype.onBackPressed || !viewArgs.cancel && !view.onBackPressed()) {
+        if (!viewArgs.cancel && (view.onBackPressed === Frame.prototype.onBackPressed || !view.onBackPressed()) {
             callSuper = view instanceof Frame ? !FrameBase.goBack() : true;
         }
 

--- a/nativescript-core/ui/frame/frame.android.ts
+++ b/nativescript-core/ui/frame/frame.android.ts
@@ -1221,20 +1221,17 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 
         const view = this._rootView;
         let callSuper = false;
-        if (view instanceof Frame) {
-            callSuper = !FrameBase.goBack();
-        } else {
-            const viewArgs = <application.AndroidActivityBackPressedEventData>{
-                eventName: "activityBackPressed",
-                object: view,
-                activity: activity,
-                cancel: false,
-            };
-            view.notify(viewArgs);
-
-            if (!viewArgs.cancel && !view.onBackPressed()) {
-                callSuper = true;
-            }
+        
+        const viewArgs = <application.AndroidActivityBackPressedEventData>{
+            eventName: "activityBackPressed",
+            object: view,
+            activity: activity,
+            cancel: false,
+        };
+        view.notify(viewArgs);
+        
+        if (!viewArgs.cancel && !view.onBackPressed()) {
+            callSuper = view instanceof Frame ? !FrameBase.goBack() : true;
         }
 
         if (callSuper) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Currently, 'onBackPressed' callback will never get called in the case of a frame root.

## What is the new behavior?
Developers will be able to handle back press for frame root.