### PR TITLE
fix(core-android): ActivityIndicator changed transferred its color to other ActivityIndicators of the same page

### DIFF
--- a/apps/ui/src/progress-bar/activity-indicator-page.xml
+++ b/apps/ui/src/progress-bar/activity-indicator-page.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Page>
-  <ActivityIndicator busy="true" verticalAlignment="center" horizontalAlignment="center"/>
+  <StackLayout>
+    <ActivityIndicator busy="true" color="red" verticalAlignment="center" horizontalAlignment="center"/>
+    <ActivityIndicator busy="true" color="green" verticalAlignment="center" horizontalAlignment="center"/>
+    <ActivityIndicator busy="true" color="blue" verticalAlignment="center" horizontalAlignment="center"/>
+  </StackLayout>
 </Page>

--- a/apps/ui/src/progress-bar/activity-indicator-page.xml
+++ b/apps/ui/src/progress-bar/activity-indicator-page.xml
@@ -4,5 +4,6 @@
     <ActivityIndicator busy="true" color="red" verticalAlignment="center" horizontalAlignment="center"/>
     <ActivityIndicator busy="true" color="green" verticalAlignment="center" horizontalAlignment="center"/>
     <ActivityIndicator busy="true" color="blue" verticalAlignment="center" horizontalAlignment="center"/>
+    <ActivityIndicator busy="true" color="" verticalAlignment="center" horizontalAlignment="center"/>
   </StackLayout>
 </Page>

--- a/packages/core/ui/activity-indicator/index.android.ts
+++ b/packages/core/ui/activity-indicator/index.android.ts
@@ -11,7 +11,6 @@ export class ActivityIndicator extends ActivityIndicatorBase {
 		const progressBar = new android.widget.ProgressBar(this._context);
 		progressBar.setVisibility(android.view.View.INVISIBLE);
 		progressBar.setIndeterminate(true);
-		progressBar.getIndeterminateDrawable().mutate();
 
 		return progressBar;
 	}
@@ -49,10 +48,11 @@ export class ActivityIndicator extends ActivityIndicatorBase {
 	}
 	[colorProperty.setNative](value: number | Color) {
 		const color = value instanceof Color ? value.android : value;
+		const drawable = this.nativeViewProtected.getIndeterminateDrawable().mutate();
 		if (color) {
-			this.nativeViewProtected.getIndeterminateDrawable().setColorFilter(color, android.graphics.PorterDuff.Mode.SRC_IN);
+			drawable.setColorFilter(color, android.graphics.PorterDuff.Mode.SRC_IN);
 		} else {
-			this.nativeViewProtected.getIndeterminateDrawable().clearColorFilter();
+			drawable.clearColorFilter();
 		}
 	}
 }

--- a/packages/core/ui/activity-indicator/index.android.ts
+++ b/packages/core/ui/activity-indicator/index.android.ts
@@ -11,6 +11,7 @@ export class ActivityIndicator extends ActivityIndicatorBase {
 		const progressBar = new android.widget.ProgressBar(this._context);
 		progressBar.setVisibility(android.view.View.INVISIBLE);
 		progressBar.setIndeterminate(true);
+		progressBar.getIndeterminateDrawable().mutate();
 
 		return progressBar;
 	}
@@ -47,8 +48,9 @@ export class ActivityIndicator extends ActivityIndicatorBase {
 		return -1;
 	}
 	[colorProperty.setNative](value: number | Color) {
-		if (value instanceof Color) {
-			this.nativeViewProtected.getIndeterminateDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+		const color = value instanceof Color ? value.android : value;
+		if (color) {
+			this.nativeViewProtected.getIndeterminateDrawable().setColorFilter(color, android.graphics.PorterDuff.Mode.SRC_IN);
 		} else {
 			this.nativeViewProtected.getIndeterminateDrawable().clearColorFilter();
 		}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Changing color to an ActivityIndicator applies the new color to all other ActivityIndicators in the same page.
That only applies to Android.

## What is the new behavior?
Each indicator has independent color by calling `mutate()` on indicator drawable instance at the creation of view.

Fixes/Closes #9021 .
