### PR TITLE
feat(webpack): filter common undesirable warnings by default

### DIFF
--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -47,6 +47,7 @@
 		"webpack-bundle-analyzer": "^4.4.0",
 		"webpack-chain": "^6.5.1",
 		"webpack-cli": "^4.5.0",
+		"webpack-filter-warnings-plugin": "^1.2.1",
 		"webpack-merge": "^5.4.0",
 		"webpack-virtual-modules": "^0.4.2",
 		"worker-plugin": "^5.0.0"

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -3,9 +3,9 @@ import Config from 'webpack-chain';
 import { resolve } from 'path';
 
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
-import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 
 // import { WatchStateLoggerPlugin } from '../plugins/WatchStateLoggerPlugin';

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
+import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 
 // import { WatchStateLoggerPlugin } from '../plugins/WatchStateLoggerPlugin';
@@ -232,6 +233,13 @@ export default function (config: Config, env: IWebpackEnv): Config {
 	config.plugin('PlatformSuffixPlugin').use(PlatformSuffixPlugin, [
 		{
 			platform,
+		},
+	]);
+
+	// useful for filtering common undesirable warnings
+	config.plugin('FilterWarningsPlugin').use(FilterWarningsPlugin, [
+		{
+			exclude: /System.import/,
 		},
 	]);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Undesirable warnings display during webpack build.
For example:
```
WARNING in ./node_modules/@angular/core/fesm2015/core.js 29714:15-102
System.import() is deprecated and will be removed soon. Use import() instead.
For more info visit https://webpack.js.org/guides/code-splitting/
```

## What is the new behavior?

Clean build output.

