### PR TITLE
fix: ensure globals do not get tree shaked

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,9 @@
       "url": "https://github.com/NativeScript/NativeScript"
   },
   "sideEffects": [
-    "./globals/index.js"
+    "bundle-entry-points.js",
+    "./globals/index.js",
+    "./globals"
   ],
   "files": [
       "**/*.d.ts",


### PR DESCRIPTION
For some reason we need to have the three of those for it to work correctly
Fixes https://github.com/NativeScript/NativeScript/issues/8925
