### PR TITLE
fix(ios/textview): switch order of _setNativeText and _refreshColor in showText-method

### DIFF
--- a/packages/core/ui/text-view/index.ios.ts
+++ b/packages/core/ui/text-view/index.ios.ts
@@ -234,8 +234,8 @@ export class TextView extends TextViewBaseCommon {
 
 	public showText() {
 		this._isShowingHint = false;
-		this._refreshColor();
 		this._setNativeText();
+		this._refreshColor();
 		this.requestLayout();
 	}
 


### PR DESCRIPTION
fix(ios/textview): switch order of _setNativeText and _refreshColor in showText-method

The color should be refreshed after setting the text to keep the styles.

Fixes #8764

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?


## What is the new behavior?
Fixes #8764 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

