### PR TITLE
Fix: Fix iOS 10 Issue with UILayoutGuide

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -201,7 +201,7 @@ export class IOSHelper {
 
 	static initLayoutGuide(controller: UIViewController) {
 		const rootView = controller.view;
-		const layoutGuide = UILayoutGuide.alloc().init();
+		const layoutGuide = new UILayoutGuide();
 		rootView.addLayoutGuide(layoutGuide);
 		NSLayoutConstraint.activateConstraints(<any>[layoutGuide.topAnchor.constraintEqualToAnchor(controller.topLayoutGuide.bottomAnchor), layoutGuide.bottomAnchor.constraintEqualToAnchor(controller.bottomLayoutGuide.topAnchor), layoutGuide.leadingAnchor.constraintEqualToAnchor(rootView.leadingAnchor), layoutGuide.trailingAnchor.constraintEqualToAnchor(rootView.trailingAnchor)]);
 

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -201,7 +201,7 @@ export class IOSHelper {
 
 	static initLayoutGuide(controller: UIViewController) {
 		const rootView = controller.view;
-		const layoutGuide = new UILayoutGuide();
+		const layoutGuide = UILayoutGuide.new();
 		rootView.addLayoutGuide(layoutGuide);
 		NSLayoutConstraint.activateConstraints(<any>[layoutGuide.topAnchor.constraintEqualToAnchor(controller.topLayoutGuide.bottomAnchor), layoutGuide.bottomAnchor.constraintEqualToAnchor(controller.bottomLayoutGuide.topAnchor), layoutGuide.leadingAnchor.constraintEqualToAnchor(rootView.leadingAnchor), layoutGuide.trailingAnchor.constraintEqualToAnchor(rootView.trailingAnchor)]);
 


### PR DESCRIPTION
iOS 10 seems to have an issue with reallocing UILayoutGuide after a init.  So on the second pass thru this function that app will crash on iOS 10 with an error about `init` not being a function. 

I suspect there might be a issue with Allocation size of the object on iOS 10, and bears some detailed debugging.  But at this point using the new() works around the issue so that the app won't crash on iOS 10.