### PR TITLE
fix(webpack5): angular scss rule not ignoring regular scss

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -231,8 +231,8 @@ exports[`angular configuration for android 1`] = `
       {
         test: /\\\\.scss$/,
         exclude: [
-          '__jest__/src/app.css',
-          '__jest__/src/app.android.css',
+          '__jest__/src/app.scss',
+          '__jest__/src/app.android.scss',
           /node_modules/
         ],
         use: [
@@ -616,8 +616,8 @@ exports[`angular configuration for ios 1`] = `
       {
         test: /\\\\.scss$/,
         exclude: [
-          '__jest__/src/app.css',
-          '__jest__/src/app.ios.css',
+          '__jest__/src/app.scss',
+          '__jest__/src/app.ios.scss',
           /node_modules/
         ],
         use: [

--- a/packages/webpack5/src/configuration/angular.ts
+++ b/packages/webpack5/src/configuration/angular.ts
@@ -83,8 +83,8 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	// and instead use raw-loader, since that's what angular expects
 	config.module
 		.rule('scss|component')
-		.exclude.add(resolve(getEntryDirPath(), 'app.css'))
-		.add(resolve(getEntryDirPath(), `app.${platform}.css`))
+		.exclude.add(resolve(getEntryDirPath(), 'app.scss'))
+		.add(resolve(getEntryDirPath(), `app.${platform}.scss`))
 		.add(/node_modules/)
 		.end()
 		.test(/\.scss$/)


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes #9499.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

