### PR TITLE
fix: ios textfield resizing (auto width) on text change

### DIFF
--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -217,7 +217,10 @@ export class TextField extends TextFieldBase {
 		if (this.formattedText) {
 			_updateCharactersInRangeReplacementString(this.formattedText, range.location, range.length, replacementString);
 		}
-
+		if (this.width === 'auto') {
+			// if the textfield is in auto size we need to request a layout to take the new text width into account
+			this.requestLayout();
+		}
 		this.firstEdit = false;
 
 		return true;


### PR DESCRIPTION
This fixes iOS behavior to correctly resize on text change.
Was already working on Android