### PR TITLE
fix: allow navigationFrom event for deep navigation within modal frame

### DIFF
--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -214,7 +214,7 @@ class UIViewControllerImpl extends UIViewController {
 		// or because we are closing a modal page,
 		// or because we are in tab and another controller is selected.
 		const tab = this.tabBarController;
-		if (owner.onNavigatingFrom && !owner._presentedViewController && !this.presentingViewController && frame && frame.currentPage === owner) {
+		if (owner.onNavigatingFrom && !owner._presentedViewController && frame && (!this.presentingViewController || frame.backStack.length > 0) && frame.currentPage === owner) {
 			const willSelectViewController = tab && (<any>tab)._willSelectViewController;
 			if (!willSelectViewController || willSelectViewController === tab.selectedViewController) {
 				const isBack = isBackNavigationFrom(this, owner);


### PR DESCRIPTION
On iOS if you were to use a frame modally, the deep(backStack >0) `navigatingFrom` events were not fired.
The reason is pretty simple, it was seen as modal and thus no event (yet `navigatingTo` was fired...)
That PR simply bypass the check if frame backstack length is > 0. That way we get the events for deep navigation but we still "skip" it when closing the modal itself.