### PR TITLE
feat: don't cache device language & region

### DIFF
--- a/packages/core/platform/index.android.ts
+++ b/packages/core/platform/index.android.ts
@@ -67,8 +67,6 @@ class DeviceRef {
 	private _sdkVersion: string;
 	private _deviceType: 'Phone' | 'Tablet';
 	private _uuid: string;
-	private _language: string;
-	private _region: string;
 
 	get manufacturer(): string {
 		if (!this._manufacturer) {
@@ -130,19 +128,11 @@ class DeviceRef {
 	}
 
 	get language(): string {
-		if (!this._language) {
-			this._language = java.util.Locale.getDefault().getLanguage().replace('_', '-');
-		}
-
-		return this._language;
+		return java.util.Locale.getDefault().getLanguage().replace('_', '-');
 	}
 
 	get region(): string {
-		if (!this._region) {
-			this._region = java.util.Locale.getDefault().getCountry();
-		}
-
-		return this._region;
+		return java.util.Locale.getDefault().getCountry();
 	}
 }
 

--- a/packages/core/platform/index.ios.ts
+++ b/packages/core/platform/index.ios.ts
@@ -10,8 +10,6 @@ class DeviceRef {
 	private _osVersion: string;
 	private _sdkVersion: string;
 	private _deviceType: 'Phone' | 'Tablet';
-	private _language: string;
-	private _region: string;
 
 	get manufacturer(): string {
 		return 'Apple';
@@ -72,20 +70,11 @@ class DeviceRef {
 	}
 
 	get language(): string {
-		if (!this._language) {
-			const languages = NSLocale.preferredLanguages;
-			this._language = languages[0];
-		}
-
-		return this._language;
+		return NSLocale.preferredLanguages[0];
 	}
 
 	get region(): string {
-		if (!this._region) {
-			this._region = NSLocale.currentLocale.objectForKey(NSLocaleCountryCode);
-		}
-
-		return this._region;
+		return NSLocale.currentLocale.objectForKey(NSLocaleCountryCode);
 	}
 }
 


### PR DESCRIPTION
Returning to the app after language/region change will correctly reflect w/o restarting the app