### PR TITLE
fix(webpack5): change typescript declaration file filter regex

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -313,7 +313,7 @@ exports[`typescript configuration for android 1`] = `
     /* config.plugin('VirtualModulesPlugin') */
     new VirtualModulesPlugin(
       {
-        '__jest__/src/__@nativescript_webpack_virtual_entry_typescript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /\\\\\\\\.(xml|js|(?<!d\\\\\\\\.)ts|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
+        '__jest__/src/__@nativescript_webpack_virtual_entry_typescript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /\\\\\\\\.(xml|js|(?<!\\\\\\\\.d\\\\\\\\.)ts|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
       }
     )
   ],
@@ -642,7 +642,7 @@ exports[`typescript configuration for ios 1`] = `
     /* config.plugin('VirtualModulesPlugin') */
     new VirtualModulesPlugin(
       {
-        '__jest__/src/__@nativescript_webpack_virtual_entry_typescript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /\\\\\\\\.(xml|js|(?<!d\\\\\\\\.)ts|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
+        '__jest__/src/__@nativescript_webpack_virtual_entry_typescript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /\\\\\\\\.(xml|js|(?<!\\\\\\\\.d\\\\\\\\.)ts|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
       }
     )
   ],

--- a/packages/webpack5/__tests__/configuration/typescript.spec.ts
+++ b/packages/webpack5/__tests__/configuration/typescript.spec.ts
@@ -14,4 +14,38 @@ describe('typescript configuration', () => {
 			expect(typescript(new Config()).toString()).toMatchSnapshot();
 		});
 	}
+
+	it('filter typescript declaration files', () => {
+		init({
+			ios: true,
+		});
+
+		const tsConfig = typescript(new Config());
+		let regex: RegExp;
+
+		// Get the filterRE from the typescript configuration
+		tsConfig.plugin('VirtualModulesPlugin').tap((args) => {
+			const options = args[0];
+			const virtualConfig: string = options[Object.keys(options)[0]];
+			const filterLine = virtualConfig
+				.split('\n')
+				.find((v) => v.includes('filter'));
+			const matches = filterLine.match(/\/(?<filter>\S+)\//);
+
+			if (matches) {
+				regex = new RegExp(matches.groups.filter);
+			}
+
+			return args;
+		});
+
+		expect(regex).toBeDefined();
+
+		expect('test.ts').toMatch(regex);
+		expect('test.d.ts').not.toMatch(regex);
+		expect('tested.ts').toMatch(regex);
+		expect('tested.d.ts').not.toMatch(regex);
+		expect('test.d.tested.ts').toMatch(regex);
+		expect('test.d.tested.d.ts').not.toMatch(regex);
+	});
 });

--- a/packages/webpack5/src/configuration/typescript.ts
+++ b/packages/webpack5/src/configuration/typescript.ts
@@ -8,7 +8,7 @@ import base from './base';
 export default function (config: Config, env: IWebpackEnv = _env): Config {
 	base(config, env);
 	const entryPath = getEntryPath();
-	const filterRE = '/\\.(xml|js|(?<!d\\.)ts|s?css)$/';
+	const filterRE = '/\\.(xml|js|(?<!\\.d\\.)ts|s?css)$/';
 	const virtualEntryPath = addVirtualEntry(
 		config,
 		'typescript',


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With webpack5, typescript projects do not load filenames that end with a `d` e.g. `tested.ts`

Per the [regex lookbehind proposal](https://github.com/tc39/proposal-regexp-lookbehind)

> Patterns normally match starting from the leftmost sub-pattern and move on to the sub-pattern on the right if the left sub-pattern succeeds. When contained within a lookbehind assertion, the order of matching would be reversed. Patterns would match starting from the rightmost sub-pattern and advance to the left instead. For example, given /(?<=\$\d+\.)\d+/, the pattern would first find a number and ensure first that it is preceded by . going backward, then \d+ starting from ., and lastly $ starting from where \d+ within the assertion begins. The backtracking direction would also be reversed as a result of this.

## What is the new behavior?
<!-- Describe the changes. -->
The filter regex for typescript declaration files will correctly match only `.d.ts`