### PR TITLE
feat: rewrite the ObservableArray

### DIFF
--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -1,6 +1,4 @@
-/* eslint-disable prefer-rest-params */
 import { Observable, EventData } from '../observable';
-import * as types from '../../utils/types';
 
 export class ChangeType {
 	static Add = 'add';
@@ -38,362 +36,263 @@ export interface ChangedData<T> extends EventData {
 
 const CHANGE = 'change';
 
-/**
- * Advanced array like class used when you want to be notified when a change occurs.
- */
-export class ObservableArray<T> extends Observable {
-	/**
-	 * String value used when hooking to change event.
-	 */
-	public static changeEvent = CHANGE;
+class ObservableArray extends Observable {
+}
+type ObservableArrayConstructor = (new <T>(...args) => ObservableArray & T[]) & {changeEvent: string};
 
-	private _array: Array<any>;
-	private _addArgs: ChangedData<T>;
-	private _deleteArgs: ChangedData<T>;
+class ObservableArrayInsideObservable<T> extends Observable {
+    _addArgs?: ChangedData<T>;
+    _deleteArgs?: ChangedData<T>;
+    parent: WeakRef<ObservableArrayConstructor>;
+    toString() {
+        return '[ObservableArrayInsideObservable]';
+    }
+    constructor(parent) {
+        super();
+        this.parent = new WeakRef(parent);
+        this._addArgs = {
+            eventName: CHANGE,
+            action: ChangeType.Add,
+            index: null as any,
+            removed: [],
+            addedCount: 1,
+        } as any;
 
-	/**
-	 * Create ObservableArray<T> from source Array<T>.
-	 */
-	constructor(args?: T[] | number) {
-		super();
+        this._deleteArgs = {
+            eventName: CHANGE,
+            action: ChangeType.Delete,
+            index: null as any,
+            removed: null as any,
+            addedCount: 0,
+        } as any;
+    }
 
-		if (arguments.length === 1 && Array.isArray(arguments[0])) {
-			this._array = arguments[0].slice();
-		} else {
-			// eslint-disable-next-line prefer-spread
-			this._array = Array.apply(null, arguments);
-		}
+    notify(args) {
+        const parent = this.parent && this.parent.get();
+        args.object = parent || args.object;
+        super.notify(args);
+    }
+    _notifyLengthChange() {
+        const parent = this.parent && this.parent.get();
+        if (parent)  {
+            const lengthChangedData = this._createPropertyChangeData('length', parent.length);
+            this.notify(lengthChangedData);
+        }
+    }
+}
+// @ts-ignore
+const ObservableArrayImpl = class<T>{
+    public static changeEvent = CHANGE;
+    length: number;
+    private _observable: ObservableArrayInsideObservable<T>;
 
-		this._addArgs = {
-			eventName: CHANGE,
-			object: this,
-			action: ChangeType.Add,
-			index: null,
-			removed: [],
-			addedCount: 1,
-		};
+    // push,, shift ... will trigger set proxy handler call
+    // in those cases we dont want single change notification
+    // we will trigger after the full operation is finished
+    private shouldIgnoreSet = false;
 
-		this._deleteArgs = {
-			eventName: CHANGE,
-			object: this,
-			action: ChangeType.Delete,
-			index: null,
-			removed: null,
-			addedCount: 0,
-		};
-	}
+    // reverse will call delete, push ....
+    // in those cases we dont want single change notification
+    // we will trigger after the full operation is finished
+    private shouldIgnoreOps = false;
 
-	/**
-	 * Returns item at specified index.
-	 */
-	getItem(index: number): T {
-		return this._array[index];
-	}
+    constructor(...args) {
+        this._observable = new ObservableArrayInsideObservable<T>(this);
+        if (args.length === 1) {
+            return new Proxy(args[0].slice(), this);
+        } else {
+            return new Proxy([...args], this);
+        }
+    }
 
-	/**
+    toString() {
+        return '[ObservableArray]';
+    }
+    getItem(index: number): T {
+        return this[index];
+    }
+    /**
 	 * Sets item at specified index.
 	 */
-	setItem(index: number, value: T) {
-		const oldValue = this._array[index];
-		this._array[index] = value;
+    setItem(index: number, value: T) {
+        this[index] = value;
+    }
+    static [Symbol.hasInstance](instance) {
+        return true;
+    }
+    getPrototypeOf (target) {
+        return Observable.prototype;
+    }
+    get(target, prop) {
+        const that = this;
+        const notifier = that._observable;
+        const val = target[prop];
+        if (typeof prop === 'symbol') {
+            return target[prop];
+        }
+        if (!val && typeof notifier[prop] === 'function') {
+            return notifier[prop].bind(notifier);
+        }
+        if (typeof val === 'function') {
+            if (prop === 'toString') {
+                return function (){
+                    return JSON.stringify(target);
+                };
+            }
+            if (this.shouldIgnoreOps) {
+                return val;
+            }
+            // TODO: do we need concat? does not seem to make sense
+            if (prop === 'concat') {
+		        notifier._addArgs.index = this.length;
+            }
 
-		this.notify(<ChangedData<T>>{
-			eventName: CHANGE,
-			object: this,
-			action: ChangeType.Update,
-			index: index,
-			removed: [oldValue],
-			addedCount: 1,
-		});
-	}
+            if (prop === 'reverse') {
+		        return function (el) {
+                    that.shouldIgnoreSet = true;
+                    const removed = [...target];
+                    // eslint-disable-next-line prefer-rest-params
+                    const result = Array.prototype[prop].apply(this, arguments);
+                    that.shouldIgnoreSet = false;
+                    notifier.notify({
+                        eventName: CHANGE,
+                        object: this,
+                        action: ChangeType.Splice,
+                        index: 0,
+                        removed,
+                        addedCount: target.length,
+                    });
+                    return result;
+                };
+            }
+            if (prop === 'push') {
+                return function (el) {
+                    notifier._addArgs.index = target.length;
+                    that.shouldIgnoreSet = true;
+                    // eslint-disable-next-line prefer-rest-params
+                    const result = Array.prototype[prop].apply(this, arguments);
+                    that.shouldIgnoreSet = false;
+                    notifier._addArgs.addedCount = target.length - notifier._addArgs.index;
 
-	/**
-	 * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
-	 */
-	get length(): number {
-		return this._array.length;
-	}
+                    notifier.notify(notifier._addArgs);
+                    notifier._notifyLengthChange();
+                    return result;
+                };
+            }
+            if (prop === 'unshift') {
+                return function (el) {
+                    const length = target.length;
+                    that.shouldIgnoreSet = true;
+                    // eslint-disable-next-line prefer-rest-params
+                    const result = Array.prototype[prop].apply(this, arguments);
+                    that.shouldIgnoreSet = false;
+                    notifier._addArgs.index = 0;
+                    notifier._addArgs.addedCount = result - length;
+                    notifier.notify(notifier._addArgs);
+                    notifier._notifyLengthChange();
 
-	set length(value: number) {
-		if (types.isNumber(value) && this._array && this._array.length !== value) {
-			const added=[];
-			for (let i=this._array.length;i < value;++i) {
-				added.push(undefined);
-			}
-			this.splice(value, this._array.length - value, ...added);
-		}
-	}
+                    return result;
+                };
+            }
+            if (prop === 'pop') {
+                return function (el) {
+                    notifier._deleteArgs.index = target.length - 1;
+                    that.shouldIgnoreSet = true;
+                    // eslint-disable-next-line prefer-rest-params
+                    const result = Array.prototype[prop].apply(this, arguments);
+                    that.shouldIgnoreSet = false;
+                    notifier._deleteArgs.removed = [result];
+                    notifier.notify(notifier._deleteArgs);
+                    notifier._notifyLengthChange();
+                    return result;
+                };
+            }
+            if (prop === 'shift') {
+                return function (el) {
+                    that.shouldIgnoreSet = true;
+                    // eslint-disable-next-line prefer-rest-params
+                    const result = Array.prototype[prop].apply(this, arguments);
+                    that.shouldIgnoreSet = false;
+                    notifier._deleteArgs.index = 0;
+                    notifier._deleteArgs.removed = [result];
+                    notifier.notify(notifier._deleteArgs);
+                    notifier._notifyLengthChange();
+                    return result;
+                };
+            }
+            if (prop === 'splice') {
+                return function (start) {
+                    const length = target.length;
+                    that.shouldIgnoreSet = true;
+                    // eslint-disable-next-line prefer-rest-params
+                    const result = Array.prototype[prop].apply(this, arguments);
+                    that.shouldIgnoreSet = false;
+                    notifier.notify({
+                        eventName: CHANGE,
+                        object: this,
+                        action: ChangeType.Splice,
 
-	/**
-	 * Returns a string representation of an array.
-	 */
-	toString(): string {
-		return this._array.toString();
-	}
-
-	toLocaleString(): string {
-		return this._array.toLocaleString();
-	}
-
-	/**
-	 * Combines two or more arrays.
-	 * @param items Additional items to add to the end of array1.
-	 */
-	concat(...args): T[] {
-		this._addArgs.index = this._array.length;
-		const result = this._array.concat(...args);
-
-		return result;
-	}
-
-	/**
-	 * Adds all the elements of an array separated by the specified separator string.
-	 * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
-	 */
-	join(separator?: string): string {
-		return this._array.join(separator);
-	}
-
-	/**
-	 * Removes the last element from an array and returns it.
-	 */
-	pop(): T {
-		this._deleteArgs.index = this._array.length - 1;
-
-		const result = this._array.pop();
-
-		this._deleteArgs.removed = [result];
-
-		this.notify(this._deleteArgs);
-		this._notifyLengthChange();
-
-		return result;
-	}
-
-	/**
-	 * Appends new elements to an array, and returns the new length of the array.
-	 * @param item New element of the Array.
-	 */
-	push(...args: any): number {
-		this._addArgs.index = this._array.length;
-
-		if (arguments.length === 1 && Array.isArray(arguments[0])) {
-			const source = <Array<T>>arguments[0];
-
-			for (let i = 0, l = source.length; i < l; i++) {
-				this._array.push(source[i]);
-			}
-		} else {
-			this._array.push(...args);
-		}
-
-		this._addArgs.addedCount = this._array.length - this._addArgs.index;
-
-		this.notify(this._addArgs);
-		this._notifyLengthChange();
-
-		return this._array.length;
-	}
-
-	_notifyLengthChange() {
-		const lengthChangedData = this._createPropertyChangeData('length', this._array.length);
-		this.notify(lengthChangedData);
-	}
-
-	/**
-	 * Reverses the elements in an Array.
-	 */
-	reverse(): T[] {
-		return this._array.reverse();
-	}
-
-	/**
-	 * Removes the first element from an array and returns it.
-	 */
-	shift(): T {
-		const result = this._array.shift();
-
-		this._deleteArgs.index = 0;
-		this._deleteArgs.removed = [result];
-
-		this.notify(this._deleteArgs);
-		this._notifyLengthChange();
-
-		return result;
-	}
-
-	/**
-	 * Returns a section of an array.
-	 * @param start The beginning of the specified portion of the array.
-	 * @param end The end of the specified portion of the array.
-	 */
-	slice(start?: number, end?: number): T[] {
-		return this._array.slice(start, end);
-	}
-
-	/**
-	 * Sorts an array.
-	 * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
-	 */
-	sort(compareFn?: (a: T, b: T) => number): T[] {
-		return this._array.sort(compareFn);
-	}
-
-	/**
-	 * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
-	 * @param start The zero-based location in the array from which to start removing elements.
-	 * @param deleteCount The number of elements to remove.
-	 * @param items Elements to insert into the array in place of the deleted elements.
-	 */
-	splice(start: number, deleteCount?: number, ...items: any): T[] {
-		const length = this._array.length;
-		const result = this._array.splice(start, deleteCount, ...items);
-
-		this.notify(<ChangedData<T>>{
-			eventName: CHANGE,
-			object: this,
-			action: ChangeType.Splice,
-
-			// The logic here is a bit weird; so lets explain why it is written this way
-			// First of all, if you ADD any items to the array, we want the index to point to
-			//   the first value of the index, so this fixes it when you put a value to high in
-			// If you remove items from the array, then the index needs to point to the INDEX
-			//   where you removed the item.
-			// If you add and remove items, the index will point to the remove location as that
-			//   is the index you passed in.
-			index: Math.max(Math.min(start, length - (result.length > 0 ? 1 : 0)), 0),
-			removed: result,
-			addedCount: this._array.length + result.length - length,
-		});
-		if (this._array.length !== length) {
-			this._notifyLengthChange();
-		}
-
-		return result;
-	}
-
-	/**
-	 * Inserts new elements at the start of an array.
-	 * @param items  Elements to insert at the start of the Array.
-	 */
-	unshift(...args: any): number {
-		const length = this._array.length;
-		const result = this._array.unshift(...args);
-
-		this._addArgs.index = 0;
-		this._addArgs.addedCount = result - length;
-
-		this.notify(this._addArgs);
-		this._notifyLengthChange();
-
-		return result;
-	}
-
-	/**
-	 * Returns the index of the first occurrence of a value in an array.
-	 * @param searchElement The value to locate in the array.
-	 * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
-	 */
-	indexOf(searchElement: T, fromIndex?: number): number {
-		const index = fromIndex ? fromIndex : 0;
-		for (let i = index, l = this._array.length; i < l; i++) {
-			if (this._array[i] === searchElement) {
-				return i;
-			}
-		}
-
-		return -1;
-	}
-
-	/**
-	 * Returns the index of the last occurrence of a specified value in an array.
-	 * @param searchElement The value to locate in the array.
-	 * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
-	 */
-	lastIndexOf(searchElement: T, fromIndex?: number): number {
-		const index = fromIndex ? fromIndex : this._array.length - 1;
-
-		for (let i = index; i >= 0; i--) {
-			if (this._array[i] === searchElement) {
-				return i;
-			}
-		}
-
-		return -1;
-	}
-
-	/**
-	 * Determines whether all the members of an array satisfy the specified test.
-	 * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
-	 * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-	 */
-	every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean {
-		return this._array.every(callbackfn, thisArg);
-	}
-
-	/**
-	 * Determines whether the specified callback function returns true for any element of an array.
-	 * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
-	 * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-	 */
-	some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean {
-		return this._array.some(callbackfn, thisArg);
-	}
-
-	/**
-	 * Performs the specified action for each element in an array.
-	 * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
-	 * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-	 */
-	forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void {
-		this._array.forEach(callbackfn, thisArg);
-	}
-
-	/**
-	 * Calls a defined callback function on each element of an array, and returns an array that contains the results.
-	 * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
-	 * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-	 */
-	map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[] {
-		return this._array.map(callbackfn, thisArg);
-	}
-
-	/**
-	 * Returns the elements of an array that meet the condition specified in a callback function.
-	 * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
-	 * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-	 */
-	filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[] {
-		return this._array.filter(callbackfn, thisArg);
-	}
-
-	/**
-	 * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
-	 */
-	reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T {
-		return initialValue !== undefined ? this._array.reduce(callbackfn, initialValue) : this._array.reduce(callbackfn);
-	}
-
-	/**
-	 * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
-	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
-	 */
-	reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T {
-		return initialValue !== undefined ? this._array.reduceRight(callbackfn, initialValue) : this._array.reduceRight(callbackfn);
-	}
-}
-
-export interface ObservableArray<T> {
-	/**
-	 * A basic method signature to hook an event listener (shortcut alias to the addEventListener method).
-	 * @param eventNames - String corresponding to events (e.g. "propertyChange"). Optionally could be used more events separated by `,` (e.g. "propertyChange", "change").
-	 * @param callback - Callback function which will be executed when event is raised.
-	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
-	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-
-	on(event: 'change', callback: (args: ChangedData<T>) => void, thisArg?: any): void;
-}
+                        // The logic here is a bit weird; so lets explain why it is written this way
+                        // First of all, if you ADD any items to the array, we want the index to point to
+                        //   the first value of the index, so this fixes it when you put a value to high in
+                        // If you remove items from the array, then the index needs to point to the INDEX
+                        //   where you removed the item.
+                        // If you add and remove items, the index will point to the remove location as that
+                        //   is the index you passed in.
+                        index: Math.max(Math.min(start, length - (result.length > 0 ? 1 : 0)), 0),
+                        removed: result,
+                        addedCount: target.length + result.length - length,
+                    });
+                    if (target.length !== length) {
+                        notifier._notifyLengthChange();
+                    }
+                    return result;
+                };
+            }
+            return val;
+        }
+        return val;
+    }
+    set(target, key, value) {
+        let event;
+        if (Number.isInteger(Number(key)) || key === 'length') {
+            if (!this.shouldIgnoreSet) {
+                event  ={
+                    eventName: CHANGE,
+                    object: this,
+                    action: ChangeType.Update,
+                    index: key,
+                    removed: [target[key]],
+                    addedCount: 1,
+                };
+            }
+        }
+        target[key] = value;
+        if (event) {
+            this._observable.notify(event);
+        }
+        return true;
+    }
+    deleteProperty(target, key) {
+        const notifier = this._observable;
+        let event;
+        if (Number.isInteger(Number(key)) || key === 'length') {
+            if (!this.shouldIgnoreSet) {
+                event = {
+                    eventName: CHANGE,
+                    object: this,
+                    action: ChangeType.Update,
+                    index: key,
+                    removed: [target[key]],
+                    addedCount: 1,
+                };
+            }
+        }
+        delete target[key];
+        if (event) {
+            notifier.notify(event);
+        }
+        return true;
+    }
+} as ObservableArrayConstructor ;
+export {ObservableArrayImpl as ObservableArray};


### PR DESCRIPTION
This is now an ArrayLike object. Meaning we can do `test[4]= 4;` and the array will be changed as well as a change event trigger.
It should work exactly as the current implementation.
One nice feature i would have liked which does not work yet is ` test instanceof Array`.
If that was to work it means an `ObservableArray` could be used anywhere and even passed to native methods (i think)
