### PR TITLE
feat: allow property overrides at runtime

### DIFF
--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -557,7 +557,7 @@ export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> imp
 							}
 						} else {
 							if (childValueSource <= ValueSource.Inherited) {
-								setFunc(ValueSource.Inherited).call(child, newValue);
+								setInheritedValue.call(child, newValue);
 							}
 						}
 
@@ -566,7 +566,8 @@ export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> imp
 				}
 			};
 
-		this.setInheritedValue = setFunc(ValueSource.Inherited);
+		const setInheritedValue = setFunc(ValueSource.Inherited);
+		this.setInheritedValue = setInheritedValue;
 
 		this.set = setFunc(ValueSource.Local);
 
@@ -1205,7 +1206,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 							}
 						} else {
 							if (childValueSource <= ValueSource.Inherited) {
-								setFunc(ValueSource.Inherited).call(childStyle, value);
+								setInheritedFunc.call(childStyle, value);
 							}
 						}
 
@@ -1215,8 +1216,9 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 			};
 
 		const setDefaultFunc = setFunc(ValueSource.Default);
+		const setInheritedFunc = setFunc(ValueSource.Inherited);
 
-		this.setInheritedValue = setFunc(ValueSource.Inherited);
+		this.setInheritedValue = setInheritedFunc;
 		this.cssValueDescriptor.set = setFunc(ValueSource.Css);
 		this.localValueDescriptor.set = setFunc(ValueSource.Local);
 

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -3,7 +3,7 @@ import * as reduceCSSCalc from 'reduce-css-calc';
 import { ViewBase } from '../view-base';
 
 // Types.
-import { WrappedValue, PropertyChangeData } from '../../../data/observable';
+import { PropertyChangeData, WrappedValue } from '../../../data/observable';
 import { Trace } from '../../../trace';
 
 import { Style } from '../../styling/style';
@@ -11,7 +11,7 @@ import { Style } from '../../styling/style';
 import { profile } from '../../../profiling';
 
 /**
- * Value specifing that Property should be set to its initial value.
+ * Value specifying that Property should be set to its initial value.
  */
 export const unsetValue: any = new Object();
 
@@ -183,6 +183,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 
 	public get: () => U;
 	public set: (value: U) => void;
+	public overrideHandlers: (options: PropertyOptions<T, U>) => void;
 	public enumerable = true;
 	public configurable = true;
 
@@ -206,10 +207,26 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 		this.defaultValue = defaultValue;
 
 		const eventName = propertyName + 'Change';
-		const equalityComparer = options.equalityComparer;
-		const affectsLayout: boolean = options.affectsLayout;
-		const valueChanged = options.valueChanged;
-		const valueConverter = options.valueConverter;
+
+		let equalityComparer = options.equalityComparer;
+		let affectsLayout: boolean = options.affectsLayout;
+		let valueChanged = options.valueChanged;
+		let valueConverter = options.valueConverter;
+
+		this.overrideHandlers = function (options: PropertyOptions<T, U>) {
+			if (typeof options.equalityComparer !== 'undefined') {
+				equalityComparer = options.equalityComparer;
+			}
+			if (typeof options.affectsLayout !== 'undefined') {
+				affectsLayout = options.affectsLayout;
+			}
+			if (typeof options.valueChanged !== 'undefined') {
+				valueChanged = options.valueChanged;
+			}
+			if (typeof options.valueConverter !== 'undefined') {
+				valueConverter = options.valueConverter;
+			}
+		};
 
 		const property = this;
 
@@ -364,13 +381,31 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
 		const coerceKey = Symbol(propertyName + ':coerceKey');
 
 		const eventName = propertyName + 'Change';
-		const affectsLayout: boolean = options.affectsLayout;
-		const equalityComparer = options.equalityComparer;
-		const valueChanged = options.valueChanged;
-		const valueConverter = options.valueConverter;
-		const coerceCallback = options.coerceValue;
+		let affectsLayout: boolean = options.affectsLayout;
+		let equalityComparer = options.equalityComparer;
+		let valueChanged = options.valueChanged;
+		let valueConverter = options.valueConverter;
+		let coerceCallback = options.coerceValue;
 
 		const property = this;
+
+		this.overrideHandlers = function (options: CoerciblePropertyOptions<T, U>) {
+			if (typeof options.equalityComparer !== 'undefined') {
+				equalityComparer = options.equalityComparer;
+			}
+			if (typeof options.affectsLayout !== 'undefined') {
+				affectsLayout = options.affectsLayout;
+			}
+			if (typeof options.valueChanged !== 'undefined') {
+				valueChanged = options.valueChanged;
+			}
+			if (typeof options.valueConverter !== 'undefined') {
+				valueConverter = options.valueConverter;
+			}
+			if (typeof options.coerceValue !== 'undefined') {
+				coerceCallback = options.coerceValue;
+			}
+		};
 
 		this.coerce = function (target: T): void {
 			const originalValue: U = coerceKey in target ? target[coerceKey] : defaultValue;
@@ -522,7 +557,7 @@ export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> imp
 							}
 						} else {
 							if (childValueSource <= ValueSource.Inherited) {
-								setInheritedValue.call(child, newValue);
+								setFunc(ValueSource.Inherited).call(child, newValue);
 							}
 						}
 
