### PR TITLE
feat(android): provide ability to get registered broadCastReceiver #9466

### DIFF
--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -111,6 +111,10 @@ export class AndroidApplication extends Observable implements AndroidApplication
 		this._systemAppearance = value;
 	}
 
+	public getRegisteredBroadcastReceiver(intentFilter: string): android.content.BroadcastReceiver | undefined {
+		return this._registeredReceivers[intentFilter];
+	}
+
 	public registerBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void): void {
 		ensureBroadCastReceiverClass();
 		const registerFunc = (context: android.content.Context) => {

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -629,6 +629,12 @@ export class AndroidApplication extends Observable {
 	public static activityRequestPermissionsEvent: string;
 
 	/**
+	 * Get a registered BroadcastReceiver, then you can get the result code of BroadcastReceiver in onReceiveCallback method.
+	 * @param intentFilter A string containing the intent filter.
+	 */
+	public getRegisteredBroadcastReceiver(intentFilter: string): android.content.BroadcastReceiver | undefined;
+
+	/**
 	 * Register a BroadcastReceiver to be run in the main activity thread. The receiver will be called with any broadcast Intent that matches filter, in the main application thread.
 	 * For more information, please visit 'http://developer.android.com/reference/android/content/Context.html#registerReceiver%28android.content.BroadcastReceiver,%20android.content.IntentFilter%29'
 	 * @param intentFilter A string containing the intent filter.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
Sorry, I did not find the tests folder.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->
You can use this interface below to get registered broadcastReceiver, then you can get result code in onReceiveCallback when you are using registerBroadcastReceiver.
```
Application.android.getRegisteredBroadcastReceiver(intentFilter: string)
```

Fixes/Implements/Closes #[Issue Number].
#9466 
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

