### PR TITLE
fix(core): protected class getter webpack issue

### DIFF
--- a/apps/automated/package.json
+++ b/apps/automated/package.json
@@ -17,7 +17,7 @@
     "@nativescript/android": "7.0.1",
     "@nativescript/ios": "7.2.0",
     "@nativescript/webpack": "file:../../dist/packages/nativescript-webpack.tgz",
-    "typescript": "file:../../node_modules/typescript"
+    "typescript": "~4.0.0"
   },
   "gitHead": "c06800e52ee1a184ea2dffd12a6702aaa43be4e3",
   "readme": "NativeScript Application"

--- a/apps/toolbox/package.json
+++ b/apps/toolbox/package.json
@@ -14,6 +14,6 @@
     "@nativescript/android": "7.0.1",
     "@nativescript/ios": "7.2.0",
     "@nativescript/webpack": "file:../../dist/packages/nativescript-webpack.tgz",
-    "typescript": "4.0.7"
+    "typescript": "~4.0.0"
   }
 }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -14,7 +14,7 @@
     "@nativescript/android": "7.0.1",
     "@nativescript/ios": "7.2.0",
     "@nativescript/webpack": "file:../../dist/packages/nativescript-webpack.tgz",
-    "typescript": "file:../../node_modules/typescript"
+    "typescript": "~4.0.0"
   },
   "gitHead": "8ab7726d1ee9991706069c1359c552e67ee0d1a4",
   "readme": "NativeScript Application",

--- a/packages/core/trace/index.d.ts
+++ b/packages/core/trace/index.d.ts
@@ -121,7 +121,7 @@ export namespace Trace {
 		export const ModuleNameResolver = 'ModuleNameResolver';
 
 		export const separator = ',';
-		export const All: Array<string>;
+		export const All: string;
 
 		export function concat(...args: any): string;
 	}

--- a/packages/core/trace/index.ts
+++ b/packages/core/trace/index.ts
@@ -203,7 +203,7 @@ export namespace Trace {
 		export const ModuleNameResolver = 'ModuleNameResolver';
 
 		export const separator = ',';
-		export const All = [VisualTreeEvents, Layout, Style, ViewHierarchy, NativeLifecycle, Debug, Navigation, Test, Binding, Error, Animation, Transition, Livesync, ModuleNameResolver].join(separator);
+		export const All: string = [VisualTreeEvents, Layout, Style, ViewHierarchy, NativeLifecycle, Debug, Navigation, Test, Binding, Error, Animation, Transition, Livesync, ModuleNameResolver].join(separator);
 
 		export function concat(...args: any): string {
 			let result: string;

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -389,10 +389,10 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		return this._isLoaded;
 	}
 
-	get class(): string {
+	get ['class'](): string {
 		return this.className;
 	}
-	set class(v: string) {
+	set ['class'](v: string) {
 		this.className = v;
 	}
 


### PR DESCRIPTION
## What is the current behavior?

webpack loader can cause build failure due to protected `class` getter/setters in view-base.

```
ERROR in ./node_modules/@nativescript/core/ui/core/view-base/index.js 199:8
Module parse failed: Unexpected token (199:8)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|         return this._isLoaded;
|     }
>     get class() {
|         return this.className;
|     }
 @ ./node_modules/@nativescript/core/ui/index.js 10:0-104 10:0-104 10:0-104 10:0-104 10:0-104 10:0-104
 @ ./node_modules/@nativescript/core/bundle-entry-points.js 5:0-44 6:53-66
 @ ./app/__@nativescript_webpack_virtual_entry_typescript__ 2:0-49
```

## What is the new behavior?

Builds successfully.

This PR also includes:
* typings correction to Trace.categories.All
* npm 7 issue with typescript being includes as file ref

