### PR TITLE
fix(core): Enums deprecation adjustment

### DIFF
--- a/packages/core/core-types/index.d.ts
+++ b/packages/core/core-types/index.d.ts
@@ -743,20 +743,6 @@ export type LengthType = CoreTypes.LengthType;
 export type PercentLengthType = CoreTypes.PercentLengthType;
 
 /**
- * @deprecated Use `CoreTypes` instead. Enums will be removed in 9.0
- */
-export namespace Enums {
-	export type DeviceOrientationType = CoreTypes.DeviceOrientationType;
-	export type HorizontalAlignmentType = CoreTypes.HorizontalAlignmentType;
-	export type VerticalAlignmentTextType = CoreTypes.VerticalAlignmentTextType;
-	export type VerticalAlignmentType = CoreTypes.VerticalAlignmentType;
-	export type OrientationType = CoreTypes.OrientationType;
-	export type TextAlignmentType = CoreTypes.TextAlignmentType;
-	export type TextTransformType = CoreTypes.TextTransformType;
-	export type VisibilityType = CoreTypes.VisibilityType;
-}
-
-/**
  * @deprecated Use `CoreTypes.AnimationCurve` instead.
  */
 export const AnimationCurve: typeof CoreTypes.AnimationCurve;
@@ -770,3 +756,38 @@ export type HorizontalAlignment = CoreTypes.HorizontalAlignmentType;
  * @deprecated Use `CoreTypes.VerticalAlignmentType` instead.
  */
 export type VerticalAlignment = CoreTypes.VerticalAlignmentType;
+
+/**
+ * @deprecated Use `CoreTypes` instead. Enums will be removed in 9.0
+ */
+export declare const Enums: {
+	Accuracy: typeof CoreTypes.Accuracy;
+	AndroidActionBarIconVisibility: typeof CoreTypes.AndroidActionBarIconVisibility;
+	AndroidActionItemPosition: typeof CoreTypes.AndroidActionItemPosition;
+	AnimationCurve: typeof CoreTypes.AnimationCurve;
+	AutocapitalizationType: typeof CoreTypes.AutocapitalizationType;
+	BackgroundRepeat: typeof CoreTypes.BackgroundRepeat;
+	DeviceOrientation: typeof CoreTypes.DeviceOrientation;
+	DeviceType: typeof CoreTypes.DeviceType;
+	Dock: typeof CoreTypes.Dock;
+	FontAttributes: typeof CoreTypes.FontAttributes;
+	FontStyle: typeof CoreTypes.FontStyle;
+	FontWeight: typeof CoreTypes.FontWeight;
+	HorizontalAlignment: typeof CoreTypes.HorizontalAlignment;
+	IOSActionItemPosition: typeof CoreTypes.IOSActionItemPosition;
+	ImageFormat: typeof CoreTypes.ImageFormat;
+	KeyboardType: typeof CoreTypes.KeyboardType;
+	NavigationBarVisibility: typeof CoreTypes.NavigationBarVisibility;
+	Orientation: typeof CoreTypes.Orientation;
+	ReturnKeyType: typeof CoreTypes.ReturnKeyType;
+	StatusBarStyle: typeof CoreTypes.StatusBarStyle;
+	Stretch: typeof CoreTypes.ImageStretch;
+	SystemAppearance: typeof CoreTypes.SystemAppearance;
+	TextAlignment: CoreTypes.TextAlignmentType;
+	TextDecoration: CoreTypes.TextDecorationType;
+	TextTransform: CoreTypes.TextTransformType;
+	UpdateTextTrigger: CoreTypes.UpdateTextTriggerType;
+	VerticalAlignment: CoreTypes.VerticalAlignmentType;
+	Visibility: CoreTypes.VisibilityType;
+	WhiteSpace: CoreTypes.WhiteSpaceType;
+};

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -307,20 +307,6 @@ export type LengthType = CoreTypes.LengthType;
 export type PercentLengthType = CoreTypes.PercentLengthType;
 
 /**
- * @deprecated Use `CoreTypes` instead. Enums will be removed in 9.0
- */
-export namespace Enums {
-	export type DeviceOrientationType = CoreTypes.DeviceOrientationType;
-	export type HorizontalAlignmentType = CoreTypes.HorizontalAlignmentType;
-	export type VerticalAlignmentTextType = CoreTypes.VerticalAlignmentTextType;
-	export type VerticalAlignmentType = CoreTypes.VerticalAlignmentType;
-	export type OrientationType = CoreTypes.OrientationType;
-	export type TextAlignmentType = CoreTypes.TextAlignmentType;
-	export type TextTransformType = CoreTypes.TextTransformType;
-	export type VisibilityType = CoreTypes.VisibilityType;
-}
-
-/**
  * @deprecated Use `CoreTypes.AnimationCurve` instead.
  */
 export const AnimationCurve = CoreTypes.AnimationCurve;
@@ -334,3 +320,38 @@ export type HorizontalAlignment = CoreTypes.HorizontalAlignmentType;
  * @deprecated Use `CoreTypes.VerticalAlignmentType` instead.
  */
 export type VerticalAlignment = CoreTypes.VerticalAlignmentType;
+
+/**
+ * @deprecated Use `CoreTypes` instead. Enums will be removed in 9.0
+ */
+export const Enums = {
+	Accuracy: CoreTypes.Accuracy,
+	AndroidActionBarIconVisibility: CoreTypes.AndroidActionBarIconVisibility,
+	AndroidActionItemPosition: CoreTypes.AndroidActionItemPosition,
+	AnimationCurve: CoreTypes.AnimationCurve,
+	AutocapitalizationType: CoreTypes.AutocapitalizationType,
+	BackgroundRepeat: CoreTypes.BackgroundRepeat,
+	DeviceOrientation: CoreTypes.DeviceOrientation,
+	DeviceType: CoreTypes.DeviceType,
+	Dock: CoreTypes.Dock,
+	FontAttributes: CoreTypes.FontAttributes,
+	FontStyle: CoreTypes.FontStyle,
+	FontWeight: CoreTypes.FontWeight,
+	HorizontalAlignment: CoreTypes.HorizontalAlignment,
+	IOSActionItemPosition: CoreTypes.IOSActionItemPosition,
+	ImageFormat: CoreTypes.ImageFormat,
+	KeyboardType: CoreTypes.KeyboardType,
+	NavigationBarVisibility: CoreTypes.NavigationBarVisibility,
+	Orientation: CoreTypes.Orientation,
+	ReturnKeyType: CoreTypes.ReturnKeyType,
+	StatusBarStyle: CoreTypes.StatusBarStyle,
+	Stretch: CoreTypes.ImageStretch,
+	SystemAppearance: CoreTypes.SystemAppearance,
+	TextAlignment: CoreTypes.TextAlignment,
+	TextDecoration: CoreTypes.TextDecoration,
+	TextTransform: CoreTypes.TextTransform,
+	UpdateTextTrigger: CoreTypes.UpdateTextTrigger,
+	VerticalAlignment: CoreTypes.VerticalAlignment,
+	Visibility: CoreTypes.Visibility,
+	WhiteSpace: CoreTypes.WhiteSpace,
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

`Enums` could not be used exactly as they were in 7.0.

## What is the new behavior?

`Enums` can be used as normal as they were in 7.0 and a proper deprecation is displayed to move to `CoreTypes`.

closes https://github.com/NativeScript/NativeScript/issues/9298

