### PR TITLE
fix: add missing configuration keys and move profiling out of android

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "start": "nps",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
-	"private": true,
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/NativeScript/NativeScript.git"
-	},
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NativeScript/NativeScript.git"
+  },
   "dependencies": {
     "nativescript-theme-core": "^1.0.4"
   },

--- a/packages/core/config/config.interface.ts
+++ b/packages/core/config/config.interface.ts
@@ -1,4 +1,6 @@
-interface IConfigPlaform {
+import type {InstrumentationMode} from '../profiling'
+
+interface IConfigPlatform {
 	/**
 	 * App's bundle id
 	 */
@@ -10,9 +12,10 @@ interface IConfigPlaform {
 	discardUncaughtJsExceptions?: boolean;
 }
 
-interface IConfigIOS extends IConfigPlaform {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface IConfigIOS extends IConfigPlatform {}
 
-interface IConfigAndroid extends IConfigPlaform {
+interface IConfigAndroid extends IConfigPlatform {
 	/**
 	 * These are the v8 runtime flags you can pass in, you must have "--expose_gc" as this is used in the runtime
 	 */
@@ -45,11 +48,6 @@ interface IConfigAndroid extends IConfigPlaform {
 	 * Docs: https://docs.nativescript.org/core-concepts/android-runtime/advanced-topics/memory-management
 	 */
 	gcThrottleTime?: number;
-
-	/**
-	 * Enabled "timeline" profiling by setting this key to "timeline", default: ""
-	 */
-	profiling?: string;
 
 	/**
 	 * "none" & "full" is supported, "full" is depreciated
@@ -91,8 +89,8 @@ interface IConfigAndroid extends IConfigPlaform {
 	enableLineBreakpoints?: boolean;
 
 	/**
-	 * Enabled the multithreaded JavaScript engine, this will probably break plugins...
-	 * Disabled/Default: false
+	 * Enable the multithreaded JavaScript engine, this will probably break plugins...
+	 * Default: false - disabled.
 	 */
 	enableMultithreadedJavascript?: boolean;
 }
@@ -104,9 +102,13 @@ export interface NativeScriptConfig {
 	 */
 	id?: string;
 	/**
-	 * App's main entry file
+	 * App's main entry file (currently ignored - set it in package.json main field)
 	 */
 	main?: string;
+	/**
+	 * Path to the app source directory
+	 * This is often the `src` or `app` directory however can be changed.
+	 */
 	appPath?: string;
 	/**
 	 * App_Resources path
@@ -131,4 +133,15 @@ export interface NativeScriptConfig {
 	 * Various Android specific configurations including Android runtime flags.
 	 */
 	android?: IConfigAndroid;
+	/**
+	 * Enable profiling for the application. Default: no profiling
+	 * In most cases when profiling, you will want to use "timeline"
+	 */
+	profiling?: InstrumentationMode;
+	/**
+	 * Set the default CSS parser that NativeScript will use.
+	 * Default: css-tree
+	 */
+	cssParser?: 'rework' | 'nativescript' | 'css-tree';
 }
+


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`profiling` is nested in the `android` key - and is ignored.
no `cssParser` property in config.

## What is the new behavior?
<!-- Describe the changes. -->
`profiling` is now at the proper root level, and is picked up by core (after https://github.com/NativeScript/nativescript-cli/commit/9641bea992e05978dbb64d28dc7d60bf14ea2f76 is released) 
`cssParser` is now read from the config.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

