### PR TITLE
fix(core): conflicting node global types

### DIFF
--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -151,13 +151,6 @@ interface ModuleContext {
 	path: string;
 }
 
-// Define a minimal subset of NodeRequire and NodeModule so user apps can compile without
-// installing @types/node
-
-interface NodeRequire {
-	(id: string): any;
-}
-
 interface NodeModule {
 	exports: any;
 	id: string;
@@ -218,10 +211,6 @@ interface RequireContext {
 	(id: string): any;
 	<T>(id: string): T;
 	resolve(id: string): string;
-}
-
-interface NodeRequire {
-	context(path: string, deep?: boolean, filter?: RegExp): RequireContext;
 }
 
 declare var __dirname: string;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Global types conflict with node types as used in various integrations differently. This was particularly problematic for Vue 3 and works well for all integrations with this removed.

```
node_modules/@nativescript/core/global-types.d.ts:157:11 - error TS2430: Interface 'NodeRequire' incorrectly extends interface 'Require'.
157 interface NodeRequire {
              ~~~~~~~~~~~
node_modules/@nativescript/core/global-types.d.ts:157:11 - error TS2430: Interface 'NodeRequire' incorrectly extends interface 'Require'.
  The types returned by 'context(...)' are incompatible between these types.
    Property 'id' is missing in type 'RequireContext' but required in type '__WebpackModuleApi.RequireContext'.
157 interface NodeRequire {
              ~~~~~~~~~~~
  node_modules/@types/webpack-env/index.d.ts:23:9
    23         id: string;
               ~~
    'id' is declared here.
Found 2 errors.
```

## What is the new behavior?

Global types no longer interfere with standard node types.

closes https://github.com/NativeScript/NativeScript/issues/7841