### PR TITLE
fix(webpack): exclude files starting with _ from require.context

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -318,6 +318,10 @@ exports[`javascript configuration for android 1`] = `
       {
         '__jest__/src/__@nativescript_webpack_virtual_entry_javascript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /.(xml|js|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
       }
+    ),
+    /* config.plugin('ContextExclusionPlugin|exclude_files') */
+    new ContextExclusionPlugin(
+      /\\\\b_.+\\\\./
     )
   ],
   entry: {
@@ -651,6 +655,10 @@ exports[`javascript configuration for ios 1`] = `
       {
         '__jest__/src/__@nativescript_webpack_virtual_entry_javascript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /.(xml|js|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
       }
+    ),
+    /* config.plugin('ContextExclusionPlugin|exclude_files') */
+    new ContextExclusionPlugin(
+      /\\\\b_.+\\\\./
     )
   ],
   entry: {

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -318,6 +318,10 @@ exports[`typescript configuration for android 1`] = `
       {
         '__jest__/src/__@nativescript_webpack_virtual_entry_typescript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /\\\\\\\\.(xml|js|(?<!\\\\\\\\.d\\\\\\\\.)ts|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
       }
+    ),
+    /* config.plugin('ContextExclusionPlugin|exclude_files') */
+    new ContextExclusionPlugin(
+      /\\\\b_.+\\\\./
     )
   ],
   entry: {
@@ -651,6 +655,10 @@ exports[`typescript configuration for ios 1`] = `
       {
         '__jest__/src/__@nativescript_webpack_virtual_entry_typescript__': '// VIRTUAL ENTRY START\\\\nrequire(\\\\'@nativescript/core/bundle-entry-points\\\\')\\\\nconst context = require.context(\\"~/\\", /* deep: */ true, /* filter: */ /\\\\\\\\.(xml|js|(?<!\\\\\\\\.d\\\\\\\\.)ts|s?css)$/);\\\\nglobal.registerWebpackModules(context);\\\\n// VIRTUAL ENTRY END'
       }
+    ),
+    /* config.plugin('ContextExclusionPlugin|exclude_files') */
+    new ContextExclusionPlugin(
+      /\\\\b_.+\\\\./
     )
   ],
   entry: {

--- a/packages/webpack5/src/configuration/javascript.ts
+++ b/packages/webpack5/src/configuration/javascript.ts
@@ -4,6 +4,7 @@ import { getEntryPath, getEntryDirPath } from '../helpers/platform';
 import { addVirtualEntry } from '../helpers/virtualModules';
 import { chainedSetAddAfter } from '../helpers/chain';
 import { env as _env, IWebpackEnv } from '../index';
+import { ContextExclusionPlugin } from 'webpack';
 import base from './base';
 
 export default function (config: Config, env: IWebpackEnv = _env): Config {
@@ -21,6 +22,11 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		// VIRTUAL ENTRY END
 	`
 	);
+
+	// exclude files starting with _ from require.context
+	config
+		.plugin(`ContextExclusionPlugin|exclude_files`)
+		.use(ContextExclusionPlugin, [/\b_.+\./]);
 
 	chainedSetAddAfter(
 		config.entry('bundle'),

--- a/packages/webpack5/src/configuration/typescript.ts
+++ b/packages/webpack5/src/configuration/typescript.ts
@@ -4,6 +4,7 @@ import { getEntryDirPath, getEntryPath } from '../helpers/platform';
 import { addVirtualEntry } from '../helpers/virtualModules';
 import { chainedSetAddAfter } from '../helpers/chain';
 import { env as _env, IWebpackEnv } from '../index';
+import { ContextExclusionPlugin } from 'webpack';
 import base from './base';
 
 export default function (config: Config, env: IWebpackEnv = _env): Config {
@@ -21,6 +22,11 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		// VIRTUAL ENTRY END
 	`
 	);
+
+	// exclude files starting with _ from require.context
+	config
+		.plugin(`ContextExclusionPlugin|exclude_files`)
+		.use(ContextExclusionPlugin, [/\b_.+\./]);
 
 	chainedSetAddAfter(
 		config.entry('bundle'),


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In plain flavors (TypeScript and JavaScript), having scss files starting with `_` are not ignored from the require.context causing build errors because they are treated as root stylesheets.

## What is the new behavior?
<!-- Describe the changes. -->
Files starting with an `_` are now properly ignored from the `require.context()` that maps out all the files in the app and will no longer cause build errors due to treating these stylesheets as root ones.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

