### PR TITLE
fix(8.2-alpha): `Application.android` and `Application.ios` were undefined in startup

### DIFF
--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -215,6 +215,7 @@ export function _resetRootView(entry?: NavigationEntry | string): void {
 	}
 	callbacks.resetActivityContent(activity);
 }
+export const resetRootView = _resetRootView;
 
 export function getMainEntry() {
 	return mainEntry;

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -464,6 +464,7 @@ export function _resetRootView(entry?: NavigationEntry | string) {
 	mainEntry = typeof entry === 'string' ? { moduleName: entry } : entry;
 	iosApp.setWindowContent();
 }
+export const resetRootView = _resetRootView;
 
 export function getNativeApplication(): UIApplication {
 	return iosApp.nativeApp;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,44 +5,7 @@ import './globals';
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
 
-import { fontScaleChangedEvent, launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance, setAutoSystemAppearanceChanged } from './application';
-export const Application = {
-	launchEvent,
-	displayedEvent,
-	uncaughtErrorEvent,
-	discardedErrorEvent,
-	suspendEvent,
-	resumeEvent,
-	exitEvent,
-	lowMemoryEvent,
-	orientationChangedEvent,
-	systemAppearanceChangedEvent,
-	systemAppearanceChanged,
-	fontScaleChangedEvent,
-
-	getMainEntry,
-	getRootView,
-	resetRootView: _resetRootView,
-	getResources,
-	setResources,
-	setCssFileName,
-	getCssFileName,
-	loadAppCss,
-	addCss,
-	on,
-	off,
-	notify,
-	hasListeners,
-	run,
-	orientation,
-	getNativeApplication,
-	hasLaunched,
-	systemAppearance,
-	setAutoSystemAppearanceChanged,
-
-	android: appAndroid,
-	ios: iosApp,
-};
+export * as Application from './application';
 
 // Export all methods from "application-settings" as ApplicationSettings
 import { setString, getString, clear, flush, getAllKeys, getBoolean, getNumber, hasKey, remove, setBoolean, setNumber } from './application-settings';


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Since application instances are now created during the call of `Application.run`, core `index.ts` of NativeScript will always export `Application.android` and `Application.ios` as undefined.
This was tested with a JavaScript app on android device.

I believe the reason is that these properties are exported inside a constant named `Application`, therefore imported properties are never updated when changed.

Here is the root of the problem:
```js
export const Application = {
	launchEvent,
	displayedEvent,
	uncaughtErrorEvent,
	discardedErrorEvent,
	suspendEvent,
	resumeEvent,
	exitEvent,
	lowMemoryEvent,
	orientationChangedEvent,
	systemAppearanceChangedEvent,
	systemAppearanceChanged,
	fontScaleChangedEvent,

	getMainEntry,
	getRootView,
	resetRootView: _resetRootView,
	getResources,
	setResources,
	setCssFileName,
	getCssFileName,
	loadAppCss,
	addCss,
	on,
	off,
	notify,
	hasListeners,
	run,
	orientation,
	getNativeApplication,
	hasLaunched,
	systemAppearance,
	setAutoSystemAppearanceChanged,

	android: appAndroid,
	ios: iosApp,
};

```
## What is the new behavior?
New behaviour will export everything from application module using ECMA2020 `export * as`.
This is not perfect as it exports everything, but the other alternative is to initialize application instances much earlier like before.


@NathanWalker This is related to changes here: https://github.com/NativeScript/NativeScript/commit/88e355d8144cff4d13c59ac83cdbc2c00fd2fe35
I'm not sure how this will affect things but `android` and `ios` application properties will be undefined before `Application.run` is called. There might be people who tend to use these properties before application runs.

Another alternative could perhaps be meddling with `export default` in application android and ios files.