### PR TITLE
default typings for android to 29

### DIFF
--- a/packages/types-android/src/lib/android.d.ts
+++ b/packages/types-android/src/lib/android.d.ts
@@ -1,1 +1,1 @@
-/// <reference path="./android-17.d.ts" />
+/// <reference path="./android-29.d.ts" />


### PR DESCRIPTION
most plugins / apps depends on newer APIs than 17. Plus it wont break anything, will just add more typings (i think)

