### PR TITLE
fix: invalid cli tag version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "^8.0.1",
     "mocha-typescript": "^1.1.17",
     "module-alias": "^2.2.2",
-    "nativescript": "rc7",
+    "nativescript": "~7.0.6",
     "node-sass": "~4.14.1",
     "parse-css": "git+https://github.com/tabatkins/parse-css.git",
     "parserlib": "^1.1.1",


### PR DESCRIPTION
There is no `rc7` tag for the `nativescript` package.