### PR TITLE
fix for android snapshot

### DIFF
--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "noImplicitAny": false,
     "noImplicitUseStrict": true,
     "removeComments": false,
-    "emitDecoratorMetadata": true,
+    "emitDecoratorMetadata": false,
     "experimentalDecorators": true,
     "diagnostics": true,
     "sourceMap": true,


### PR DESCRIPTION
using metadata will make parameters type appear in js files like for this one
https://github.com/NativeScript/NativeScript/blob/master/packages/core/ui/frame/index.android.ts#L831

```
    profile,
    __metadata("design:type", Function),
    __metadata("design:paramtypes", [androidx.fragment.app.Fragment, Number, Boolean, Number, Function]),
    __metadata("design:returntype", android.animation.Animator)
], FragmentCallbacksImplementation.prototype, "onCreateAnimator", null);
```
Then the snapshot tool will complain about not knowing android / androidx
