### PR TITLE
fix(ios): getVisibleViewController maximum call stack exceeded

### DIFF
--- a/packages/core/utils/native-helper.ios.ts
+++ b/packages/core/utils/native-helper.ios.ts
@@ -96,19 +96,12 @@ export namespace iOSNativeHelper {
 	}
 
 	export function getVisibleViewController(rootViewController: UIViewController): UIViewController {
-		if (rootViewController.presentedViewController) {
-			return getVisibleViewController(rootViewController.presentedViewController);
-		}
+		let viewController = rootViewController;
 
-		if (rootViewController.isKindOfClass(UINavigationController.class())) {
-			return getVisibleViewController((<UINavigationController>rootViewController).visibleViewController);
+		while (viewController && viewController.presentedViewController) {
+			viewController = viewController.presentedViewController;
 		}
-
-		if (rootViewController.isKindOfClass(UITabBarController.class())) {
-			return getVisibleViewController(<UITabBarController>rootViewController);
-		}
-
-		return rootViewController;
+		return viewController;
 	}
 
 	export function applyRotateTransform(transform: CATransform3D, x: number, y: number, z: number): CATransform3D {
@@ -125,33 +118,33 @@ export namespace iOSNativeHelper {
 		}
 
 		return transform;
-  }
-  
-  export function createUIDocumentInteractionControllerDelegate(): NSObject {
-    @NativeClass
-    class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UIDocumentInteractionControllerDelegate {
-      public static ObjCProtocols = [UIDocumentInteractionControllerDelegate];
-  
-      public getViewController(): UIViewController {
-        const app = UIApplication.sharedApplication;
-  
-        return app.keyWindow.rootViewController;
-      }
-  
-      public documentInteractionControllerViewControllerForPreview(controller: UIDocumentInteractionController) {
-        return this.getViewController();
-      }
-  
-      public documentInteractionControllerViewForPreview(controller: UIDocumentInteractionController) {
-        return this.getViewController().view;
-      }
-  
-      public documentInteractionControllerRectForPreview(controller: UIDocumentInteractionController): CGRect {
-        return this.getViewController().view.frame;
-      }
-    }
-    return new UIDocumentInteractionControllerDelegateImpl();
-  }
+	}
+
+	export function createUIDocumentInteractionControllerDelegate(): NSObject {
+		@NativeClass
+		class UIDocumentInteractionControllerDelegateImpl extends NSObject implements UIDocumentInteractionControllerDelegate {
+			public static ObjCProtocols = [UIDocumentInteractionControllerDelegate];
+
+			public getViewController(): UIViewController {
+				const app = UIApplication.sharedApplication;
+
+				return app.keyWindow.rootViewController;
+			}
+
+			public documentInteractionControllerViewControllerForPreview(controller: UIDocumentInteractionController) {
+				return this.getViewController();
+			}
+
+			public documentInteractionControllerViewForPreview(controller: UIDocumentInteractionController) {
+				return this.getViewController().view;
+			}
+
+			public documentInteractionControllerRectForPreview(controller: UIDocumentInteractionController): CGRect {
+				return this.getViewController().view.frame;
+			}
+		}
+		return new UIDocumentInteractionControllerDelegateImpl();
+	}
 
 	export function isRealDevice() {
 		try {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Using `Utils.ios.getVisibleViewController` from different view controller contexts can crash with maximum call stack exceeded.

## What is the new behavior?

`Utils.ios.getVisibleViewController` works as expected under all circumstances.

closes https://github.com/NativeScript/plugins/issues/39