### PR TITLE
fix(ios) Navigation via swipe leads to crash

### DIFF
--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -54,7 +54,7 @@ export class Frame extends FrameBase {
 	public setCurrent(entry: BackstackEntry, navigationType: NavigationType): void {
 		const current = this._currentEntry;
 		const currentEntryChanged = current !== entry;
-		if (currentEntryChanged) {
+		if (entry?.resolvedPage && currentEntryChanged) {
 			this._updateBackstack(entry, navigationType);
 
 			super.setCurrent(entry, navigationType);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Sometimes the application crashes when the user back the page with iOS back swipe.

## What is the new behavior?
This commit adds a new check to verify if the new page is available before checking the frame.
It seems to fix random crashes when navigating on iOS device.

Fixes #9096 