### PR TITLE
fix(android-transitions): remove hard-coded flip transition duration/curve

### DIFF
--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -149,7 +149,6 @@ export function _setAndroidFragmentTransitions(animated: boolean, navigationTran
 			setupCurrentFragmentExplodeTransition(navigationTransition, currentEntry);
 		}
 	} else if (name.indexOf('flip') === 0) {
-		navigationTransition = { duration: 3000, curve: null };
 		const direction = name.substr('flip'.length) || 'right'; //Extract the direction from the string
 		const flipTransition = new FlipTransition(direction, navigationTransition.duration, navigationTransition.curve);
 


### PR DESCRIPTION
## What is the current behavior?

When navigating with a `flip*` transition, the `duration` and `curve` are not honoured. Duration is hard-coded to 3000 which results in a low transition. This may have been accidentally left in during testing.

## What is the new behavior?

Hard-coded line is removed, the transition now honours the passed options.
