### PR TITLE
fix(webpack): exclude other platforms from require.context

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -316,6 +316,10 @@ exports[`angular configuration for android 1`] = `
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -716,6 +720,10 @@ exports[`angular configuration for ios 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -232,6 +232,10 @@ exports[`base configuration for android 1`] = `
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -535,6 +539,10 @@ exports[`base configuration for ios 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -232,6 +232,10 @@ exports[`javascript configuration for android 1`] = `
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -544,6 +548,10 @@ exports[`javascript configuration for ios 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
@@ -254,6 +254,10 @@ exports[`react configuration > android > adds ReactRefreshWebpackPlugin when HMR
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -568,6 +572,10 @@ exports[`react configuration > android > base config 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
@@ -891,6 +899,10 @@ exports[`react configuration > ios > adds ReactRefreshWebpackPlugin when HMR ena
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -1206,6 +1218,10 @@ exports[`react configuration > ios > base config 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -259,6 +259,10 @@ exports[`svelte configuration for android 1`] = `
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -583,6 +587,10 @@ exports[`svelte configuration for ios 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -232,6 +232,10 @@ exports[`typescript configuration for android 1`] = `
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -544,6 +548,10 @@ exports[`typescript configuration for ios 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
@@ -272,6 +272,10 @@ exports[`vue configuration for android 1`] = `
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
     ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(ios)\\\\.(\\\\w+)$/
+    ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(
       {
@@ -609,6 +613,10 @@ exports[`vue configuration for ios 1`] = `
     /* config.plugin('ContextExclusionPlugin|App_Resources') */
     new ContextExclusionPlugin(
       /(.*)App_Resources(.*)/
+    ),
+    /* config.plugin('ContextExclusionPlugin|Other_Platforms') */
+    new ContextExclusionPlugin(
+      /\\\\.(android)\\\\.(\\\\w+)$/
     ),
     /* config.plugin('DefinePlugin') */
     new DefinePlugin(

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -25,6 +25,7 @@ import {
 	getAbsoluteDistPath,
 	getEntryDirPath,
 	getEntryPath,
+	getAvailablePlatforms,
 } from '../helpers/platform';
 
 export default function (config: Config, env: IWebpackEnv = _env): Config {
@@ -333,6 +334,18 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	config
 		.plugin('ContextExclusionPlugin|App_Resources')
 		.use(ContextExclusionPlugin, [new RegExp(`(.*)App_Resources(.*)`)]);
+
+	// Makes sure that require.context will never include code from
+	// another platform (ie .android.ts when building for ios)
+	const otherPlatformsRE = getAvailablePlatforms()
+		.filter((platform) => platform !== getPlatformName())
+		.join('|');
+
+	config
+		.plugin('ContextExclusionPlugin|Other_Platforms')
+		.use(ContextExclusionPlugin, [
+			new RegExp(`\\.(${otherPlatformsRE})\\.(\\w+)$`),
+		]);
 
 	// Filter common undesirable warnings
 	config.set(

--- a/packages/webpack5/src/helpers/platform.ts
+++ b/packages/webpack5/src/helpers/platform.ts
@@ -41,6 +41,13 @@ export function getPlatform(): INativeScriptPlatform {
 }
 
 /**
+ * Utility to get all registered/available platforms
+ */
+export function getAvailablePlatforms(): string[] {
+	return Object.keys(platforms);
+}
+
+/**
  * Utility to get the currently targeted platform name
  */
 export function getPlatformName(): Platform {
@@ -61,7 +68,7 @@ export function getPlatformName(): Platform {
 		throw error(`
 			Invalid platform: ${env.platform}
 
-			Valid platforms: ${Object.keys(platforms).join(', ')}
+			Valid platforms: ${getAvailablePlatforms().join(', ')}
 		`);
 	}
 


### PR DESCRIPTION

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`require.context` may include `.android.ts` etc files when building for ios, and the other way around.

## What is the new behavior?
<!-- Describe the changes. -->
`require.context` should not include other platforms code.

fixes #9682

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

