### PR TITLE
feat(8.2-alpha): Addition of "global" context for expressions inside XML

### DIFF
--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -178,7 +178,7 @@ const expressionParsers = {
 
 function getContext(key, model, changedModel) {
 	let context = key in changedModel ? changedModel : model;
-	if (!context && key in global) {
+	if (!(key in context)) {
 		context = global;
 	}
 	return context;

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -177,7 +177,11 @@ const expressionParsers = {
 };
 
 function getContext(key, model, changedModel) {
-	return key in changedModel ? changedModel : model;
+	let context = key in changedModel ? changedModel : model;
+	if (!context && key in global) {
+		context = global;
+	}
+	return context;
 }
 
 function getConverter(converterSchema, context, args, isBackConvert: boolean) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

This is an addition to my work for vanilla NS expression parsing. It contains few tweaks regarding binding contexts.

## What is the current behavior?
1) Expression parser cannot parse indentifiers that belong to global.
2) Converter callbacks use object they are declared into as a context.

## What is the new behavior?
1) Expression parser will now check if an identifier belongs to global.
2) Converter callbacks will have current binding context or the instance they were called from as function context just like the old way.

Hello World app sample with an example of supporting `global`:
```xml
<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo">
   <ActionBar title="My App" icon="" />

    <StackLayout class="p-20">
        <Label text="Tap the button" class="h1 text-center" />
        <Button text="TAP" tap="{{ onTap }}" class="-primary" />
        <Label text="{{ message }}" class="h2 text-center" textWrap="true" />
        <!-- Use of `Math` here -->
        <Label text="{{ Math.abs(_counter * -1) }}" class="h2 text-center" textWrap="true" />
    </StackLayout>
</Page>
```

