### PR TITLE
feat: boolean to disable systemAppearanceChanged (theme)

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -148,9 +148,9 @@ export function orientationChanged(rootView: View, newOrientation: 'portrait' | 
 		applyCssClass(rootModalView, ORIENTATION_CSS_CLASSES, newOrientationCssClass);
 	});
 }
-
+export let autoSystemAppearanceChanged = true;
 export function systemAppearanceChanged(rootView: View, newSystemAppearance: 'dark' | 'light'): void {
-	if (!rootView) {
+	if (!rootView || !autoSystemAppearanceChanged) {
 		return;
 	}
 

--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -149,6 +149,11 @@ export function orientationChanged(rootView: View, newOrientation: 'portrait' | 
 	});
 }
 export let autoSystemAppearanceChanged = true;
+
+export function setAutoSystemAppearanceChanged(value: boolean) {
+	autoSystemAppearanceChanged = value;
+}
+
 export function systemAppearanceChanged(rootView: View, newSystemAppearance: 'dark' | 'light'): void {
 	if (!rootView || !autoSystemAppearanceChanged) {
 		return;

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -58,6 +58,12 @@ export const systemAppearanceChangedEvent: string;
  * Boolean to enable/disable systemAppearanceChanged
  */
 export let autoSystemAppearanceChanged = true;
+
+/**
+ * enable/disable systemAppearanceChanged
+ */
+export function setAutoSystemAppearanceChanged (value: boolean);
+
 /**
  * Updates root view classes including those of modals
  * @param rootView the root view

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -55,6 +55,10 @@ export const orientationChangedEvent: string;
 export const systemAppearanceChangedEvent: string;
 
 /**
+ * Boolean to enable/disable systemAppearanceChanged
+ */
+export let autoSystemAppearanceChanged = true;
+/**
  * Updates root view classes including those of modals
  * @param rootView the root view
  * @param newSystemAppearance the new appearance change


### PR DESCRIPTION
With es2017 `@nativescript/theme` wont work because of an error like that 
```
Cannot set property systemAppearanceChanged of #<Object> which has only a getter
```

Now i think it is best to not "override" that method but to have a boolean to disable 