### PR TITLE
fix: replace autofill string in textfield

### DIFF
--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -205,7 +205,8 @@ export class TextField extends TextFieldBase {
 		}
 
 		if (this.updateTextTrigger === 'textChanged') {
-			if (textField.secureTextEntry && this.firstEdit) {
+			const shouldReplaceString = (textField.secureTextEntry && this.firstEdit) || delta > 1;
+			if (shouldReplaceString) {
 				textProperty.nativeValueChange(this, replacementString);
 			} else {
 				if (range.location <= textField.text.length) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
On iOS if we type a few character and use the auto-fill function it will concat the strings instead of replacing to the suggested one.
Video example in the issue: https://github.com/NativeScript/NativeScript/issues/9486

## What is the new behavior?
After typing the the start of an e-mail and tap on auto-fill, it will replace the text.

**Note:**
The solution is based on the string's delta, which means if we copy and paste a text to a textfield, it will behave like we used auto-fill and replace the text in the view model.

Fixes #9486

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

