### PR TITLE
fix: Android 'isScrollEnabled' not applied to scroll view if changed during gesture

### DIFF
--- a/e2e/ui-tests-app/app/scroll-view/main-page.ts
+++ b/e2e/ui-tests-app/app/scroll-view/main-page.ts
@@ -17,6 +17,7 @@ export function loadExamples() {
     examples.set("safe-area-images", "scroll-view/safe-area-images-page");
     examples.set("safe-area-images-overflow", "scroll-view/safe-area-images-overflow-page");
     examples.set("layout-outside-scroll", "scroll-view/layout-outside-scroll-page");
+    examples.set("scroll-enabled", "scroll-view/scroll-enabled-page");
 
     return examples;
 }

--- a/e2e/ui-tests-app/app/scroll-view/scroll-enabled-page.ts
+++ b/e2e/ui-tests-app/app/scroll-view/scroll-enabled-page.ts
@@ -1,0 +1,25 @@
+import { EventData as ObservableEventData } from "tns-core-modules/data/observable";
+import { GestureStateTypes, PanGestureEventData } from "tns-core-modules/ui/gestures";
+import { Page } from "tns-core-modules/ui/page";
+
+export function pageLoaded(args: ObservableEventData) {
+    var page = <Page>args.object;
+}
+
+export function panLayout(args: PanGestureEventData)
+{
+	const scrollView = args.object.parent;
+
+	if (args.state === GestureStateTypes.began) {
+		args.object.previousDeltaY = 0;
+		scrollView.isScrollEnabled = false;
+	}
+	else if (args.state === GestureStateTypes.changed) {
+		const diff = (args.deltaY - args.object.previousDeltaY);
+		args.object.translateY += diff;
+		args.object.previousDeltaY = args.deltaY;
+	}
+	else if (args.state === GestureStateTypes.ended) {
+		scrollView.isScrollEnabled = true;
+	}
+}

--- a/e2e/ui-tests-app/app/scroll-view/scroll-enabled-page.ts
+++ b/e2e/ui-tests-app/app/scroll-view/scroll-enabled-page.ts
@@ -8,18 +8,18 @@ export function pageLoaded(args: ObservableEventData) {
 
 export function panLayout(args: PanGestureEventData)
 {
-	const scrollView = args.object.parent;
+    const scrollView = args.object.parent;
 
-	if (args.state === GestureStateTypes.began) {
-		args.object.previousDeltaY = 0;
-		scrollView.isScrollEnabled = false;
-	}
-	else if (args.state === GestureStateTypes.changed) {
-		const diff = (args.deltaY - args.object.previousDeltaY);
-		args.object.translateY += diff;
-		args.object.previousDeltaY = args.deltaY;
-	}
-	else if (args.state === GestureStateTypes.ended) {
-		scrollView.isScrollEnabled = true;
-	}
+    if (args.state === GestureStateTypes.began) {
+        args.object.previousDeltaY = 0;
+        scrollView.isScrollEnabled = false;
+    }
+    else if (args.state === GestureStateTypes.changed) {
+        const diff = (args.deltaY - args.object.previousDeltaY);
+        args.object.translateY += diff;
+        args.object.previousDeltaY = args.deltaY;
+    }
+    else if (args.state === GestureStateTypes.ended) {
+        scrollView.isScrollEnabled = true;
+    }
 }

--- a/e2e/ui-tests-app/app/scroll-view/scroll-enabled-page.xml
+++ b/e2e/ui-tests-app/app/scroll-view/scroll-enabled-page.xml
@@ -1,0 +1,7 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" loaded="pageLoaded" class="page">
+    <ScrollView id="scroll-view" height="300">
+        <StackLayout height="500" backgroundColor="red" pan="panLayout">
+            <Label text="Move Me" color="#fff" fontSize="22"/>
+        </StackLayout>
+    </ScrollView>
+</Page>

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/HorizontalScrollView.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/HorizontalScrollView.java
@@ -70,7 +70,7 @@ public class HorizontalScrollView extends android.widget.HorizontalScrollView {
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        if (!this.scrollEnabled && ev.getAction() == MotionEvent.ACTION_DOWN) {
+        if (!this.scrollEnabled && (ev.getAction() == MotionEvent.ACTION_DOWN || ev.getAction() == MotionEvent.ACTION_MOVE)) {
             return false;
         }
 

--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/VerticalScrollView.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/VerticalScrollView.java
@@ -70,7 +70,7 @@ public class VerticalScrollView extends ScrollView {
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        if (!this.scrollEnabled && ev.getAction() == MotionEvent.ACTION_DOWN) {
+        if (!this.scrollEnabled && (ev.getAction() == MotionEvent.ACTION_DOWN || ev.getAction() == MotionEvent.ACTION_MOVE)) {
             return false;
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Android property 'isScrollEnabled' does not apply to scroll view if changed while gesture is underway.

## What is the new behavior?
Android property 'isScrollEnabled' will apply to scroll view if changed while gesture is underway.

Fixes #8545 .

This fixes issues of implementations related to moving views inside a ScrollView (e.g. BottomSheet).
Here is a sample from @rigor789  that was done using android native touch listener: https://play.nativescript.org/?template=play-vue&id=v1t5Pe&v=2

With this fix, there is the possibility of implementing such features using pure NativeScript. :)