### PR TITLE
fix: background failing when parsing color #9559

### DIFF
--- a/packages/core/css/parser.ts
+++ b/packages/core/css/parser.ts
@@ -23,7 +23,7 @@ export interface LinearGradient {
 	colors: ColorStop[];
 }
 export interface Background {
-	readonly color?: number;
+	readonly color?: number | Color;
 	readonly image?: URL | LinearGradient;
 	readonly repeat?: BackgroundRepeat;
 	readonly position?: BackgroundPosition;

--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -838,7 +838,10 @@ backgroundPositionProperty.register(Style);
 function convertToBackgrounds(this: void, value: string): [CssProperty<any, any>, any][] {
 	if (typeof value === 'string') {
 		const backgrounds = parser.parseBackground(value).value;
-		const backgroundColor = backgrounds.color ? new Color(backgrounds.color) : unsetValue;
+		let backgroundColor = unsetValue;
+		if (backgrounds.color) {
+			backgroundColor = backgrounds.color instanceof Color ? backgrounds.color : new Color(backgrounds.color);
+		}
 
 		let backgroundImage: string | LinearGradient;
 		if (typeof backgrounds.image === 'object' && backgrounds.image) {


### PR DESCRIPTION
The parser now returns a `Color` directly.  We need to test for it and not try to create an new instance of `Color`