### PR TITLE
fix: BottomNavigation error on back press (application exit)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ Provide version numbers for the following components (information can be retriev
  - Cross-platform modules:
  - Android Runtime:
  - iOS Runtime:
+ - XCode Version:
  - Plugin(s):
 
 **Describe the bug**

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -954,10 +954,13 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 			const hasRemovingParent = fragment.getRemovingParentFragment();
 
 			if (hasRemovingParent) {
-				const bitmapDrawable = new android.graphics.drawable.BitmapDrawable(application.android.context.getResources(), this.backgroundBitmap);
-				this.frame._originalBackground = this.frame.backgroundColor || new Color('White');
-				this.frame.nativeViewProtected.setBackgroundDrawable(bitmapDrawable);
-				this.backgroundBitmap = null;
+				const nativeFrameView = this.frame.nativeViewProtected;
+				if (nativeFrameView) {
+					const bitmapDrawable = new android.graphics.drawable.BitmapDrawable(application.android.context.getResources(), this.backgroundBitmap);
+					this.frame._originalBackground = this.frame.backgroundColor || new Color('White');
+					nativeFrameView.setBackgroundDrawable(bitmapDrawable);
+					this.backgroundBitmap = null;
+				}
 			}
 		} finally {
 			superFunc.call(fragment);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Apps that have Bottom Navigation nested inside Frame & Page throw exception on exit.

## What is the new behavior?
Exception thrown on exit is solved.

Closes #8828 