### PR TITLE
feat: reusable views

### DIFF
--- a/apps/ui/src/issues/issue-7469-page.css
+++ b/apps/ui/src/issues/issue-7469-page.css
@@ -1,0 +1,15 @@
+.test-label {
+    padding: 10;
+    background-color: black;
+    color: white;
+  }
+  
+  .stack1 {
+    background-color: green;
+    color: white;
+  }
+  
+  .stack2 {
+    background-color: blue;
+    color: red;
+  }

--- a/apps/ui/src/issues/issue-7469-page.ts
+++ b/apps/ui/src/issues/issue-7469-page.ts
@@ -1,0 +1,158 @@
+import { EventData, Label, StackLayout } from '@nativescript/core';
+import { addCallback, removeCallback, start, stop } from '@nativescript/core/fps-meter';
+
+let callbackId;
+let fpsLabel: any;
+export function startFPSMeter() {
+	callbackId = addCallback((fps: number, minFps: number) => {
+		// console.log(`Frames per seconds: ${fps.toFixed(2)}`);
+		// console.log(minFps.toFixed(2));
+		if (fpsLabel) {
+			fpsLabel.text = `${fps}`;
+		}
+	});
+	start();
+}
+
+export function stopFPSMeter() {
+	removeCallback(callbackId);
+	stop();
+}
+
+let timeouts = [];
+let intervals = [];
+
+let reusableItem;
+let vcToggle;
+let loaded = false;
+let isIn1 = false;
+
+function updateVcToggleText() {
+	vcToggle.text = `Container is${reusableItem.reusable ? ' ' : ' NOT '}Reusable`
+}
+
+export function pageLoaded(args) {
+	startFPSMeter();
+	if (loaded) {
+		fpsLabel = null;
+		// stopFPSMeter();
+		timeouts.forEach((v) => clearTimeout(v));
+		intervals.forEach((v) => clearInterval(v));
+		reusableItem._tearDownUI(true);
+	}
+	loaded = true;
+	reusableItem = args.object.getViewById('reusableItem');
+	vcToggle = args.object.getViewById('vcToggle');
+	updateVcToggleText();
+	fpsLabel = args.object.getViewById('fpslabel');
+	const stack1: StackLayout = args.object.getViewById('stack1');
+	const stack2: StackLayout = args.object.getViewById('stack2');
+	setTimeout(() => {
+		// label.android.setTextColor(new Color("red").android);
+		// label.android.setBackgroundColor(new Color("red").android);
+		startFPSMeter();
+		console.log('setRed');
+	}, 1000);
+	// console.log(label._context);
+	// isIn1 = false;
+	// timeouts.push(setTimeout(() => {
+	//     intervals.push(setInterval(() => {
+	//         label.parent.removeChild(label);
+	//         // console.log(label.nativeView);
+	//         if(isIn1) {
+	//             isIn1 = false;
+	//             stack2.addChild(label);
+	//         } else {
+	//             isIn1 = true;
+	//             stack1.addChild(label);
+	//         }
+	//     }, 10));
+	// }, 1001));
+}
+
+export function pageUnloaded(args) {
+	//
+}
+
+export function makeReusable(args: EventData) {
+	console.log('loaded:', args.object);
+	// console.log("making reusable");
+	if ((args.object as any).___reusableRan) {
+		return;
+	}
+	(args.object as any).___reusableRan = true;
+	(args.object as any).reusable = true;
+	if(args.object === reusableItem) {
+		updateVcToggleText();
+	}
+}
+
+export function onReusableUnloaded(args: EventData) {
+	console.log('unloaded:', args.object);
+}
+var testLabel: Label;
+
+export function test(args: any) {
+	const page = args.object.page;
+	reusableItem = page.getViewById('reusableItem');
+	const stack1: StackLayout = page.getViewById('stack1');
+	const stack2: StackLayout = page.getViewById('stack2');
+	if (!testLabel) {
+		testLabel = new Label();
+		testLabel.text = 'This label is not reusable and is dynamic';
+		testLabel.on('loaded', () => {
+			console.log('LODADED testLabel');
+		});
+		testLabel.on('unloaded', () => {
+			console.log('UNLODADED testLabel');
+		});
+	}
+	reusableItem.parent.removeChild(reusableItem);
+	if (!reusableItem._suspendNativeUpdatesCount) {
+		console.log('reusableItem SHOULD BE UNLOADED');
+	}
+	if (!testLabel._suspendNativeUpdatesCount) {
+		console.log('testLabel SHOULD BE UNLOADED');
+	}
+	if (!testLabel.parent) {
+		reusableItem.addChild(testLabel);
+	}
+	if (!testLabel.nativeView) {
+		console.log('testLabel NATIVE VIEW SHOULD BE CREATED');
+	}
+	if (!testLabel._suspendNativeUpdatesCount) {
+		console.log('testLabel SHOULD BE UNLOADED');
+	}
+	if (isIn1) {
+		isIn1 = false;
+		stack2.addChild(reusableItem);
+	} else {
+		isIn1 = true;
+		stack1.addChild(reusableItem);
+	}
+	if (reusableItem._suspendNativeUpdatesCount) {
+		console.log('reusableItem SHOULD BE LOADED AND RECEIVING UPDATES');
+	}
+	if (testLabel._suspendNativeUpdatesCount) {
+		console.log('testLabel SHOULD BE LOADED AND RECEIVING UPDATES');
+	}
+	// console.log("onTap");
+	// alert("onTap");
+}
+let ignoreInput = false;
+
+export function toggleReusable(args: EventData) {
+	if (ignoreInput) {
+		return;
+	}
+	ignoreInput = true;
+	setTimeout(() => (ignoreInput = false), 0); // hack to avoid gesture collision
+	const target: any = args.object;
+	target.reusable = !target.reusable;
+	console.log(`${target} is now ${target.reusable ? '' : 'NOT '}reusable`);
+}
+
+export function toggleVCReusable() {
+	reusableItem.reusable = !reusableItem.reusable;
+	updateVcToggleText();
+}

