### PR TITLE
fix: ObservableArray splice with start only

### DIFF
--- a/packages/core/__tests__/observable/observable-array.ts
+++ b/packages/core/__tests__/observable/observable-array.ts
@@ -1,0 +1,47 @@
+import { ObservableArray } from '@nativescript/core/data/observable-array';
+import { assert } from 'chai';
+
+describe('observable-array', () => {
+	describe('splice', () => {
+		it('removes an item', () => {
+			const _array = new ObservableArray();
+
+			_array.push(1);
+			_array.push(2);
+
+			_array.splice(0, 1);
+
+			assert.equal(2, _array.getItem(0));
+		});
+
+		it('replaces an item', () => {
+			const _array = new ObservableArray();
+
+			_array.push(1);
+			_array.push(2);
+
+			_array.splice(0, 1, 3);
+
+			assert.equal(3, _array.getItem(0));
+		});
+
+		it('empties on start zero and no delete count', () => {
+			const _array = new ObservableArray();
+
+			_array.push(1);
+
+			_array.splice(0);
+			assert.equal(0, _array.length);
+		});
+
+		it('empties on length set to zero', () => {
+			const _array = new ObservableArray();
+
+			_array.push(1);
+			_array.push(2);
+
+			_array.length = 0;
+			assert.equal(0, _array.length);
+		});
+	});
+});

--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -33,7 +33,6 @@ export interface ChangedData<T> extends EventData {
 	 * Number of added items.
 	 */
 	addedCount: number;
-
 }
 
 const CHANGE = 'change';
@@ -116,8 +115,8 @@ export class ObservableArray<T> extends Observable {
 
 	set length(value: number) {
 		if (types.isNumber(value) && this._array && this._array.length !== value) {
-			const added=[];
-			for (let i=this._array.length;i < value;++i) {
+			const added = [];
+			for (let i = this._array.length; i < value; ++i) {
 				added.push(undefined);
 			}
 			this.splice(value, this._array.length - value, ...added);
@@ -247,7 +246,7 @@ export class ObservableArray<T> extends Observable {
 	 */
 	splice(start: number, deleteCount?: number, ...items: any): T[] {
 		const length = this._array.length;
-		const result = this._array.splice(start, deleteCount, ...items);
+		const result = arguments.length === 1 ? this._array.splice(start) : this._array.splice(start, deleteCount, ...items);
 
 		this.notify(<ChangedData<T>>{
 			eventName: CHANGE,


### PR DESCRIPTION
Fix for when using splice on ObservableArray and specifying the start only. Passing `undefined` as the deleteCount to Array doesn't work as expected.

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
https://github.com/NativeScript/NativeScript/issues/9157

## What is the new behavior?
Passing only a start to splice on an ObservableArray has intended results.

Fixes/Implements/Closes 9157.

