### PR TITLE
WIP: feat!: update svelte config to use svelte-loader

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`svelte configuration for android 1`] = `
     '~/package.json'
   ],
   devtool: 'inline-source-map',
-  target: 'node',
+  target: 'electron-main',
   watchOptions: {
     ignored: [
       '__jest__/platforms/**',
@@ -30,7 +30,8 @@ exports[`svelte configuration for android 1`] = `
     symlinks: true,
     alias: {
       '~': '__jest__/src',
-      '@': '__jest__/src'
+      '@': '__jest__/src',
+      'tns-core-modules': '@nativescript/core'
     },
     extensions: [
       '.android.svelte',
@@ -122,7 +123,7 @@ exports[`svelte configuration for android 1`] = `
       },
       /* config.module.rule('workers') */
       {
-        test: /\\\\.(js|ts)$/,
+        test: /\\\\.(js|ts|svelte)$/,
         exclude: [
           /node_modules/
         ],
@@ -194,18 +195,19 @@ exports[`svelte configuration for android 1`] = `
           /node_modules/
         ],
         use: [
-          /* config.module.rule('svelte').use('svelte-loader-hot') */
+          /* config.module.rule('svelte').use('svelte-loader') */
           {
-            loader: 'svelte-loader-hot',
+            loader: 'svelte-loader',
             options: {
-              dev: true,
+              compilerOptions: {
+                dev: true
+              },
               preprocess: undefined,
               hotReload: true,
               hotOptions: {
                 injectCss: false,
                 'native': true
-              },
-              onwarn: function () { /* omitted long function */ }
+              }
             }
           }
         ]
@@ -324,7 +326,7 @@ exports[`svelte configuration for ios 1`] = `
     '~/package.json'
   ],
   devtool: 'inline-source-map',
-  target: 'node',
+  target: 'electron-main',
   watchOptions: {
     ignored: [
       '__jest__/platforms/**',
@@ -346,7 +348,8 @@ exports[`svelte configuration for ios 1`] = `
     symlinks: true,
     alias: {
       '~': '__jest__/src',
-      '@': '__jest__/src'
+      '@': '__jest__/src',
+      'tns-core-modules': '@nativescript/core'
     },
     extensions: [
       '.ios.svelte',
@@ -438,7 +441,7 @@ exports[`svelte configuration for ios 1`] = `
       },
       /* config.module.rule('workers') */
       {
-        test: /\\\\.(js|ts)$/,
+        test: /\\\\.(js|ts|svelte)$/,
         exclude: [
           /node_modules/
         ],
@@ -510,18 +513,19 @@ exports[`svelte configuration for ios 1`] = `
           /node_modules/
         ],
         use: [
-          /* config.module.rule('svelte').use('svelte-loader-hot') */
+          /* config.module.rule('svelte').use('svelte-loader') */
           {
-            loader: 'svelte-loader-hot',
+            loader: 'svelte-loader',
             options: {
-              dev: true,
+              compilerOptions: {
+                dev: true
+              },
               preprocess: undefined,
               hotReload: true,
               hotOptions: {
                 injectCss: false,
                 'native': true
-              },
-              onwarn: function () { /* omitted long function */ }
+              }
             }
           }
         ]

--- a/packages/webpack5/src/configuration/svelte.ts
+++ b/packages/webpack5/src/configuration/svelte.ts
@@ -24,6 +24,9 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	// the order is reversed because we are using prepend!
 	config.resolve.extensions.prepend('.svelte').prepend(`.${platform}.svelte`);
 
+	// add worker support to .svelte files (new Worker('./path'))
+	config.module.rule('workers').test(/\.(js|ts|svelte)$/);
+
 	// add a rule for .svelte files
 	config.module
 		.rule('svelte')
@@ -48,6 +51,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 				},
 			};
 		});
+
 	return config;
 }
 

