### PR TITLE
fix: prevent circular reference && Cannot access … before initialization

### DIFF
--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -6,7 +6,7 @@ import { Property, CssProperty } from '../core/properties';
 import { Style } from '../styling/style';
 import { Color } from '../../color';
 import { EventData } from '../../data/observable';
-import { Frame } from '../frame';
+import type { Frame } from '../frame';
 import { ActionBar } from '../action-bar';
 import { KeyframeAnimationInfo } from '../animation/keyframe-animation';
 import { profile } from '../../profiling';

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -94,7 +94,7 @@ export class PageBase extends ContentView {
 	get frame(): Frame {
 		const frame = this.parent;
 
-		return frame instanceof Frame ? frame : undefined;
+		return (frame && frame.constructor.name === 'Frame') ? frame as Frame : undefined;
 	}
 
 	private createNavigatedData(eventName: string, isBackNavigation: boolean): NavigatedData {


### PR DESCRIPTION
I am not sure why i dont see the issue in all apps but the issue is definitely there:
* `Page` imports `Frame`
*  `Frame` imports `Page`
I ended up in a case  where i got `Cannot access … before initialization` because of that.
By using `frame.constructor.name === 'Frame'` now `Frame` is just used as a type in `page-common` and thus we dont get a circular referecence anymore