@@ -531,8 +566,7 @@ export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> imp
 				}
 			};
 
-		const setInheritedValue = setFunc(ValueSource.Inherited);
-		this.setInheritedValue = setInheritedValue;
+		this.setInheritedValue = setFunc(ValueSource.Inherited);
 
 		this.set = setFunc(ValueSource.Local);
 
@@ -558,6 +592,8 @@ export class CssProperty<T extends Style, U> implements CssProperty<T, U> {
 	public readonly sourceKey: symbol;
 	public readonly defaultValueKey: symbol;
 	public readonly defaultValue: U;
+
+	public overrideHandlers: (options: CssPropertyOptions<T, U>) => void;
 
 	constructor(options: CssPropertyOptions<T, U>) {
 		const propertyName = options.name;
@@ -587,10 +623,25 @@ export class CssProperty<T extends Style, U> implements CssProperty<T, U> {
 		this.defaultValue = defaultValue;
 
 		const eventName = propertyName + 'Change';
-		const affectsLayout: boolean = options.affectsLayout;
-		const equalityComparer = options.equalityComparer;
-		const valueChanged = options.valueChanged;
-		const valueConverter = options.valueConverter;
+		let affectsLayout: boolean = options.affectsLayout;
+		let equalityComparer = options.equalityComparer;
+		let valueChanged = options.valueChanged;
+		let valueConverter = options.valueConverter;
+
+		this.overrideHandlers = function (options: CssPropertyOptions<T, U>) {
+			if (typeof options.equalityComparer !== 'undefined') {
+				equalityComparer = options.equalityComparer;
+			}
+			if (typeof options.affectsLayout !== 'undefined') {
+				affectsLayout = options.affectsLayout;
+			}
+			if (typeof options.valueChanged !== 'undefined') {
+				valueChanged = options.valueChanged;
+			}
+			if (typeof options.valueConverter !== 'undefined') {
+				valueConverter = options.valueConverter;
+			}
+		};
 
 		const property = this;
 
@@ -1015,6 +1066,7 @@ CssAnimationProperty.prototype.isStyleProperty = true;
 
 export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> implements InheritedCssProperty<T, U> {
 	public setInheritedValue: (value: U) => void;
+	public overrideHandlers: (options: CssPropertyOptions<T, U>) => void;
 
 	constructor(options: CssPropertyOptions<T, U>) {
 		super(options);
@@ -1027,13 +1079,28 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 		const defaultValueKey = this.defaultValueKey;
 
 		const eventName = propertyName + 'Change';
-		const defaultValue: U = options.defaultValue;
-		const affectsLayout: boolean = options.affectsLayout;
-		const equalityComparer = options.equalityComparer;
-		const valueChanged = options.valueChanged;
-		const valueConverter = options.valueConverter;
+		let defaultValue: U = options.defaultValue;
+		let affectsLayout: boolean = options.affectsLayout;
+		let equalityComparer = options.equalityComparer;
+		let valueChanged = options.valueChanged;
+		let valueConverter = options.valueConverter;
 
 		const property = this;
+
+		this.overrideHandlers = function (options: CssPropertyOptions<T, U>) {
+			if (typeof options.equalityComparer !== 'undefined') {
+				equalityComparer = options.equalityComparer;
+			}
+			if (typeof options.affectsLayout !== 'undefined') {
+				affectsLayout = options.affectsLayout;
+			}
+			if (typeof options.valueChanged !== 'undefined') {
+				valueChanged = options.valueChanged;
+			}
+			if (typeof options.valueConverter !== 'undefined') {
+				valueConverter = options.valueConverter;
+			}
+		};
 
 		const setFunc = (valueSource: ValueSource) =>
 			function (this: T, boxedValue: any): void {
@@ -1138,7 +1205,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 							}
 						} else {
 							if (childValueSource <= ValueSource.Inherited) {
-								setInheritedFunc.call(childStyle, value);
+								setFunc(ValueSource.Inherited).call(childStyle, value);
 							}
 						}
 
@@ -1148,9 +1215,8 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 			};
 
 		const setDefaultFunc = setFunc(ValueSource.Default);
-		const setInheritedFunc = setFunc(ValueSource.Inherited);
 
-		this.setInheritedValue = setInheritedFunc;
+		this.setInheritedValue = setFunc(ValueSource.Inherited);
 		this.cssValueDescriptor.set = setFunc(ValueSource.Css);
 		this.localValueDescriptor.set = setFunc(ValueSource.Local);
 


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: 
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In NativeScript 6, we were able to override the entire property itself.   Unfortunately when moving to NS 7, you can no longer override the property once it has been created.   This breaks a plugin that I frequently use  (Since NS 2) in my apps, that needs to override the some properties valueChanges and valueConverter functions.   

## What is the new behavior?
This adds a new "function"  `overrideHandlers`  to several of the property types which allows you to pass in the same options as at creation time, and if any of them exist in the new options array it replaces the existing property handler.  

## Notes:
I have opened a RFC here to replace the property system in NS 8(?) (https://github.com/NativeScript/rfcs/discussions/29) as this is really more of a hack so that we don't have to make any breaking changes to the property system at this point while still allowing the property to be changed at runtime to allow a some plugins to continue to work.   

