### PR TITLE
fix(webpack): apply-css-loader not applying css

### DIFF
--- a/packages/webpack/helpers/apply-css-loader.js
+++ b/packages/webpack/helpers/apply-css-loader.js
@@ -27,7 +27,7 @@ module.exports = function (content, map) {
 
     content += `
     const { Application } = require("@nativescript/core");
-    //require("@nativescript/core/ui/styling/style-scope");
+    require("@nativescript/core/ui/styling/style-scope");
 
     if (___CSS_LOADER_EXPORT___ && typeof ___CSS_LOADER_EXPORT___.forEach === "function") {
         ___CSS_LOADER_EXPORT___.forEach(cssExport => {

--- a/packages/webpack/helpers/apply-css-loader.js
+++ b/packages/webpack/helpers/apply-css-loader.js
@@ -26,14 +26,14 @@ module.exports = function (content, map) {
     }
 
     content += `
-    const nsCore = require("@nativescript/core");
-    require("@nativescript/core/ui/styling/style-scope");
+    const { Application } = require("@nativescript/core");
+    //require("@nativescript/core/ui/styling/style-scope");
 
-    if (typeof exports.forEach === "function") {
-        exports.forEach(cssExport => {
+    if (___CSS_LOADER_EXPORT___ && typeof ___CSS_LOADER_EXPORT___.forEach === "function") {
+        ___CSS_LOADER_EXPORT___.forEach(cssExport => {
             if (cssExport.length > 1 && cssExport[1]) {
                 // applying the second item of the export as it contains the css contents
-                nsCore.Application.addCss(cssExport[1]);
+                Application.addCss(cssExport[1]);
             }
         });
     }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/webpack",
-  "version": "3.0.0",
+  "version": "3.0.1-rc.0",
   "main": "index",
   "description": "Webpack plugin for NativeScript",
   "homepage": "https://nativescript.org",


### PR DESCRIPTION
Now that everything is using ES modules, the `exports` object no longer exists.

`css-loader` adds the `___CSS_LOADER_EXPORT___` variable to the module, and then exports it. This allows us to hook into it, and apply the css to a NativeScript app. 

This fixes Vue apps in NativeScript 7. See https://github.com/nativescript-vue/nativescript-vue/issues/715

I believe `require("@nativescript/core/ui/styling/style-scope")` is no longer needed - because globals are handled differently (testing the change in an app works fine) - but @NathanWalker please take a look!

The change has been released under `3.0.1-rc.0`.