### PR TITLE
WIP: feat(text-base): allow to set image for span

### DIFF
--- a/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
+++ b/nativescript-core/ui/editable-text-base/editable-text-base.android.ts
@@ -60,8 +60,19 @@ function initializeEditTextListeners(): void {
             return global.__native(this);
         }
 
-        public beforeTextChanged(text: string, start: number, count: number, after: number): void {
-            //
+        public beforeTextChanged(text: any, start: number, count: number, after: number): void {
+            if (count === 0) {
+                return;
+            }
+            if (text instanceof android.text.Spanned) {
+                // if we have a formatted text with an ImageSpan and we press the delete key,
+                // remove the whole ImageSpan instead of just one character or the underlying text */
+                // from: https://stackoverflow.com/a/60021470
+                const spansToRemove = text.getSpans(start + 1, start + 1 + count, android.text.style.ImageSpan.class);
+                for(const span in spansToRemove) {
+                    text.removeSpan(span);
+                }
+            }
         }
 
         public onTextChanged(text: string, start: number, before: number, count: number): void {

--- a/nativescript-core/ui/text-base/span.d.ts
+++ b/nativescript-core/ui/text-base/span.d.ts
@@ -47,6 +47,16 @@ export class Span extends ViewBase {
     public backgroundColor: Color;
 
     /**
+     * Gets or sets the height for the image of the span. The aspect ratio is preserved.
+     */
+    public imageHeight: number;
+
+    /**
+     * Gets or sets the image source for the span.
+     */
+    public imageSrc: string;
+
+    /**
      * Gets or sets the text for the span.
      */
     public text: string;

--- a/nativescript-core/ui/text-base/span.d.ts
+++ b/nativescript-core/ui/text-base/span.d.ts
@@ -52,7 +52,7 @@ export class Span extends ViewBase {
     public imageHeight: number;
 
     /**
-     * Gets or sets the image source for the span.
+     * Gets or sets the image source for the span. Image is displayed instead of text. The image must be a local file.
      */
     public imageSrc: string;
 

--- a/nativescript-core/ui/text-base/span.ts
+++ b/nativescript-core/ui/text-base/span.ts
@@ -60,6 +60,23 @@ export class Span extends ViewBase implements SpanDefinition {
         this.style.backgroundColor = value;
     }
 
+    get imageHeight(): number {
+        return this.style.imageHeight;
+    }
+    set imageHeight(value: number) {
+        this.style.imageHeight = value;
+    }
+
+    get imageSrc(): string {
+        return this._imageSrc;
+    }
+    set imageSrc(value: string) {
+        if (this._imageSrc !== value) {
+            this._imageSrc = value;
+            this.notifyPropertyChange("imageSrc", value);
+        }
+    }
+
     get text(): string {
         return this._text;
     }

--- a/nativescript-core/ui/text-base/text-base.android.ts
+++ b/nativescript-core/ui/text-base/text-base.android.ts
@@ -10,8 +10,10 @@ import {
     paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length,
     whiteSpaceProperty, lineHeightProperty, FormattedString, layout, Span, Color, isBold, resetSymbol
 } from "./text-base-common";
+import { Length } from "../core/view";
 import { isString } from "../../utils/types";
 
+import * as platform from "../../platform";
 export * from "./text-base-common";
 
 let TextTransformation: TextTransformation;
@@ -554,6 +556,23 @@ function setSpanModifiers(ssb: android.text.SpannableStringBuilder, span: Span, 
 
     if (align) {
       ssb.setSpan(new BaselineAdjustedSpan(defaultFontSize * layout.getDisplayDensity(), align), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+
+    const imageSrc = span.imageSrc;
+    if (imageSrc && imageSrc !== "") {
+        const drawable = android.graphics.drawable.Drawable.createFromPath(imageSrc);
+        if (drawable != null) {
+            const screen = platform.screen.mainScreen;
+            var height = drawable.getMinimumHeight();
+            var width = drawable.getMinimumWidth();
+            if (spanStyle.imageHeight) {
+                const w_h_ratio = width / height;
+                height = Math.min(Length.toDevicePixels(spanStyle.imageHeight, 0), screen.heightPixels);
+                width = height * w_h_ratio;
+            }
+            drawable.setBounds(0, 0, width, height);
+            ssb.setSpan(new android.text.style.ImageSpan(drawable, android.text.style.DynamicDrawableSpan.ALIGN_CENTER), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
     }
 
     const tappable = span.tappable;

--- a/nativescript-core/ui/text-base/text-base.ios.ts
+++ b/nativescript-core/ui/text-base/text-base.ios.ts
@@ -365,10 +365,10 @@ export class TextBase extends TextBaseCommon {
                     spanText = getTransformedText(spanText, textTransform);
                 }
 
-                const nsAttributedString = this.createMutableStringForSpan(span, spanText);
+                const nsAttributedString = this.createStringForSpan(span, spanText);
                 mas.insertAttributedStringAtIndex(nsAttributedString, spanStart);
-                this._spanRanges.push({location: spanStart, length: spanText.length});
-                spanStart += spanText.length;
+                this._spanRanges.push({location: spanStart, length: nsAttributedString.length});
+                spanStart += nsAttributedString.length;
             }
         }
 
@@ -409,7 +409,7 @@ export class TextBase extends TextBaseCommon {
         }
     }
 
-    createMutableStringForSpan(span: Span, text: string): NSMutableAttributedString {
+    createStringForSpan(span: Span, text: string): NSAttributedString {
         const viewFont = this.nativeTextViewProtected.font;
         const attrDict = <{ key: string, value: any }>{};
         const style = span.style;
@@ -417,6 +417,19 @@ export class TextBase extends TextBaseCommon {
 
         const font = new Font(style.fontFamily, style.fontSize, style.fontStyle, style.fontWeight);
         const iosFont = font.getUIFont(viewFont);
+
+        const imageSrc = span.imageSrc;
+        if (imageSrc && imageSrc !== "") {
+            const txtAttachment = NSTextAttachment.alloc().init();
+            var img = UIImage.imageWithContentsOfFile(imageSrc);
+            if (style.imageHeight) {
+                const scaleFactor = img.size.height / style.imageHeight;
+                img = UIImage.imageWithCGImageScaleOrientation(img.CGImage, scaleFactor, UIImageOrientationUp);
+            }
+            txtAttachment.image = img;
+
+            return NSAttributedString.attributedStringWithAttachment(txtAttachment);
+        }
 
         attrDict[NSFontAttributeName] = iosFont;
 


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
You can not add images to formatted text even though iOS and Android provide this ability.

## What is the new behavior?
You can add image to `<Span>` by using `imageSrc`. 

It seems like on Android if using `createFromPath` it does not apply the file's resolution. That's why I also added `imageHeight`. On iOS this is optional as it applies the file's resolution by default.

Fixes/Implements/Closes https://github.com/NativeScript/NativeScript/issues/6366

