### PR TITLE
fix(ios): background color property on Button

### DIFF
--- a/packages/core/ui/button/index.ios.ts
+++ b/packages/core/ui/button/index.ios.ts
@@ -1,10 +1,11 @@
 import { ControlStateChangeListener } from '../core/control-state-change';
 import { ButtonBase } from './button-common';
 import { View, PseudoClassHandler } from '../core/view';
-import { borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty, paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty } from '../styling/style-properties';
+import { backgroundColorProperty, borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty, paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty } from '../styling/style-properties';
 import { textAlignmentProperty, whiteSpaceProperty } from '../text-base';
 import { layout } from '../../utils';
 import { CoreTypes } from '../../core-types';
+import { Color } from '../../color';
 
 export * from './button-common';
 
@@ -54,6 +55,14 @@ export class Button extends ButtonBase {
 		} else {
 			this._stateChangedHandler.stop();
 		}
+	}
+
+	[backgroundColorProperty.getDefault](): UIColor {
+		return this.nativeViewProtected.backgroundColor;
+	}
+
+	[backgroundColorProperty.setNative](value: UIColor | Color) {
+		this.nativeViewProtected.backgroundColor = value instanceof Color ? value.ios : value;
 	}
 
 	[borderTopWidthProperty.getDefault](): CoreTypes.LengthType {


### PR DESCRIPTION
Currently Button on iOS doesn't respond to background color changes
after it is created. This commit implements the backgroundColorProperty
to access the native UIButton's backgroundColor property.

Fixes NativeScript/NativeScript#9523