### PR TITLE
fix(core): ListViewCell.initWithEmptyBackground

### DIFF
--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -30,7 +30,7 @@ class ListViewCell extends UITableViewCell {
 	public static initWithEmptyBackground(): ListViewCell {
 		const cell = <ListViewCell>ListViewCell.new();
 		// Clear background by default - this will make cells transparent
-		cell.backgroundColor = null;
+		cell.backgroundColor = UIColor.clearColor;
 
 		return cell;
 	}
@@ -38,7 +38,7 @@ class ListViewCell extends UITableViewCell {
 	initWithStyleReuseIdentifier(style: UITableViewCellStyle, reuseIdentifier: string): this {
 		const cell = <this>super.initWithStyleReuseIdentifier(style, reuseIdentifier);
 		// Clear background by default - this will make cells transparent
-		cell.backgroundColor = null;
+		cell.backgroundColor = UIColor.clearColor;
 
 		return cell;
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
iOS 14 broke the default transparency of ListViewCell. UITableViewCell now adds a default UIBackgroundConfiguration unless backgroundColor is set on the cell. Because of this, ListViewCell are created with a white background instead of the expected transparent background.

## What is the new behavior?
New instances of ListViewCell are now properly transparent on iOS14. The fix doesn't break previous versions of iOS.

