### PR TITLE
fix(webpack/transform): Change NativeClass properties to enumerable

### DIFF
--- a/packages/webpack/transformers/ns-transform-native-classes.ts
+++ b/packages/webpack/transformers/ns-transform-native-classes.ts
@@ -22,7 +22,7 @@ export default function (ctx: ts.TransformationContext) {
 		return ts.createIdentifier(
 			ts.transpileModule(node.getText().replace(/@NativeClass(\((.|\n)*?\))?/gm, ''), {
 				compilerOptions: { noEmitHelpers: true, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES5 },
-			}).outputText
+			}).outputText.replace(/(Object\.defineProperty\(.*?{.*?)(enumerable:\s*false)(.*?}\))/gs, '$1enumerable: true$3')
 		);
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
With TS 3.9+ when transpiling TS to ES5 if a property has a get/set defined, it marks the properties as `enumerable: false`. ([TS commit reference](https://github.com/microsoft/TypeScript/commit/5c85febb0ce9d6088cbe9b09cb42f73f9ee8ea05)) This prevents v8/JSC to correctly access them. 

## What is the new behavior?
The added regex patches the output of the transpile and marks all properties as `enumerable: true`

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

