### PR TITLE
fix(ios): actionbar show/hide should trigger page layout

### DIFF
--- a/nativescript-core/ui/frame/frame.ios.ts
+++ b/nativescript-core/ui/frame/frame.ios.ts
@@ -217,6 +217,8 @@ export class Frame extends FrameBase {
             this._ios._disableNavBarAnimation = true;
         }
 
+        // when showing/hiding navigationbar, the page needs a relayout to avoid overlapping or hidden layouts
+        const needsPageLayout = this._ios.showNavigationBar !== newValue;
         this._ios.showNavigationBar = newValue;
 
         if (disableNavBarAnimation) {
@@ -225,6 +227,10 @@ export class Frame extends FrameBase {
 
         if (this._ios.controller.navigationBar) {
             this._ios.controller.navigationBar.userInteractionEnabled = this.navigationQueueIsEmpty();
+        }
+
+        if (needsPageLayout && page) {
+          page.requestLayout();
         }
     }
 


### PR DESCRIPTION
* [x] Fixes issue where ActionBar could overlap page content when showing the ActionBar at a later time (after the initial layout of the page.