### PR TITLE
feat: disable aot, optional angular dep and tsconfig utils

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -400,7 +400,8 @@ exports[`angular configuration for android 1`] = `
     new AngularWebpackPlugin(
       {
         tsconfig: '__jest__/tsconfig.json',
-        directTemplateLoading: false
+        directTemplateLoading: false,
+        jitMode: false
       }
     )
   ],
@@ -816,7 +817,8 @@ exports[`angular configuration for ios 1`] = `
     new AngularWebpackPlugin(
       {
         tsconfig: '__jest__/tsconfig.json',
-        directTemplateLoading: false
+        directTemplateLoading: false,
+        jitMode: false
       }
     )
   ],

--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -54,6 +54,7 @@
 		"webpack-virtual-modules": "^0.4.0"
 	},
 	"devDependencies": {
+		"@angular-devkit/build-angular": "^13.1.2",
 		"@types/css": "0.0.33",
 		"@types/jest": "27.0.1",
 		"@types/loader-utils": "2.0.3",

--- a/packages/webpack5/src/configuration/angular.ts
+++ b/packages/webpack5/src/configuration/angular.ts
@@ -3,17 +3,17 @@ import { extname, resolve } from 'path';
 import Config from 'webpack-chain';
 import { existsSync } from 'fs';
 
+import { getDependencyPath } from '../helpers/dependencies';
 import { getProjectFilePath } from '../helpers/project';
 import { env as _env, IWebpackEnv } from '../index';
+import { readTsConfig } from '../helpers/tsconfig';
+import { warnOnce } from '../helpers/log';
 import {
 	getEntryDirPath,
 	getEntryPath,
 	getPlatformName,
 } from '../helpers/platform';
 import base from './base';
-import { getDependencyPath } from '../helpers/dependencies';
-import { warnOnce } from '../helpers/log';
-import { readTsConfig } from '../helpers/tsconfig';
 
 export default function (config: Config, env: IWebpackEnv = _env): Config {
 	base(config, env);
@@ -175,6 +175,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 				.use('angular-hot-loader')
 				.loader('angular-hot-loader');
 		});
+
 		const buildAngularPath = getDependencyPath('@angular-devkit/build-angular');
 		if (buildAngularPath) {
 			const tsConfig = readTsConfig(tsConfigPath);
@@ -204,9 +205,8 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			warnOnce(
 				'build-angular-missing',
 				`
-				@angular-devkit/build-angular is missing!
-				Please install it to be able to use Angular to it's full potential.
-			`
+				@angular-devkit/build-angular is missing! Some features may not work as expected. Please install it manually to get rid of this warning.
+				`
 			);
 		}
 	}

--- a/packages/webpack5/src/helpers/index.ts
+++ b/packages/webpack5/src/helpers/index.ts
@@ -26,6 +26,7 @@ import {
 	getPlatform,
 	getPlatformName,
 } from './platform';
+import { readTsConfig } from './tsconfig';
 
 // intentionally populated manually
 // as this generates nicer typings
@@ -74,5 +75,8 @@ export default {
 	virtualModules: {
 		addVirtualEntry,
 		addVirtualModule,
+	},
+	tsconfig: {
+		readTsConfig,
 	},
 };

--- a/packages/webpack5/src/helpers/tsconfig.ts
+++ b/packages/webpack5/src/helpers/tsconfig.ts
@@ -1,5 +1,5 @@
-import { dirname } from 'path';
 import { readConfigFile, parseJsonConfigFileContent, sys } from 'typescript';
+import { dirname } from 'path';
 
 export function readTsConfig(path: string) {
 	const f = readConfigFile(path, sys.readFile);

--- a/packages/webpack5/src/helpers/tsconfig.ts
+++ b/packages/webpack5/src/helpers/tsconfig.ts
@@ -1,0 +1,19 @@
+import { dirname } from 'path';
+import { readConfigFile, parseJsonConfigFileContent, sys } from 'typescript';
+
+export function readTsConfig(path: string) {
+	const f = readConfigFile(path, sys.readFile);
+
+	const parsed = parseJsonConfigFileContent(
+		f.config,
+		{
+			fileExists: sys.fileExists,
+			readFile: sys.readFile,
+			readDirectory: sys.readDirectory,
+			useCaseSensitiveFileNames: true,
+		},
+		dirname(path)
+	);
+
+	return parsed;
+}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
throws when no @angular-devkit/build-angular is installed and uses ESNext always

## What is the new behavior?
shows warning instead, reads tsconfig and adds --env.disableAOT flag

