### PR TITLE
fix(list-view): handle reusing wrong view

### DIFF
--- a/apps/automated/src/ui/list-view/list-view-tests.ts
+++ b/apps/automated/src/ui/list-view/list-view-tests.ts
@@ -608,7 +608,7 @@ export class ListViewTest extends UITest<ListView> {
 
 		if (isAndroid) {
 			// simulates Angular way of removing views
-			(<any>listView)._realizedItems.forEach((view, nativeView, map) => {
+			(<any>listView)._realizedItems.forEach(({ view }, nativeView, map) => {
 				//console.log("view: " + view);
 				listView._removeView(view);
 			});
@@ -900,6 +900,29 @@ export class ListViewTest extends UITest<ListView> {
 
 		TKUnit.assertEqual(firstNativeElementText, 'red', 'first element text');
 		TKUnit.assertEqual(secondNativeElementText, 'green', 'second element text');
+	}
+
+	public test_ItemTemplateSelector_DoesNotThrowWhenItemsChangeMidRender() {
+		let listView = this.testView;
+		listView.height = 200;
+
+		listView.itemTemplates = this._itemTemplatesString;
+		listView.itemTemplateSelector = "age === 0 ? 'red' : 'green'";
+		listView.items = ListViewTest.generateItemsForMultipleTemplatesTests(4);
+		listView.items[0].age = 0;
+		listView.once('itemLoading', () => {
+			if (listView.items && listView.items.length) {
+				listView.items[0].age = listView.items[0].age !== 0 ? 0 : 1;
+			}
+		});
+		listView.refresh();
+		TKUnit.wait(0.1);
+		listView.scrollToIndex(1);
+		TKUnit.wait(0.1);
+		listView.scrollToIndex(2);
+		TKUnit.wait(0.1);
+		listView.scrollToIndex(3);
+		TKUnit.wait(0.1);
 	}
 
 	public test_ItemTemplateSelector_TestVirtualization() {

--- a/packages/core/ui/list-view/index.android.ts
+++ b/packages/core/ui/list-view/index.android.ts
@@ -38,7 +38,7 @@ function initializeItemClickListener(): void {
 
 		onItemClick<T extends android.widget.Adapter>(parent: android.widget.AdapterView<T>, convertView: android.view.View, index: number, id: number) {
 			const owner = this.owner;
-			const view = owner._realizedTemplates.get(owner._getItemTemplate(index).key).get(convertView);
+			const view = owner._realizedItems.get(convertView).view;
 			owner.notify({
 				eventName: ITEMTAP,
 				object: owner,
@@ -53,10 +53,70 @@ function initializeItemClickListener(): void {
 
 export class ListView extends ListViewBase {
 	nativeViewProtected: android.widget.ListView;
-	private _androidViewId: number = -1;
+	private _androidViewId = -1;
 
-	public _realizedItems = new Map<android.view.View, View>();
+	public _realizedItems = new Map<
+		android.view.View,
+		{
+			view: View;
+			templateKey: string;
+		}
+	>();
+	public _availableViews = new Map<string, Set<android.view.View>>();
 	public _realizedTemplates = new Map<string, Map<android.view.View, View>>();
+
+	private _ensureAvailableViews(templateKey: string) {
+		if (!this._availableViews.has(templateKey)) {
+			this._availableViews.set(templateKey, new Set());
+		}
+	}
+
+	public _registerViewToTemplate(templateKey: string, nativeView: android.view.View, view: View) {
+		this._realizedItems.set(nativeView, {
+			view,
+			templateKey,
+		});
+		if (!this._realizedTemplates.has(templateKey)) {
+			this._realizedTemplates.set(templateKey, new Map());
+		}
+		this._realizedTemplates.get(templateKey).set(nativeView, view);
+		this._ensureAvailableViews(templateKey);
+		const availableViews = this._availableViews.get(templateKey);
+		availableViews.add(nativeView);
+	}
+
+	public _markViewUsed(nativeView: android.view.View) {
+		const viewData = this._realizedItems.get(nativeView);
+		if (!viewData) {
+			throw new Error('View not registered');
+		}
+		this._ensureAvailableViews(viewData.templateKey);
+		this._availableViews.get(viewData.templateKey).delete(nativeView);
+	}
+	public _markViewUnused(nativeView: android.view.View) {
+		const viewData = this._realizedItems.get(nativeView);
+		if (!viewData) {
+			throw new Error('View not registered');
+		}
+		this._ensureAvailableViews(viewData.templateKey);
+		this._availableViews.get(viewData.templateKey).add(nativeView);
+	}
+	public _getKeyFromView(nativeView: android.view.View) {
+		return this._realizedItems.get(nativeView).templateKey;
+	}
+	public _hasAvailableView(templateKey: string) {
+		this._ensureAvailableViews(templateKey);
+		return this._availableViews.get(templateKey).size > 0;
+	}
+	public _getAvailableView(templateKey: string) {
+		this._ensureAvailableViews(templateKey);
+		if (!this._hasAvailableView(templateKey)) {
+			return null;
+		}
+		const view: android.view.View = this._availableViews.get(templateKey).values().next().value;
+		this._markViewUsed(view);
+		return view;
+	}
 
 	@profile
 	public createNativeView() {
@@ -112,7 +172,7 @@ export class ListView extends ListViewBase {
 		}
 
 		// clear bindingContext when it is not observable because otherwise bindings to items won't reevaluate
-		this._realizedItems.forEach((view, nativeView) => {
+		this._realizedItems.forEach(({ view }, nativeView) => {
 			if (!(view.bindingContext instanceof Observable)) {
 				view.bindingContext = null;
 			}
@@ -140,7 +200,7 @@ export class ListView extends ListViewBase {
 	}
 
 	public eachChildView(callback: (child: View) => boolean): void {
-		this._realizedItems.forEach((view, nativeView) => {
+		this._realizedItems.forEach(({ view }, nativeView) => {
 			if (view.parent instanceof ListView) {
 				callback(view);
 			} else {
@@ -165,7 +225,7 @@ export class ListView extends ListViewBase {
 
 	private clearRealizedCells(): void {
 		// clear the cache
-		this._realizedItems.forEach((view, nativeView) => {
+		this._realizedItems.forEach(({ view }, nativeView) => {
 			if (view.parent) {
 				// This is to clear the StackLayout that is used to wrap non LayoutBase & ProxyViewContainer instances.
 				if (!(view.parent instanceof ListView)) {
@@ -176,11 +236,12 @@ export class ListView extends ListViewBase {
 		});
 
 		this._realizedItems.clear();
+		this._availableViews.clear();
 		this._realizedTemplates.clear();
 	}
 
 	public isItemAtIndexVisible(index: number): boolean {
-		let nativeView = this.nativeViewProtected;
+		const nativeView = this.nativeViewProtected;
 		const start = nativeView.getFirstVisiblePosition();
 		const end = nativeView.getLastVisiblePosition();
 
@@ -191,7 +252,7 @@ export class ListView extends ListViewBase {
 		dividerHeight: number;
 		divider: android.graphics.drawable.Drawable;
 	} {
-		let nativeView = this.nativeViewProtected;
+		const nativeView = this.nativeViewProtected;
 
 		return {
 			dividerHeight: nativeView.getDividerHeight(),
@@ -206,7 +267,7 @@ export class ListView extends ListViewBase {
 					divider: android.graphics.drawable.Drawable;
 			  }
 	) {
-		let nativeView = this.nativeViewProtected;
+		const nativeView = this.nativeViewProtected;
 		if (value instanceof Color) {
 			nativeView.setDivider(new android.graphics.drawable.ColorDrawable(value.android));
 			nativeView.setDividerHeight(1);
@@ -250,7 +311,7 @@ function ensureListViewAdapterClass() {
 
 		public getItem(i: number) {
 			if (this.owner && this.owner.items && i < this.owner.items.length) {
-				let getItem = (<ItemsSource>this.owner.items).getItem;
+				const getItem = (<ItemsSource>this.owner.items).getItem;
 
 				return getItem ? getItem.call(this.owner.items, i) : this.owner.items[i];
 			}
@@ -259,7 +320,7 @@ function ensureListViewAdapterClass() {
 		}
 
 		public getItemId(i: number) {
-			let item = this.getItem(i);
+			const item = this.getItem(i);
 			let id = i;
 			if (this.owner && item && this.owner.items) {
 				id = this.owner.itemIdGenerator(item, i, this.owner.items);
@@ -277,8 +338,8 @@ function ensureListViewAdapterClass() {
 		}
 
 		public getItemViewType(index: number) {
-			let template = this.owner._getItemTemplate(index);
-			let itemViewType = this.owner._itemTemplatesInternal.indexOf(template);
+			const template = this.owner._getItemTemplate(index);
+			const itemViewType = this.owner._itemTemplatesInternal.indexOf(template);
 
 			return itemViewType;
 		}
@@ -291,7 +352,7 @@ function ensureListViewAdapterClass() {
 				return null;
 			}
 
-			let totalItemCount = this.owner.items ? this.owner.items.length : 0;
+			const totalItemCount = this.owner.items ? this.owner.items.length : 0;
 			if (index === totalItemCount - 1) {
 				this.owner.notify({
 					eventName: LOADMOREITEMS,
@@ -300,18 +361,22 @@ function ensureListViewAdapterClass() {
 			}
 
 			// Recycle an existing view or create a new one if needed.
-			let template = this.owner._getItemTemplate(index);
+			const template = this.owner._getItemTemplate(index);
 			let view: View;
+			// convertView is of the wrong type
+			if (convertView && this.owner._getKeyFromView(convertView) !== template.key) {
+				this.owner._markViewUnused(convertView); // release this view
+				convertView = this.owner._getAvailableView(template.key); // get a view from the right type or null
+			}
 			if (convertView) {
-				view = this.owner._realizedTemplates.get(template.key).get(convertView);
-				if (!view) {
-					throw new Error(`There is no entry with key '${convertView}' in the realized views cache for template with key'${template.key}'.`);
-				}
-			} else {
+				view = this.owner._realizedItems.get(convertView).view;
+			}
+
+			if (!view) {
 				view = template.createView();
 			}
 
-			let args: ItemEventData = {
+			const args: ItemEventData = {
 				eventName: ITEMLOADING,
 				object: this.owner,
 				index: index,
@@ -341,7 +406,7 @@ function ensureListViewAdapterClass() {
 						this.owner._addView(args.view);
 						convertView = args.view.nativeViewProtected;
 					} else {
-						let sp = new StackLayout();
+						const sp = new StackLayout();
 						sp.addChild(args.view);
 						this.owner._addView(sp);
 
@@ -349,14 +414,8 @@ function ensureListViewAdapterClass() {
 					}
 				}
 
-				// Cache the view for recycling
-				let realizedItemsForTemplateKey = this.owner._realizedTemplates.get(template.key);
-				if (!realizedItemsForTemplateKey) {
-					realizedItemsForTemplateKey = new Map<android.view.View, View>();
-					this.owner._realizedTemplates.set(template.key, realizedItemsForTemplateKey);
-				}
-				realizedItemsForTemplateKey.set(convertView, args.view);
-				this.owner._realizedItems.set(convertView, args.view);
+				this.owner._registerViewToTemplate(template.key, convertView, args.view);
+				this.owner._markViewUsed(convertView);
 			}
 
 			return convertView;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?

`public getView(index: number, convertView: android.view.View, parent: android.view.ViewGroup): android.view.View` never checks if `convertView` is of the right type for the template. This usually isn't an issue because android calls `getItemViewType(index: number)` to check if the view is of the correct type (template). If for some reason the items have changed mid-execution, though, `getItemViewType(index: number)` will return a different template from what the view actually is.

### Scenario 1
Consider this scenario (listview where only 2 items are visible):
```
red
green
green
green
```
While rendering `red`, items change to

```
green
green
green
green
```

You'll see the wrong representation because it should never change view types, but it did.
```
red // android believes this is a green view!
green
```

This is happening:
```
getItemViewType 0 red // we tell we need a red view
getView 0 null // there's no available red view, get a new view
getItemViewType 0 green // view 0 is now green, so android stores it as such
// scroll down to a green view
getItemViewType 3 green // needs a green view. Nice! we have view 0 that is green
getView 3 viewThatIsActuallyRed
// crash because red is not green
```

This mainly happens because we're first instantiating a template, then we pass this template to `itemLoading` which changes it, and then we're using the new data. Ideally these changes should never happen on `itemLoading`, but they sometimes do because #8904 isn't merged yet.

## Scenario 2

Like scenario 1, the dataset has changed mid-render (seems to happen randomly when a few frames are lost), so ListView correctly identifies that the index is of template X but when it checks again, it's now of template Y

```
getItemViewType 0 red // we tell we need a red view
getView 0 null // there's no available red view, get a new view
getItemViewType 0 red// view 0 is still red
// dataset changes
getItemViewType 0 green // it's now green
// scroll down to a green view
getItemViewType 3 green // needs a green view
getView 3 viewThatIsActuallyRed // for some reason it overwrote view 0 as green instead of red
// crash because red is not green
```


## What is the new behavior?
We always check if the correct template is being used. This may sometimes still show an inconsistent listview (like in the example above, we still show `red` on top even though it should be green), but it will not crash anymore.

I'm not sure of why this issue started happening still.

Fixes #6284.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

