### PR TITLE
Fix to ensure index remains > 0 on splice

### DIFF
--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -246,7 +246,7 @@ export class ObservableArray<T> extends Observable {
 			eventName: CHANGE,
 			object: this,
 			action: ChangeType.Splice,
-			index: Math.min(start, this._array.length-1),
+			index: Math.max(Math.min(start, this._array.length-1), 0),
 			removed: result,
 			addedCount: this._array.length + result.length - length,
 		});


### PR DESCRIPTION
Otherwise it will crash in ListView for iOS for example as it tries to animate an item with a negative row index. See issue here https://github.com/NativeScript/NativeScript/pull/8900#issuecomment-701539011
