### PR TITLE
feat(core): export additional properties for plugin usage

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -8,7 +8,7 @@
 export type { NativeScriptConfig } from './config';
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
-import { systemAppearanceChanged, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, run, orientation, getNativeApplication, hasLaunched, systemAppearance } from './application';
+import { systemAppearanceChanged, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, systemAppearance } from './application';
 export declare const Application: {
 	launchEvent: string;
 	displayedEvent: string;
@@ -32,6 +32,8 @@ export declare const Application: {
 	addCss: typeof addCss;
 	on: typeof on;
 	off: typeof off;
+	notify: typeof notify;
+	hasListeners: typeof hasListeners;
 	run: typeof run;
 	orientation: typeof orientation;
 	getNativeApplication: typeof getNativeApplication;
@@ -113,6 +115,10 @@ export declare const Utils: {
 	android: typeof androidUtils;
 	ad: typeof androidUtils;
 	ios: typeof iosUtils;
+	setTimeout: typeof setTimeout;
+	setInterval: typeof setInterval;
+	clearInterval: typeof clearInterval;
+	clearTimeout: typeof clearTimeout;
 	Source: typeof Source;
 	ClassInfo: typeof ClassInfo;
 	getClass: typeof getClass;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -6,7 +6,7 @@ nsGlobals.initGlobal();
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
 
-import { launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance } from './application';
+import { launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance } from './application';
 export const Application = {
 	launchEvent,
 	displayedEvent,
@@ -30,7 +30,9 @@ export const Application = {
 	loadAppCss,
 	addCss,
 	on,
-	off,
+  off,
+  notify,
+  hasListeners,
 	run,
 	orientation,
 	getNativeApplication,
@@ -103,7 +105,8 @@ export { profile, enable as profilingEnable, disable as profilingDisable, time a
 export type { InstrumentationMode, TimerInfo } from './profiling';
 
 export { encoding } from './text';
-
+// for developers to be explicit if they desire around globals (allows access via Utils below)
+import { setTimeout, setInterval, clearInterval, clearTimeout } from './timer';
 export * from './trace';
 
 export * from './ui';
@@ -133,7 +136,11 @@ export const Utils = {
 	android: androidUtils,
 	// legacy (a lot of plugins use the shorthand "ad" Utils.ad instead of Utils.android)
 	ad: androidUtils,
-	ios: iosUtils,
+  ios: iosUtils,
+  setTimeout, 
+  setInterval, 
+  clearInterval, 
+  clearTimeout,
 	Source,
 	ClassInfo,
 	getClass,

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -74,7 +74,7 @@ export type { TabStripItemEventData } from './tab-navigation-base/tab-strip';
 export { TabStripItem } from './tab-navigation-base/tab-strip-item';
 export { TabView, TabViewItem } from './tab-view';
 export { Tabs } from './tabs';
-export { TextBase, getTransformedText } from './text-base';
+export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, whiteSpaceProperty, lineHeightProperty } from './text-base';
 export type { TextTransform } from './text-base';
 export { FormattedString } from './text-base/formatted-string';
 export { Span } from './text-base/span';

--- a/workspace.json
+++ b/workspace.json
@@ -300,12 +300,8 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "commands": [
-              {
-                "command": "./build.sh"
-              },
-              {
-                "command": "cp -R dist/package/platforms/* ../../packages/core/platforms"
-              }
+              "./build.sh",
+              "cp -R dist/package/platforms/* ../../packages/core/platforms"
             ],
             "cwd": "packages/ui-mobile-base",
             "parallel": false
@@ -337,12 +333,8 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "commands": [
-              {
-                "command": "npm run tsc"
-              },
-              {
-                "command": "npm run jasmine"
-              }
+              "npm run tsc",
+              "npm run jasmine"
             ],
             "cwd": "packages/webpack",
             "parallel": false
@@ -353,15 +345,9 @@
           "outputs": ["dist/packages"],
           "options": {
             "commands": [
-              {
-                "command": "npm run setup"
-              },
-              {
-                "command": "mkdir -p ../../dist/packages"
-              },
-              {
-                "command": "mv \"$(npm pack | tail -n 1)\" ../../dist/packages/nativescript-webpack.tgz"
-              }
+              "npm run setup",
+              "mkdir -p ../../dist/packages",
+              "mv \"$(npm pack | tail -n 1)\" ../../dist/packages/nativescript-webpack.tgz"
             ],
             "cwd": "packages/webpack",
             "parallel": false


### PR DESCRIPTION
## What is the current behavior?

A few properties are missing from the barrel.

## What is the new behavior?

This adds the additional getter/setters for plugin usage:

```
import { 
  letterSpacingProperty, 
  textAlignmentProperty, 
  textDecorationProperty, 
  textTransformProperty, 
  whiteSpaceProperty, 
  lineHeightProperty 
} from '@nativescript/core';
```

/cc @PeterStaev 

