### PR TITLE
Fix: Angular no longer has issues with plugins that aren't named "nativescript"

### DIFF
--- a/packages/webpack/host/resolver.ts
+++ b/packages/webpack/host/resolver.ts
@@ -7,18 +7,6 @@ export function getResolver(platforms: string[], explicitResolve?: string[], nsP
 	platformSpecificExt = platformSpecificExt || ['.ts', '.js', '.scss', '.less', '.css', '.html', '.xml', '.vue', '.json'];
 
 	return function (path: string) {
-		const nmIndex = path.lastIndexOf('node_modules');
-
-		if (nmIndex !== -1) {
-			const subPath = path.substr(nmIndex + 'node_modules'.length).replace(/\\/g, '/');
-			const shouldResolve = explicitResolve.length && explicitResolve.some((packageName) => subPath.indexOf(packageName) !== -1);
-			const pathParts = subPath.split(/[/\-_]/);
-
-			if (!shouldResolve && pathParts.every((p) => nsPackageFilters.every((f) => f !== p))) {
-				return path;
-			}
-		}
-
 		const { dir, name, ext } = parse(path);
 
 		if (platformSpecificExt.indexOf(ext) === -1) {


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: 
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: 

## What is the current behavior?
When webpacking in Angular; it requires the plugins to have the name "nativescript", "@nativescript", "tns" somewhere in it.  If it doesn't have it -- it will not consider it a plugin to do any .ios. / .android. file renaming causing the build to fail.

## What is the new behavior?
Makes angular be consistent with **all** the other flavors, and now does NOT care about the package name in its check to see if it is a file it needs to rename.  

It does add about between a -10% to a +5% slowdown to just the WebPack portion of the build depending on the size of the application. (No other speed or size impacts)   In smaller apps; the webpacking is now faster.   In apps that take about 30 seconds for just the webpacking, it adds an additional second.

