### PR TITLE
fix(webpack): prepend NativeClass transformer in angular config

### DIFF
--- a/packages/webpack5/src/configuration/angular.ts
+++ b/packages/webpack5/src/configuration/angular.ts
@@ -148,7 +148,9 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			if (!transformers.before) {
 				transformers.before = [];
 			}
-			transformers.before.push(require('../transformers/NativeClass').default);
+			transformers.before.unshift(
+				require('../transformers/NativeClass').default
+			);
 			args[1] = transformers;
 			return originalCreateFileEmitter.apply(this, args);
 		};


### PR DESCRIPTION
This fixes angular JIT compilation

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Because we're pushing instead of unshifting the NativeClass transformer, angular fails to build in JIT mode

## What is the new behavior?
Prepend NativeClass transformer so it always runs first

