### PR TITLE
fix(webpack): devtools inspector_modules handling

### DIFF
--- a/packages/webpack/templates/webpack.angular.js
+++ b/packages/webpack/templates/webpack.angular.js
@@ -103,7 +103,7 @@ module.exports = env => {
     Array.isArray(env.externals) &&
     env.externals.some(e => e.indexOf('@nativescript') > -1);
   if (platform === 'ios' && !areCoreModulesExternal && !testing) {
-    entries['tns_modules/@nativescript/core/inspector_modules'] =
+    entries['tns_modules/inspector_modules'] =
       'inspector_modules';
   }
 

--- a/packages/webpack/templates/webpack.javascript.js
+++ b/packages/webpack/templates/webpack.javascript.js
@@ -85,7 +85,7 @@ module.exports = env => {
 
     const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("@nativescript") > -1);
     if (platform === "ios" && !areCoreModulesExternal && !testing) {
-        entries["tns_modules/@nativescript/core/inspector_modules"] = "inspector_modules";
+        entries["tns_modules/inspector_modules"] = "inspector_modules";
     };
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/packages/webpack/templates/webpack.svelte.js
+++ b/packages/webpack/templates/webpack.svelte.js
@@ -92,7 +92,7 @@ module.exports = env => {
 
 	const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("@nativescript") > -1);
 	if (platform === "ios" && !areCoreModulesExternal && !testing) {
-		entries["tns_modules/@nativescript/core/inspector_modules"] = "inspector_modules";
+		entries["tns_modules/inspector_modules"] = "inspector_modules";
 	};
 
 	let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/packages/webpack/templates/webpack.typescript.js
+++ b/packages/webpack/templates/webpack.typescript.js
@@ -90,7 +90,7 @@ module.exports = env => {
 
     const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("@nativescript") > -1);
     if (platform === "ios" && !areCoreModulesExternal && !testing) {
-        entries["tns_modules/@nativescript/core/inspector_modules"] = "inspector_modules";
+        entries["tns_modules/inspector_modules"] = "inspector_modules";
     };
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/packages/webpack/templates/webpack.vue.js
+++ b/packages/webpack/templates/webpack.vue.js
@@ -89,7 +89,7 @@ module.exports = env => {
 
     const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("@nativescript") > -1);
     if (platform === "ios" && !areCoreModulesExternal && !testing) {
-        entries["tns_modules/@nativescript/core/inspector_modules"] = "inspector_modules";
+        entries["tns_modules/inspector_modules"] = "inspector_modules";
     };
     console.log(`Bundling application for entryPath ${entryPath}...`);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?

Chrome devtools Elements and Network tabs do not work due to how inspector_modules is references in webpack.config.js

## What is the new behavior?

Chrome devtools Elements and Network tabs work by referencing them correctly in webpack.config.js entries.

* [ ] Confirm operational with android
* [ ] Fixes issue where tapping the network request would disconnect the socket

closes https://github.com/NativeScript/NativeScript/issues/8930