### PR TITLE
fix(android): version Android text-align justify

### DIFF
--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -296,7 +296,7 @@ export class TextBase extends TextBaseCommon {
 				this.nativeTextViewProtected.setGravity(android.view.Gravity.START | verticalGravity);
 				break;
 		}
-		if (android.os.Build.VERSION.SDK_INT >= 25) {
+		if (android.os.Build.VERSION.SDK_INT >= 26) {
 			if (value === 'justify') {
 				this.nativeTextViewProtected.setJustificationMode(android.text.Layout.JUSTIFICATION_MODE_INTER_WORD);
 			} else {


### PR DESCRIPTION
[This PR ](https://github.com/NativeScript/NativeScript/pull/9573) is pointing to the android version> = 25 and is breaking this version since this property came out in the 26 https://developer.android.com/reference/android/text/Layout#JUSTIFICATION_MODE_NONE

This PR solves the version.