### PR TITLE
fix(android): nested frames were sometimes not recreated

### DIFF
--- a/packages/core/ui/frame/fragment.android.ts
+++ b/packages/core/ui/frame/fragment.android.ts
@@ -19,6 +19,10 @@ const FragmentClass = (<any>org.nativescript.widgets.FragmentBase).extend('com.t
 		this._callbacks.onPause(this, superProto.onPause);
 	},
 
+	onResume(): void {
+		this._callbacks.onResume(this, superProto.onResume);
+	},
+
 	onCreate(savedInstanceState: android.os.Bundle) {
 		if (!this._callbacks) {
 			setFragmentCallbacks(this);

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -51,6 +51,7 @@ export interface ExpandedEntry extends BackstackEntry {
 	frameId: number;
 
 	isNestedDefaultTransition: boolean;
+	isAnimationRunning: boolean;
 }
 
 export function _setAndroidFragmentTransitions(animated: boolean, navigationTransition: NavigationTransition, currentEntry: ExpandedEntry, newEntry: ExpandedEntry, frameId: number, fragmentTransaction: androidx.fragment.app.FragmentTransaction, isNestedDefaultTransition?: boolean): void {
@@ -60,6 +61,7 @@ export function _setAndroidFragmentTransitions(animated: boolean, navigationTran
 	if (entries && entries.size > 0) {
 		throw new Error('Calling navigation before previous navigation finish.');
 	}
+	newEntry.isAnimationRunning = false;
 
 	allowTransitionOverlap(currentFragment);
 	allowTransitionOverlap(newFragment);
@@ -227,6 +229,7 @@ function getAnimationListener(): android.animation.Animator.AnimatorListener {
 				if (Trace.isEnabled()) {
 					Trace.write(`START ${animator.transitionType} for ${entry.fragmentTag}`, Trace.categories.Transition);
 				}
+				entry.isAnimationRunning = true;
 			}
 
 			onAnimationRepeat(animator: ExpandedAnimator): void {
@@ -239,6 +242,7 @@ function getAnimationListener(): android.animation.Animator.AnimatorListener {
 				if (Trace.isEnabled()) {
 					Trace.write(`END ${animator.transitionType} for ${animator.entry.fragmentTag}`, Trace.categories.Transition);
 				}
+				animator.entry.isAnimationRunning = false;
 				transitionOrAnimationCompleted(animator.entry, animator.backEntry);
 			}
 
@@ -246,6 +250,7 @@ function getAnimationListener(): android.animation.Animator.AnimatorListener {
 				if (Trace.isEnabled()) {
 					Trace.write(`CANCEL ${animator.transitionType} for ${animator.entry.fragmentTag}`, Trace.categories.Transition);
 				}
+				animator.entry.isAnimationRunning = false;
 			}
 		}
 

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -476,6 +476,7 @@ export interface AndroidFragmentCallbacks {
 	onDestroyView(fragment: any, superFunc: Function): void;
 	onDestroy(fragment: any, superFunc: Function): void;
 	onPause(fragment: any, superFunc: Function): void;
+	onResume(fragment: any, superFunc: Function): void;
 	onStop(fragment: any, superFunc: Function): void;
 	toStringOverride(fragment: any, superFunc: Function): string;
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Nested frames get into inconsistent states when destroyed and recreated.

## What is the new behavior?
We attempt to manually recreate the frames when android doesn't magically do it for us.


BREAKING CHANGES:


AndroidFragmentCallbacks now requires `onResume` as well

Migration steps:
specify `onResume` on custom fragment implementations

