### PR TITLE
fix: CSS variables should be case-sensitive.

### DIFF
--- a/packages/core/ui/styling/css-selector/index.ts
+++ b/packages/core/ui/styling/css-selector/index.ts
@@ -1,4 +1,5 @@
 import '../../../globals';
+import { isCssVariable } from '../../core/properties';
 import { isNullOrUndefined } from '../../../utils/types';
 
 import * as cssParser from '../../../css';
@@ -523,7 +524,7 @@ export function fromAstNodes(astRules: cssParser.Node[]): RuleSet[] {
 }
 
 function createDeclaration(decl: cssParser.Declaration): any {
-	return { property: decl.property.toLowerCase(), value: decl.value };
+	return { property: isCssVariable(decl.property) ? decl.property : decl.property.toLowerCase(), value: decl.value };
 }
 
 function createSimpleSelectorFromAst(ast: parser.SimpleSelector): SimpleSelector {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
CSS variables are parsed as case-insensitive.

## What is the new behavior?
CSS variables will be parsed as case-sensitive.

This is the correct behaviour according to MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#basic_usage

Note: I'm not sure what sort of test I should include for CSS variables case, so this PR contains only the fix.