### PR TITLE
fix(enums): add Visibility.hidden

### DIFF
--- a/nativescript-core/ui/enums/enums.ts
+++ b/nativescript-core/ui/enums/enums.ts
@@ -77,6 +77,7 @@ export module Stretch {
 export module Visibility {
     export const visible: string = "visible";
     export const collapse: string = "collapse";
+    export const collapsed: string = "collapsed";
     export const hidden: string = "hidden";
 }
 

--- a/nativescript-core/ui/enums/enums.ts
+++ b/nativescript-core/ui/enums/enums.ts
@@ -77,7 +77,7 @@ export module Stretch {
 export module Visibility {
     export const visible: string = "visible";
     export const collapse: string = "collapse";
-    export const collapsed: string = "collapsed";
+    export const hidden: string = "hidden";
 }
 
 export module FontAttributes {


### PR DESCRIPTION
add "hidden" to Visibility enum and remove the unused "collapsed" value

closes #8653

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Setting a view's visibility via JavaScript/TypeScript to enums.Visibility.hidden crashes the app.

logging enums.Visibility to the console results in:
```
{
    "visible": "visible",
    "collapse": "collapse",
    "collapsed": "collapsed"
}
```

collapsed is not a valid value for the visibility property.


## What is the new behavior?
Setting the visibility of a view programatically to hidden (using enums.Visibiliy.hidden) hides the view as expected and does not crash the app.

loggin enums.Visibility to the console correctly shows:
```
{
    "visible": "visible",
    "collapse": "collapse",
    "hidden": "hidden"
}
```

Fixes #8653.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

