### PR TITLE
fix(android): do not call exitEvent on activity restart

### DIFF
--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1190,12 +1190,18 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 				rootView._tearDownUI(true);
 			}
 
-			const exitArgs = {
-				eventName: application.exitEvent,
-				object: application.android,
-				android: activity,
-			};
-			application.notify(exitArgs);
+			// this may happen when the user changes the system theme
+			// In such case, isFinishing() is false (and isChangingConfigurations is true), and the app will start again (onCreate) with a savedInstanceState
+			// as a result, launchEvent will never be called
+			// possible alternative: always fire launchEvent and exitEvent, but pass extra flags to make it clear what kind of launch/destroy is happening
+			if (activity.isFinishing()) {
+				const exitArgs = {
+					eventName: application.exitEvent,
+					object: application.android,
+					android: activity,
+				};
+				application.notify(exitArgs);
+			}
 		} finally {
 			superFunc.call(activity);
 		}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

After changing the system theme (toggle dark mode)
```
JS: activityPaused
JS: activityStopped
JS: saveActivityState
JS: [exitEvent] // this destroys the angular instance, probably the same for other flavors
JS: activityDestroyed
JS: activityCreated
JS: activityStarted
JS: activityResumed
```

normal exit:
```
JS: activityBackPressed
JS: [suspendEvent]
JS: activityPaused
JS: activityStopped
JS: [exitEvent]
JS: activityDestroyed
```

normal enter (after previous exit)
```
JS: activityCreated
JS: activityNewIntent
JS: [launchEvent] // this creates the angular/other flavors instance
```

## What is the new behavior?
```
JS: activityPaused
JS: activityStopped
JS: saveActivityState
// no exit event here!
JS: activityDestroyed
JS: activityCreated
JS: activityStarted
JS: activityResumed
```

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

