### PR TITLE
feat: ImageSource resize method

### DIFF
--- a/api-reports/NativeScript.api.md
+++ b/api-reports/NativeScript.api.md
@@ -1198,6 +1198,8 @@ export class ImageSource {
     // @deprecated (undocumented)
     loadFromResource(name: string): boolean;
 
+    resize(maxSize: number, options?: any): ImageSource;
+
     rotationAngle: number;
 
     saveToFile(path: string, format: "png" | "jpeg" | "jpg", quality?: number): boolean;

--- a/nativescript-core/image-source/image-source-common.ts
+++ b/nativescript-core/image-source/image-source-common.ts
@@ -1,0 +1,27 @@
+export function getScaledDimensions(
+    width: number,
+    height: number,
+    maxSize: number
+) {
+    if (height >= width) {
+        if (height <= maxSize) {
+            // if image already smaller than the required height
+            return { width, height };
+        }
+
+        return {
+            width: Math.round((maxSize * width) / height),
+            height: maxSize
+        };
+    }
+
+    if (width <= maxSize) {
+        // if image already smaller than the required width
+        return { width, height };
+    }
+
+    return {
+        width: maxSize,
+        height: Math.round((maxSize * height) / width)
+    };
+}

--- a/nativescript-core/image-source/image-source.android.ts
+++ b/nativescript-core/image-source/image-source.android.ts
@@ -10,6 +10,8 @@ import { getNativeApplication } from "../application";
 import { Font } from "../ui/styling/font";
 import { Color } from "../color";
 
+import { getScaledDimensions } from "./image-source-common";
+
 export { isFileOrResourcePath };
 
 let http: typeof httpModule;
@@ -336,6 +338,18 @@ export class ImageSource implements ImageSourceDefinition {
         outputStream.close();
 
         return outputStream.toString();
+    }
+
+    public resize(maxSize: number, options?: any): ImageSource {
+        const dim = getScaledDimensions(this.android.getWidth(), this.android.getHeight(), maxSize);
+        const bm: android.graphics.Bitmap = android.graphics.Bitmap.createScaledBitmap(
+            this.android,
+            dim.width,
+            dim.height,
+            options && options.filter
+        );
+        
+        return new ImageSource(bm);
     }
 }
 

--- a/nativescript-core/image-source/image-source.d.ts
+++ b/nativescript-core/image-source/image-source.d.ts
@@ -209,6 +209,19 @@ export class ImageSource {
      * @param quality Optional parameter, specifying the quality of the encoding. Defaults to the maximum available quality. Quality varies on a scale of 0 to 100.
      */
     toBase64String(format: "png" | "jpeg" | "jpg", quality?: number): string;
+
+    /**
+     * Returns a new ImageSource that is a resized version of this image with the same aspect ratio, but the max dimension set to the provided maxSize.
+     * @param maxSize The maximum pixel dimension of the resulting image.
+     * @param options Optional parameter, Only used for android, options.filter is a boolean which
+     *     determines whether or not bilinear filtering should be used when scaling the bitmap.
+     *     If this is true then bilinear filtering will be used when scaling which has
+     *     better image quality at the cost of worse performance. If this is false then
+     *     nearest-neighbor scaling is used instead which will have worse image quality
+     *     but is faster. Recommended default is to set filter to 'true' as the cost of
+     *     bilinear filtering is typically minimal and the improved image quality is significant.
+     */
+    resize(maxSize: number, options?: any): ImageSource;
 }
 
 /**

--- a/nativescript-core/image-source/image-source.ios.ts
+++ b/nativescript-core/image-source/image-source.ios.ts
@@ -9,6 +9,8 @@ import { Color } from "../color";
 import { path as fsPath, knownFolders } from "../file-system";
 import { isFileOrResourcePath, RESOURCE_PREFIX, layout } from "../utils/utils";
 
+import { getScaledDimensions } from "./image-source-common";
+
 export { isFileOrResourcePath };
 
 let http: typeof httpModule;
@@ -335,6 +337,24 @@ export class ImageSource implements ImageSourceDefinition {
 
         return res;
 
+    }
+
+    public resize(maxSize: number, options?: any): ImageSource {
+        const size: CGSize = this.ios.size;
+        const dim = getScaledDimensions(
+            size.width,
+            size.height,
+            maxSize
+        );
+    
+        const newSize: CGSize = CGSizeMake(dim.width, dim.height);
+        UIGraphicsBeginImageContextWithOptions(newSize, true, this.ios.scale);
+        this.ios.drawInRect(CGRectMake(0, 0, newSize.width, newSize.height));
+
+        const resizedImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+
+        return new ImageSource(resizedImage);
     }
 }
 

--- a/tests/app/image-source/image-source-tests.ts
+++ b/tests/app/image-source/image-source-tests.ts
@@ -295,3 +295,13 @@ export function testLoadFromFontIconCode() {
     TKUnit.assert(img.width !== null, "img.width");
     TKUnit.assert(img.height !== null, "img.width");
 }
+
+export function testResize() {
+    const img = ImageSource.fromFileSync(imagePath);
+
+    const newSize = Math.floor(Math.max(img.width, img.height) / 2);
+
+    const resized = img.resize(newSize);
+
+    TKUnit.assert(resized.width === newSize || resized.height === newSize, "Image not resized correctly");
+}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There was no manner in which to resize an image. When sending images to a backend such as a social feed you typically don't want to send the full resolution image as these days mobile cameras can create huge 40 megapixel images. 

## What is the new behavior?

This provides an easy way to resize an image. Simply get an ImageSource and call resize(maxSize) on it and it will return a new ImageSource whose maximum dimension (while maintaining the aspect ratio of the original) is maxSize.

Fixes/Implements/Closes #[Issue Number].

None. I just had a need for this and thought I would share it with the community.

