### PR TITLE
fix(core): Observable splice index > length 

### DIFF
--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -246,7 +246,7 @@ export class ObservableArray<T> extends Observable {
 			eventName: CHANGE,
 			object: this,
 			action: ChangeType.Splice,
-			index: start,
+			index: Math.min(start, length),
 			removed: result,
 			addedCount: this._array.length + result.length - length,
 		});

--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -246,7 +246,7 @@ export class ObservableArray<T> extends Observable {
 			eventName: CHANGE,
 			object: this,
 			action: ChangeType.Splice,
-			index: Math.min(start, length),
+			index: Math.min(start, this._array.length-1),
 			removed: result,
 			addedCount: this._array.length + result.length - length,
 		});


### PR DESCRIPTION
In javascript you can call splice with an index > length. The result is a push.
But when you do that ObservableArray index will be wrong and thus user logic will fail.
Example:
```ts
// obsarray = [0];
obsarray.splice(2, 0, 1);
// this works, the inner array is now [0,1]
// however 'change' is called with index = 2
// when the use tries to do obsarray.getItem(eventData.index) -> crash
```
We have that issue with `svelte-native` and the `spans` `ObservableArray` of `FormattedString`
