### PR TITLE
fix(bottom-navigation): android light/dark theme change on device crash

### DIFF
--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -744,7 +744,12 @@ export class BottomNavigation extends TabNavigationBase {
     }
 
     public updateAndroidItemAt(index: number, spec: org.nativescript.widgets.TabItemSpec) {
-        this._bottomNavigationBar.updateItemAt(index, spec);
+        // this can throw when switching light/dark theme mode on device, just ignore
+        try {
+            this._bottomNavigationBar.updateItemAt(index, spec);
+        } catch (err) {
+            // ignore
+        }
     }
 
     public getTabBarBackgroundColor(): android.graphics.drawable.Drawable {

--- a/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
+++ b/nativescript-core/ui/bottom-navigation/bottom-navigation.android.ts
@@ -830,13 +830,18 @@ export class BottomNavigation extends TabNavigationBase {
     }
 
     private setIconColor(tabStripItem: TabStripItem, color?: Color) {
-        const tabBarItem = this._bottomNavigationBar.getViewForItemAt(tabStripItem._index);
+        // this can throw when switching light/dark theme mode on device, just ignore
+        try {
+            const tabBarItem = this._bottomNavigationBar.getViewForItemAt(tabStripItem._index);
 
-        const drawableInfo = this.getIconInfo(tabStripItem, color);
-        const imgView = <android.widget.ImageView>tabBarItem.getChildAt(0);
-        imgView.setImageDrawable(drawableInfo.drawable);
-        if (color) {
-            imgView.setColorFilter(color.android);
+            const drawableInfo = this.getIconInfo(tabStripItem, color);
+            const imgView = <android.widget.ImageView>tabBarItem.getChildAt(0);
+            imgView.setImageDrawable(drawableInfo.drawable);
+            if (color) {
+                imgView.setColorFilter(color.android);
+            }
+        } catch (err) {
+            // ignore
         }
     }
 


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

background the app, go to settings, change to light / dark theme, resume the app, the app crashes with:

```
System.err: An uncaught Exception occurred on "main" thread.
System.err: Calling js method onStart failed
System.err: Error: java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.View android.widget.LinearLayout.getChildAt(int)' on a null object reference
System.err: 
System.err: StackTrace:
System.err: push.../node_modules/@nativescript/core/ui/bottom-navigation/bottom-navigation.js.BottomNavigation.updateAndroidItemAt(file: node_modules/@nativescript/core/ui/bottom-navigation/bottom-navigation.android.js:580:0)
```

## What is the new behavior?

Android apps can change device dark/light theme anytime with no crash.

