### PR TITLE
fix: Accessibility breaks limiting metadata on Android

### DIFF
--- a/packages/core/platforms/android/native-api-usage.json
+++ b/packages/core/platforms/android/native-api-usage.json
@@ -24,6 +24,7 @@
         "androidx.core*:*",
         "androidx.viewpager.widget*:*",
         "androidx.fragment*:*",
-        "androidx.transition*:*"
+        "androidx.transition*:*",
+			  "android.inputmethodservice*:*"
     ]
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
If using limited metadata builds, the application will crash on startup on Android because of the new accessibility changes.

## What is the new behavior?
Application will no longer crash as we are adding the new class it needs to include metadata in the metadata exceptions list.

