### PR TITLE
fix bundle-config-loader

### DIFF
--- a/packages/core/globals/index.ts
+++ b/packages/core/globals/index.ts
@@ -358,3 +358,6 @@ export function initGlobal() {
 		};
 	}
 }
+if (!global.NativeScriptHasInitGlobal) {
+    initGlobal();
+}


### PR DESCRIPTION
This PR fixes a big issue which appeared with N 7 / esm / webpack

With webpack import / require order is not respected : https://github.com/webpack/webpack/issues/1343

Now in [bundle-config-loader](https://github.com/Nativescript/NativeScript/blob/65a3302a048fb32da78968256c16fc63a5706e3d/packages/webpack/bundle-config-loader.ts#L55) we rely on `require` to load `bundle-entry-points` thus calling `initGlobals` and making tslib functions global.
Because it uses `require` it actually end up at the end of your `main.js` (simply look at a generated bundle.js)

To keep that call up we need to use `import` 
But that is not enough!
in `bundle-entry-points` we use 'require' on 'globals'. And using `import` is not enough either because we call a method on it which will end up after all imports!

The solution to all this is call `initGlobal` inside `global/index.ts` then use `import './global'` for example.
Doing that i needed cleanup a bit and we end up with only on use of `initGlobal`

EDIT: that [app](https://github.com/nativescript-community/gesturehandler/tree/master/demo_vue) will crash on ios because of that. The reason is that i import View at the top of my main.ts which include files using `__metadata`