### PR TITLE
fix(android): BottomNavigation fragment child already has a parent

### DIFF
--- a/packages/core/ui/bottom-navigation/index.android.ts
+++ b/packages/core/ui/bottom-navigation/index.android.ts
@@ -428,7 +428,7 @@ export class BottomNavigation extends TabNavigationBase {
 		const fragmentToDetach = this._currentFragment;
 		if (fragmentToDetach) {
 			this.destroyItem((<any>fragmentToDetach).index, fragmentToDetach);
-			this.commitCurrentTransaction();
+			this.removeFragment(fragmentToDetach);
 		}
 	}
 
@@ -454,28 +454,42 @@ export class BottomNavigation extends TabNavigationBase {
 
 	private disposeTabFragments(): void {
 		const fragmentManager = this._getFragmentManager();
-		const transaction = fragmentManager.beginTransaction();
 		const fragments = fragmentManager.getFragments().toArray();
 		for (let i = 0; i < fragments.length; i++) {
-			transaction.remove(fragments[i]);
+			this.removeFragment(fragments[i]);
 		}
-
-		transaction.commitNowAllowingStateLoss();
 	}
 
-	private get currentTransaction(): androidx.fragment.app.FragmentTransaction {
-		if (!this._currentTransaction) {
-			const fragmentManager = this._getFragmentManager();
-			this._currentTransaction = fragmentManager.beginTransaction();
-		}
-
-		return this._currentTransaction;
-	}
-
-	private commitCurrentTransaction(): void {
-		if (this._currentTransaction) {
-			this._currentTransaction.commitNowAllowingStateLoss();
-			this._currentTransaction = null;
+	private attachFragment(fragment: androidx.fragment.app.Fragment, id?: number, name?: string): void {
+		const fragmentManager = this._getFragmentManager();
+		if (fragment) {
+			if (fragment.isAdded() || fragment.isRemoving()) {
+				// ignore
+			} else {
+				var fragmentExitTransition = fragment.getExitTransition();
+				if (fragmentExitTransition && fragmentExitTransition instanceof org.nativescript.widgets.CustomTransition) {
+					fragmentExitTransition.setResetOnTransitionEnd(true);
+				}
+				if (fragmentManager) {
+					if (!fragmentManager.isDestroyed()) {
+						try {
+							if (fragmentManager.isStateSaved()) {
+								if (id && name) {
+									fragmentManager.beginTransaction().add(id, fragment, name).commitNowAllowingStateLoss();
+								} else {
+									fragmentManager.beginTransaction().attach(fragment).commitNowAllowingStateLoss();
+								}
+							} else {
+								if (id && name) {
+									fragmentManager.beginTransaction().add(id, fragment, name).commitNow();
+								} else {
+									fragmentManager.beginTransaction().attach(fragment).commitNow();
+								}
+							}
+						} catch (e) {}
+					}
+				}
+			}
 		}
 	}
 
@@ -495,8 +509,6 @@ export class BottomNavigation extends TabNavigationBase {
 
 		const fragment = this.instantiateItem(this._contentView, index);
 		this.setPrimaryItem(index, fragment);
-
-		this.commitCurrentTransaction();
 	}
 
 	private instantiateItem(container: android.view.ViewGroup, position: number): androidx.fragment.app.Fragment {
@@ -505,10 +517,10 @@ export class BottomNavigation extends TabNavigationBase {
 		const fragmentManager = this._getFragmentManager();
 		let fragment: androidx.fragment.app.Fragment = fragmentManager.findFragmentByTag(name);
 		if (fragment != null) {
-			this.currentTransaction.attach(fragment);
+			this.attachFragment(fragment);
 		} else {
 			fragment = TabFragment.newInstance(this._domId, position);
-			this.currentTransaction.add(container.getId(), fragment, name);
+			this.attachFragment(fragment, container.getId(), name);
 		}
 
 		if (fragment !== this._currentFragment) {
@@ -545,7 +557,7 @@ export class BottomNavigation extends TabNavigationBase {
 
 	private destroyItem(position: number, fragment: androidx.fragment.app.Fragment): void {
 		if (fragment) {
-			this.currentTransaction.detach(fragment);
+			this.removeFragment(fragment);
 			if (this._currentFragment === fragment) {
 				this._currentFragment = null;
 			}
@@ -553,6 +565,34 @@ export class BottomNavigation extends TabNavigationBase {
 
 		if (this.items && this.items[position]) {
 			this.items[position].canBeLoaded = false;
+		}
+	}
+	private removeFragment(fragment: androidx.fragment.app.Fragment, fragmentManager?: any) {
+		if (!fragmentManager) {
+			fragmentManager = this._getFragmentManager();
+		}
+		if (fragment) {
+			if (!fragment.isAdded() || fragment.isRemoving()) {
+				// ignore
+				return;
+			} else {
+				var fragmentExitTransition = fragment.getExitTransition();
+				if (fragmentExitTransition && fragmentExitTransition instanceof org.nativescript.widgets.CustomTransition) {
+					fragmentExitTransition.setResetOnTransitionEnd(true);
+				}
+				if (fragment && fragment.isAdded() && !fragment.isRemoving()) {
+					var pfm = (<any>fragment).getParentFragmentManager ? (<any>fragment).getParentFragmentManager() : null;
+					if (pfm && !pfm.isDestroyed()) {
+						try {
+							if (pfm.isStateSaved()) {
+								pfm.beginTransaction().remove(fragment).commitNowAllowingStateLoss();
+							} else {
+								pfm.beginTransaction().remove(fragment).commitNow();
+							}
+						} catch (e) {}
+					}
+				}
+			}
 		}
 	}
 

--- a/packages/core/ui/bottom-navigation/index.android.ts
+++ b/packages/core/ui/bottom-navigation/index.android.ts
@@ -466,7 +466,7 @@ export class BottomNavigation extends TabNavigationBase {
 			if (fragment.isAdded() || fragment.isRemoving()) {
 				// ignore
 			} else {
-				var fragmentExitTransition = fragment.getExitTransition();
+				const fragmentExitTransition = fragment.getExitTransition();
 				if (fragmentExitTransition && fragmentExitTransition instanceof org.nativescript.widgets.CustomTransition) {
 					fragmentExitTransition.setResetOnTransitionEnd(true);
 				}
@@ -576,12 +576,12 @@ export class BottomNavigation extends TabNavigationBase {
 				// ignore
 				return;
 			} else {
-				var fragmentExitTransition = fragment.getExitTransition();
+				const fragmentExitTransition = fragment.getExitTransition();
 				if (fragmentExitTransition && fragmentExitTransition instanceof org.nativescript.widgets.CustomTransition) {
 					fragmentExitTransition.setResetOnTransitionEnd(true);
 				}
 				if (fragment && fragment.isAdded() && !fragment.isRemoving()) {
-					var pfm = (<any>fragment).getParentFragmentManager ? (<any>fragment).getParentFragmentManager() : null;
+					const pfm = (<any>fragment).getParentFragmentManager ? (<any>fragment).getParentFragmentManager() : null;
 					if (pfm && !pfm.isDestroyed()) {
 						try {
 							if (pfm.isStateSaved()) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Android BottomNavigation was super fragile, prone to bugs and race conditions due to poor fragment handling.

## What is the new behavior?

Android BottomNavigation is stable and reliable.

closes https://github.com/NativeScript/NativeScript/issues/8132
closes https://github.com/NativeScript/NativeScript/issues/7901
closes https://github.com/NativeScript/NativeScript/issues/9051
closes https://github.com/NativeScript/NativeScript/issues/8251