### PR TITLE
fix(android): nested dialogs

### DIFF
--- a/apps/ui/src/modal-view/nested-modal-tab.xml
+++ b/apps/ui/src/modal-view/nested-modal-tab.xml
@@ -1,0 +1,24 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd">
+
+    <ActionBar>
+        <Label text="Nested Modal Tab"></Label>
+    </ActionBar>
+
+    <TabView selectedTabTextColor="green">
+         <TabViewItem title="First">
+            <GridLayout>
+                <Frame id="nestedFrame" defaultPage="nested-frames/nested-page" actionBarVisibility="always"></Frame>
+            </GridLayout>
+        </TabViewItem>
+        <TabViewItem title="Second">
+            <GridLayout>
+                <Frame id="nestedFrame" defaultPage="nested-frames/nested-page" actionBarVisibility="always"></Frame>
+            </GridLayout>
+        </TabViewItem>
+        <TabViewItem title="Third">
+            <GridLayout>
+                <Frame id="nestedFrame" defaultPage="nested-frames/nested-page" actionBarVisibility="always"></Frame>
+            </GridLayout>
+        </TabViewItem>
+    </TabView>
+</Page>

--- a/apps/ui/src/modal-view/nested-modal.ts
+++ b/apps/ui/src/modal-view/nested-modal.ts
@@ -9,6 +9,14 @@ export function onShowingModally(args: ShownModallyData) {
 		onTap: function () {
 			Dialogs.alert('it works!');
 		},
+		openNestedModal: function () {
+			page.showModal('modal-view/nested-nested-modal', {
+				context: 'Neste mODAL',
+				closeCallback: () => {
+					console.log('nested-modal.openNestedModal');
+				},
+			});
+		},
 	});
 }
 

--- a/apps/ui/src/modal-view/nested-nested-frame.ts
+++ b/apps/ui/src/modal-view/nested-nested-frame.ts
@@ -1,0 +1,29 @@
+import { Page, EventData, fromObject, Dialogs } from '@nativescript/core';
+
+export function navigatingTo(args) {
+	const page = <Page>args.object;
+
+	page.bindingContext = fromObject({
+		context: args.context,
+		onTap: function () {
+			Dialogs.alert('it works!');
+		},
+		openNestedFrames: function () {
+			page.showModal('modal-view/nested-modal-tab', {
+				context: 'Nested Modal Tab',
+				fullscreen: true,
+				closeCallback: () => {
+					console.log('nested-modal.openNestedModal');
+				},
+			});
+		},
+	});
+}
+
+export function onLoaded(args: EventData) {
+	console.log('nested-nested-modal.onLoaded');
+}
+
+export function onUnloaded() {
+	console.log('nested-nested-modal.onUnloaded');
+}

--- a/apps/ui/src/modal-view/nested-nested-frame.xml
+++ b/apps/ui/src/modal-view/nested-nested-frame.xml
@@ -1,10 +1,9 @@
-﻿<Page xmlns="http://schemas.nativescript.org/tns.xsd"
-  showingModally="onShowingModally"
-  shownModally="onShownModally"
+<Page xmlns="http://schemas.nativescript.org/tns.xsd"
+  navigatingTo="navigatingTo"
   loaded="onLoaded" unloaded="onUnloaded" backgroundColor="Red">
   <StackLayout backgroundColor="PaleGreen" margin="10">
     <Label text="{{ context }}"/>
     <Button text="Show Alert" tap="{{ onTap }}"/>
-    <Button text="Open Nested Modal" tap="{{ openNestedModal }}"/>
+    <Button text="Open Nested Frames" tap="{{ openNestedFrames }}" />
   </StackLayout>
 </Page>

--- a/apps/ui/src/modal-view/nested-nested-modal.xml
+++ b/apps/ui/src/modal-view/nested-nested-modal.xml
@@ -1,0 +1,1 @@
+﻿<Frame defaultPage="modal-view/nested-nested-frame"></Frame>

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -345,6 +345,9 @@ export class View extends ViewCommon {
 	}
 
 	public _getFragmentManager(): androidx.fragment.app.FragmentManager {
+		if ((<any>global)._dialogFragment) {
+			return (<any>global)._dialogFragment.getChildFragmentManager();
+		}
 		let manager = this._manager;
 		if (!manager) {
 			let view: View = this;
@@ -690,20 +693,19 @@ export class View extends ViewCommon {
 		};
 
 		saveModal(dialogOptions);
-
 		this._dialogFragment = df;
+		(<any>global)._dialogFragment = df;
 		this._raiseShowingModallyEvent();
-
 		this._dialogFragment.show(parent._getRootFragmentManager(), this._domId.toString());
 	}
 
 	protected _hideNativeModalView(parent: View, whenClosedCallback: () => void) {
-		const manager = this._dialogFragment.getFragmentManager();
+		const manager = this._dialogFragment.getParentFragmentManager();
 		if (manager) {
 			this._dialogFragment.dismissAllowingStateLoss();
 		}
-
 		this._dialogFragment = null;
+		(<any>global)._dialogFragment = null;
 		whenClosedCallback();
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Android dialogs/fragments handled inside nested views can crash.

## What is the new behavior?

Android dialogs/fragments handled inside nested views no longer crash.

