### PR TITLE
fix(ios): incorrect declaration of 'jsArrayToNSArray' and 'nsArrayToJSArray'

### DIFF
--- a/packages/core/utils/native-helper.d.ts
+++ b/packages/core/utils/native-helper.d.ts
@@ -112,13 +112,13 @@ export namespace iOSNativeHelper {
 		 * Converts JavaScript array to [NSArray](https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSArray_Class/).
 		 * @param str - JavaScript string array to convert.
 		 */
-		export function jsArrayToNSArray(str: string[]): any;
+		export function jsArrayToNSArray<T>(str: T[]): NSArray<T>;
 
 		/**
 		 * Converts NSArray to JavaScript array.
 		 * @param a - NSArray to convert.
 		 */
-		export function nsArrayToJSArray(a: any): string[];
+		export function nsArrayToJSArray<T>(a: NSArray<T>): T[];
 	}
 
 	/**

--- a/packages/core/utils/native-helper.ios.ts
+++ b/packages/core/utils/native-helper.ios.ts
@@ -36,11 +36,11 @@ export namespace iOSNativeHelper {
 	}
 
 	export namespace collections {
-		export function jsArrayToNSArray(str: string[]): NSArray<any> {
-			return NSArray.arrayWithArray(<any>str);
+		export function jsArrayToNSArray<T>(str: T[]): NSArray<T> {
+			return NSArray.arrayWithArray(str);
 		}
 
-		export function nsArrayToJSArray(a: NSArray<any>): Array<Object> {
+		export function nsArrayToJSArray<T>(a: NSArray<T>): Array<T> {
 			const arr = [];
 			if (a !== undefined) {
 				const count = a.count;


### PR DESCRIPTION
Fixes incorrect declaration of ```Utils.ios.collections.jsArrayToNSArray``` and ```Utils.ios.collections.nsArrayToJSArray``` where accepted and returned ```string[]``` regardless of type of the input parameter.