### PR TITLE
fix(android): only attach if activity is CREATED

### DIFF
--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -144,8 +144,8 @@ export class Frame extends FrameBase {
 
 		// _onAttachedToWindow called from OS again after it was detach
 		// still happens with androidx.fragment:1.3.2
-		const activity = androidApplication.foregroundActivity || androidApplication.startActivity;
-		if ((this._manager && this._manager.isDestroyed()) || !activity.getLifecycle?.().getCurrentState().isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)) {
+		const lifecycleState = (androidApplication.foregroundActivity?.getLifecycle?.() || androidApplication.startActivity?.getLifecycle?.())?.getCurrentState() || androidx.lifecycle.Lifecycle.State.CREATED;
+		if ((this._manager && this._manager.isDestroyed()) || !lifecycleState.isAtLeast(androidx.lifecycle.Lifecycle.State.CREATED)) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
We currently check for `androidx.lifecycle.Lifecycle.State.STARTED`, which happens after CREATE, so when `_onAttachedToWindow` is called during activity created, it's not attached properly (like when suspending/resuming with a frame inside tabs/bottom nav)

## What is the new behavior?
Check for `androidx.lifecycle.Lifecycle.State.CREATED` instead. Also guards around `foregroundActivity` or `startActivity` not having a `getLifecycle` method and falls back to a default `androidx.lifecycle.Lifecycle.State.CREATED` (this may happen on some edge cases like: app has multiple activities and foreground is not a `androidx.fragment.app.FragmentActivity` and `startActivity` was either destroyed or is not also a `androidx.fragment.app.FragmentActivity`)


