### PR TITLE
feat(core): added testID for Detox e2e testing (#8943)

### DIFF
--- a/apps/automated/src/ui/view/view-tests-common.ts
+++ b/apps/automated/src/ui/view/view-tests-common.ts
@@ -969,6 +969,11 @@ export function test_automation_text_default_value() {
 	TKUnit.assertTrue(view.automationText === undefined, 'AutomationText default value should be UNDEFINED.');
 }
 
+export function test_test_id_default_value() {
+	let view = new Button();
+	TKUnit.assertTrue(view.testID === undefined, 'testID default value should be UNDEFINED.');
+}
+
 export function test_getLocationInWindow_IsUndefinedWhenNotInTheVisualTree() {
 	const label = new Label();
 	TKUnit.assertNull(label.getLocationInWindow());

--- a/apps/automated/src/ui/view/view-tests.android.ts
+++ b/apps/automated/src/ui/view/view-tests.android.ts
@@ -233,6 +233,17 @@ export function test_automation_text_set_to_native() {
 	helper.do_PageTest_WithStackLayout_AndButton(test);
 }
 
+export function test_test_id_set_to_native() {
+	const test = function (views: Array<View>) {
+		const newButton = new Button();
+		newButton.testID = 'Button1';
+		(<StackLayout>views[1]).addChild(newButton);
+		TKUnit.assertEqual((<android.widget.Button>newButton.android).getTag(), 'Button1', 'tag not set to native ');
+	};
+
+	helper.do_PageTest_WithStackLayout_AndButton(test);
+}
+
 export const test_StylePropertiesDefaultValuesCache = function () {
 	const testValue = 35;
 

--- a/apps/automated/src/ui/view/view-tests.ios.ts
+++ b/apps/automated/src/ui/view/view-tests.ios.ts
@@ -88,3 +88,10 @@ export function test_automation_text_set_to_native() {
 	TKUnit.assertEqual((<UIView>newButton.ios).accessibilityIdentifier, 'Button1', 'accessibilityIdentifier not set to native view.');
 	TKUnit.assertEqual((<UIView>newButton.ios).accessibilityLabel, 'Button1', 'accessibilityIdentifier not set to native view.');
 }
+
+export function test_test_id_set_to_native() {
+	var newButton = new Button();
+	newButton.testID = 'Button1';
+	helper.getCurrentPage().content = newButton;
+	TKUnit.assertEqual((<UIView>newButton.ios).accessibilityIdentifier, 'Button1', 'accessibilityIdentifier not set to native view.');
+}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -2,7 +2,7 @@
 import { Point, CustomLayoutView as CustomLayoutViewDefinition, dip } from '.';
 import { GestureTypes, GestureEventData } from '../../gestures';
 // Types.
-import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty } from './view-common';
+import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty, testIDProperty } from './view-common';
 import { paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty } from '../../styling/style-properties';
 import { layout } from '../../../utils';
 import { Trace } from '../../../trace';
@@ -731,6 +731,13 @@ export class View extends ViewCommon {
 	}
 	[automationTextProperty.setNative](value: string) {
 		this.nativeViewProtected.setContentDescription(value);
+	}
+
+	[testIDProperty.getDefault](): string {
+		return this.nativeViewProtected.getTag();
+	}
+	[testIDProperty.setNative](value: string) {
+		this.nativeViewProtected.setTag(value);
 	}
 
 	[isUserInteractionEnabledProperty.setNative](value: boolean) {

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -364,6 +364,11 @@ export abstract class View extends ViewBase {
 	automationText: string;
 
 	/**
+	 * Gets or sets the testID of the view.
+	 */
+	testID: string;
+
+	/**
 	 * Gets or sets the X component of the origin point around which the view will be transformed. The default value is 0.5 representing the center of the view.
 	 */
 	originX: number;
@@ -869,6 +874,7 @@ export interface AddChildFromBuilder {
 }
 
 export const automationTextProperty: Property<View, string>;
+export const testIDProperty: Property<View, string>;
 export const originXProperty: Property<View, number>;
 export const originYProperty: Property<View, number>;
 export const isEnabledProperty: Property<View, boolean>;

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -2,7 +2,7 @@
 import { Point, View as ViewDefinition, dip } from '.';
 
 // Requires
-import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty } from './view-common';
+import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, automationTextProperty, isUserInteractionEnabledProperty, testIDProperty } from './view-common';
 import { ShowModalOptions } from '../view-base';
 import { Trace } from '../../../trace';
 import { layout, iOSNativeHelper } from '../../../utils';
@@ -555,6 +555,13 @@ export class View extends ViewCommon implements ViewDefinition {
 	[automationTextProperty.setNative](value: string) {
 		this.nativeViewProtected.accessibilityIdentifier = value;
 		this.nativeViewProtected.accessibilityLabel = value;
+	}
+
+	[testIDProperty.getDefault](): string {
+		return this.nativeViewProtected.accessibilityIdentifier;
+	}
+	[testIDProperty.setNative](value: string) {
+		this.nativeViewProtected.accessibilityIdentifier = value;
 	}
 
 	[isUserInteractionEnabledProperty.getDefault](): boolean {

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -752,6 +752,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	//END Style property shortcuts
 
 	public automationText: string;
+	public testID: string;
 	public originX: number;
 	public originY: number;
 	public isEnabled: boolean;
@@ -1010,6 +1011,11 @@ export const automationTextProperty = new Property<ViewCommon, string>({
 	name: 'automationText',
 });
 automationTextProperty.register(ViewCommon);
+
+export const testIDProperty = new Property<ViewCommon, string>({
+	name: 'testID',
+});
+testIDProperty.register(ViewCommon);
 
 export const originXProperty = new Property<ViewCommon, number>({
 	name: 'originX',

--- a/tools/scripts/api-reports/NativeScript.api.md
+++ b/tools/scripts/api-reports/NativeScript.api.md
@@ -2787,6 +2787,7 @@ export abstract class View extends ViewBase {
     _setValue(property: any, value: any): never;
     public static showingModallyEvent: string;
     public static shownModallyEvent: string;
+    testID: string;
     translateX: dip;
     translateY: dip;
     // (undocumented)


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On Android, the current `automationText` sets the content description but not the tag. Detox uses the content description as `by.label()` and a tag as `by.id()`. There is currently no built-in way to use `by.id()` (on Android at least).
 
## What is the new behavior?
<!-- Describe the changes. -->

Implements #8943.

Adds the `testID` property which uses `setTag()` on Android and `accessibilityIdentifier` on iOS.

`testID` can be used for Detox's `by.id()` and `automationText` can be used for Detox's `by.label()`.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

