### PR TITLE
feat: ios added ignoreSafeArea property

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -262,7 +262,9 @@ export class View extends ViewCommon implements ViewDefinition {
 		if (majorVersion <= 10) {
 			return null;
 		}
-
+		if (this.iosIgnoreSafeArea) {
+            return frame;
+        }
 		if (!this.iosOverflowSafeArea || !this.iosOverflowSafeAreaEnabled) {
 			return IOSHelper.shrinkToSafeArea(this, frame);
 		} else if (this.nativeViewProtected && this.nativeViewProtected.window) {
@@ -275,7 +277,9 @@ export class View extends ViewCommon implements ViewDefinition {
 	public getSafeAreaInsets(): { left; top; right; bottom } {
 		const safeAreaInsets = this.nativeViewProtected && this.nativeViewProtected.safeAreaInsets;
 		const insets = { left: 0, top: 0, right: 0, bottom: 0 };
-
+		if (this.iosIgnoreSafeArea) {
+            return insets;
+        }
 		if (safeAreaInsets) {
 			insets.left = layout.round(layout.toDevicePixels(safeAreaInsets.left));
 			insets.top = layout.round(layout.toDevicePixels(safeAreaInsets.top));

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -758,7 +758,8 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	public isUserInteractionEnabled: boolean;
 	public iosOverflowSafeArea: boolean;
 	public iosOverflowSafeAreaEnabled: boolean;
-
+	public iosIgnoreSafeArea: boolean;
+	
 	get isLayoutValid(): boolean {
 		return this._isLayoutValid;
 	}
@@ -1055,3 +1056,9 @@ export const iosOverflowSafeAreaEnabledProperty = new InheritedProperty<ViewComm
 	valueConverter: booleanConverter,
 });
 iosOverflowSafeAreaEnabledProperty.register(ViewCommon);
+export const iosIgnoreSafeAreaProperty = new InheritedProperty({
+    name: 'iosIgnoreSafeArea',
+    defaultValue: false,
+    valueConverter: booleanConverter,
+});
+iosIgnoreSafeAreaProperty.register(ViewCommon);

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -338,10 +338,12 @@ export class IOSHelper {
 
 		let fullscreen = null;
 		let safeArea = null;
+		let controllerInWindow = {x: 0, y: 0};
 
 		if (viewControllerView) {
 			safeArea = viewControllerView.safeAreaLayoutGuide.layoutFrame;
 			fullscreen = viewControllerView.frame;
+			controllerInWindow = viewControllerView.convertPointToView(viewControllerView.bounds.origin, null);
 		} else if (scrollView) {
 			const insets = scrollView.safeAreaInsets;
 			safeArea = CGRectMake(insets.left, insets.top, scrollView.contentSize.width - insets.left - insets.right, scrollView.contentSize.height - insets.top - insets.bottom);
@@ -350,7 +352,6 @@ export class IOSHelper {
 
 		// We take into account the controller position inside the window.
 		// for example with a bottomsheet the controller will be "offset"
-		const controllerInWindow = viewControllerView.convertPointToView(viewControllerView.bounds.origin, null);
 		const locationInWindow = view.getLocationInWindow();
 		let inWindowLeft = locationInWindow.x - controllerInWindow.x;
 		let inWindowTop = locationInWindow.y - controllerInWindow.y;

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -348,9 +348,12 @@ export class IOSHelper {
 			fullscreen = CGRectMake(0, 0, scrollView.contentSize.width, scrollView.contentSize.height);
 		}
 
+		// We take into account the controller position inside the window.
+		// for example with a bottomsheet the controller will be "offset"
+		const controllerInWindow = viewControllerView.convertPointToView(viewControllerView.bounds.origin, null);
 		const locationInWindow = view.getLocationInWindow();
-		let inWindowLeft = locationInWindow.x;
-		let inWindowTop = locationInWindow.y;
+		let inWindowLeft = locationInWindow.x - controllerInWindow.x;
+		let inWindowTop = locationInWindow.y - controllerInWindow.y;
 
 		if (scrollView) {
 			inWindowLeft += scrollView.contentOffset.x;


### PR DESCRIPTION
I added a new property to completely ignore safearea computation. It gets important with components like bottomsheets.
Without it i can only get unwanted view "padding" as seen in the next screenshot.
And there is no real way right now to simply "ignore" that top safe area (because the view controller has a  safe area).
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-07 at 13 33 04](https://user-images.githubusercontent.com/655344/101351355-c6ff5380-3890-11eb-80b1-312980643ceb.png)

By setting that new property (which has no consequence when not set) i get correct "p
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-07 at 13 36 10](https://user-images.githubusercontent.com/655344/101351659-2fe6cb80-3891-11eb-877b-99c922ae908e.png)
adding"

I also think this is the property which should be set on all ListView cells to totally ignore safearea inside listviews