### PR TITLE
fix(android): KeyboardType now respects numbers

### DIFF
--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -1478,12 +1478,18 @@ export function makeValidator<T>(...values: T[]): (value: any) => value is T {
 	return (value: any): value is T => set.has(value);
 }
 
-export function makeParser<T>(isValid: (value: any) => boolean): (value: any) => T {
+export function makeParser<T>(isValid: (value: any) => boolean, allowNumbers = false): (value: any) => T {
 	return (value) => {
 		const lower = value && value.toLowerCase();
 		if (isValid(lower)) {
 			return lower;
 		} else {
+			if (allowNumbers) {
+				const convNumber = +value;
+				if (!isNaN(convNumber)) {
+					return value;
+				}
+			}
 			throw new Error('Invalid value: ' + value);
 		}
 	};

--- a/packages/core/ui/editable-text-base/editable-text-base-common.ts
+++ b/packages/core/ui/editable-text-base/editable-text-base-common.ts
@@ -48,12 +48,12 @@ export const placeholderColorProperty = new CssProperty<Style, Color>({
 });
 placeholderColorProperty.register(Style);
 
-const keyboardTypeConverter = makeParser<KeyboardType>(makeValidator<KeyboardType>('datetime', 'phone', 'number', 'url', 'email', 'integer'));
+const keyboardTypeConverter = makeParser<KeyboardType>(makeValidator<KeyboardType>('datetime', 'phone', 'number', 'url', 'email', 'integer'), true);
 
 export const keyboardTypeProperty = new Property<EditableTextBase, KeyboardType>({ name: 'keyboardType', valueConverter: keyboardTypeConverter });
 keyboardTypeProperty.register(EditableTextBase);
 
-const returnKeyTypeConverter = makeParser<ReturnKeyType>(makeValidator<ReturnKeyType>('done', 'next', 'go', 'search', 'send'));
+const returnKeyTypeConverter = makeParser<ReturnKeyType>(makeValidator<ReturnKeyType>('done', 'next', 'go', 'search', 'send'), true);
 
 export const returnKeyTypeProperty = new Property<EditableTextBase, ReturnKeyType>({ name: 'returnKeyType', valueConverter: returnKeyTypeConverter });
 returnKeyTypeProperty.register(EditableTextBase);
@@ -68,7 +68,7 @@ editableProperty.register(EditableTextBase);
 export const updateTextTriggerProperty = new Property<EditableTextBase, UpdateTextTrigger>({ name: 'updateTextTrigger', defaultValue: 'textChanged' });
 updateTextTriggerProperty.register(EditableTextBase);
 
-const autocapitalizationTypeConverter = makeParser<AutocapitalizationType>(makeValidator<AutocapitalizationType>('none', 'words', 'sentences', 'allcharacters'));
+const autocapitalizationTypeConverter = makeParser<AutocapitalizationType>(makeValidator<AutocapitalizationType>('none', 'words', 'sentences', 'allcharacters'), true);
 
 export const autocapitalizationTypeProperty = new Property<EditableTextBase, AutocapitalizationType>({
 	name: 'autocapitalizationType',

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -472,4 +472,15 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			this.nativeTextViewProtected.setFilters(newFilters);
 		}
 	}
+
+	public setSelection(start: number, stop?: number) {
+		const view = this.nativeTextViewProtected;
+		if (view) {
+			if (stop !== undefined) {
+				view.setSelection(start, stop);
+			} else {
+				view.setSelection(start);
+			}
+		}
+	}
 }

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -285,7 +285,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 				if (!isNaN(inputType)) {
 					newInputType = inputType;
 				} else {
-					newInputType = android.text.InputType.TYPE_DATETIME_VARIATION_NORMAL;
+					newInputType = android.text.InputType.TYPE_CLASS_TEXT;
 				}
 				break;
 		}

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -144,6 +144,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 	/* tslint:enable */
 
 	nativeViewProtected: android.widget.EditText;
+	nativeTextViewProtected: android.widget.EditText;
 	private _keyListenerCache: android.text.method.KeyListener;
 	private _inputType: number;
 
@@ -215,7 +216,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 		const nativeView = this.nativeTextViewProtected;
 		try {
 			this._changeFromCode = true;
-			nativeView.setInputType(parseInt(<any>inputType,10));
+			nativeView.setInputType(parseInt(<any>inputType, 10));
 		} finally {
 			this._changeFromCode = false;
 		}
@@ -332,7 +333,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			case 'send':
 				newImeOptions = android.view.inputmethod.EditorInfo.IME_ACTION_SEND;
 				break;
-			default:{
+			default: {
 				const ime = +value;
 				if (!isNaN(ime)) {
 					newImeOptions = ime;
@@ -387,7 +388,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			case 'allcharacters':
 				inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS; //4096 (0x00010000) 13th bit
 				break;
-			default:{
+			default: {
 				const number = +value;
 				// We set the default value.
 				if (!isNaN(number)) {

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -144,7 +144,6 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 	/* tslint:enable */
 
 	nativeViewProtected: android.widget.EditText;
-	nativeTextViewProtected: android.widget.EditText;
 	private _keyListenerCache: android.text.method.KeyListener;
 	private _inputType: number;
 
@@ -216,7 +215,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 		const nativeView = this.nativeTextViewProtected;
 		try {
 			this._changeFromCode = true;
-			nativeView.setInputType(inputType);
+			nativeView.setInputType(parseInt(<any>inputType,10));
 		} finally {
 			this._changeFromCode = false;
 		}
@@ -281,7 +280,12 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 				break;
 
 			default:
-				newInputType = value;
+				const inputType = +value;
+				if (!isNaN(inputType)) {
+					newInputType = inputType;
+				} else {
+					newInputType = android.text.InputType.TYPE_DATETIME_VARIATION_NORMAL;
+				}
 				break;
 		}
 
@@ -328,7 +332,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			case 'send':
 				newImeOptions = android.view.inputmethod.EditorInfo.IME_ACTION_SEND;
 				break;
-			default: {
+			default:{
 				const ime = +value;
 				if (!isNaN(ime)) {
 					newImeOptions = ime;
@@ -383,7 +387,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			case 'allcharacters':
 				inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS; //4096 (0x00010000) 13th bit
 				break;
-			default: {
+			default:{
 				const number = +value;
 				// We set the default value.
 				if (!isNaN(number)) {
@@ -465,17 +469,6 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
 			newFilters.push(lengthFilter);
 			this.nativeTextViewProtected.setFilters(newFilters);
-		}
-	}
-
-	public setSelection(start: number, stop?: number) {
-		const view = this.nativeTextViewProtected;
-		if (view) {
-			if (stop !== undefined) {
-				view.setSelection(start, stop);
-			} else {
-				view.setSelection(start);
-			}
 		}
 	}
 }

--- a/packages/core/ui/text-field/index.android.ts
+++ b/packages/core/ui/text-field/index.android.ts
@@ -27,6 +27,13 @@ export class TextField extends TextFieldBase {
 	setSecureAndKeyboardType(): void {
 		let inputType: number;
 
+		// Check for a passed in Number value
+		const value = +this.keyboardType;
+		if (!isNaN(value)) {
+			this._setInputType(value);
+			return;
+		}
+
 		// Password variations are supported only for Text and Number classes.
 		if (this.secure) {
 			if (this.keyboardType === 'number') {


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Passing in a number value for the Android Keyboard type is supposed to be supported, however it wasn't converting the "string" value to a number.

## What is the new behavior?
It will now convert the number to a string.

