### PR TITLE
fix(ios): TextView respect editable binding

### DIFF
--- a/packages/core/ui/text-view/index.ios.ts
+++ b/packages/core/ui/text-view/index.ios.ts
@@ -134,7 +134,7 @@ export class TextView extends TextViewBaseCommon {
 			this.showText();
 		}
 
-		return true;
+		return this.editable;
 	}
 
 	public textViewDidBeginEditing(textView: UITextView): void {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

<TextView editable="false"/>

Had no effect on edibility thus could not properly disable it.

## What is the new behavior?

<TextView editable="false"/>

Now properly disabled the field to no longer be editable.


