### PR TITLE
fix(core): guard unstable init contexts under async conditions

### DIFF
--- a/packages/core/ui/action-bar/index.ios.ts
+++ b/packages/core/ui/action-bar/index.ios.ts
@@ -353,6 +353,9 @@ export class ActionBar extends ActionBarBase {
 	}
 
 	private setColor(navBar: UINavigationBar, color?: Color) {
+		if (!navBar) {
+			return;
+		}
 		if (color) {
 			navBar.titleTextAttributes = <any>{
 				[NSForegroundColorAttributeName]: color.ios,
@@ -443,13 +446,12 @@ export class ActionBar extends ActionBarBase {
 	}
 
 	private get navBar(): UINavigationBar {
-		const page = this.page;
 		// Page should be attached to frame to update the action bar.
-		if (!page || !page.frame) {
+		if (this.page?.frame?.ios?.controller) {
+			return (<UINavigationController>this.page.frame.ios.controller).navigationBar;
+		} else {
 			return undefined;
 		}
-
-		return (<UINavigationController>page.frame.ios.controller).navigationBar;
 	}
 
 	[colorProperty.getDefault](): UIColor {

--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -224,7 +224,7 @@ export class Frame extends FrameBase {
 			this._ios._disableNavBarAnimation = disableNavBarAnimationCache;
 		}
 
-		if (this._ios.controller.navigationBar) {
+		if (this._ios.controller?.navigationBar) {
 			this._ios.controller.navigationBar.userInteractionEnabled = this.navigationQueueIsEmpty();
 		}
 
@@ -666,7 +666,9 @@ class iOSFrame implements iOSFrameDefinition {
 	}
 	public set showNavigationBar(value: boolean) {
 		this._showNavigationBar = value;
-		this._controller.setNavigationBarHiddenAnimated(!value, !this._disableNavBarAnimation);
+		if (this._controller) {
+			this._controller.setNavigationBarHiddenAnimated(!value, !this._disableNavBarAnimation);
+		}
 	}
 
 	public get navBarVisibility(): 'auto' | 'never' | 'always' {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -177,7 +177,7 @@ class UIViewControllerImpl extends UIViewController {
 			}
 
 			// If page was shown with custom animation - we need to set the navigationController.delegate to the animatedDelegate.
-			if (frame.ios && frame.ios.controller) {
+			if (frame.ios?.controller) {
 				frame.ios.controller.delegate = this[DELEGATE];
 			}
 

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -177,7 +177,9 @@ class UIViewControllerImpl extends UIViewController {
 			}
 
 			// If page was shown with custom animation - we need to set the navigationController.delegate to the animatedDelegate.
-			frame.ios.controller.delegate = this[DELEGATE];
+			if (frame.ios && frame.ios.controller) {
+				frame.ios.controller.delegate = this[DELEGATE];
+			}
 
 			frame._processNavigationQueue(owner);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Under various async conditions of initializing an application on boot (for example the new Angular 12 integration coming soon provides more flexibility around boot conditions), these areas of core were frail and subject to crashes.

## What is the new behavior?

Guards the unstable areas to ensure smooth handling on boot or init of page/frame under more versatile conditions.

