### PR TITLE
chore(webpack5): update react-refresh

### DIFF
--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@babel/core": "^7.0.0",
-		"@pmmmwh/react-refresh-webpack-plugin": "^0.4.0",
+		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 		"acorn": "^8.0.0",
 		"acorn-stage3": "^4.0.0",
 		"babel-loader": "^8.0.0",
@@ -37,7 +37,7 @@
 		"postcss-import": "^14.0.0",
 		"postcss-loader": "^6.0.0",
 		"raw-loader": "^4.0.0",
-		"react-refresh": "~0.8.3",
+		"react-refresh": "~0.11.0",
 		"sass": "^1.0.0",
 		"sass-loader": "^12.0.0",
 		"sax": "^1.0.0",


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When installing `@nativescript/webpack@5` the following warnings are shown
```
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
```

## What is the new behavior?
The deprecated packages have been updated so no warnings are shown.


