### PR TITLE
feat: add property css text-aling justify

### DIFF
--- a/packages/core/core-types/index.d.ts
+++ b/packages/core/core-types/index.d.ts
@@ -104,7 +104,7 @@ export namespace CoreTypes {
 		export const send: string;
 	}
 
-	export type TextAlignmentType = 'initial' | 'left' | 'center' | 'right';
+	export type TextAlignmentType = 'initial' | 'left' | 'center' | 'right' | 'justify';
 	/**
 	 * Represents a text-align enumeration.
 	 */
@@ -123,6 +123,11 @@ export namespace CoreTypes {
 		 * Represents right text-align.
 		 */
 		export const right: TextAlignmentType;
+		
+		/**
+		 * Represents right text-align.
+		 */
+		 export const justify: TextAlignmentType;
 	}
 
 	export type OrientationType = 'horizontal' | 'vertical';

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -57,11 +57,12 @@ export namespace CoreTypes {
 		export const send = 'send';
 	}
 
-	export type TextAlignmentType = 'initial' | 'left' | 'center' | 'right';
+	export type TextAlignmentType = 'initial' | 'left' | 'center' | 'right' | 'justify';
 	export module TextAlignment {
 		export const left = 'left';
 		export const center = 'center';
 		export const right = 'right';
+		export const justify = 'justify';
 	}
 
 	export type TextDecorationType = 'none' | 'underline' | 'line-through' | 'underline line-through';

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -298,6 +298,11 @@ export class TextBase extends TextBaseCommon {
 			case 'right':
 				this.nativeTextViewProtected.setGravity(android.view.Gravity.END | verticalGravity);
 				break;
+			case 'justify':
+				//if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+						this.nativeTextViewProtected.setJustificationMode(android.text.Layout.JUSTIFICATION_MODE_INTER_WORD );
+				//	}
+				break;
 		}
 	}
 

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -301,7 +301,7 @@ export class TextBase extends TextBaseCommon {
 			case 'justify':
 				// android.os.Build.VERSION_CODES.O
 				if (android.os.Build.VERSION.SDK_INT >= 25) {
-						this.nativeTextViewProtected.setJustificationMode(android.text.Layout.JUSTIFICATION_MODE_INTER_WORD );
+						this.nativeTextViewProtected.setJustificationMode(android.text.Layout.JUSTIFICATION_MODE_INTER_WORD);
 				}
 				break;
 		}

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -299,9 +299,10 @@ export class TextBase extends TextBaseCommon {
 				this.nativeTextViewProtected.setGravity(android.view.Gravity.END | verticalGravity);
 				break;
 			case 'justify':
-				//if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+				// android.os.Build.VERSION_CODES.O
+				if (android.os.Build.VERSION.SDK_INT >= 25) {
 						this.nativeTextViewProtected.setJustificationMode(android.text.Layout.JUSTIFICATION_MODE_INTER_WORD );
-				//	}
+				}
 				break;
 		}
 	}

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -171,6 +171,9 @@ export class TextBase extends TextBaseCommon {
 			case 'right':
 				nativeView.textAlignment = NSTextAlignment.Right;
 				break;
+			case 'justify':
+				nativeView.textAlignment = NSTextAlignment.Justified;
+			break;
 		}
 	}
 

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -246,7 +246,7 @@ export function getClosestPropertyValue<T>(property: CssProperty<any, T>, span: 
 	}
 }
 
-const textAlignmentConverter = makeParser<CoreTypes.TextAlignmentType>(makeValidator<CoreTypes.TextAlignmentType>('initial', 'left', 'center', 'right'));
+const textAlignmentConverter = makeParser<CoreTypes.TextAlignmentType>(makeValidator<CoreTypes.TextAlignmentType>('initial', 'left', 'center', 'right', 'justify'));
 export const textAlignmentProperty = new InheritedCssProperty<Style, CoreTypes.TextAlignmentType>({
 	name: 'textAlignment',
 	cssName: 'text-align',


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Now the `text-align: justify` property is not supported

## What is the new behavior?
Now it supports the property, in android it is supported since version 8

