### PR TITLE
fix(webpack): respect hmr flag

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -84,13 +84,6 @@ exports[`angular configuration for android 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -471,13 +464,6 @@ exports[`angular configuration for ios 1`] = `
             loader: 'app-css-loader',
             options: {
               platform: 'ios'
-            }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
             }
           }
         ]

--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -87,13 +87,6 @@ exports[`angular configuration for android 1`] = `
           }
         ]
       },
-      /* config.module.rule('js') */
-      {
-        test: /\\\\.js$/,
-        exclude: [
-          /node_modules/
-        ]
-      },
       /* config.module.rule('workers') */
       {
         test: /\\\\.(js|ts)$/,
@@ -102,6 +95,13 @@ exports[`angular configuration for android 1`] = `
           {
             loader: 'nativescript-worker-loader'
           }
+        ]
+      },
+      /* config.module.rule('js') */
+      {
+        test: /\\\\.js$/,
+        exclude: [
+          /node_modules/
         ]
       },
       /* config.module.rule('xml') */
@@ -468,13 +468,6 @@ exports[`angular configuration for ios 1`] = `
           }
         ]
       },
-      /* config.module.rule('js') */
-      {
-        test: /\\\\.js$/,
-        exclude: [
-          /node_modules/
-        ]
-      },
       /* config.module.rule('workers') */
       {
         test: /\\\\.(js|ts)$/,
@@ -483,6 +476,13 @@ exports[`angular configuration for ios 1`] = `
           {
             loader: 'nativescript-worker-loader'
           }
