### PR TITLE
fix: npm clean to ignore .idea / .vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.1",
   "license": "MIT",
   "scripts": {
-    "clean": "git clean -f -X -d",
+    "clean": "git clean -f -X -d --exclude=!.idea/ --exclude=!.vscode/*",
     "setup": "npm run clean && npm install",
     "setup:yarn": "yarn run clean && yarn",
     "setup:pnpm": "pnpm run clean && pnpm install",


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?
`npm run clean` will delete most editor files in the `.vscode`, and completely remove the `.idea`.   Under an intellij editor, this removal causes the editor to become unstable and crash or lockup.   So it is not recommended to clean the `.idea` folder.

## What is the new behavior?
Tells the git clean command to ignore the .idea and .vscode folders during a clean.


