### PR TITLE
fix: android modal not following activity windowSoftInputMode

### DIFF
--- a/packages/core/ui/core/view-base/index.d.ts
+++ b/packages/core/ui/core/view-base/index.d.ts
@@ -83,6 +83,10 @@ export interface ShowModalOptions {
 		 * An optional parameter specifying whether the modal view can be dismissed when not in full-screen mode.
 		 */
 		cancelable?: boolean;
+		/**
+		 * An optional parameter specifying the windowSoftInputMode of the dialog window
+		 */
+		windowSoftInputMode?: number;
 	};
 	/**
 	 * An optional parameter specifying whether the modal view can be dismissed when not in full-screen mode.

--- a/packages/core/ui/core/view-base/index.d.ts
+++ b/packages/core/ui/core/view-base/index.d.ts
@@ -85,6 +85,7 @@ export interface ShowModalOptions {
 		cancelable?: boolean;
 		/**
 		 * An optional parameter specifying the windowSoftInputMode of the dialog window
+		 * For possible values see https://developer.android.com/reference/android/view/WindowManager.LayoutParams#softInputMode
 		 */
 		windowSoftInputMode?: number;
 	};

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -89,7 +89,8 @@ export interface ShowModalOptions {
 		cancelable?: boolean;
 
 		/**
-		 * An optional parameter specifying the windowSoftInputMode of the dialog window
+		 * An optional parameter specifying the windowSoftInputMode of the dialog window.
+		 * For possible values see https://developer.android.com/reference/android/view/WindowManager.LayoutParams#softInputMode
 		 */
 		windowSoftInputMode?: number;
 	};

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -87,6 +87,11 @@ export interface ShowModalOptions {
 		 * An optional parameter specifying whether the modal view can be dismissed when not in full-screen mode.
 		 */
 		cancelable?: boolean;
+
+		/**
+		 * An optional parameter specifying the windowSoftInputMode of the dialog window
+		 */
+		windowSoftInputMode?: number;
 	};
 	/**
 	 * An optional parameter specifying whether the modal view can be dismissed when not in full-screen mode.

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -238,7 +238,7 @@ function initializeDialogFragment() {
 			if (this._windowSoftInputMode !== undefined) {
 				window.setSoftInputMode(this._windowSoftInputMode);
 			} else {
-				// the dialog seems to not follow the default activity softinputmode,
+				// the dialog seems to not follow the default activity softInputMode,
 				// thus set we set it here.
 				window.setSoftInputMode((<androidx.appcompat.app.AppCompatActivity>owner._context).getWindow().getAttributes().softInputMode);
 			}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -232,6 +232,16 @@ function initializeDialogFragment() {
 			owner._setupAsRootView(this.getActivity());
 			owner._isAddedToNativeVisualTree = true;
 
+			// we need to set the window SoftInputMode here.
+			// it wont work is set in onStart
+			const window = this.getDialog().getWindow();
+			if (this._windowSoftInputMode !== undefined) {
+				window.setSoftInputMode(this._windowSoftInputMode);
+			} else {
+				// the dialog seems to not follow the default activity softinputmode,
+				// thus set we set it here.
+				window.setSoftInputMode((<androidx.appcompat.app.AppCompatActivity>owner._context).getWindow().getAttributes().softInputMode);
+			}
 			return owner.nativeViewProtected;
 		}
 
@@ -246,20 +256,8 @@ function initializeDialogFragment() {
 			}
 
 			const owner = this.owner;
-			if (owner) {
-				if (!owner.isLoaded) {
-					owner.callLoaded();
-				}
-
-				
-				const window = this.getDialog().getWindow();
-				if (this._windowSoftInputMode !== undefined) {
-					window.setSoftInputMode(this._windowSoftInputMode);
-				} else {
-					// the dialog seems to not follow the default activity softinputmode,
-					// thus set we set it here.
-					window.setSoftInputMode((<androidx.appcompat.app.AppCompatActivity>owner._context).getWindow().getAttributes().softInputMode);
-				}
+			if (owner && !owner.isLoaded) {
+				owner.callLoaded();
 			}
 
 			this._shownCallback();


### PR DESCRIPTION
I use `android:windowSoftInputMode="stateHidden|adjustPan"`  however when i open a modal window the softInputMode is set to `adjustResize`. This PR makes the android `DialogFragment` follow your default activity setting.

Also added an android modal parameter to set a custom windowSoftInputMode