+        ]
+      },
+      /* config.module.rule('js') */
+      {
+        test: /\\\\.js$/,
+        exclude: [
+          /node_modules/
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -75,6 +75,16 @@ exports[`base configuration for android 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -101,16 +111,6 @@ exports[`base configuration for android 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -379,6 +379,16 @@ exports[`base configuration for ios 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -405,16 +415,6 @@ exports[`base configuration for ios 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -72,13 +72,6 @@ exports[`base configuration for android 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -382,13 +375,6 @@ exports[`base configuration for ios 1`] = `
             loader: 'app-css-loader',
             options: {
               platform: 'ios'
-            }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
             }
           }
         ]

--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -72,13 +72,6 @@ exports[`javascript configuration for android 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -181,23 +174,6 @@ exports[`javascript configuration for android 1`] = `
           /* config.module.rule('scss').use('sass-loader') */
           {
             loader: 'sass-loader'
-          }
-        ]
-      },
-      /* config.module.rule('hmr-core') */
-      {
-        test: /\\\\.js$/,
-        exclude: [
-          /node_modules/,
-          '__jest__/src/app.js'
-        ],
-        use: [
-          /* config.module.rule('hmr-core').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              appPath: '__jest__/src'
-            }
           }
         ]
       }
@@ -409,13 +385,6 @@ exports[`javascript configuration for ios 1`] = `
             options: {
               platform: 'ios'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -518,23 +487,6 @@ exports[`javascript configuration for ios 1`] = `
           /* config.module.rule('scss').use('sass-loader') */
           {
             loader: 'sass-loader'
-          }
-        ]
-      },
-      /* config.module.rule('hmr-core') */
-      {
-        test: /\\\\.js$/,
-        exclude: [
-          /node_modules/,
-          '__jest__/src/app.js'
-        ],
-        use: [
-          /* config.module.rule('hmr-core').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              appPath: '__jest__/src'
-            }
           }
         ]
       }

--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -75,6 +75,16 @@ exports[`javascript configuration for android 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -101,16 +111,6 @@ exports[`javascript configuration for android 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -388,6 +388,16 @@ exports[`javascript configuration for ios 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -414,16 +424,6 @@ exports[`javascript configuration for ios 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
@@ -408,13 +408,6 @@ exports[`react configuration > android > base config 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -1052,13 +1045,6 @@ exports[`react configuration > ios > base config 1`] = `
             loader: 'app-css-loader',
             options: {
               platform: 'ios'
-            }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
             }
           }
         ]

--- a/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
@@ -85,6 +85,16 @@ exports[`react configuration > android > adds ReactRefreshWebpackPlugin when HMR
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -123,16 +133,6 @@ exports[`react configuration > android > adds ReactRefreshWebpackPlugin when HMR
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -411,6 +411,16 @@ exports[`react configuration > android > base config 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -438,16 +448,6 @@ exports[`react configuration > android > base config 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -722,6 +722,16 @@ exports[`react configuration > ios > adds ReactRefreshWebpackPlugin when HMR ena
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -760,16 +770,6 @@ exports[`react configuration > ios > adds ReactRefreshWebpackPlugin when HMR ena
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -1049,6 +1049,16 @@ exports[`react configuration > ios > base config 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -1076,16 +1086,6 @@ exports[`react configuration > ios > base config 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -79,6 +79,16 @@ exports[`svelte configuration for android 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts|svelte)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -105,16 +115,6 @@ exports[`svelte configuration for android 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts|svelte)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -404,6 +404,16 @@ exports[`svelte configuration for ios 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts|svelte)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -430,16 +440,6 @@ exports[`svelte configuration for ios 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts|svelte)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -76,13 +76,6 @@ exports[`svelte configuration for android 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -407,13 +400,6 @@ exports[`svelte configuration for ios 1`] = `
             loader: 'app-css-loader',
             options: {
               platform: 'ios'
-            }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
             }
           }
         ]

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -75,6 +75,16 @@ exports[`typescript configuration for android 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -101,16 +111,6 @@ exports[`typescript configuration for android 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -388,6 +388,16 @@ exports[`typescript configuration for ios 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -414,16 +424,6 @@ exports[`typescript configuration for ios 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -72,13 +72,6 @@ exports[`typescript configuration for android 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -181,23 +174,6 @@ exports[`typescript configuration for android 1`] = `
           /* config.module.rule('scss').use('sass-loader') */
           {
             loader: 'sass-loader'
-          }
-        ]
-      },
-      /* config.module.rule('hmr-core') */
-      {
-        test: /\\\\.(js|ts)$/,
-        exclude: [
-          /node_modules/,
-          '__jest__/src/app.js'
-        ],
-        use: [
-          /* config.module.rule('hmr-core').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              appPath: '__jest__/src'
-            }
           }
         ]
       }
@@ -409,13 +385,6 @@ exports[`typescript configuration for ios 1`] = `
             options: {
               platform: 'ios'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -518,23 +487,6 @@ exports[`typescript configuration for ios 1`] = `
           /* config.module.rule('scss').use('sass-loader') */
           {
             loader: 'sass-loader'
-          }
-        ]
-      },
-      /* config.module.rule('hmr-core') */
-      {
-        test: /\\\\.(js|ts)$/,
-        exclude: [
-          /node_modules/,
-          '__jest__/src/app.js'
-        ],
-        use: [
-          /* config.module.rule('hmr-core').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              appPath: '__jest__/src'
-            }
           }
         ]
       }

--- a/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
@@ -75,13 +75,6 @@ exports[`vue configuration for android 1`] = `
             options: {
               platform: 'android'
             }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
-            }
           }
         ]
       },
@@ -419,13 +412,6 @@ exports[`vue configuration for ios 1`] = `
             loader: 'app-css-loader',
             options: {
               platform: 'ios'
-            }
-          },
-          /* config.module.rule('bundle').use('nativescript-hot-loader') */
-          {
-            loader: 'nativescript-hot-loader',
-            options: {
-              injectHMRRuntime: true
             }
           }
         ]

--- a/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
@@ -78,6 +78,16 @@ exports[`vue configuration for android 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -107,16 +117,6 @@ exports[`vue configuration for android 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */
@@ -416,6 +416,16 @@ exports[`vue configuration for ios 1`] = `
           }
         ]
       },
+      /* config.module.rule('workers') */
+      {
+        test: /\\\\.(js|ts)$/,
+        use: [
+          /* config.module.rule('workers').use('nativescript-worker-loader') */
+          {
+            loader: 'nativescript-worker-loader'
+          }
+        ]
+      },
       /* config.module.rule('ts') */
       {
         test: [
@@ -445,16 +455,6 @@ exports[`vue configuration for ios 1`] = `
         test: /\\\\.js$/,
         exclude: [
           /node_modules/
-        ]
-      },
-      /* config.module.rule('workers') */
-      {
-        test: /\\\\.(js|ts)$/,
-        use: [
-          /* config.module.rule('workers').use('nativescript-worker-loader') */
-          {
-            loader: 'nativescript-worker-loader'
-          }
         ]
       },
       /* config.module.rule('xml') */

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -209,6 +209,14 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			});
 	});
 
