### PR TITLE
fix(text-view): only reload text if hint is showing on ios

### DIFF
--- a/nativescript-core/ui/text-view/text-view.ios.ts
+++ b/nativescript-core/ui/text-view/text-view.ios.ts
@@ -88,7 +88,7 @@ class NoScrollAnimationUITextView extends UITextView {
 export class TextView extends TextViewBaseCommon {
     nativeViewProtected: UITextView;
     private _delegate: UITextViewDelegateImpl;
-    private _isShowingHint: boolean;
+    _isShowingHint: boolean;
     public _isEditing: boolean;
 
     private _hintColor = (majorVersion <= 12 || !UIColor.placeholderTextColor) ? UIColor.blackColor.colorWithAlphaComponent(0.22) : UIColor.placeholderTextColor;
@@ -129,7 +129,9 @@ export class TextView extends TextViewBaseCommon {
     }
 
     public textViewShouldBeginEditing(textView: UITextView): boolean {
-        this.showText();
+        if (this._isShowingHint) {
+            this.showText();
+        }
 
         return true;
     }


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
iOS TextView reloads text every time the TextView is focused

## What is the new behavior?
Only reload text if necessary (i.e. previously was the hint shown)

Fixes/Implements/Closes https://github.com/NativeScript/NativeScript/issues/8620

