### PR TITLE
Feat/monorepo fix fragment transitions 2

### DIFF
--- a/apps/automated/app/ui/page/page-tests-common.ts
+++ b/apps/automated/app/ui/page/page-tests-common.ts
@@ -181,7 +181,7 @@ function _test_PageNavigation_EventSequence(withTransition: boolean) {
 	helper.navigateWithEntry(navigationEntry);
 	helper.goBack();
 
-	const expectedEventSequence = ['navigatingTo', 'loaded', 'navigatedTo', 'navigatingFrom', 'unloaded', 'navigatedFrom'];
+	const expectedEventSequence = ['navigatingTo', 'loaded', 'navigatedTo', 'navigatingFrom', 'navigatedFrom', 'unloaded'];
 	TKUnit.arrayAssert(eventSequence, expectedEventSequence, 'Actual event sequence is not equal to expected. Actual: ' + eventSequence + '; Expected: ' + expectedEventSequence);
 }
 

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -392,7 +392,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		if (this._isLoaded) {
 			return;
 		}
-
+		if (Trace.isEnabled()) {
+			Trace.write(`${this}.onLoaded()`, Trace.categories.ViewHierarchy);
+		}
 		this._isLoaded = true;
 		this._cssState.onLoaded();
 		this._resumeNativeUpdates(SuspendType.Loaded);
@@ -412,7 +414,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		if (!this._isLoaded) {
 			return;
 		}
