### PR TITLE
Feat/monorepo esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "nx": "nx",
     "format": "nx format:write",
-    "setup": "npx rimraf -- hooks node_modules package-lock.json && npm i && nx run core:setup"
+    "setup": "npx rimraf -- hooks node_modules package-lock.json && npm i && ts-patch install && nx run core:setup"
   },
   "private": true,
   "dependencies": {
@@ -49,6 +49,7 @@
     "terser-webpack-plugin": "~3.0.6",
     "ts-jest": "~26.1.1",
     "ts-node": "~8.10.2",
+    "ts-patch": "^1.2.5",
     "tslint": "~6.1.2",
     "typescript": "~3.9.0",
     "webpack": "~4.43.0",

--- a/packages/core/__tests__/e2e/automated/app/ui/layouts/layout-helper.android.ts
+++ b/packages/core/__tests__/e2e/automated/app/ui/layouts/layout-helper.android.ts
@@ -8,6 +8,7 @@ import * as def from "./layout-helper";
 
 var DELTA = 0.1;
 
+@NativeClass
 class NativeButton extends android.widget.Button {
     constructor(context: android.content.Context, public owner: def.MeasuredView) {
         super(context);
@@ -28,6 +29,7 @@ class NativeButton extends android.widget.Button {
     }
 }
 
+@NativeClass
 class NativeStackLayout extends org.nativescript.widgets.StackLayout {
     constructor(context: android.content.Context, public owner: def.MeasuredView) {
         super(context);
@@ -48,6 +50,7 @@ class NativeStackLayout extends org.nativescript.widgets.StackLayout {
     }
 }
 
+@NativeClass
 class NativeGridLayout extends org.nativescript.widgets.GridLayout {
     constructor(context: android.content.Context, public owner: def.MeasuredView) {
         super(context);

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -478,6 +478,7 @@ function ensureBroadCastReceiverClass() {
 		return;
 	}
 
+	@NativeClass
 	class BroadcastReceiver extends android.content.BroadcastReceiver {
 		private _onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void;
 
@@ -500,6 +501,7 @@ function ensureBroadCastReceiverClass() {
 
 declare namespace com {
 	namespace tns {
+		@NativeClass
 		class NativeScriptApplication extends android.app.Application {
 			static getInstance(): NativeScriptApplication;
 		}

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -25,6 +25,16 @@ const majorVersion = iOSNativeHelper.MajorVersion;
 // NOTE: UIResponder with implementation of window - related to https://github.com/NativeScript/ios-runtime/issues/430
 // TODO: Refactor the UIResponder to use Typescript extends when this issue is resolved:
 // https://github.com/NativeScript/ios-runtime/issues/1012
+@NativeClass
+// class Responder extends UIResponder {
+// 	public static ObjCProtocols = [UIApplicationDelegate];
+// 	get window() {
+// 		return iosApp ? iosApp.window : undefined;
+// 	}
+// 	set window(setWindow) {
+// 		// NOOP
+// 	}
+// }
 const Responder = (<any>UIResponder).extend(
 	{
 		get window() {
@@ -39,6 +49,7 @@ const Responder = (<any>UIResponder).extend(
 	}
 );
 
+@NativeClass
 class NotificationObserver extends NSObject {
 	private _onReceiveCallback: (notification: NSNotification) => void;
 
@@ -61,6 +72,8 @@ class NotificationObserver extends NSObject {
 let displayedOnce = false;
 let displayedLinkTarget;
 let displayedLink;
+
+@NativeClass
 class CADisplayLinkTarget extends NSObject {
 	onDisplayed(link: CADisplayLink) {
 		link.invalidate();

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -25,16 +25,7 @@ const majorVersion = iOSNativeHelper.MajorVersion;
 // NOTE: UIResponder with implementation of window - related to https://github.com/NativeScript/ios-runtime/issues/430
 // TODO: Refactor the UIResponder to use Typescript extends when this issue is resolved:
 // https://github.com/NativeScript/ios-runtime/issues/1012
-@NativeClass
-// class Responder extends UIResponder {
-// 	public static ObjCProtocols = [UIApplicationDelegate];
-// 	get window() {
-// 		return iosApp ? iosApp.window : undefined;
-// 	}
-// 	set window(setWindow) {
-// 		// NOOP
-// 	}
-// }
+
 const Responder = (<any>UIResponder).extend(
 	{
 		get window() {

--- a/packages/core/connectivity/index.android.ts
+++ b/packages/core/connectivity/index.android.ts
@@ -109,29 +109,31 @@ let networkCallback;
 let notifyCallback;
 export function startMonitoring(connectionTypeChangedCallback: (newConnectionType: number) => void): void {
 	if (android.os.Build.VERSION.SDK_INT >= 28) {
-		const manager = getConnectivityManager() as any;
+		const manager = getConnectivityManager();
 		if (manager) {
 			notifyCallback = () => {
 				let newConnectionType = getConnectionType();
 				let zoneCallback = <any>zonedCallback(connectionTypeChangedCallback);
 				zoneCallback(newConnectionType);
 			};
-			const ConnectivityManager = (android as any).net.ConnectivityManager;
+			const ConnectivityManager = android.net.ConnectivityManager;
 			if (!networkCallback) {
-				networkCallback = ConnectivityManager.NetworkCallback.extend({
-					onAvailable(network) {
+				@NativeClass 
+				class NetworkCallbackImpl extends ConnectivityManager.NetworkCallback{
+					onAvailable(network: android.net.Network) {
 						notifyCallback();
-					},
-					onCapabilitiesChanged(network, networkCapabilities) {
+					}
+					onCapabilitiesChanged(network: android.net.Network, networkCapabilities: android.net.NetworkCapabilities) {
 						notifyCallback();
-					},
+					}
 					onLost(network) {
 						notifyCallback();
-					},
+					}
 					onUnavailable() {
 						notifyCallback();
-					},
-				});
+					}
+				};
+				networkCallback = NetworkCallbackImpl;
 			}
 			callback = new networkCallback();
 			manager.registerDefaultNetworkCallback(callback);

--- a/packages/core/fps-meter/fps-native.ios.ts
+++ b/packages/core/fps-meter/fps-native.ios.ts
@@ -1,5 +1,6 @@
 import * as definition from './fps-native';
 
+@NativeClass
 class FrameHandlerImpl extends NSObject {
 	private _owner: WeakRef<FPSCallback>;
 

--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -202,6 +202,18 @@ declare var exports: any;
 declare function Deprecated(target: Object, key?: string | symbol, value?: any): void;
 declare function Experimental(target: Object, key?: string | symbol, value?: any): void;
 
+declare interface NativeClassOptions {
+	nativeClassName?: string; // for @JavaProxy and
+	protocols?: any[];
+	interfaces?: any[];
+}
+
+/**
+ * Decorates class that extends a native class(iOS or Android)
+ */
+declare function NativeClass<T extends {new(...args:any[]):{}}>(constructor:T);
+declare function NativeClass<T extends {new(...args:any[]):{}}>(options?:NativeClassOptions);
+
 /**
  * Decorates class that implements native Java interfaces.
  * @param interfaces Implemented interfaces.

--- a/packages/core/http/http-request/index.ios.ts
+++ b/packages/core/http/http-request/index.ios.ts
@@ -31,6 +31,7 @@ function parseJSON(source: string): any {
 	return JSON.parse(src);
 }
 
+@NativeClass
 class NSURLSessionTaskDelegateImpl extends NSObject implements NSURLSessionTaskDelegate {
 	public static ObjCProtocols = [NSURLSessionTaskDelegate];
 	public URLSessionTaskWillPerformHTTPRedirectionNewRequestCompletionHandler(session: NSURLSession, task: NSURLSessionTask, response: NSHTTPURLResponse, request: NSURLRequest, completionHandler: (p1: NSURLRequest) => void): void {

--- a/packages/core/timer/index.ios.ts
+++ b/packages/core/timer/index.ios.ts
@@ -7,6 +7,7 @@ interface KeyValuePair<K, V> {
 	v: V;
 }
 
+@NativeClass
 class TimerTargetImpl extends NSObject {
 	private callback: Function;
 	private disposed: boolean;

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -16,8 +16,8 @@
     "rootDir": "./",
     "types": ["node"],
     "plugins": [
-      { "transform": "../webpack/transformers/ns-transform-native-classes.ts", "type": "raw" },
-  ]
+      { "transform": "../../../packages/webpack/transformers/ns-transform-native-classes.ts", "type": "raw" }
+    ]
   },
   "exclude": ["**/*.spec.ts", "dist", "__tests__"],
   "include": ["**/*.ts", "./references.d.ts"]

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "noEmitOnError": true,
     "noEmitHelpers": true,
-    "target": "es5",
     "declaration": true,
     "noImplicitAny": false,
     "noImplicitUseStrict": true,
@@ -12,11 +11,13 @@
     "diagnostics": true,
     "sourceMap": true,
     "inlineSourceMap": false,
-    "module": "commonjs",
     "baseUrl": ".",
     "outDir": "../../dist/out-tsc",
     "rootDir": "./",
-    "types": ["node"]
+    "types": ["node"],
+    "plugins": [
+      { "transform": "../webpack/transformers/ns-transform-native-classes.ts", "type": "raw" },
+  ]
   },
   "exclude": ["**/*.spec.ts", "dist", "__tests__"],
   "include": ["**/*.ts", "./references.d.ts"]

--- a/packages/core/ui/action-bar/index.ios.ts
+++ b/packages/core/ui/action-bar/index.ios.ts
@@ -35,6 +35,7 @@ function loadActionIcon(item: ActionItemDefinition): any /* UIImage */ {
 	return img;
 }
 
+@NativeClass
 class TapBarItemHandlerImpl extends NSObject {
 	private _owner: WeakRef<ActionItemDefinition>;
 

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -29,6 +29,7 @@ class AnimationInfo {
 	public delay: number;
 }
 
+@NativeClass
 class AnimationDelegateImpl extends NSObject implements CAAnimationDelegate {
 	public nextAnimation: Function;
 

--- a/packages/core/ui/bottom-navigation/index.android.ts
+++ b/packages/core/ui/bottom-navigation/index.android.ts
@@ -54,6 +54,7 @@ function initializeNativeClasses() {
 		return;
 	}
 
+	@NativeClass
 	class TabFragmentImplementation extends org.nativescript.widgets.FragmentBase {
 		private owner: BottomNavigation;
 		private index: number;
@@ -143,6 +144,7 @@ function initializeNativeClasses() {
 		}
 	}
 
+	@NativeClass
 	class BottomNavigationBarImplementation extends org.nativescript.widgets.BottomNavigationBar {
 		constructor(context: android.content.Context, public owner: BottomNavigation) {
 			super(context);

--- a/packages/core/ui/bottom-navigation/index.ios.ts
+++ b/packages/core/ui/bottom-navigation/index.ios.ts
@@ -94,6 +94,7 @@ class UITabBarControllerImpl extends UITabBarController {
 	}
 }
 
+@NativeClass
 class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControllerDelegate {
 	public static ObjCProtocols = [UITabBarControllerDelegate];
 
@@ -160,6 +161,7 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 	}
 }
 
+@NativeClass
 class UINavigationControllerDelegateImpl extends NSObject implements UINavigationControllerDelegate {
 	public static ObjCProtocols = [UINavigationControllerDelegate];
 

--- a/packages/core/ui/button/index.ios.ts
+++ b/packages/core/ui/button/index.ios.ts
@@ -265,6 +265,7 @@ export class Button extends ButtonBase {
 	}
 }
 
+@NativeClass
 class TapHandlerImpl extends NSObject {
 	private _owner: WeakRef<Button>;
 

--- a/packages/core/ui/core/control-state-change/index.ios.ts
+++ b/packages/core/ui/core/control-state-change/index.ios.ts
@@ -1,6 +1,7 @@
 ﻿/* tslint:disable:no-unused-variable */
 import { ControlStateChangeListener as ControlStateChangeListenerDefinition } from '.';
 
+@NativeClass
 class ObserverClass extends NSObject {
 	// NOTE: Refactor this - use Typescript property instead of strings....
 	observeValueForKeyPathOfObjectChangeContext(path: string) {

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -127,6 +127,7 @@ function initializeDialogFragment() {
 		return;
 	}
 
+	@NativeClass
 	class DialogImpl extends android.app.Dialog {
 		constructor(public fragment: DialogFragmentImpl, context: android.content.Context, themeResId: number) {
 			super(context, themeResId);

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -316,7 +316,8 @@ export namespace IOSHelper {
 		}
 	}
 
-	export class UIAdaptivePresentationControllerDelegateImp extends NSObject implements UIAdaptivePresentationControllerDelegate {
+	@NativeClass
+export class UIAdaptivePresentationControllerDelegateImp extends NSObject implements UIAdaptivePresentationControllerDelegate {
 		public static ObjCProtocols = [UIAdaptivePresentationControllerDelegate];
 
 		private owner: WeakRef<View>;
@@ -338,7 +339,8 @@ export namespace IOSHelper {
 		}
 	}
 
-	export class UIPopoverPresentationControllerDelegateImp extends NSObject implements UIPopoverPresentationControllerDelegate {
+	@NativeClass
+export class UIPopoverPresentationControllerDelegateImp extends NSObject implements UIPopoverPresentationControllerDelegate {
 		public static ObjCProtocols = [UIPopoverPresentationControllerDelegate];
 
 		private owner: WeakRef<View>;

--- a/packages/core/ui/date-picker/index.ios.ts
+++ b/packages/core/ui/date-picker/index.ios.ts
@@ -82,6 +82,7 @@ export class DatePicker extends DatePickerBase {
 	}
 }
 
+@NativeClass
 class UIDatePickerChangeHandlerImpl extends NSObject {
 	private _owner: WeakRef<DatePicker>;
 

--- a/packages/core/ui/frame/fragment.android.ts
+++ b/packages/core/ui/frame/fragment.android.ts
@@ -1,6 +1,7 @@
 import { AndroidFragmentCallbacks, setFragmentCallbacks, setFragmentClass } from '.';
 
 @JavaProxy('com.tns.FragmentClass')
+@NativeClass
 class FragmentClass extends org.nativescript.widgets.FragmentBase {
 	// This field is updated in the frame module upon `new` (although hacky this eases the Fragment->callbacks association a lot)
 	private _callbacks: AndroidFragmentCallbacks;

--- a/packages/core/ui/frame/fragment.transitions.ios.ts
+++ b/packages/core/ui/frame/fragment.transitions.ios.ts
@@ -17,6 +17,7 @@ module UIViewControllerAnimatedTransitioningMethods {
 	}
 }
 
+@NativeClass
 class AnimatedTransitioning extends NSObject implements UIViewControllerAnimatedTransitioning {
 	public static ObjCProtocols = [UIViewControllerAnimatedTransitioning];
 

--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -300,6 +300,7 @@ export class Frame extends FrameBase {
 
 let transitionDelegates = new Array<TransitionDelegate>();
 
+@NativeClass
 class TransitionDelegate extends NSObject {
 	private _id: string;
 
@@ -348,6 +349,7 @@ class TransitionDelegate extends NSObject {
 
 const _defaultTransitionDuration = 0.35;
 
+@NativeClass
 class UINavigationControllerAnimatedDelegate extends NSObject implements UINavigationControllerDelegate {
 	public static ObjCProtocols = [UINavigationControllerDelegate];
 

--- a/packages/core/ui/gestures/index.android.ts
+++ b/packages/core/ui/gestures/index.android.ts
@@ -23,6 +23,7 @@ function initializeTapAndDoubleTapGestureListener() {
 		return;
 	}
 
+	@NativeClass
 	class TapAndDoubleTapGestureListenerImpl extends android.view.GestureDetector.SimpleOnGestureListener {
 		private _observer: GesturesObserver;
 		private _target: View;
@@ -107,6 +108,7 @@ function initializePinchGestureListener() {
 		return;
 	}
 
+	@NativeClass
 	class PinchGestureListenerImpl extends android.view.ScaleGestureDetector.SimpleOnScaleGestureListener {
 		private _observer: GesturesObserver;
 		private _target: View;
@@ -163,6 +165,7 @@ function initializeSwipeGestureListener() {
 		return;
 	}
 
+	@NativeClass
 	class SwipeGestureListenerImpl extends android.view.GestureDetector.SimpleOnGestureListener {
 		private _observer: GesturesObserver;
 		private _target: View;

--- a/packages/core/ui/gestures/index.ios.ts
+++ b/packages/core/ui/gestures/index.ios.ts
@@ -19,6 +19,7 @@ export function observe(target: View, type: GestureTypes, callback: (args: Gestu
 	return observer;
 }
 
+@NativeClass
 class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecognizerDelegate {
 	public static ObjCProtocols = [UIGestureRecognizerDelegate];
 
@@ -38,6 +39,7 @@ class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecog
 }
 let recognizerDelegateInstance: UIGestureRecognizerDelegateImpl = <UIGestureRecognizerDelegateImpl>UIGestureRecognizerDelegateImpl.new();
 
+@NativeClass
 class UIGestureRecognizerImpl extends NSObject {
 	public static ObjCExposedMethods = {
 		recognize: {

--- a/packages/core/ui/image-cache/index.android.ts
+++ b/packages/core/ui/image-cache/index.android.ts
@@ -7,6 +7,7 @@ function ensureLruBitmapCacheClass() {
 		return;
 	}
 
+	@NativeClass
 	class LruBitmapCache extends android.util.LruCache<string, android.graphics.Bitmap> {
 		constructor(cacheSize: number) {
 			super(cacheSize);

--- a/packages/core/ui/image-cache/index.ios.ts
+++ b/packages/core/ui/image-cache/index.ios.ts
@@ -12,6 +12,7 @@ function ensureHttpRequest() {
 	}
 }
 
+@NativeClass
 class MemmoryWarningHandler extends NSObject {
 	static new(): MemmoryWarningHandler {
 		return <MemmoryWarningHandler>super.new();

--- a/packages/core/ui/list-picker/index.ios.ts
+++ b/packages/core/ui/list-picker/index.ios.ts
@@ -77,6 +77,7 @@ export class ListPicker extends ListPickerBase {
 	}
 }
 
+@NativeClass
 class ListPickerDataSource extends NSObject implements UIPickerViewDataSource {
 	public static ObjCProtocols = [UIPickerViewDataSource];
 
@@ -100,6 +101,7 @@ class ListPickerDataSource extends NSObject implements UIPickerViewDataSource {
 	}
 }
 
+@NativeClass
 class ListPickerDelegateImpl extends NSObject implements UIPickerViewDelegate {
 	public static ObjCProtocols = [UIPickerViewDelegate];
 

--- a/packages/core/ui/list-view/index.android.ts
+++ b/packages/core/ui/list-view/index.android.ts
@@ -235,6 +235,7 @@ function ensureListViewAdapterClass() {
 		return;
 	}
 
+	@NativeClass
 	class ListViewAdapter extends android.widget.BaseAdapter {
 		constructor(public owner: ListView) {
 			super();

--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -73,6 +73,7 @@ function notifyForItemAtIndex(listView: ListViewBase, cell: any, view: View, eve
 	return args;
 }
 
+@NativeClass
 class DataSource extends NSObject implements UITableViewDataSource {
 	public static ObjCProtocols = [UITableViewDataSource];
 
@@ -118,6 +119,7 @@ class DataSource extends NSObject implements UITableViewDataSource {
 	}
 }
 
+@NativeClass
 class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
 	public static ObjCProtocols = [UITableViewDelegate];
 
@@ -182,6 +184,7 @@ class UITableViewDelegateImpl extends NSObject implements UITableViewDelegate {
 	}
 }
 
+@NativeClass
 class UITableViewRowHeightDelegateImpl extends NSObject implements UITableViewDelegate {
 	public static ObjCProtocols = [UITableViewDelegate];
 

--- a/packages/core/ui/scroll-view/index.ios.ts
+++ b/packages/core/ui/scroll-view/index.ios.ts
@@ -7,6 +7,7 @@ export * from './scroll-view-common';
 
 const majorVersion = iOSNativeHelper.MajorVersion;
 
+@NativeClass
 class UIScrollViewDelegateImpl extends NSObject implements UIScrollViewDelegate {
 	private _owner: WeakRef<ScrollView>;
 

--- a/packages/core/ui/search-bar/index.ios.ts
+++ b/packages/core/ui/search-bar/index.ios.ts
@@ -9,6 +9,7 @@ export * from './search-bar-common';
 
 const majorVersion = iOSNativeHelper.MajorVersion;
 
+@NativeClass
 class UISearchBarDelegateImpl extends NSObject implements UISearchBarDelegate {
 	public static ObjCProtocols = [UISearchBarDelegate];
 

--- a/packages/core/ui/segmented-bar/index.android.ts
+++ b/packages/core/ui/segmented-bar/index.android.ts
@@ -76,6 +76,7 @@ function initializeNativeClasses(): void {
 		}
 	}
 
+	@NativeClass
 	class TabHostImpl extends android.widget.TabHost {
 		constructor(context: android.content.Context, attrs: android.util.AttributeSet) {
 			super(context, attrs);

--- a/packages/core/ui/segmented-bar/index.ios.ts
+++ b/packages/core/ui/segmented-bar/index.ios.ts
@@ -106,6 +106,7 @@ export class SegmentedBar extends SegmentedBarBase {
 	}
 }
 
+@NativeClass
 class SelectionHandlerImpl extends NSObject {
 	private _owner: WeakRef<SegmentedBar>;
 

--- a/packages/core/ui/slider/index.ios.ts
+++ b/packages/core/ui/slider/index.ios.ts
@@ -6,6 +6,7 @@ import { Color } from '../../color';
 
 export * from './slider-common';
 
+@NativeClass
 class SliderChangeHandlerImpl extends NSObject {
 	private _owner: WeakRef<Slider>;
 

--- a/packages/core/ui/switch/index.ios.ts
+++ b/packages/core/ui/switch/index.ios.ts
@@ -5,6 +5,7 @@ import { layout } from '../../utils';
 
 export * from './switch-common';
 
+@NativeClass
 class SwitchChangeHandlerImpl extends NSObject {
 	private _owner: WeakRef<Switch>;
 

--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -45,6 +45,7 @@ function initializeNativeClasses() {
 		return;
 	}
 
+	@NativeClass
 	class TabFragmentImplementation extends org.nativescript.widgets.FragmentBase {
 		private owner: TabView;
 		private index: number;

--- a/packages/core/ui/tab-view/index.ios.ts
+++ b/packages/core/ui/tab-view/index.ios.ts
@@ -86,6 +86,7 @@ class UITabBarControllerImpl extends UITabBarController {
 	}
 }
 
+@NativeClass
 class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControllerDelegate {
 	public static ObjCProtocols = [UITabBarControllerDelegate];
 
@@ -133,6 +134,7 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 	}
 }
 
+@NativeClass
 class UINavigationControllerDelegateImpl extends NSObject implements UINavigationControllerDelegate {
 	public static ObjCProtocols = [UINavigationControllerDelegate];
 

--- a/packages/core/ui/tabs/index.android.ts
+++ b/packages/core/ui/tabs/index.android.ts
@@ -51,6 +51,7 @@ function initializeNativeClasses() {
 		return;
 	}
 
+	@NativeClass
 	class TabFragmentImplementation extends org.nativescript.widgets.FragmentBase {
 		private owner: Tabs;
 		private index: number;
@@ -280,6 +281,7 @@ function initializeNativeClasses() {
 		}
 	}
 
+	@NativeClass
 	class TabsBarImplementation extends org.nativescript.widgets.TabsBar {
 		constructor(context: android.content.Context, public owner: Tabs) {
 			super(context);

--- a/packages/core/ui/tabs/index.ios.ts
+++ b/packages/core/ui/tabs/index.ios.ts
@@ -34,6 +34,7 @@ const invokeOnRunLoop = (function () {
 	};
 })();
 
+@NativeClass
 class MDCTabBarDelegateImpl extends NSObject implements MDCTabBarDelegate {
 	public static ObjCProtocols = [MDCTabBarDelegate];
 
@@ -79,6 +80,7 @@ class MDCTabBarDelegateImpl extends NSObject implements MDCTabBarDelegate {
 	}
 }
 
+@NativeClass
 class BackgroundIndicatorTemplate extends NSObject implements MDCTabBarIndicatorTemplate {
 	public static ObjCProtocols = [MDCTabBarIndicatorTemplate];
 
@@ -259,6 +261,7 @@ class UIPageViewControllerImpl extends UIPageViewController {
 	}
 }
 
+@NativeClass
 class UIPageViewControllerDataSourceImpl extends NSObject implements UIPageViewControllerDataSource {
 	public static ObjCProtocols = [UIPageViewControllerDataSource];
 
@@ -345,6 +348,7 @@ class UIPageViewControllerDataSourceImpl extends NSObject implements UIPageViewC
 	}
 }
 
+@NativeClass
 class UIPageViewControllerDelegateImpl extends NSObject implements UIPageViewControllerDelegate {
 	public static ObjCProtocols = [UIPageViewControllerDelegate];
 

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -65,6 +65,7 @@ function initializeClickableSpan(): void {
 		return;
 	}
 
+	@NativeClass
 	class ClickableSpanImpl extends android.text.style.ClickableSpan {
 		owner: WeakRef<Span>;
 
@@ -100,6 +101,7 @@ function initializeBaselineAdjustedSpan(): void {
 	if (BaselineAdjustedSpan) {
 		return;
 	}
+	@NativeClass
 	class BaselineAdjustedSpanImpl extends android.text.style.MetricAffectingSpan {
 		fontSize: number;
 		align: VerticalAlignment = 'baseline';

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -15,6 +15,7 @@ export * from './text-base-common';
 
 const majorVersion = iOSNativeHelper.MajorVersion;
 
+@NativeClass
 class UILabelClickHandlerImpl extends NSObject {
 	private _owner: WeakRef<TextBase>;
 

--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -13,6 +13,7 @@ const zeroLength: Length = {
 	unit: 'px',
 };
 
+@NativeClass
 class UITextFieldDelegateImpl extends NSObject implements UITextFieldDelegate {
 	public static ObjCProtocols = [UITextFieldDelegate];
 

--- a/packages/core/ui/text-view/index.ios.ts
+++ b/packages/core/ui/text-view/index.ios.ts
@@ -11,6 +11,7 @@ import { profile } from '../../profiling';
 
 const majorVersion = iOSNativeHelper.MajorVersion;
 
+@NativeClass
 class UITextViewDelegateImpl extends NSObject implements UITextViewDelegate {
 	public static ObjCProtocols = [UITextViewDelegate];
 

--- a/packages/core/ui/time-picker/index.ios.ts
+++ b/packages/core/ui/time-picker/index.ios.ts
@@ -114,6 +114,7 @@ export class TimePicker extends TimePickerBase {
 	}
 }
 
+@NativeClass
 class UITimePickerChangeHandlerImpl extends NSObject {
 	private _owner: WeakRef<TimePicker>;
 

--- a/packages/core/ui/web-view/index.android.ts
+++ b/packages/core/ui/web-view/index.android.ts
@@ -11,6 +11,7 @@ function initializeWebViewClient(): void {
 		return;
 	}
 
+	@NativeClass
 	class WebViewClientImpl extends android.webkit.WebViewClient {
 		constructor(public owner: WebViewBase) {
 			super();

--- a/packages/core/ui/web-view/index.ios.ts
+++ b/packages/core/ui/web-view/index.ios.ts
@@ -5,6 +5,7 @@ import { Trace } from '../../trace';
 export * from './web-view-common';
 import { knownFolders } from '../../file-system';
 
+@NativeClass
 class WKNavigationDelegateImpl extends NSObject implements WKNavigationDelegate {
 	public static ObjCProtocols = [WKNavigationDelegate];
 	public static initWithOwner(owner: WeakRef<WebView>): WKNavigationDelegateImpl {

--- a/packages/core/utils/native-helper.ios.ts
+++ b/packages/core/utils/native-helper.ios.ts
@@ -127,7 +127,8 @@ export namespace iOSNativeHelper {
 		return transform;
 	}
 
-	export class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UIDocumentInteractionControllerDelegate {
+	@NativeClass
+export class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UIDocumentInteractionControllerDelegate {
 		public static ObjCProtocols = [UIDocumentInteractionControllerDelegate];
 
 		public getViewController(): UIViewController {

--- a/packages/webpack/transformers/ns-transform-native-classes.ts
+++ b/packages/webpack/transformers/ns-transform-native-classes.ts
@@ -1,0 +1,34 @@
+import * as ts from "typescript";
+
+export default function (ctx: ts.TransformationContext) {
+    function isNativeClassExtension(node: ts.ClassDeclaration) {
+        return (
+            node.decorators &&
+            node.decorators.filter(
+                (d) => d.getFullText().trim().indexOf("@NativeClass") === 0
+            ).length > 0
+        );
+    }
+    function visitNode(node: ts.Node): ts.Node {
+        if (ts.isClassDeclaration(node) && isNativeClassExtension(node)) {
+            return createHelper(node);
+        }
+        return ts.visitEachChild(node, visitNode, ctx);
+    }
+
+    function createHelper(node: ts.Node) {
+        const decoratorIndex= node.decorators.findIndex(d=>d.getFullText().trim().indexOf("@NativeClass") === 0);
+        node.decorators.slice(decoratorIndex, 1);
+        return ts.createIdentifier(
+            ts.transpileModule(node.getText(), {
+                compilerOptions: { noEmitHelpers:true, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES5 },
+            }).outputText
+        );
+    }
+
+    return (source: ts.SourceFile) =>
+        ts.updateSourceFileNode(
+            source,
+            ts.visitNodes(source.statements, visitNode)
+        );
+}

--- a/packages/webpack/transformers/ns-transform-native-classes.ts
+++ b/packages/webpack/transformers/ns-transform-native-classes.ts
@@ -17,10 +17,9 @@ export default function (ctx: ts.TransformationContext) {
     }
 
     function createHelper(node: ts.Node) {
-        const decoratorIndex= node.decorators.findIndex(d=>d.getFullText().trim().indexOf("@NativeClass") === 0);
-        node.decorators.slice(decoratorIndex, 1);
+        // we remove the decorator for now!
         return ts.createIdentifier(
-            ts.transpileModule(node.getText(), {
+            ts.transpileModule(node.getText().replace(/@NativeClass(\((.|\n)*?\))?/gm, ''), {
                 compilerOptions: { noEmitHelpers:true, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES5 },
             }).outputText
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compileOnSave": false,
   "compilerOptions": {
     "rootDir": ".",
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES2017",
+    "module": "esnext",
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",


### PR DESCRIPTION
This PR moves the core to a full es2017 js build.

* it adds a new `@NativeClass` decorator
* it uses a ts transformer to detect that decorator and transform those classes to es5
* the decorator is removed from the generated es5 (to not require changes to the runtimes)

To apply the transformer using `tsc` we need a modified version of `typescript`. To do that i use [ts-patch](https://github.com/nonara/ts-patch). I added it to the `setup` npm task. That's enough!

Here you go with that the core is build in es2017 ...