--- a/packages/webpack5/src/configuration/svelte.ts
+++ b/packages/webpack5/src/configuration/svelte.ts
@@ -1,6 +1,6 @@
 import Config from 'webpack-chain';
 
-import { getProjectFilePath, getProjectRootPath } from '../helpers/project';
+import { getProjectFilePath } from '../helpers/project';
 import { getPlatformName } from '../helpers/platform';
 import { env as _env, IWebpackEnv } from '../index';
 import { error } from '../helpers/log';
@@ -13,47 +13,47 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	const mode = env.production ? 'production' : 'development';
 	const production = mode === 'production';
 
+	// target('node') is the default but causes svelte-loader to detect it as a "server" render, disabling HMR
+	// electron-main sneaks us past the target == 'node' check and gets us HMR
+	config.target('electron-main');
+
+	// svelte-hmr still references tns-core-modules, so we shim it here for compat.
+	config.resolve.alias.set('tns-core-modules', '@nativescript/core');
+
 	// resolve .svelte files
 	// the order is reversed because we are using prepend!
 	config.resolve.extensions.prepend('.svelte').prepend(`.${platform}.svelte`);
+
 	// add a rule for .svelte files
 	config.module
 		.rule('svelte')
 		.test(/\.svelte$/)
 		.exclude.add(/node_modules/)
 		.end()
-		.use('svelte-loader-hot')
-		.loader('svelte-loader-hot')
+		.use('svelte-loader')
+		.loader('svelte-loader')
 		.tap((options) => {
+			const svelteConfig = getSvelteConfig();
 			return {
 				...options,
-				dev: !production,
-				preprocess: getSvelteConfigPreprocessor(),
+				compilerOptions: {
+					...svelteConfig.compilerOptions,
+					dev: !production,
+				},
+				preprocess: svelteConfig?.preprocess,
 				hotReload: !production,
 				hotOptions: {
 					injectCss: false,
 					native: true,
 				},
-				// Suppress A11y warnings
-				onwarn(warning, warn) {
-					if (!/A11y:/.test(warning.message)) {
-						warn(warning);
-					}
-				},
 			};
 		});
-
 	return config;
-}
-
-function getSvelteConfigPreprocessor(): any {
-	const config = getSvelteConfig();
-
-	return config?.preprocess;
 }
 
 interface ISvelteConfig {
 	preprocess: any;
+	compilerOptions: any;
 }
 
 function getSvelteConfig(): ISvelteConfig | undefined {

--- a/packages/webpack5/src/configuration/svelte.ts
+++ b/packages/webpack5/src/configuration/svelte.ts
@@ -37,7 +37,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			return {
 				...options,
 				compilerOptions: {
-					...svelteConfig.compilerOptions,
+					...svelteConfig?.compilerOptions,
 					dev: !production,
 				},
 				preprocess: svelteConfig?.preprocess,


### PR DESCRIPTION
These are the changes that should be made for the svelte webpack config.  Main changes are:

* Change target to `electron-main` this ensures we get HMR support from svelte loader (which disables hmr if target=='node')
* add `tns-core-modules` alias to `@nativescript/core` since `svelte-hmr` refers to tns-core-modules still
* Change loader from `svelte-loader-hot` to `svelte-loader` as HMR support has been merged into the official loader
* Import svelte compiler options from `svelte.config.js` this allows the code to set svelte compiler options such as dom namespace, which removes the a11y warnings from the output and forces case sensitive props. 

**Problem** :@rigor789 This is marked as WIP since I couldn't test this code. Building the new nativescript webpack5 package worked but when I link it against my demo project via `package.json` using `"@nativescript/webpack": "file:../../NativeScript/packages/webpack5",` I was getting errors deep in the guts of NativescriptHMRPlugin. How do I test this code during development?


BREAKING CHANGES:
Requires `svelte-loader` instead of `svelte-loader-hot`

Migration steps:
update project's package.json to include `svelte-loader` and remove `svelte-loader-hot`