-
+		if (Trace.isEnabled()) {
+			Trace.write(`${this}.onUnloaded()`, Trace.categories.ViewHierarchy);
+		}
 		this._suspendNativeUpdates(SuspendType.Loaded);
 
 		this.eachChild((child) => {

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -504,7 +504,7 @@ function setEnterTransition(navigationTransition: NavigationTransition, entry: E
 	fragment.setEnterTransition(transition);
 }
 
-function xsetExitTransition(navigationTransition: NavigationTransition, entry: ExpandedEntry, transition: androidx.transition.Transition): void {
+function setExitTransition(navigationTransition: NavigationTransition, entry: ExpandedEntry, transition: androidx.transition.Transition): void {
 	setUpNativeTransition(navigationTransition, transition);
 	const listener = addNativeTransitionListener(entry, transition);
 

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -26,6 +26,7 @@ let AnimationListener: android.animation.Animator.AnimatorListener;
 
 interface ExpandedTransitionListener extends androidx.transition.Transition.TransitionListener {
 	entry: ExpandedEntry;
+	backEntry?: BackstackEntry;
 	transition: androidx.transition.Transition;
 }
 
@@ -223,6 +224,7 @@ function getAnimationListener(): android.animation.Animator.AnimatorListener {
 
 			onAnimationStart(animator: ExpandedAnimator): void {
 				const entry = animator.entry;
+				const backEntry = animator.backEntry;
 				addToWaitingQueue(entry);
 				if (Trace.isEnabled()) {
 					Trace.write(`START ${animator.transitionType} for ${entry.fragmentTag}`, Trace.categories.Transition);
@@ -236,10 +238,13 @@ function getAnimationListener(): android.animation.Animator.AnimatorListener {
 			}
 
 			onAnimationEnd(animator: ExpandedAnimator): void {
+				const entry = animator.entry;
+				const backEntry = animator.backEntry;
 				if (Trace.isEnabled()) {
-					Trace.write(`END ${animator.transitionType} for ${animator.entry.fragmentTag}`, Trace.categories.Transition);
+					Trace.write(`END ${animator.transitionType} for ${entry.fragmentTag} backEntry:${backEntry ? backEntry.fragmentTag : 'none'}`, Trace.categories.Transition);
 				}
-				transitionOrAnimationCompleted(animator.entry, animator.backEntry);
+				transitionOrAnimationCompleted(entry, backEntry);
+				animator.backEntry = null;
 			}
 
 			onAnimationCancel(animator: ExpandedAnimator): void {
@@ -345,10 +350,12 @@ function getTransitionListener(entry: ExpandedEntry, transition: androidx.transi
 
 			onTransitionEnd(transition: androidx.transition.Transition): void {
 				const entry = this.entry;
+				const backEntry = this.backEntry;
 				if (Trace.isEnabled()) {
-					Trace.write(`END ${toShortString(transition)} transition for ${entry.fragmentTag}`, Trace.categories.Transition);
+					Trace.write(`END ${toShortString(transition)} transition for ${entry.fragmentTag} backEntry:${backEntry ? backEntry.fragmentTag : 'none'}`, Trace.categories.Transition);
 				}
-				transitionOrAnimationCompleted(entry, this.backEntry);
+				transitionOrAnimationCompleted(entry, backEntry);
+				this.backEntry = null;
 			}
 
 			onTransitionResume(transition: androidx.transition.Transition): void {
@@ -497,7 +504,7 @@ function setEnterTransition(navigationTransition: NavigationTransition, entry: E
 	fragment.setEnterTransition(transition);
 }
 
-function setExitTransition(navigationTransition: NavigationTransition, entry: ExpandedEntry, transition: androidx.transition.Transition): void {
+function xsetExitTransition(navigationTransition: NavigationTransition, entry: ExpandedEntry, transition: androidx.transition.Transition): void {
 	setUpNativeTransition(navigationTransition, transition);
 	const listener = addNativeTransitionListener(entry, transition);
 
@@ -660,6 +667,7 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: Backsta
 	if (!entries) {
 		return;
 	}
+	console.log('transitionOrAnimationCompleted', frameId, backEntry && backEntry.fragmentTag, waitingQueue.size, entries.size, completedEntries.size );
 
 	entries.delete(entry);
 	if (entries.size === 0) {

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -143,13 +143,12 @@ export function _setAndroidFragmentTransitions(animated: boolean, navigationTran
 		if (currentFragmentNeedsDifferentAnimation) {
 			setupCurrentFragmentFadeTransition(navigationTransition, currentEntry);
 		}
-	} else if (name === 'explode') {
+	} else if (name === 'explode') { 
 		setupNewFragmentExplodeTransition(navigationTransition, newEntry);
 		if (currentFragmentNeedsDifferentAnimation) {
 			setupCurrentFragmentExplodeTransition(navigationTransition, currentEntry);
 		}
 	} else if (name.indexOf('flip') === 0) {
-		navigationTransition = { duration: 3000, curve: null };
 		const direction = name.substr('flip'.length) || 'right'; //Extract the direction from the string
 		const flipTransition = new FlipTransition(direction, navigationTransition.duration, navigationTransition.curve);
 

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -259,7 +259,7 @@ export class FrameBase extends CustomLayoutView {
 	public _updateBackstack(entry: BackstackEntry, navigationType: NavigationType): void {
 		const isBack = navigationType === NavigationType.back;
 		const isReplace = navigationType === NavigationType.replace;
-		this.raiseCurrentPageNavigatedEvents(isBack, isReplace, entry.entry.clearHistory);
+		this.raiseCurrentPageNavigatedEvents(isBack);
 		const current = this._currentEntry;
 
 		// Do nothing for Hot Module Replacement
@@ -293,14 +293,9 @@ export class FrameBase extends CustomLayoutView {
 		return false;
 	}
 
-	private raiseCurrentPageNavigatedEvents(isBack: boolean, isReplace: boolean, clearHistory: boolean) {
+	private raiseCurrentPageNavigatedEvents(isBack: boolean) {
 		const page = this.currentPage;
 		if (page) {
-			if ((isBack || isReplace || clearHistory) && page.isLoaded) {
-				console.log('unloading current page');
-				// Forward navigation does not remove page from frame so we raise unloaded manually.
-				page.callUnloaded();
-			}
 			page.onNavigatedFrom(isBack);
 		}
 	}

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -259,7 +259,7 @@ export class FrameBase extends CustomLayoutView {
 	public _updateBackstack(entry: BackstackEntry, navigationType: NavigationType): void {
 		const isBack = navigationType === NavigationType.back;
 		const isReplace = navigationType === NavigationType.replace;
-		this.raiseCurrentPageNavigatedEvents(isBack);
+		this.raiseCurrentPageNavigatedEvents(isBack, isReplace, entry.entry.clearHistory);
 		const current = this._currentEntry;
 
 		// Do nothing for Hot Module Replacement
@@ -293,9 +293,14 @@ export class FrameBase extends CustomLayoutView {
 		return false;
 	}
 
-	private raiseCurrentPageNavigatedEvents(isBack: boolean) {
+	private raiseCurrentPageNavigatedEvents(isBack: boolean, isReplace: boolean, clearHistory: boolean) {
 		const page = this.currentPage;
 		if (page) {
+			if ((isBack || isReplace || clearHistory) && page.isLoaded) {
+				console.log('unloading current page');
+				// Forward navigation does not remove page from frame so we raise unloaded manually.
+				page.callUnloaded();
+			}
 			page.onNavigatedFrom(isBack);
 		}
 	}

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -296,10 +296,6 @@ export class FrameBase extends CustomLayoutView {
 	private raiseCurrentPageNavigatedEvents(isBack: boolean) {
 		const page = this.currentPage;
 		if (page) {
-			if (page.isLoaded) {
-				// Forward navigation does not remove page from frame so we raise unloaded manually.
-				page.callUnloaded();
-			}
 			page.onNavigatedFrom(isBack);
 		}
 	}

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -259,8 +259,8 @@ export class FrameBase extends CustomLayoutView {
 	public _updateBackstack(entry: BackstackEntry, navigationType: NavigationType): void {
 		const isBack = navigationType === NavigationType.back;
 		const isReplace = navigationType === NavigationType.replace;
-		this.raiseCurrentPageNavigatedEvents(isBack);
 		const current = this._currentEntry;
+		this.raiseCurrentPageNavigatedEvents(isBack);
 
 		// Do nothing for Hot Module Replacement
 		if (isBack) {

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -324,6 +324,8 @@ export class Frame extends FrameBase {
 
 			// If we had real navigation process queue.
 			this._processNavigationQueue(entry.resolvedPage);
+
+
 		} else {
 			// Otherwise currentPage was recreated so this wasn't real navigation.
 			// Continue with next item in the queue.
@@ -436,7 +438,7 @@ export class Frame extends FrameBase {
 			//transaction.setTransition(androidx.fragment.app.FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
 		}
 
-		transaction.replace(this.containerViewId, newFragment, newFragmentTag);
+		transaction.add(this.containerViewId, newFragment, newFragmentTag);
 		transaction.commitAllowingStateLoss();
 	}
 
@@ -458,8 +460,30 @@ export class Frame extends FrameBase {
 
 		_reverseTransitions(backstackEntry, this._currentEntry);
 
-		transaction.replace(this.containerViewId, backstackEntry.fragment, backstackEntry.fragmentTag);
-
+		const currentIndex =this.backStack.length;
+		const gotBackToIndex = this.backStack.indexOf(backstackEntry);
+		
+		for (let index = gotBackToIndex + 1; index < currentIndex; index++) {
+			transaction.remove(this.backStack[index].fragment);
+		}
+		if (this._currentEntry !== backstackEntry) {
+			// if we are going back we need to store where we are backing to
+			// so that we can set the current entry
+			if ((this._currentEntry as any).exitTransitionListener) {
+				(this._currentEntry as any).exitTransitionListener.backEntry = backstackEntry;
+			}
+			if ((this._currentEntry as any).returnTransitionListener) {
+				(this._currentEntry as any).returnTransitionListener.backEntry = backstackEntry;
+			}
+			if ((this._currentEntry as any).enterTransitionListener) {
+				(this._currentEntry as any).enterTransitionListener.backEntry = backstackEntry;
+			}
+			if ((this._currentEntry as any).reenterTransitionListener) {
+				(this._currentEntry as any).reenterTransitionListener.backEntry = backstackEntry;
+			}
+			transaction.remove((this._currentEntry).fragment);
+			
+		}
 		transaction.commitAllowingStateLoss();
 	}
 

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -439,7 +439,11 @@ export class Frame extends FrameBase {
 			//transaction.setTransition(androidx.fragment.app.FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
 		}
 
-		transaction.add(this.containerViewId, newFragment, newFragmentTag);
+		if (clearHistory) {
+			transaction.replace(this.containerViewId, newFragment, newFragmentTag);
+		} else  {
+			transaction.add(this.containerViewId, newFragment, newFragmentTag);
+		}
 		transaction.commitAllowingStateLoss();
 	}
 

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -439,7 +439,7 @@ export class Frame extends FrameBase {
 			//transaction.setTransition(androidx.fragment.app.FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
 		}
 
-		if (clearHistory) {
+		if (clearHistory || isReplace) {
 			transaction.replace(this.containerViewId, newFragment, newFragmentTag);
 		} else  {
 			transaction.add(this.containerViewId, newFragment, newFragmentTag);

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -19,6 +19,7 @@ import { Builder } from '../builder';
 import { CSSUtils } from '../../css/system-classes';
 import { Device } from '../../platform';
 import { profile } from '../../profiling';
+import { ExpandedEntry } from './fragment.transitions.android';
 
 export * from './frame-common';
 
@@ -463,26 +464,21 @@ export class Frame extends FrameBase {
 		const currentIndex =this.backStack.length;
 		const gotBackToIndex = this.backStack.indexOf(backstackEntry);
 		
-		for (let index = gotBackToIndex + 1; index < currentIndex; index++) {
-			transaction.remove(this.backStack[index].fragment);
-		}
+		// the order is important so that the transition listener called be 
+		// the one from the current entry we are going back from
 		if (this._currentEntry !== backstackEntry) {
+			const entry = this._currentEntry as ExpandedEntry;
 			// if we are going back we need to store where we are backing to
 			// so that we can set the current entry
-			if ((this._currentEntry as any).exitTransitionListener) {
-				(this._currentEntry as any).exitTransitionListener.backEntry = backstackEntry;
+			// it only needs to be done on the return transition
+			if (entry.returnTransitionListener) {
+				entry.returnTransitionListener.backEntry = backstackEntry;
 			}
-			if ((this._currentEntry as any).returnTransitionListener) {
-				(this._currentEntry as any).returnTransitionListener.backEntry = backstackEntry;
-			}
-			if ((this._currentEntry as any).enterTransitionListener) {
-				(this._currentEntry as any).enterTransitionListener.backEntry = backstackEntry;
-			}
-			if ((this._currentEntry as any).reenterTransitionListener) {
-				(this._currentEntry as any).reenterTransitionListener.backEntry = backstackEntry;
-			}
-			transaction.remove((this._currentEntry).fragment);
 			
+			transaction.remove((this._currentEntry).fragment);	
+		}
+		for (let index = gotBackToIndex + 1; index < currentIndex; index++) {
+			transaction.remove(this.backStack[index].fragment);
 		}
 		transaction.commitAllowingStateLoss();
 	}

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -444,6 +444,9 @@ export class Frame extends FrameBase {
 		} else  {
 			transaction.add(this.containerViewId, newFragment, newFragmentTag);
 		}
+		if (this._currentEntry && this._currentEntry.entry.backstackVisible === false) {
+			transaction.remove(this._currentEntry.fragment);
+		}
 		transaction.commitAllowingStateLoss();
 	}
 
@@ -466,7 +469,7 @@ export class Frame extends FrameBase {
 		_reverseTransitions(backstackEntry, this._currentEntry);
 
 		const currentIndex =this.backStack.length;
-		const gotBackToIndex = this.backStack.indexOf(backstackEntry);
+		const goBackToIndex = this.backStack.indexOf(backstackEntry);
 		
 		// the order is important so that the transition listener called be 
 		// the one from the current entry we are going back from
@@ -481,9 +484,10 @@ export class Frame extends FrameBase {
 			
 			transaction.remove((this._currentEntry).fragment);	
 		}
-		for (let index = gotBackToIndex + 1; index < currentIndex; index++) {
+		for (let index = goBackToIndex + 1; index < currentIndex; index++) {
 			transaction.remove(this.backStack[index].fragment);
 		}
+		
 		transaction.commitAllowingStateLoss();
 	}
 


### PR DESCRIPTION
Another try at fixing this.
Tested with clearHistory and multiple in between fragments while going back.

One note though on this: `unloaded` event wont be called anymore  on fragment 1 when going "forward" from fragment 1 to fragment 2.  The reason is simply that fragment 1 is not unloaded anymore (so that we dont see the black thing while going back).

@NathanaelA can you guide on how to test this the way you did?