### PR TITLE
fix(ios): Utils.openFile

### DIFF
--- a/packages/core/utils/index.ios.ts
+++ b/packages/core/utils/index.ios.ts
@@ -11,7 +11,7 @@ export function openFile(filePath: string): boolean {
 		let path = iOSNativeHelper.isRealDevice() ? filePath.replace('~', appPath) : filePath;
 
 		const controller = UIDocumentInteractionController.interactionControllerWithURL(NSURL.fileURLWithPath(path));
-		controller.delegate = <UIDocumentInteractionControllerDelegate>new iOSNativeHelper.UIDocumentInteractionControllerDelegateImpl();
+		controller.delegate = iOSNativeHelper.createUIDocumentInteractionControllerDelegate();
 
 		return controller.presentPreviewAnimated(true);
 	} catch (e) {

--- a/packages/core/utils/native-helper.d.ts
+++ b/packages/core/utils/native-helper.d.ts
@@ -168,7 +168,10 @@ export namespace iOSNativeHelper {
 	 */
 	export function applyRotateTransform(transform: any /* CATransform3D*/, x: number, y: number, z: number): any; /* CATransform3D*/
 
-	export class UIDocumentInteractionControllerDelegateImpl {}
+  /**
+   * Create a UIDocumentInteractionControllerDelegate implementation for use with UIDocumentInteractionController
+   */
+	export function createUIDocumentInteractionControllerDelegate(): any;
 
 	/**
 	 * Checks whether the application is running on real device and not on simulator.

--- a/packages/core/utils/native-helper.ios.ts
+++ b/packages/core/utils/native-helper.ios.ts
@@ -14,7 +14,7 @@ function openFileAtRootModule(filePath: string): boolean {
 		let path = iOSNativeHelper.isRealDevice() ? filePath.replace('~', appPath) : filePath;
 
 		const controller = UIDocumentInteractionController.interactionControllerWithURL(NSURL.fileURLWithPath(path));
-		controller.delegate = new iOSNativeHelper.UIDocumentInteractionControllerDelegateImpl();
+		controller.delegate = iOSNativeHelper.createUIDocumentInteractionControllerDelegate();
 
 		return controller.presentPreviewAnimated(true);
 	} catch (e) {
@@ -125,30 +125,33 @@ export namespace iOSNativeHelper {
 		}
 
 		return transform;
-	}
-
-	@NativeClass
-	export class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UIDocumentInteractionControllerDelegate {
-		public static ObjCProtocols = [UIDocumentInteractionControllerDelegate];
-
-		public getViewController(): UIViewController {
-			const app = UIApplication.sharedApplication;
-
-			return app.keyWindow.rootViewController;
-		}
-
-		public documentInteractionControllerViewControllerForPreview(controller: UIDocumentInteractionController) {
-			return this.getViewController();
-		}
-
-		public documentInteractionControllerViewForPreview(controller: UIDocumentInteractionController) {
-			return this.getViewController().view;
-		}
-
-		public documentInteractionControllerRectForPreview(controller: UIDocumentInteractionController): CGRect {
-			return this.getViewController().view.frame;
-		}
-	}
+  }
+  
+  export function createUIDocumentInteractionControllerDelegate(): NSObject {
+    @NativeClass
+    class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UIDocumentInteractionControllerDelegate {
+      public static ObjCProtocols = [UIDocumentInteractionControllerDelegate];
+  
+      public getViewController(): UIViewController {
+        const app = UIApplication.sharedApplication;
+  
+        return app.keyWindow.rootViewController;
+      }
+  
+      public documentInteractionControllerViewControllerForPreview(controller: UIDocumentInteractionController) {
+        return this.getViewController();
+      }
+  
+      public documentInteractionControllerViewForPreview(controller: UIDocumentInteractionController) {
+        return this.getViewController().view;
+      }
+  
+      public documentInteractionControllerRectForPreview(controller: UIDocumentInteractionController): CGRect {
+        return this.getViewController().view.frame;
+      }
+    }
+    return new UIDocumentInteractionControllerDelegateImpl();
+  }
 
 	export function isRealDevice() {
 		try {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. 
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?

On iOS, `Utils.openFile(somePath)` doesn't work.

## What is the new behavior?

On iOS, `Utils.openFile(somePath)` works as expected.

**NOTE**: This is published under @nativescript/core "rc" tag now so if anyone needs this right away you can use the rc. (specifically under `7.0.8-rc.0`)

closes https://github.com/NativeScript/NativeScript/issues/8913

