### PR TITLE
fix: Add old names to platform for compatibility

### DIFF
--- a/packages/core/platform/index.android.ts
+++ b/packages/core/platform/index.android.ts
@@ -57,9 +57,8 @@ export class Screen {
 	static mainScreen = new MainScreen();
 }
 
-export class screen {
-	static mainScreen = Screen.mainScreen;
-}
+// This retains compatibility with NS6
+export const screen = Screen;
 
 class DeviceRef {
 	private _manufacturer: string;
@@ -148,6 +147,8 @@ class DeviceRef {
 }
 
 export const Device = new DeviceRef();
+
+// This retains compatibility with NS6
 export const device = Device;
 
 export const isAndroid = global.isAndroid;

--- a/packages/core/platform/index.android.ts
+++ b/packages/core/platform/index.android.ts
@@ -57,6 +57,10 @@ export class Screen {
 	static mainScreen = new MainScreen();
 }
 
+export class screen {
+	static mainScreen = Screen.mainScreen;
+}
+
 class DeviceRef {
 	private _manufacturer: string;
 	private _model: string;
@@ -144,6 +148,7 @@ class DeviceRef {
 }
 
 export const Device = new DeviceRef();
+export const device = Device;
 
 export const isAndroid = global.isAndroid;
 export const isIOS = global.isIOS;

--- a/packages/core/platform/index.d.ts
+++ b/packages/core/platform/index.d.ts
@@ -122,6 +122,20 @@ export class Screen {
 }
 
 /**
+ * An object describing general information about a display.
+ *
+ * This retains compatibility with NS6
+ */
+export const screen = Screen;
+
+/**
  * Gets the current device information.
  */
 export const Device: IDevice;
+
+/**
+ * Gets the current device information.
+ *
+ * This retains compatibility with NS6
+ */
+export const device = Device;

--- a/packages/core/platform/index.ios.ts
+++ b/packages/core/platform/index.ios.ts
@@ -127,9 +127,7 @@ export class Screen {
 }
 
 // This retains compatibility with NS6
-export class screen {
-	static mainScreen = Screen.mainScreen;
-}
+export const screen = Screen;
 
 export const isAndroid = global.isAndroid;
 export const isIOS = global.isIOS;

--- a/packages/core/platform/index.ios.ts
+++ b/packages/core/platform/index.ios.ts
@@ -119,8 +119,16 @@ class MainScreen {
 
 export const Device = new DeviceRef();
 
+// This retains compatibility with NS6
+export const device = Device;
+
 export class Screen {
 	static mainScreen = new MainScreen();
+}
+
+// This retains compatibility with NS6
+export class screen {
+	static mainScreen = Screen.mainScreen;
 }
 
 export const isAndroid = global.isAndroid;


### PR DESCRIPTION
# PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
We somehow renamed `Platform.screen` & `Platform.device` to `Platform.Screen` and `Platform.Device` in the Mono-Repo transition.   This breaks plugins and applications, including all versions of NS-Theme's 2.x.   This also breaks all examples and the current documentation.

## What is the new behavior?
Adds a simple compatibility classes so that `Platform.screen` and `Platform.device` both point to the upper case version, to allow every plugin and use of this to work.   The new name Platform.Screen and Platform.Device still work as we are using them in other places...