### PR TITLE
feat(android-timer): setInterval closer to web spec

### DIFF
--- a/apps/automated/src/timer/timer-tests.ts
+++ b/apps/automated/src/timer/timer-tests.ts
@@ -174,20 +174,12 @@ export function test_setInterval_callbackCalledWithExtraArgs(done) {
 export function test_setInterval_callbackNotDelayedByBusyWork() {
 	let calls = 0;
 
-	function busyWait(ms: number) {
-		const waitStart = Date.now();
-		while (true) {
-			if (Date.now() - waitStart >= ms) {
-				break;
-			}
-		}
-	}
 	let firstCall = true;
 	const id = timer.setInterval(() => {
 		calls++;
 		if (firstCall) {
 			firstCall = false;
-			busyWait(25);
+			TKUnit.wait(0.025);
 		}
 	}, 50);
 

--- a/apps/automated/src/timer/timer-tests.ts
+++ b/apps/automated/src/timer/timer-tests.ts
@@ -171,6 +171,31 @@ export function test_setInterval_callbackCalledWithExtraArgs(done) {
 	);
 }
 
+export function test_setInterval_callbackNotDelayedByBusyWork() {
+	let calls = 0;
+
+	function busyWait(ms: number) {
+		const waitStart = Date.now();
+		while (true) {
+			if (Date.now() - waitStart >= ms) {
+				break;
+			}
+		}
+	}
+	let firstCall = true;
+	const id = timer.setInterval(() => {
+		calls++;
+		if (firstCall) {
+			firstCall = false;
+			busyWait(25);
+		}
+	}, 50);
+
+	TKUnit.wait(0.11);
+	timer.clearInterval(id);
+	TKUnit.assertEqual(calls, 2, 'Callback should be called multiple times with busy wait');
+}
+
 export function test_setInterval_callbackShouldBeCleared(done) {
 	const start = TKUnit.time();
 	// >> timer-set-interval

--- a/apps/automated/src/timer/timer-tests.ts
+++ b/apps/automated/src/timer/timer-tests.ts
@@ -188,6 +188,23 @@ export function test_setInterval_callbackNotDelayedByBusyWork() {
 	TKUnit.assertEqual(calls, 2, 'Callback should be called multiple times with busy wait');
 }
 
+export function test_setInterval_callbackSkippedByBusyWork() {
+	let calls = 0;
+
+	let firstCall = true;
+	const id = timer.setInterval(() => {
+		calls++;
+		if (firstCall) {
+			firstCall = false;
+			TKUnit.wait(0.051);
+		}
+	}, 50);
+
+	TKUnit.wait(0.16);
+	timer.clearInterval(id);
+	TKUnit.assertEqual(calls, 2, 'Callback should be called skipped when it takes too long to process');
+}
+
 export function test_setInterval_callbackShouldBeCleared(done) {
 	const start = TKUnit.time();
 	// >> timer-set-interval

--- a/packages/core/timer/index.android.ts
+++ b/packages/core/timer/index.android.ts
@@ -58,9 +58,9 @@ export function setInterval(callback: Function, milliseconds = 0, ...args): numb
 	const handler = timeoutHandler;
 	const invoke = () => callback(...args);
 	const zoneBound = zonedCallback(invoke);
-	const start = Date.now();
+	const startOffset = milliseconds > 0 ? Date.now() % milliseconds : 0;
 	function nextCallMs() {
-		return milliseconds > 0 ? milliseconds - ((Date.now() - start) % milliseconds) : milliseconds;
+		return milliseconds > 0 ? milliseconds - ((Date.now() - startOffset) % milliseconds) : milliseconds;
 	}
 
 	const runnable = new java.lang.Runnable({

--- a/packages/core/timer/index.android.ts
+++ b/packages/core/timer/index.android.ts
@@ -58,12 +58,16 @@ export function setInterval(callback: Function, milliseconds = 0, ...args): numb
 	const handler = timeoutHandler;
 	const invoke = () => callback(...args);
 	const zoneBound = zonedCallback(invoke);
+	const start = Date.now();
+	function nextCallMs() {
+		return milliseconds > 0 ? milliseconds - ((Date.now() - start) % milliseconds) : milliseconds;
+	}
 
 	const runnable = new java.lang.Runnable({
 		run: () => {
 			zoneBound();
 			if (timeoutCallbacks[id]) {
-				handler.postDelayed(runnable, long(milliseconds));
+				handler.postDelayed(runnable, long(nextCallMs()));
 			}
 		},
 	});
@@ -72,7 +76,7 @@ export function setInterval(callback: Function, milliseconds = 0, ...args): numb
 		timeoutCallbacks[id] = runnable;
 	}
 
-	timeoutHandler.postDelayed(runnable, long(milliseconds));
+	timeoutHandler.postDelayed(runnable, long(nextCallMs()));
 
 	return id;
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
setInterval on Android will keep delaying if busy work is done during the callback

`setInterval(..., 1000)` will almost never call 10 times every exact 10s.

## What is the new behavior?
setInterval now works like the web, calling every x ms, which means sometimes it'll call more/less often depending on the amount of work being done.

`setInterval(..., 1000)` will almost always call 10 times every 10s (exception is if work took longer than 1000ms to be called)
