### PR TITLE
fix(styling): change transform parameters parsing

### DIFF
--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -736,7 +736,13 @@ function normalizeTransformation({ property, value }: Transformation): Transform
 }
 
 function convertTransformValue(property: string, stringValue: string): TransformationValue {
-	const [x, y = x, z = y] = stringValue.split(',').map(parseFloat);
+	let [x, y, z] = stringValue.split(',').map(parseFloat);
+	if (property === 'translate') {
+		y ??= IDENTITY_TRANSFORMATION.translate.y;
+	} else {
+		y ??= x;
+		z ??= y;
+	}
 
 	if (property === 'rotate' || property === 'rotateX' || property === 'rotateY') {
 		return stringValue.slice(-3) === 'rad' ? radiansToDegrees(x) : x;


### PR DESCRIPTION
Fixed the incorrectly applied short form of "transform: translate" style property.

#5202

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
https://github.com/NativeScript/NativeScript/issues/5202

## What is the new behavior?
For now "transform: translate(10)" style property is treated as "transform: translate(10, 0)". All other options remain the same
FIxes #5202
