### PR TITLE
fix(android): dont dispose fragment on onloaded

### DIFF
--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -241,11 +241,6 @@ export class Frame extends FrameBase {
 
 	onUnloaded() {
 		super.onUnloaded();
-
-		// calling dispose fragment after super.onUnloaded() means we are not relying on the built-in Android logic
-		// to automatically remove child fragments when parent fragment is removed;
-		// this fixes issue with missing nested fragment on app suspend / resume;
-		this.disposeCurrentFragment();
 	}
 
 	private disposeCurrentFragment(): void {


### PR DESCRIPTION
As explained here #6659
That hack has bad consequences.
Also i actually cant see any wrong behavior using the sample provided in the issue and upgrading to latest N.