### PR TITLE
fix(webpack): compilation errors should no longer ignored

### DIFF
--- a/packages/webpack5/src/bin/index.ts
+++ b/packages/webpack5/src/bin/index.ts
@@ -98,6 +98,9 @@ program
 			}
 
 			if (stats) {
+				// Set the process exit code depending on errors
+				process.exitCode = stats.hasErrors() ? 1 : 0;
+
 				console.log(
 					stats.toString({
 						chunks: false,

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -231,6 +231,11 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			.plugin('ForkTsCheckerWebpackPlugin')
 			.use(ForkTsCheckerWebpackPlugin, [
 				{
+					// If we use "async" errors compiling typescript will be ignored by
+					// WebPack (we will send the "compilation" message back to the CLI,
+					// and the process exit code will be zero), therefore we will end
+					// up with a broken build
+					async: false,
 					typescript: {
 						memoryLimit: 4096,
 					},

--- a/packages/webpack5/src/plugins/WatchStatePlugin.ts
+++ b/packages/webpack5/src/plugins/WatchStatePlugin.ts
@@ -48,9 +48,15 @@ export class WatchStatePlugin {
 				isWatchMode ? messages.startWatching : messages.compilationComplete
 			);
 
+			// Do not notify the CLI if the compilation failed
+			const stats = compilation.getStats();
+			if (stats.hasErrors()) {
+				return;
+			}
+
 			// logic taken from CleanWebpackPlugin
 			const assets =
-				compilation.getStats().toJson(
+				stats.toJson(
 					{
 						assets: true,
 					},


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

When something is broken within WebPack compilation, the NativeScript WebPack CLI will simply ignore those and let the NativeScript CLI continue with the build as if nothing happened...

## What is the new behavior?

When the WebPack build fails, also the NativeScript build should fail.