### PR TITLE
fix: some eslint fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,9 +7,15 @@
 		"project": ["packages/core/tsconfig.json", "packages/webpack/tsconfig.json"]
 	},
 	"ignorePatterns": ["**/*"],
-	"plugins": ["@typescript-eslint", "@nrwl/nx"],
-	"extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier", "prettier/@typescript-eslint"],
+	"plugins": ["prettier", "@typescript-eslint", "@nrwl/nx"],
+	"extends": [
+		"eslint:recommended",
+		"plugin:@typescript-eslint/recommended",
+		"prettier/@typescript-eslint",
+		"plugin:prettier/recommended"
+	],
 	"rules": {
+		"prettier/prettier": "warn",
 		"@typescript-eslint/explicit-member-accessibility": "off",
 		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/no-parameter-properties": "off",

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,7 +16,7 @@ packages/ui-mobile-base
 tools/assets/App_Resources
 *.cmd
 *.md
-*.json
+package.json
 *.js
 *.map
 *.css

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"dotenv": "~8.2.0",
 		"eslint": "~7.10.0",
 		"eslint-config-prettier": "~6.11.0",
+		"eslint-plugin-prettier": "^3.3.1",
 		"gonzales": "^1.0.7",
 		"husky": "^4.2.5",
 		"jest": "~26.2.2",


### PR DESCRIPTION
* add `eslint-plugin-prettier` so that eslint can format code too
* fixed eslint config file:
   - wrong “prettier” extend
   - added config for eslint/prettier
* allow eslint/prettier to format JSON files except package.json files (which are formatted by npm)
