### PR TITLE
fix(android): background-image 'none'

### DIFF
--- a/packages/core/ui/styling/background.android.ts
+++ b/packages/core/ui/styling/background.android.ts
@@ -175,7 +175,7 @@ function refreshBorderDrawable(this: void, view: View, borderDrawable: org.nativ
 		const blackColor = -16777216; //android.graphics.Color.BLACK;
 
 		let imageUri: string;
-		if (background.image && typeof background.image === 'string') {
+		if (background.image && typeof background.image === 'string' && background.image !== 'none') {
 			imageUri = background.image;
 			const match = imageUri.match(pattern);
 			if (match && match[2]) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

On Android background-image: none would cause a crash.

## What is the new behavior?

No longer crashes.

closes https://github.com/NativeScript/NativeScript/issues/9546