--- a/apps/ui/src/issues/issue-7469-page.xml
+++ b/apps/ui/src/issues/issue-7469-page.xml
@@ -1,0 +1,37 @@
+<Page
+    xmlns="http://schemas.nativescript.org/tns.xsd" class="page" loaded="pageLoaded" unloaded="pageUnloaded">
+    <StackLayout class="p-20">
+        <Button text="Swap locations" tap="test"/>
+        <Button id="vcToggle" text="" tap="toggleVCReusable"/>
+        <Label text="Longpress items to toggle reusability"></Label>
+        <Label id="fpslabel" text=""></Label>
+        <StackLayout id="reusableItem" loaded="makeReusable">
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <Label longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" text="abc"></Label>
+          <WebView longPress="toggleReusable" loaded="makeReusable" unloaded="onReusableUnloaded" width="100" height="100" src="https://google.com"></WebView>
+        </StackLayout>
+        <StackLayout id="stack1" class="stack1">
+          <Label text="Stack 1"></Label>
+        </StackLayout>
+        <StackLayout id="stack2" class="stack2">
+          <Label text="Stack 2"></Label>
+        </StackLayout>
+    </StackLayout>
+</Page>

--- a/apps/ui/src/issues/main-page.ts
+++ b/apps/ui/src/issues/main-page.ts
@@ -32,6 +32,7 @@ export function loadExamples() {
 	examples.set('ng-repo-1626', 'issues/issue-ng-repo-1626-page');
 	examples.set('6439', 'issues/issue-6439-page');
 	examples.set('open-file-6895', 'issues/open-file-6895-page');
+	examples.set("7469", "issues/issue-7469-page");
 
 	return examples;
 }

--- a/packages/core/ui/core/view-base/index.d.ts
+++ b/packages/core/ui/core/view-base/index.d.ts
@@ -237,6 +237,12 @@ export abstract class ViewBase extends Observable {
 	public bindingContext: any;
 
 	/**
+     * Gets or sets if the view is reusable.
+     * Reusable views are not automatically destroyed when removed from the View tree.
+     */
+    public reusable: boolean;
+
+	/**
 	 * Gets the name of the constructor function for this instance. E.g. for a Button class this will return "Button".
 	 */
 	public typeName: string;
@@ -364,6 +370,13 @@ export abstract class ViewBase extends Observable {
 	 * This method should *not* be overridden by derived views.
 	 */
 	_tearDownUI(force?: boolean): void;
+
+	/**
+     * Tears down the UI of a reusable node by making it no longer reusable.
+     * @see _tearDownUI
+     * @param forceDestroyChildren Force destroy the children (even if they are reusable)
+     */
+    destroyNode(forceDestroyChildren?: boolean): void;
 
 	/**
 	 * Creates a native view.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Views and view trees are destroyed when removed from the view tree.

## What is the new behavior?
Views can be marked as `reusable` and will not be destroyed when removed from view tree. Removing these nodes require the developer to do: 
```
view.destroyNode();
// which calls
view.reusable = false;
view._tearDownUI();
```

For implementation details on how frameworks should deal with it, see my work in `nativescript-angular`: https://github.com/edusperoni/nativescript-angular/tree/reusable-views

Implements #7469.
Rewrite of #8184


-------
## To be defined:

What happens when a reusable view with children gets removed? The current implementation does not call _tearDownUI on children, but we should still suspendNativeUpdates down the chain (`this._suspendNativeUpdates(SuspendType.UISetup);`).

Maybe we should we create a new SuspendType (Detached)? Maybe this isn't even needed as the view should be unloaded by `_removeViewCore` which eventually calls `this._suspendNativeUpdates(SuspendType.Loaded);` on all children.


## Possible refactoring needed (not directly related to this PR)

The current logic of `_resumeNativeUpdates` will call `initNativeView`. In most places I checked, `initNativeView` creates delegates that are only removed in `disposeNativeView`. This behavior is probably already an issue on loading/unloading views (like navigation) because of `this._resumeNativeUpdates(SuspendType.Loaded);`, meaning `initNativeView` is called multiple times during the application lifecycle, but the delegates are only cleaned up once.

During my tests with WebView, calling `initNativeView` did not result in a performance impact