+	// worker loader should be before ts-loader
+	// we're not using .before because "ts" might not exist in all configurations
+	config.module
+		.rule('workers')
+		.test(/\.(js|ts)$/)
+		.use('nativescript-worker-loader')
+		.loader('nativescript-worker-loader');
+
 	// set up ts support
 	config.module
 		.rule('ts')
@@ -252,12 +260,6 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		.test(/\.js$/)
 		.exclude.add(/node_modules/)
 		.end();
-
-	config.module
-		.rule('workers')
-		.test(/\.(js|ts)$/)
-		.use('nativescript-worker-loader')
-		.loader('nativescript-worker-loader');
 
 	// config.resolve.extensions.add('.xml');
 	// set up xml

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -198,12 +198,16 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		.options({
 			platform,
 		})
-		.end()
-		.use('nativescript-hot-loader')
-		.loader('nativescript-hot-loader')
-		.options({
-			injectHMRRuntime: true,
-		});
+		.end();
+	config.when(env.hmr, (config) => {
+		config.module
+			.rule('bundle')
+			.use('nativescript-hot-loader')
+			.loader('nativescript-hot-loader')
+			.options({
+				injectHMRRuntime: true,
+			});
+	});
 
 	// set up ts support
 	config.module

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -199,6 +199,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			platform,
 		})
 		.end();
+
 	config.when(env.hmr, (config) => {
 		config.module
 			.rule('bundle')
@@ -209,8 +210,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			});
 	});
 
-	// worker loader should be before ts-loader
-	// we're not using .before because "ts" might not exist in all configurations
+	// worker-loader should be declared before ts-loader
 	config.module
 		.rule('workers')
 		.test(/\.(js|ts)$/)

--- a/packages/webpack5/src/configuration/javascript.ts
+++ b/packages/webpack5/src/configuration/javascript.ts
@@ -34,18 +34,20 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		virtualEntryPath
 	);
 
-	// set up core HMR
-	config.module
-		.rule('hmr-core')
-		.test(/\.js$/)
-		.exclude.add(/node_modules/)
-		.add(entryPath)
-		.end()
-		.use('nativescript-hot-loader')
-		.loader('nativescript-hot-loader')
-		.options({
-			appPath: getEntryDirPath(),
-		});
+	config.when(env.hmr, (config) => {
+		// set up core HMR
+		config.module
+			.rule('hmr-core')
+			.test(/\.js$/)
+			.exclude.add(/node_modules/)
+			.add(entryPath)
+			.end()
+			.use('nativescript-hot-loader')
+			.loader('nativescript-hot-loader')
+			.options({
+				appPath: getEntryDirPath(),
+			});
+	});
 
 	return config;
 }

--- a/packages/webpack5/src/configuration/javascript.ts
+++ b/packages/webpack5/src/configuration/javascript.ts
@@ -38,6 +38,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		// set up core HMR
 		config.module
 			.rule('hmr-core')
+			.before('js')
 			.test(/\.js$/)
 			.exclude.add(/node_modules/)
 			.add(entryPath)

--- a/packages/webpack5/src/configuration/typescript.ts
+++ b/packages/webpack5/src/configuration/typescript.ts
@@ -34,18 +34,20 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		virtualEntryPath
 	);
 
-	// set up core HMR
-	config.module
-		.rule('hmr-core')
-		.test(/\.(js|ts)$/)
-		.exclude.add(/node_modules/)
-		.add(entryPath)
-		.end()
-		.use('nativescript-hot-loader')
-		.loader('nativescript-hot-loader')
-		.options({
-			appPath: getEntryDirPath(),
-		});
+	config.when(env.hmr, (config) => {
+		// set up core HMR
+		config.module
+			.rule('hmr-core')
+			.test(/\.(js|ts)$/)
+			.exclude.add(/node_modules/)
+			.add(entryPath)
+			.end()
+			.use('nativescript-hot-loader')
+			.loader('nativescript-hot-loader')
+			.options({
+				appPath: getEntryDirPath(),
+			});
+	});
 
 	return config;
 }

--- a/packages/webpack5/src/configuration/typescript.ts
+++ b/packages/webpack5/src/configuration/typescript.ts
@@ -38,6 +38,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		// set up core HMR
 		config.module
 			.rule('hmr-core')
+			.before('ts')
 			.test(/\.(js|ts)$/)
 			.exclude.add(/node_modules/)
 			.add(entryPath)


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
webpack 5 includes nativescript-hot-loader and the hmr runtime regardless if it's being used or not (which have a nasty side effect of removing sourcemaps for code coverage)

## What is the new behavior?
Those are only added when env.hmr is true
