### PR TITLE
fix(webpack/svelte): Map 'svelte' to 'svelte/internal' to avoid forced SSR

### DIFF
--- a/packages/webpack5/src/configuration/svelte.ts
+++ b/packages/webpack5/src/configuration/svelte.ts
@@ -1,4 +1,3 @@
-import { merge } from 'webpack-merge';
 import Config from 'webpack-chain';
 
 import { getProjectFilePath } from '../helpers/project';
@@ -18,6 +17,10 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	// target('node') is the default but causes svelte-loader to detect it as a "server" render, disabling HMR
 	// electron-main sneaks us past the target == 'node' check and gets us HMR
 	config.target('electron-main');
+
+	// turns out this isn't enough now. svelte uses "node" of which "electron-main" is a subset in its export map forcing imports
+	// for 'svelte' to 'ssr.mjs'. We define an alias here to force it back.
+	config.resolve.alias.set('svelte$', 'svelte/internal');
 
 	// svelte-hmr still references tns-core-modules, so we shim it here for compat.
 	config.resolve.alias.set('tns-core-modules', '@nativescript/core');


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it. - N/A
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application. - On windows so no, but that was the case before the change :)
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md. -N/A

## What is the current behavior?
When using a new svelte template, the current webpack config will import the SSR version of svelte, instead of the runtime version. This is due to it the node like target triggering a condition in Svelte's export maps

## What is the new behavior?
An alias is added to force 'svelte' to resolve to 'svelte/internal' (the runtime version of svelte)
(unused merge import is also removed)