### PR TITLE
fix(core): prevent iOS views to be measured if no native view

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -80,7 +80,7 @@ export class View extends ViewCommon implements ViewDefinition {
 	public measure(widthMeasureSpec: number, heightMeasureSpec: number): void {
 		const measureSpecsChanged = this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
 		const forceLayout = (this._privateFlags & PFLAG_FORCE_LAYOUT) === PFLAG_FORCE_LAYOUT;
-		if (forceLayout || measureSpecsChanged) {
+		if (this.nativeViewProtected && (forceLayout || measureSpecsChanged)) {
 			// first clears the measured dimension flag
 			this._privateFlags &= ~PFLAG_MEASURED_DIMENSION_SET;
 


### PR DESCRIPTION
This should not happen but it does. Did not manage to find the real source but it seems ok to test it here. Plus if it happens the measurement chain for that view will be broken