### PR TITLE
fix(nativescript-core/ui): Fix syntax error in comments for property of View, originX and originY. 

### DIFF
--- a/nativescript-core/ui/core/view/view.d.ts
+++ b/nativescript-core/ui/core/view/view.d.ts
@@ -368,12 +368,12 @@ export abstract class View extends ViewBase {
     automationText: string;
 
     /**
-     * Gets or sets the X component of the origin point around which the view will be transformed. The deafault value is 0.5 representing the center of the view.
+     * Gets or sets the X component of the origin point around which the view will be transformed. The default value is 0.5 representing the center of the view.
      */
     originX: number;
 
     /**
-     * Gets or sets the Y component of the origin point around which the view will be transformed. The deafault value is 0.5 representing the center of the view.
+     * Gets or sets the Y component of the origin point around which the view will be transformed. The default value is 0.5 representing the center of the view.
      */
     originY: number;
 


### PR DESCRIPTION
Replace the 'deafault' with 'default'.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes NativeScript/NativeScript#8668

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

