### PR TITLE
fix(text-base): apply dynamic text color change on button for ios

### DIFF
--- a/e2e/ui-tests-app/app/app.css
+++ b/e2e/ui-tests-app/app/app.css
@@ -21,3 +21,22 @@
     color: yellow;
     margin-left: 30;
 }
+
+.ui-tests-app-issue-ng-1453-yellow {
+    color: yellow;
+    background-color: black;
+}
+
+.ui-tests-app-issue-ng-1453-pink {
+    color: pink;
+}
+
+.ui-tests-app-issue-ng-1453-base {
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 14;
+  text-align: center;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+}

--- a/e2e/ui-tests-app/app/fonts-tests/button-page.ts
+++ b/e2e/ui-tests-app/app/fonts-tests/button-page.ts
@@ -1,4 +1,5 @@
 import * as stack from "tns-core-modules/ui/layouts/stack-layout";
+import { Button } from "@nativescript/core/ui/button";
 import * as view from "tns-core-modules/ui/core/view";
 import { unsetValue } from "tns-core-modules/ui/core/view";
 
@@ -30,4 +31,11 @@ export function resetStyles(args) {
 
         return true;
     });
+}
+
+export function issue_ng_1453_loaded(args) {
+  var btn = <Button>args.object;
+  setTimeout(() => {
+    btn.className = "ui-tests-app-issue-ng-1453-base ui-tests-app-issue-ng-1453-yellow";
+  }, 2000);
 }

--- a/e2e/ui-tests-app/app/fonts-tests/button-page.xml
+++ b/e2e/ui-tests-app/app/fonts-tests/button-page.xml
@@ -4,6 +4,7 @@
     <Button text="left"    style="text-align: left" />
     <Button text="center"  style="text-align: center" />
     <Button text="right"   style="text-align: right" />
+    <Button text="Yellow text / black bg after 2s" class="ui-tests-app-issue-ng-1453-base ui-tests-app-issue-ng-1453-pink" loaded="issue_ng_1453_loaded" />
 
     <WrapLayout>
       <Button text="RESET" tap="resetStyles"/>

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -293,12 +293,6 @@ export class TextBase extends TextBaseCommon {
             }
         }
 
-        if (style.color) {
-            dict.set(NSForegroundColorAttributeName, style.color.ios);
-        } else if (majorVersion >= 13 && UIColor.labelColor) {
-            dict.set(NSForegroundColorAttributeName, UIColor.labelColor);
-        }
-
         const isTextView = this.nativeTextViewProtected instanceof UITextView;
         if (style.lineHeight) {
             const paragraphStyle = NSMutableParagraphStyle.alloc().init();


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Updating the color property on a button in iOS does not change its text color. This seems to only happen if the letter spacing property is also set. On Android the issue does not happen.

## What is the new behavior?
Color is changed properly.

Fixes/Implements/Closes #[Issue Number].
Previous PR: https://github.com/NativeScript/NativeScript/pull/8617
Playground demo: https://play.nativescript.org/?template=play-js&id=r7ubMC&v=3

