### PR TITLE
fix(android/utils): add check in ad.dismissSoftInput(nativeView?) to make sure the dismissed nativeView has focus at that moment

### DIFF
--- a/nativescript-core/utils/native-helper.android.ts
+++ b/nativescript-core/utils/native-helper.android.ts
@@ -62,6 +62,9 @@ export module ad {
         let windowToken: android.os.IBinder;
 
         if (nativeView instanceof android.view.View) {
+            if (!nativeView.hasFocus()) {
+                return;
+            }
             windowToken = nativeView.getWindowToken();
         } else if (androidApp.foregroundActivity instanceof androidx.appcompat.app.AppCompatActivity) {
             const decorView = androidApp.foregroundActivity.getWindow().getDecorView();


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
See #8713 

## What is the new behavior?
<!-- Describe the changes. -->
We now check whether the view has focus when the argument is given to ad.dismissSoftInput(nativeView?), when the given view is not focused, we don't do anything.

Fixes/Implements/Closes #8713 

I did not create a test for this change, as I did not see any existing tests for this functionality.
I also had 3 failing tests on the current master that are unrelated to this change.