### PR TITLE
[android] dont use replace transaction anymore.

### DIFF
--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -31,10 +31,11 @@ interface ExpandedTransitionListener extends androidx.transition.Transition.Tran
 
 interface ExpandedAnimator extends android.animation.Animator {
 	entry: ExpandedEntry;
+	backEntry?: BackstackEntry;
 	transitionType?: string;
 }
 
-interface ExpandedEntry extends BackstackEntry {
+export interface ExpandedEntry extends BackstackEntry {
 	enterTransitionListener: ExpandedTransitionListener;
 	exitTransitionListener: ExpandedTransitionListener;
 	reenterTransitionListener: ExpandedTransitionListener;
@@ -52,7 +53,7 @@ interface ExpandedEntry extends BackstackEntry {
 	isNestedDefaultTransition: boolean;
 }
 
-export function _setAndroidFragmentTransitions(animated: boolean, navigationTransition: NavigationTransition, currentEntry: ExpandedEntry, newEntry: ExpandedEntry, frameId: number, fragmentTransaction: any, isNestedDefaultTransition?: boolean): void {
+export function _setAndroidFragmentTransitions(animated: boolean, navigationTransition: NavigationTransition, currentEntry: ExpandedEntry, newEntry: ExpandedEntry, frameId: number, fragmentTransaction: androidx.fragment.app.FragmentTransaction, isNestedDefaultTransition?: boolean): void {
 	const currentFragment: androidx.fragment.app.Fragment = currentEntry ? currentEntry.fragment : null;
 	const newFragment: androidx.fragment.app.Fragment = newEntry.fragment;
 	const entries = waitingQueue.get(frameId);
@@ -142,12 +143,13 @@ export function _setAndroidFragmentTransitions(animated: boolean, navigationTran
 		if (currentFragmentNeedsDifferentAnimation) {
 			setupCurrentFragmentFadeTransition(navigationTransition, currentEntry);
 		}
-	} else if (name === 'explode') {
+	} else if (name === 'explode') { 
 		setupNewFragmentExplodeTransition(navigationTransition, newEntry);
 		if (currentFragmentNeedsDifferentAnimation) {
 			setupCurrentFragmentExplodeTransition(navigationTransition, currentEntry);
 		}
 	} else if (name.indexOf('flip') === 0) {
+		navigationTransition = { duration: 3000, curve: null }
 		const direction = name.substr('flip'.length) || 'right'; //Extract the direction from the string
 		const flipTransition = new FlipTransition(direction, navigationTransition.duration, navigationTransition.curve);
 
@@ -238,7 +240,7 @@ function getAnimationListener(): android.animation.Animator.AnimatorListener {
 				if (Trace.isEnabled()) {
 					Trace.write(`END ${animator.transitionType} for ${animator.entry.fragmentTag}`, Trace.categories.Transition);
 				}
-				transitionOrAnimationCompleted(animator.entry);
+				transitionOrAnimationCompleted(animator.entry, animator.backEntry);
 			}
 
 			onAnimationCancel(animator: ExpandedAnimator): void {
@@ -327,6 +329,7 @@ function getTransitionListener(entry: ExpandedEntry, transition: androidx.transi
 		@NativeClass
 		@Interfaces([(<any>androidx).transition.Transition.TransitionListener])
 		class TransitionListenerImpl extends java.lang.Object implements androidx.transition.Transition.TransitionListener {
+			public backEntry?: BackstackEntry
 			constructor(public entry: ExpandedEntry, public transition: androidx.transition.Transition) {
 				super();
 
@@ -346,8 +349,7 @@ function getTransitionListener(entry: ExpandedEntry, transition: androidx.transi
 				if (Trace.isEnabled()) {
 					Trace.write(`END ${toShortString(transition)} transition for ${entry.fragmentTag}`, Trace.categories.Transition);
 				}
-
-				transitionOrAnimationCompleted(entry);
+				transitionOrAnimationCompleted(entry, this.backEntry);
 			}
 
 			onTransitionResume(transition: androidx.transition.Transition): void {
@@ -649,7 +651,7 @@ export function addNativeTransitionListener(entry: ExpandedEntry, nativeTransiti
 	return listener;
 }
 
-function transitionOrAnimationCompleted(entry: ExpandedEntry): void {
+function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: BackstackEntry): void {
 	const frameId = entry.frameId;
 	const entries = waitingQueue.get(frameId);
 	// https://github.com/NativeScript/NativeScript/issues/5759
@@ -678,7 +680,7 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry): void {
 		// Will be null if Frame is shown modally...
 		// transitionOrAnimationCompleted fires again (probably bug in android).
 		if (current) {
-			setTimeout(() => frame.setCurrent(current, navigationContext.navigationType));
+			setTimeout(() => frame.setCurrent(backEntry||current, navigationContext.navigationType));
 		}
 	} else {
 		completedEntries.set(frameId, entry);

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -296,11 +296,6 @@ export class FrameBase extends CustomLayoutView {
 	private raiseCurrentPageNavigatedEvents(isBack: boolean) {
 		const page = this.currentPage;
 		if (page) {
-			if (page.isLoaded) {
-				// Forward navigation does not remove page from frame so we raise unloaded manually.
-				page.callUnloaded();
-			}
-
 			page.onNavigatedFrom(isBack);
 		}
 	}

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -324,6 +324,8 @@ export class Frame extends FrameBase {
 
 			// If we had real navigation process queue.
 			this._processNavigationQueue(entry.resolvedPage);
+
+
 		} else {
 			// Otherwise currentPage was recreated so this wasn't real navigation.
 			// Continue with next item in the queue.
@@ -436,7 +438,7 @@ export class Frame extends FrameBase {
 			//transaction.setTransition(androidx.fragment.app.FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
 		}
 
-		transaction.replace(this.containerViewId, newFragment, newFragmentTag);
+		transaction.add(this.containerViewId, newFragment, newFragmentTag);
 		transaction.commitAllowingStateLoss();
 	}
 
@@ -458,7 +460,30 @@ export class Frame extends FrameBase {
 
 		_reverseTransitions(backstackEntry, this._currentEntry);
 
-		transaction.replace(this.containerViewId, backstackEntry.fragment, backstackEntry.fragmentTag);
+		const currentIndex =this.backStack.length;
+		const gotBackToIndex = this.backStack.indexOf(backstackEntry);
+		
+		for (let index = gotBackToIndex + 1; index < currentIndex; index++) {
+			transaction.remove(this.backStack[index].fragment);
+		}
+		if (this._currentEntry !== backstackEntry) {
+			// if we are going back we need to store where we are backing to
+			// so that we can set the current entry
+			if ((this._currentEntry as any).exitTransitionListener) {
+				(this._currentEntry as any).exitTransitionListener.backEntry = backstackEntry;
+			}
+			if ((this._currentEntry as any).returnTransitionListener) {
+				(this._currentEntry as any).returnTransitionListener.backEntry = backstackEntry;
+			}
+			if ((this._currentEntry as any).enterTransitionListener) {
+				(this._currentEntry as any).enterTransitionListener.backEntry = backstackEntry;
+			}
+			if ((this._currentEntry as any).reenterTransitionListener) {
+				(this._currentEntry as any).reenterTransitionListener.backEntry = backstackEntry;
+			}
+			transaction.remove((this._currentEntry).fragment);
+			
+		}
 		transaction.commitAllowingStateLoss();
 	}
 


### PR DESCRIPTION
So this is a long coming fix for me in all my apps.
Kind of in the same vibe as https://github.com/NativeScript/NativeScript/pull/8561

Until now when transitioning between fragment we were using `replace` which means that moving to a new fragment the current fragment was destroyed and re created on back.
This was bad for maps and any opengl rendered views.
Here is an example of what it looked like before
![file1](https://user-images.githubusercontent.com/655344/89633012-7278a700-d8a3-11ea-93ad-00d54b982ff8.gif)

This PR changes that behavior by using `add` and `remove`.
I hacked the transition life handlers a bit the get the entry we are moving to and the entry we are moving from.
Another plus of this is that back navigations should be faster as we dont recreate the views.
We will also keep the positions in any scroll view!!!

Here is what it looks like now:

![file](https://user-images.githubusercontent.com/655344/89633286-e3b85a00-d8a3-11ea-9824-ebde60956006.gif)

