### PR TITLE
fix: allow subclass to override createFormattedTextNative

### DIFF
--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -40,7 +40,7 @@ function initializeTextTransformation(): void {
 			// NOTE: Do we need to transform the new text here?
 			const formattedText = this.textBase.formattedText;
 			if (formattedText) {
-				return createSpannableStringBuilder(formattedText, (<android.widget.TextView>view).getTextSize());
+				return this.textBase.createFormattedTextNative(formattedText);
 			} else {
 				const text = this.textBase.text;
 				const stringValue = isNullOrUndefined(text) ? '' : text.toString();
@@ -233,7 +233,9 @@ export class TextBase extends TextBaseCommon {
 
 		this._setNativeText(reset);
 	}
-
+	createFormattedTextNative(value: FormattedString) {
+		return createSpannableStringBuilder(value, this.style.fontSize);
+	}
 	[formattedTextProperty.setNative](value: FormattedString) {
 		const nativeView = this.nativeTextViewProtected;
 		if (!value) {
@@ -247,7 +249,7 @@ export class TextBase extends TextBaseCommon {
 			return;
 		}
 
-		const spannableStringBuilder = createSpannableStringBuilder(value, this.style.fontSize);
+		const spannableStringBuilder = this.createFormattedTextNative(value);
 		nativeView.setText(<any>spannableStringBuilder);
 		this._setTappableState(isStringTappable(value));
 
@@ -443,7 +445,7 @@ export class TextBase extends TextBaseCommon {
 
 		let transformedText: any;
 		if (this.formattedText) {
-			transformedText = createSpannableStringBuilder(this.formattedText, this.style.fontSize);
+			transformedText = this.createFormattedTextNative(this.formattedText);
 		} else {
 			const text = this.text;
 			const stringValue = text === null || text === undefined ? '' : text.toString();

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -226,8 +226,11 @@ export class TextBase extends TextBaseCommon {
 		}
 	}
 
+	createFormattedTextNative(value: FormattedString) {
+		return this.createNSMutableAttributedString(value);
+	}
 	setFormattedTextDecorationAndTransform() {
-		const attrText = this.createNSMutableAttributedString(this.formattedText);
+		const attrText = this.createFormattedTextNative(this.formattedText);
 		// TODO: letterSpacing should be applied per Span.
 		if (this.letterSpacing !== 0) {
 			attrText.addAttributeValueRange(NSKernAttributeName, this.letterSpacing * this.nativeTextViewProtected.font.pointSize, { location: 0, length: attrText.length });


### PR DESCRIPTION
This PR adds move the generation of the native `FormattedString` to a class method so that it can be overriden by subclasses and plugins.
This is used, for example, by my `@nativescript-community/text` to override the default implementation for all `TextBase`  to make it faster and add more functionnalities.