### PR TITLE
fix(core): global index typing fix for unit testing framework

### DIFF
--- a/packages/core/globals/index.d.ts
+++ b/packages/core/globals/index.d.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../data/observable';
 export declare class NativeScriptGlobalState {
-	events: Observable<any>;
+	events: Observable;
 	launched: boolean;
 }
 export function installPolyfills(moduleName: string, exportNames: string[]): void;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?

When using @nativescript/unit-test-runner the following typing's issue will occur:

```
node_modules/@nativescript/core/globals/index.d.ts:3:10 - error TS2315: Type 'Observable' is not generic.

3  events: Observable<any>;
```

## What is the new behavior?

Runs without error.
