### PR TITLE
fix(core): global handling with env.production flag

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "main": "index",
   "types": "index.d.ts",
   "description": "NativeScript Core Modules",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "homepage": "https://nativescript.org",
   "repository": {
       "type": "git",

--- a/packages/core/ui/styling/css-selector/index.ts
+++ b/packages/core/ui/styling/css-selector/index.ts
@@ -1,3 +1,4 @@
+import '../../../globals';
 import { isNullOrUndefined } from '../../../utils/types';
 
 import * as cssParser from '../../../css';


### PR DESCRIPTION
closes https://github.com/NativeScript/NativeScript/issues/8778
closes https://github.com/NativeScript/NativeScript/issues/8872

`--env.production` flag causes css-selector to be imported at top and needs globals setup first.