### PR TITLE
fix(android): tabs inside modal throw error on close

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -252,15 +252,15 @@ function initializeDialogFragment() {
 
 		public onDismiss(dialog: android.content.DialogInterface): void {
 			super.onDismiss(dialog);
+			const owner = this.owner;
+			if (owner && owner.isLoaded) {
+				owner.callUnloaded();
+			}
+
 			const manager = this.getFragmentManager();
 			if (manager) {
 				removeModal(this.owner._domId);
 				this._dismissCallback();
-			}
-
-			const owner = this.owner;
-			if (owner && owner.isLoaded) {
-				owner.callUnloaded();
 			}
 		}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When closing a modal with back button (or tapping outside), things that depend on Fragments (like Tabs) will throw an error because the fragment was already disposed.

## What is the new behavior?
Unloaded is called first, giving a chance for the components to clean up before modal close.

Might be worth it to wait for e2e testing to work again before merge.

Fixes https://github.com/NativeScript/nativescript-angular/issues/2259.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

