### PR TITLE
feat: Add possibility to choose theme in android dialogs

### DIFF
--- a/packages/core/ui/dialogs/dialogs-common.ts
+++ b/packages/core/ui/dialogs/dialogs-common.ts
@@ -53,6 +53,8 @@ export interface ActionOptions extends CancelableOptions {
 	 * [iOS only] Gets or sets the indexes of destructive actions.
 	 */
 	destructiveActionsIndexes?: Array<number>;
+
+  theme?: number;
 }
 
 /**

--- a/packages/core/ui/dialogs/dialogs-common.ts
+++ b/packages/core/ui/dialogs/dialogs-common.ts
@@ -23,6 +23,11 @@ export interface CancelableOptions {
 	 * [Android only] Gets or sets if the dialog can be canceled by taping outside of the dialog.
 	 */
 	cancelable?: boolean;
+
+	/**
+	 * [Android only] Sets the theme of the Dialog. Usable themes can be found: https://developer.android.com/reference/android/R.style
+	 */
+	theme?: number;
 }
 
 /**
@@ -53,8 +58,6 @@ export interface ActionOptions extends CancelableOptions {
 	 * [iOS only] Gets or sets the indexes of destructive actions.
 	 */
 	destructiveActionsIndexes?: Array<number>;
-
-  theme?: number;
 }
 
 /**

--- a/packages/core/ui/dialogs/index.android.ts
+++ b/packages/core/ui/dialogs/index.android.ts
@@ -12,7 +12,7 @@ function isString(value): value is string {
 }
 
 function createAlertDialog(options?: DialogOptions): android.app.AlertDialog.Builder {
-	const alert = new android.app.AlertDialog.Builder(androidApp.foregroundActivity);
+	const alert = new android.app.AlertDialog.Builder(androidApp.foregroundActivity, options.theme ? options.theme : -1);
 	alert.setTitle(options && isString(options.title) ? options.title : '');
 	alert.setMessage(options && isString(options.message) ? options.message : '');
 	if (options && options.cancelable === false) {
@@ -325,7 +325,7 @@ export function action(...args): Promise<string> {
 	return new Promise<string>((resolve, reject) => {
 		try {
 			const activity = androidApp.foregroundActivity || androidApp.startActivity;
-			const alert = new android.app.AlertDialog.Builder(activity);
+			const alert = new android.app.AlertDialog.Builder(activity, options.theme ? options.theme : -1);
 			const message = options && isString(options.message) ? options.message : '';
 			const title = options && isString(options.title) ? options.title : '';
 			if (options && options.cancelable === false) {

--- a/packages/core/ui/dialogs/index.d.ts
+++ b/packages/core/ui/dialogs/index.d.ts
@@ -142,6 +142,11 @@ export interface CancelableOptions {
 	 * [Android only] Gets or sets if the dialog can be canceled by taping outside of the dialog.
 	 */
 	cancelable?: boolean;
+
+	/**
+	 * [Android only] Sets the theme of the Dialog. Usable themes can be found: https://developer.android.com/reference/android/R.style
+	 */
+	theme?: number;
 }
 
 /**


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, you can't change the theme for android dialogs.

## What is the new behavior?
A theme attribute has been added to change the theme of android dialogs. Available themes are: https://developer.android.com/reference/android/R.style

