### PR TITLE
fix: color date/time ios14 tests

### DIFF
--- a/apps/automated/src/ui/date-picker/date-picker-tests.ts
+++ b/apps/automated/src/ui/date-picker/date-picker-tests.ts
@@ -1,15 +1,14 @@
 import * as TKUnit from '../../tk-unit';
 import * as testModule from '../../ui-test';
 import * as datePickerTestsNative from './date-picker-tests-native';
-import * as color from '@nativescript/core/color';
 import * as platform from '@nativescript/core/platform';
+import { Color } from '@nativescript/core';
 
 // >> date-picker-require
 import * as datePickerModule from '@nativescript/core/ui/date-picker';
 // << date-picker-require
 
 import * as helper from '../../ui-helper';
-import {Device} from "../../../../../packages/core";
 
 export function test_recycling() {
 	helper.nativeView_recycling_test(() => new datePickerModule.DatePicker());
@@ -80,7 +79,7 @@ export class DatePickerTest extends testModule.UITest<datePickerModule.DatePicke
 		if (platform.Device.os === platform.platformNames.ios) {
 			const SUPPORT_TEXT_COLOR = parseFloat(platform.Device.osVersion) < 14.0;
 			if (SUPPORT_TEXT_COLOR) {
-				this.testView.color = new color.Color('red');
+				this.testView.color = new Color('red');
 				TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey('textColor').CGColor, 'datePicker.color');
 			}
 		}

--- a/apps/automated/src/ui/date-picker/date-picker-tests.ts
+++ b/apps/automated/src/ui/date-picker/date-picker-tests.ts
@@ -9,6 +9,7 @@ import * as datePickerModule from '@nativescript/core/ui/date-picker';
 // << date-picker-require
 
 import * as helper from '../../ui-helper';
+import {Device} from "../../../../../packages/core";
 
 export function test_recycling() {
 	helper.nativeView_recycling_test(() => new datePickerModule.DatePicker());
@@ -77,8 +78,11 @@ export class DatePickerTest extends testModule.UITest<datePickerModule.DatePicke
 
 	public test_set_color() {
 		if (platform.Device.os === platform.platformNames.ios) {
-			this.testView.color = new color.Color('red');
-			TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey('textColor').CGColor, 'datePicker.color');
+			const SUPPORT_TEXT_COLOR = parseFloat(platform.Device.osVersion) < 14.0;
+			if (SUPPORT_TEXT_COLOR) {
+				this.testView.color = new color.Color('red');
+				TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey('textColor').CGColor, 'datePicker.color');
+			}
 		}
 	}
 

--- a/apps/automated/src/ui/time-picker/time-picker-tests.ts
+++ b/apps/automated/src/ui/time-picker/time-picker-tests.ts
@@ -50,8 +50,11 @@ export class TimePickerTest extends testModule.UITest<timePickerModule.TimePicke
 	// Supported in iOS only.
 	public test_set_color() {
 		if (platform.Device.os === platform.platformNames.ios) {
-			this.testView.color = new color.Color('red');
-			TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey('textColor').CGColor, 'timePicker.color');
+			const SUPPORT_TEXT_COLOR = parseFloat(platform.Device.osVersion) < 14.0;
+			if (SUPPORT_TEXT_COLOR) {
+				this.testView.color = new color.Color('red');
+				TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey('textColor').CGColor, 'timePicker.color');
+			}
 		}
 	}
 

--- a/apps/automated/src/ui/time-picker/time-picker-tests.ts
+++ b/apps/automated/src/ui/time-picker/time-picker-tests.ts
@@ -1,9 +1,9 @@
 import * as TKUnit from '../../tk-unit';
 import * as testModule from '../../ui-test';
 import * as timePickerTestsNative from './time-picker-tests-native';
-import * as color from '@nativescript/core/color';
 import * as platform from '@nativescript/core/platform';
 import * as helper from '../../ui-helper';
+import { Color } from '@nativescript/core';
 
 // >> require-time-picker
 import * as timePickerModule from '@nativescript/core/ui/time-picker';
@@ -52,7 +52,7 @@ export class TimePickerTest extends testModule.UITest<timePickerModule.TimePicke
 		if (platform.Device.os === platform.platformNames.ios) {
 			const SUPPORT_TEXT_COLOR = parseFloat(platform.Device.osVersion) < 14.0;
 			if (SUPPORT_TEXT_COLOR) {
-				this.testView.color = new color.Color('red');
+				this.testView.color = new Color('red');
 				TKUnit.assertEqual(this.testView.color.ios.CGColor, this.testView.ios.valueForKey('textColor').CGColor, 'timePicker.color');
 			}
 		}

--- a/packages/core/ui/tabs/index.ios.ts
+++ b/packages/core/ui/tabs/index.ios.ts
@@ -34,10 +34,6 @@ const invokeOnRunLoop = (function () {
 	};
 })();
 
-function NSRunOnLoop(fun) {
-	NSRunLoop.mainRunLoop.performBlock(fun);
-}
-
 @NativeClass
 class MDCTabBarDelegateImpl extends NSObject implements MDCTabBarDelegate {
 	public static ObjCProtocols = [MDCTabBarDelegate];
@@ -1125,30 +1121,14 @@ export class Tabs extends TabsBase {
 
 			invokeOnRunLoop(() =>
 				this.viewController.setViewControllersDirectionAnimatedCompletion(controllers, navigationDirection, this.animationEnabled, (finished: boolean) => {
+					this.visitFrames(item, (frame) => (frame._animationInProgress = false));
 					if (finished) {
-						if (this.animationEnabled) {
-							// HACK: UIPageViewController fix; see https://stackoverflow.com/a/17330606
-							// Prior Hack fails on iOS 10.3 during tests with v8 engine...
-							// Leaving the link in case we need to special case this for only iOS < 11?
+						// HACK: UIPageViewController fix; see https://stackoverflow.com/a/17330606
+						invokeOnRunLoop(() => this.viewController.setViewControllersDirectionAnimatedCompletion(controllers, navigationDirection, false, null));
 
-							// HACK: UIPageViewController fix; see https://stackoverflow.com/questions/15325891
-							invokeOnRunLoop(() => {
-								this.viewController.dataSource = null;
-								(<any>this.viewController).dataSource = this.viewController;
-
-								this.visitFrames(item, (frame) => (frame._animationInProgress = false));
-
-								this._canSelectItem = true;
-								this._setCanBeLoaded(value);
-								this._loadUnloadTabItems(value);
-							});
-						} else {
-							this.visitFrames(item, (frame) => (frame._animationInProgress = false));
-
-							this._canSelectItem = true;
-							this._setCanBeLoaded(value);
-							this._loadUnloadTabItems(value);
-						}
+						this._canSelectItem = true;
+						this._setCanBeLoaded(value);
+						this._loadUnloadTabItems(value);
 					}
 				})
 			);


### PR DESCRIPTION


- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.

## What is the current behavior?
iOS 14 removed support for text color on Date/Time except for the Wheel.   Tests were trying to read the color attribute directly on iOS 14 to compare it to what was set; which of course then failed as the Date/Time items are not using the wheel.

## What is the new behavior?
Fixes both tests to detect if on iOS 14, and then ignore that test.

