### PR TITLE
fix: #8666 #6981 #5054

### DIFF
--- a/e2e/ui-tests-app/app/list-view/main-page.ts
+++ b/e2e/ui-tests-app/app/list-view/main-page.ts
@@ -22,6 +22,7 @@ export function loadExamples() {
     examples.set("width-percent", "list-view/width-percent-page");
     examples.set("item-re-layout", "list-view/item-re-layout-page");
     examples.set("safe-area", "list-view/safe-area-page");
+    examples.set("parents-expression", "list-view/parents-expression-page");
 
     return examples;
 }

--- a/e2e/ui-tests-app/app/list-view/parents-expression-page.ts
+++ b/e2e/ui-tests-app/app/list-view/parents-expression-page.ts
@@ -1,0 +1,27 @@
+import { fromObject } from "tns-core-modules/data/observable";
+
+export function onLoaded(args)
+{
+    const page = args.object;
+    page.bindingContext = fromObject(
+    {
+	   	prefix: "This is a prefix for: ",
+	   	languageData: [
+			{
+				name: "English",
+			},
+			{
+				name: "Portuguese"
+			},
+			{
+				name: "Spanish"
+			},
+			{
+				name: "Russian"
+			},
+			{
+				name: "Greek"
+			}
+		]
+	});
+}

--- a/e2e/ui-tests-app/app/list-view/parents-expression-page.ts
+++ b/e2e/ui-tests-app/app/list-view/parents-expression-page.ts
@@ -3,25 +3,25 @@ import { fromObject } from "tns-core-modules/data/observable";
 export function onLoaded(args)
 {
     const page = args.object;
-	page.bindingContext = fromObject(
+    page.bindingContext = fromObject(
     {
-		prefix: "This is a prefix for: ",
-		languageData: [
-			{
-				name: "English",
-			},
-			{
-				name: "Portuguese"
-			},
-			{
-				name: "Spanish"
-			},
-			{
-				name: "Russian"
-			},
-			{
-				name: "Greek"
-			}
-		]
-	});
+        prefix: "This is a prefix for: ",
+            languageData: [
+            {
+                name: "English",
+            },
+            {
+                name: "Portuguese"
+            },
+            {
+                name: "Spanish"
+            },
+            {
+                name: "Russian"
+            },
+            {
+                name: "Greek"
+            }
+        ]
+    });
 }

--- a/e2e/ui-tests-app/app/list-view/parents-expression-page.ts
+++ b/e2e/ui-tests-app/app/list-view/parents-expression-page.ts
@@ -3,10 +3,10 @@ import { fromObject } from "tns-core-modules/data/observable";
 export function onLoaded(args)
 {
     const page = args.object;
-    page.bindingContext = fromObject(
+	page.bindingContext = fromObject(
     {
-	   	prefix: "This is a prefix for: ",
-	   	languageData: [
+		prefix: "This is a prefix for: ",
+		languageData: [
 			{
 				name: "English",
 			},

--- a/e2e/ui-tests-app/app/list-view/parents-expression-page.xml
+++ b/e2e/ui-tests-app/app/list-view/parents-expression-page.xml
@@ -1,0 +1,20 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" loaded="onLoaded" class="page">
+
+    <Page.actionBar>
+        <ActionBar title="My App" icon="" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+
+    <ListView items="{{ languageData }}" separatorColor="red">
+        <ListView.itemTemplate>
+            <StackLayout columns="*,40" rows="*,*">
+                <!-- It works if not an expression -->
+                <Label row="1" text="{{ $parents['Page'].prefix }}"
+                    class="font-weight-bold" fontSize="16" />
+                <!-- Until component gets loaded, $parents['Page'].prefix will return undefined -->
+                <Label row="1" text="{{ $parents['Page'].prefix + name }}"
+                    class="font-weight-bold" fontSize="16" />
+            </StackLayout>
+        </ListView.itemTemplate>
+    </ListView>
+</Page>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Reference '$parents' or '$parent' can be undefined when included in expressions that are nested inside a ListView or a Repeater.
Playground Sample: https://play.nativescript.org/?template=play-js&id=TERk3c&v=11

**Note:** A component sample called 'parents-expression' is included inside ui-tests-app list-view section.

## What is the new behavior?
Parent referenced expression-values will be loaded properly using an 'update' call just like core already does with sourceProperties.

Fixes #8666 #6981 #5054



