### PR TITLE
fix: Setting property 'isEnabled' to false does not disable SegmentedBar in Android

### DIFF
--- a/e2e/ui-tests-app/app/main-page.ts
+++ b/e2e/ui-tests-app/app/main-page.ts
@@ -29,7 +29,7 @@ export function pageLoaded(args: EventData) {
     examples.set("page", "page/main-page");
     examples.set("perf", "perf/main-page");
     examples.set("scroll-view", "scroll-view/main-page");
-    examples.set("segStyle", "segmented-bar/all-page");
+    examples.set("segmented-bar", "segmented-bar/main-page");
     examples.set("search-bar", "search-bar/main-page");
     examples.set("tab-view", "tab-view/main-page");
     examples.set("timePicker", "time-picker/time-picker-page");

--- a/e2e/ui-tests-app/app/segmented-bar/android-enabled-page.ts
+++ b/e2e/ui-tests-app/app/segmented-bar/android-enabled-page.ts
@@ -1,0 +1,5 @@
+﻿import * as frame from "tns-core-modules/ui/frame";
+
+export function navigate() {
+    frame.topmost().goBack();
+}

--- a/e2e/ui-tests-app/app/segmented-bar/android-enabled-page.xml
+++ b/e2e/ui-tests-app/app/segmented-bar/android-enabled-page.xml
@@ -1,0 +1,10 @@
+<Page>
+    <StackLayout>
+        <SegmentedBar selectedIndex="1" isEnabled="false">
+            <SegmentedBarItem title="Item 1" />
+            <SegmentedBarItem title="Item 2" />
+            <SegmentedBarItem title="Item 3" />
+        </SegmentedBar>
+        <Button text="go to previous page" tap="navigate" />
+    </StackLayout>
+</Page>

--- a/e2e/ui-tests-app/app/segmented-bar/clean-page.xml
+++ b/e2e/ui-tests-app/app/segmented-bar/clean-page.xml
@@ -1,12 +1,12 @@
 <Page>
-  <StackLayout>
-    <SegmentedBar selectedIndex="1">
-      <SegmentedBar.items>
-        <SegmentedBarItem title="Item 1" />
-        <SegmentedBarItem title="Item 2" />
-        <SegmentedBarItem title="Item 3" />
-      </SegmentedBar.items>
-    </SegmentedBar>
-    <Button text="go to previous page" tap="navigate"/>
-  </StackLayout>
+    <StackLayout>
+        <SegmentedBar selectedIndex="1">
+            <SegmentedBar.items>
+                <SegmentedBarItem title="Item 1" />
+                <SegmentedBarItem title="Item 2" />
+                <SegmentedBarItem title="Item 3" />
+            </SegmentedBar.items>
+        </SegmentedBar>
+        <Button text="go to previous page" tap="navigate" />
+    </StackLayout>
 </Page>

--- a/e2e/ui-tests-app/app/segmented-bar/main-page.ts
+++ b/e2e/ui-tests-app/app/segmented-bar/main-page.ts
@@ -1,0 +1,19 @@
+import { EventData } from "tns-core-modules/data/observable";
+import { SubMainPageViewModel } from "../sub-main-page-view-model";
+import { WrapLayout } from "tns-core-modules/ui/layouts/wrap-layout";
+import { Page } from "tns-core-modules/ui/page";
+
+export function pageLoaded(args: EventData) {
+    const page = <Page>args.object;
+    const wrapLayout = <WrapLayout>page.getViewById("wrapLayoutWithExamples");
+    page.bindingContext = new SubMainPageViewModel(wrapLayout, loadExamples());
+}
+
+export function loadExamples() {
+    const examples = new Map<string, string>();
+    examples.set("segStyle", "segmented-bar/all-page");
+    examples.set("clean", "segmented-bar/clean-page");
+    examples.set("android-enabled", "segmented-bar/android-enabled-page");
+
+    return examples;
+}

--- a/e2e/ui-tests-app/app/segmented-bar/main-page.xml
+++ b/e2e/ui-tests-app/app/segmented-bar/main-page.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Page loaded="pageLoaded">
+    <ScrollView orientation="vertical" row="1">
+        <WrapLayout id="wrapLayoutWithExamples"/>
+    </ScrollView>
+</Page>

--- a/nativescript-core/ui/segmented-bar/segmented-bar.android.ts
+++ b/nativescript-core/ui/segmented-bar/segmented-bar.android.ts
@@ -1,6 +1,6 @@
 import { Font } from "../styling/font";
 import {
-    SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, selectedBackgroundColorProperty,
+    SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsProperty, isEnabledProperty, selectedBackgroundColorProperty,
     colorProperty, fontInternalProperty, fontSizeProperty, Color, layout
 } from "./segmented-bar-common";
 
@@ -30,6 +30,7 @@ let TabHost: TabHost;
 let TabChangeListener: TabChangeListener;
 let TabContentFactory: TabContentFactory;
 
+// TODO: All TabHost public methods become deprecated in API 30.
 function initializeNativeClasses(): void {
     if (TabChangeListener) {
         return;
@@ -238,6 +239,17 @@ export class SegmentedBar extends SegmentedBarBase {
         super.disposeNativeView();
     }
 
+    public onLoaded() {
+        super.onLoaded();
+        
+        // Can only be applied after view is loaded
+        const tabWidget = this.nativeViewProtected.getTabWidget();
+        if (tabWidget)
+        {
+            tabWidget.setEnabled(tabWidget.isEnabled());
+        }
+    }
+
     private insertTab(tabItem: SegmentedBarItem, index: number): void {
         const tabHost = this.nativeViewProtected;
         const tab = tabHost.newTabSpec(index + "");
@@ -269,5 +281,12 @@ export class SegmentedBar extends SegmentedBarBase {
         }
 
         selectedIndexProperty.coerce(this);
+    }
+    [isEnabledProperty.setNative](value: boolean) {
+        const tabWidget = this.nativeViewProtected.getTabWidget();
+        if (tabWidget)
+        {
+            tabWidget.setEnabled(value);
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Setting property 'isEnabled' to false does not disable SegmentedBar in Android.

## What is the new behavior?
Setting property 'isEnabled' to false disables SegmentedBar in Android.


**Note:** Most of TabHost's public methods (including getTabWidget) are getting deprecated in Android API 30.
So far, no alternative has been released by Google on how to manage TabHosts.