### PR TITLE
fix(a11y): add missing application event for `fontScaleChanged`

### DIFF
--- a/packages/core/accessibility/font-scale.android.ts
+++ b/packages/core/accessibility/font-scale.android.ts
@@ -11,6 +11,7 @@ function fontScaleChanged(origFontScale: number) {
 		Application.notify({
 			eventName: Application.fontScaleChangedEvent,
 			object: Application,
+			newValue: currentFontScale,
 		});
 	}
 }

--- a/packages/core/accessibility/font-scale.ios.ts
+++ b/packages/core/accessibility/font-scale.ios.ts
@@ -11,6 +11,7 @@ function fontScaleChanged(origFontScale: number) {
 		Application.notify({
 			eventName: Application.fontScaleChangedEvent,
 			object: Application,
+			newValue: currentFontScale,
 		});
 	}
 }

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -136,6 +136,16 @@ export interface SystemAppearanceChangedEventData extends ApplicationEventData {
 }
 
 /**
+ * Event data containing information for font scale changed event.
+ */
+export interface FontScaleChangedEventData extends ApplicationEventData {
+	/**
+	 * New font scale value.
+	 */
+	newValue: number;
+}
+
+/**
  * Event data containing information about unhandled application errors.
  */
 export interface UnhandledErrorEventData extends ApplicationEventData {
@@ -327,6 +337,8 @@ export function on(event: 'orientationChanged', callback: (args: OrientationChan
  * between light and dark mode (for iOS) and vice versa.
  */
 export function on(event: 'systemAppearanceChanged', callback: (args: SystemAppearanceChangedEventData) => void, thisArg?: any);
+
+export function on(event: 'fontScaleChanged', callback: (args: FontScaleChangedEventData) => void, thisArg?: any);
 
 /**
  * Gets the orientation of the application.

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -20,6 +20,7 @@ export declare const Application: {
 	lowMemoryEvent: string;
 	orientationChangedEvent: string;
 	systemAppearanceChangedEvent: string;
+	fontScaleChangedEvent: string;
 	systemAppearanceChanged: typeof systemAppearanceChanged;
 	getMainEntry: typeof getMainEntry;
 	getRootView: typeof getRootView;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,7 +5,7 @@ import './globals';
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
 
-import { launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance } from './application';
+import { fontScaleChangedEvent, launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance } from './application';
 export const Application = {
 	launchEvent,
 	displayedEvent,
@@ -18,6 +18,7 @@ export const Application = {
 	orientationChangedEvent,
 	systemAppearanceChangedEvent,
 	systemAppearanceChanged,
+	fontScaleChangedEvent,
 
 	getMainEntry,
 	getRootView,


### PR DESCRIPTION
The `fontScaleChanged` event was wired up, but not exposed as part of the `Application` events. This PR adds `fontScaleChanged` to `Application` so you can use it as follows:

```typescript
Application.on(Application.fontScaleChangedEvent, (args) => {
  console.log('fontScaleChangedEvent newValue', args.newValue);
});
```

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

