### PR TITLE
fix: Qualifier matcher did not support multiple qualifiers for a single file

### DIFF
--- a/packages/core/module-name-resolver/qualifier-matcher/index.ts
+++ b/packages/core/module-name-resolver/qualifier-matcher/index.ts
@@ -119,20 +119,21 @@ const supportedQualifiers: Array<QualifierSpec> = [minWidthHeightQualifier, minW
 
 function checkQualifiers(path: string, context: PlatformContext): number {
 	let result = 0;
+	let value: number;
 	for (let i = 0; i < supportedQualifiers.length; i++) {
 		const qualifier = supportedQualifiers[i];
 		if (qualifier.isMatch(path)) {
 			const occurences = qualifier.getMatchOccurences(path);
 			// Always get the last qualifier among identical occurences
-			result = qualifier.getMatchValue(occurences[occurences.length - 1], context);
-			if (result < 0) {
+			value = qualifier.getMatchValue(occurences[occurences.length - 1], context);
+			if (value < 0) {
 				// Non of the supported qualifiers matched this or the match was not satisfied
 				return -1;
 			}
 
-			result += (supportedQualifiers.length - i) * PRIORITY_STEP;
-
-			return result;
+			if (value > 0) {
+				result += value + (supportedQualifiers.length - i) * PRIORITY_STEP;
+			}
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Screen qualifier matcher does not support multiple qualifiers for a file.

## What is the new behavior?
Screen qualifier matcher will support multiple qualifiers for a file.

Fixes/Closes #9706 