### PR TITLE
feat: allow app to start without a root view

### DIFF
--- a/packages/core/application/application-interfaces.ts
+++ b/packages/core/application/application-interfaces.ts
@@ -20,7 +20,7 @@ export interface ApplicationEventData extends EventData {
 }
 
 export interface LaunchEventData extends ApplicationEventData {
-	root?: View;
+	root?: View | null;
 	savedInstanceState?: any /* android.os.Bundle */;
 }
 

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -191,7 +191,7 @@ export function addCss(cssText: string, attributeScoped?: boolean): void {
 const CALLBACKS = '_callbacks';
 
 export function _resetRootView(entry?: NavigationEntry | string): void {
-	const activity = androidApp.foregroundActivity;
+	const activity = androidApp.foregroundActivity || androidApp.startActivity;
 	if (!activity) {
 		throw new Error('Cannot find android activity.');
 	}

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -103,8 +103,9 @@ export interface LaunchEventData extends ApplicationEventData {
 	/**
 	 * The root view for this Window on iOS or Activity for Android.
 	 * If not set a new Frame will be created as a root view in order to maintain backwards compatibility.
+	 * If explicitly set to null, there will be no root view.
 	 */
-	root?: View;
+	root?: View | null;
 
 	savedInstanceState?: any /* android.os.Bundle */;
 }

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -207,7 +207,9 @@ export class iOSApplication implements iOSApplicationDefinition {
 
 		// this._window will be undefined when NS app is embedded in a native one
 		if (this._window) {
-			this.setWindowContent(args.root);
+			if (args.root !== null) {
+				this.setWindowContent(args.root);
+			}
 		} else {
 			this._window = UIApplication.sharedApplication.delegate.window;
 		}

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1301,6 +1301,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 		if (!rootView) {
 			const mainEntry = application.getMainEntry();
 			const intent = activity.getIntent();
+			// useful for integrations that would like to set rootView asynchronously after app launch
 			let shouldRootViewBeEmpty = false;
 
 			if (fireLaunchEvent) {

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1301,16 +1301,16 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 		if (!rootView) {
 			const mainEntry = application.getMainEntry();
 			const intent = activity.getIntent();
-			let ensureNoRootView = false;
+			let shouldRootViewBeEmpty = false;
 
 			if (fireLaunchEvent) {
 				// entry point for Angular and Vue frameworks
 				rootView = notifyLaunch(intent, <any>savedInstanceState, null);
-				ensureNoRootView = rootView === null;
+				shouldRootViewBeEmpty = rootView === null;
 			}
 
 			if (!rootView) {
-				if(ensureNoRootView) {
+				if (shouldRootViewBeEmpty) {
 					return;
 				}
 				// entry point for NS Core

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1301,13 +1301,18 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 		if (!rootView) {
 			const mainEntry = application.getMainEntry();
 			const intent = activity.getIntent();
+			let ensureNoRootView = false;
 
 			if (fireLaunchEvent) {
 				// entry point for Angular and Vue frameworks
 				rootView = notifyLaunch(intent, <any>savedInstanceState, null);
+				ensureNoRootView = rootView === null;
 			}
 
 			if (!rootView) {
+				if(ensureNoRootView) {
+					return;
+				}
 				// entry point for NS Core
 				if (!mainEntry) {
 					// Also handles scenarios with Angular and Vue where the notifyLaunch didn't return a root view.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
When you bootstrap the app, the root view MUST be created synchronously.

## What is the new behavior?
When bootstrapping the app, you can set the root view to `null` which will ensure the app will start without a root view (blank screen). It's then up to the developer (usually flavor) to set this root view.

In the Angular context, this is now possible:

1. on launch, begin AppModule bootstrap
2. set the rootview to null
3. schedule a macroTask to check if bootstrap is done
3.1. if it is, set the rootView (no flashes)
3.2. if it isn't, set the rootView as a temporary view (user provided splash screen)
4. on bootstrap complete, set root view from AppModule's rootView


