### PR TITLE
fix(layouts): prevent android touch event to pass through views underneath

### DIFF
--- a/packages/core/ui/layouts/root-layout/index.android.ts
+++ b/packages/core/ui/layouts/root-layout/index.android.ts
@@ -10,6 +10,26 @@ export class RootLayout extends RootLayoutBase {
 		super();
 	}
 
+	insertChild(view: View, atIndex: number): void {
+		super.insertChild(view, atIndex);
+		if (!view.hasGestureObservers()) {
+			// block tap events from going through to layers behind the view
+			view.nativeViewProtected.setOnTouchListener(
+				new android.view.View.OnTouchListener({
+					onTouch: function (view, event) {
+						return true;
+					},
+				})
+			);
+		}
+	}
+	removeChild(view: View): void {
+		if (view.hasGestureObservers()) {
+			view.nativeViewProtected.setOnTouchListener(null);
+		}
+		super.removeChild(view);
+	}
+
 	protected _bringToFront(view: View) {
 		(<android.view.View>view.nativeViewProtected).bringToFront();
 	}


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When there is no tap event on a view that is added dynamically via RootLayout, tap events are passing through the views underneath it on Android

## What is the new behavior?
<!-- Describe the changes. -->
Dynamic views added via RootLayout catches tap events and doesn't let it pass through views underneath it

Fixes/Implements/Closes #9340.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

