### PR TITLE
Ios modal status bar

### DIFF
--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -129,7 +129,7 @@ class UIViewControllerImpl extends UIViewController {
 			// because changes happen in an interactive transition - IOS will animate between the the states.
 			// If canceled - viewWillAppear will be called for the current page(which is already loaded) and we need to
 			// update the action bar explicitly, so that it is not left styles as the previous page.
-			owner.actionBar.update();
+			owner.updateWithWillAppear();
 		}
 	}
 
@@ -367,6 +367,12 @@ export class Page extends PageBase {
 		if (this.hasActionBar) {
 			this.actionBar.update();
 		}
+	}
+	updateWithWillAppear() {
+		// this method is important because it allows plugins to react to modal page close
+		// for example allowing updating status bar background color
+		this.actionBar.update();
+		this.updateStatusBar();
 	}
 
 	public updateStatusBar() {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -129,7 +129,7 @@ class UIViewControllerImpl extends UIViewController {
 			// because changes happen in an interactive transition - IOS will animate between the the states.
 			// If canceled - viewWillAppear will be called for the current page(which is already loaded) and we need to
 			// update the action bar explicitly, so that it is not left styles as the previous page.
-			owner.updateWithWillAppear();
+			owner.updateWithWillAppear(animated);
 		}
 	}
 
@@ -221,6 +221,7 @@ class UIViewControllerImpl extends UIViewController {
 				owner.onNavigatingFrom(isBack);
 			}
 		}
+		owner.updateWithWillDisappear(animated);
 	}
 
 	@profile
@@ -368,11 +369,16 @@ export class Page extends PageBase {
 			this.actionBar.update();
 		}
 	}
-	updateWithWillAppear() {
+	updateWithWillAppear(animated: boolean) {
 		// this method is important because it allows plugins to react to modal page close
 		// for example allowing updating status bar background color
 		this.actionBar.update();
 		this.updateStatusBar();
+	}
+
+	updateWithWillDisappear(animated: boolean) {
+		// this method is important because it allows plugins to react to modal page close
+		// for example allowing updating status bar background color
 	}
 
 	public updateStatusBar() {


### PR DESCRIPTION
I have a plugin `@nativescript-community/system-ui` which allows to change status bar background color.
without `updateWithWillAppear` there was no way for my plugin to rollback the status bar color once i closed a modal page which was changing it.
the `updateWithWillDisappear` allows to have smoother modal close by changing the status bar color as soon as the modal close animation starts
My plugin can hook those methods through class mixins
This is mostly used by fullscreen modals.

This PR mostly dont change behavior. I just added `updateStatusBar` from `updateWithWillAppear` to ensure the status bar style is also updated in the modal close case.

Working on that i saw that N is not firing page navigation events for modals. I would raise the question should we not bring it back? I feel it weird for a page that i show with modal not to get the events. Same for the page being navigating from.