### PR TITLE
fix(android): autofillType on apiLevel < 26

### DIFF
--- a/packages/core/ui/builder/component-builder/index.ts
+++ b/packages/core/ui/builder/component-builder/index.ts
@@ -15,7 +15,7 @@ export interface ComponentModule {
 	exports: any;
 }
 
-const legacyShortBarrels = __UI_USE_EXTERNAL_RENDERER__?[]:[
+const legacyShortBarrels = [
 	'text/formatted-string',
 	'text/span',
 	'ui/text-base/formatted-string',


### PR DESCRIPTION
The old way of setting `apiLevel` was not working. For some reason (sadly did not have time to investigate more) the `createNativeView` did not seem to have been called first and thus the `apiLevel` was not set.
We now do it the same way we do in other parts of N code. 
This is fixes apps crashing on <26