### PR TITLE
feat(ui): TouchManager for ease in adding interactivity

### DIFF
--- a/apps/automated/src/http/http-string-worker.ts
+++ b/apps/automated/src/http/http-string-worker.ts
@@ -1,13 +1,13 @@
 // todo: figure out why this worker is including the whole core and not just the Http module
 // ie. tree-shaking is not working as expected here. (same setup works in a separate app)
-import { initGlobal } from '@nativescript/core/globals/index';
-initGlobal();
+// import { initGlobal } from '@nativescript/core/globals/index';
+// initGlobal();
 
-import { Http } from '@nativescript/core';
+import { getString } from '@nativescript/core/http';
 
 declare var postMessage: any;
 
-Http.getString('https://httpbin.org/get').then(
+getString('https://httpbin.org/get').then(
 	function (r) {
 		postMessage(r);
 	},

--- a/apps/toolbox/src/app.css
+++ b/apps/toolbox/src/app.css
@@ -5,6 +5,9 @@
 The following CSS rule changes the font size of all UI
 components that have the btn class name.
 */
+Button {
+    text-transform: none;
+}
 .btn-view-demo {
   background-color: #65ADF1;
   border-radius: 5;

--- a/apps/toolbox/src/main-page.xml
+++ b/apps/toolbox/src/main-page.xml
@@ -6,14 +6,15 @@
   <StackLayout class="p-20">
     <ScrollView class="h-full">
       <StackLayout>
-        <Button text="list-page" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="box-shadow" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="root-layout" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="a11y" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="css-playground" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="visibility-vs-hidden" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="image-async" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
-        <Button text="vector-image" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo"/>
+        <Button text="list-page" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="box-shadow" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="root-layout" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="a11y" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="css-playground" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="visibility-vs-hidden" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="image-async" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="vector-image" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="touch-animations" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
       </StackLayout>
     </ScrollView>
   </StackLayout>

--- a/apps/toolbox/src/pages/touch-animations.ts
+++ b/apps/toolbox/src/pages/touch-animations.ts
@@ -1,0 +1,198 @@
+import { Observable, EventData, Page, CoreTypes, TouchManager, TouchAnimationOptions, Color, View } from '@nativescript/core';
+
+let page: Page;
+
+export function navigatingTo(args: EventData) {
+	page = <Page>args.object;
+	page.bindingContext = new TouchAnimationsModel(page);
+}
+
+export class TouchAnimationsModel extends Observable {
+	touchAnimation: TouchAnimationOptions = {
+		down: {
+			scale: { x: 0.95, y: 0.95 },
+			backgroundColor: new Color('purple'),
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+		up: {
+			scale: { x: 1, y: 1 },
+			backgroundColor: new Color('#30bcff'),
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+	};
+
+	touchAnimationLabel: TouchAnimationOptions = {
+		down: {
+			scale: { x: 0.85, y: 0.85 },
+			duration: 150,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+		up: {
+			scale: { x: 1, y: 1 },
+			duration: 150,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+	};
+
+	touchAnimationLayout: TouchAnimationOptions = {
+		down: {
+			scale: { x: 0.85, y: 0.85 },
+			opacity: 0.7,
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+		up: {
+			scale: { x: 1, y: 1 },
+			opacity: 1,
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+	};
+
+	touchAnimationNative: TouchAnimationOptions = {
+		down: (view: View) => {
+			if (global.isIOS) {
+				// (<UIButton>view.ios).setTitleColorForState(new Color('white').ios, UIControlState.Selected | UIControlState.Normal | UIControlState.Highlighted);
+				// 		(<UIButton>view.ios).titleLabel.textColor = new Color('white').ios;
+				UIView.animateWithDurationDelayUsingSpringWithDampingInitialSpringVelocityOptionsAnimationsCompletion(
+					0.4,
+					0,
+					0.5,
+					3,
+					UIViewAnimationOptions.CurveEaseInOut,
+					() => {
+						view.ios.transform = CGAffineTransformMakeScale(0.95, 0.95);
+						view.opacity = 0.5;
+						view.ios.backgroundColor = new Color('red').ios;
+						view.color = new Color('white');
+					},
+					() => {
+						// shake when all the way down
+						view
+							.animate({ translate: { x: -20, y: 0 }, scale: { x: 0.95, y: 0.95 }, duration: 60, curve: CoreTypes.AnimationCurve.linear })
+							.then(function () {
+								return view.animate({ translate: { x: 20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: -20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: 20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: -10, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: 10, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: -5, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: 5, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {
+								return view.animate({ translate: { x: 0, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+							})
+							.then(function () {});
+					}
+				);
+			} else {
+			}
+		},
+		up: (view: View) => {
+			if (global.isIOS) {
+				UIView.animateWithDurationDelayUsingSpringWithDampingInitialSpringVelocityOptionsAnimationsCompletion(
+					0.4,
+					0,
+					0.5,
+					3,
+					UIViewAnimationOptions.CurveEaseInOut,
+					() => {
+						view.ios.transform = CGAffineTransformMakeScale(1.2, 1.2);
+					},
+					() => {
+						UIView.animateWithDurationDelayUsingSpringWithDampingInitialSpringVelocityOptionsAnimationsCompletion(
+							0.2,
+							0,
+							0.5,
+							3,
+							UIViewAnimationOptions.CurveEaseInOut,
+							() => {
+								view.ios.transform = CGAffineTransformIdentity;
+								view.opacity = 1;
+								view.ios.backgroundColor = new Color('#aee406').ios;
+								view.color = new Color('black');
+							},
+							() => {
+								// complete
+							}
+						);
+					}
+				);
+			} else {
+			}
+		},
+	};
+
+	touchAnimationRotate: TouchAnimationOptions = {
+		down: {
+			scale: { x: 0.85, y: 0.85 },
+			rotate: 6,
+			opacity: 0.7,
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+		up: {
+			scale: { x: 1, y: 1 },
+			rotate: 0,
+			opacity: 1,
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+	};
+
+	touchAnimationGrow: TouchAnimationOptions = {
+		down: {
+			scale: { x: 1.2, y: 1.2 },
+			backgroundColor: new Color('#325279'),
+			rotate: -4,
+			duration: 250,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+		up: {
+			scale: { x: 1, y: 1 },
+			backgroundColor: new Color('#006968'),
+			rotate: 0,
+			duration: 900,
+			curve: CoreTypes.AnimationCurve.easeInOut,
+		},
+	};
+
+	constructor(private page: Page) {
+		super();
+		TouchManager.enableGlobalTapAnimations = true;
+		this.page.on('navigatingFrom', () => {
+			TouchManager.enableGlobalTapAnimations = false;
+		});
+
+		// reuse instance level animations but customize to ensure they are different
+		TouchManager.animations = {
+			down: {
+				...this.touchAnimation.down,
+				backgroundColor: new Color('rgba(48, 188, 255, .7)'),
+				duration: 150,
+			},
+			up: {
+				...this.touchAnimation.up,
+				duration: 150,
+			},
+		};
+	}
+
+	onTapAnything() {
+		console.log('onTapAnything');
+	}
+}

--- a/apps/toolbox/src/pages/touch-animations.ts
+++ b/apps/toolbox/src/pages/touch-animations.ts
@@ -53,9 +53,37 @@ export class TouchAnimationsModel extends Observable {
 
 	touchAnimationNative: TouchAnimationOptions = {
 		down: (view: View) => {
+			const shakeIt = () => {
+				// shake when all the way down
+				view
+					.animate({ translate: { x: -20, y: 0 }, scale: { x: 0.95, y: 0.95 }, duration: 60, curve: CoreTypes.AnimationCurve.linear })
+					.then(function () {
+						return view.animate({ translate: { x: 20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: -20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: 20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: -10, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: 10, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: -5, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: 5, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {
+						return view.animate({ translate: { x: 0, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
+					})
+					.then(function () {});
+			};
 			if (global.isIOS) {
-				// (<UIButton>view.ios).setTitleColorForState(new Color('white').ios, UIControlState.Selected | UIControlState.Normal | UIControlState.Highlighted);
-				// 		(<UIButton>view.ios).titleLabel.textColor = new Color('white').ios;
 				UIView.animateWithDurationDelayUsingSpringWithDampingInitialSpringVelocityOptionsAnimationsCompletion(
 					0.4,
 					0,
@@ -69,37 +97,22 @@ export class TouchAnimationsModel extends Observable {
 						view.color = new Color('white');
 					},
 					() => {
-						// shake when all the way down
-						view
-							.animate({ translate: { x: -20, y: 0 }, scale: { x: 0.95, y: 0.95 }, duration: 60, curve: CoreTypes.AnimationCurve.linear })
-							.then(function () {
-								return view.animate({ translate: { x: 20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: -20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: 20, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: -10, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: 10, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: -5, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: 5, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {
-								return view.animate({ translate: { x: 0, y: 0 }, duration: 60, curve: CoreTypes.AnimationCurve.linear });
-							})
-							.then(function () {});
+						shakeIt();
 					}
 				);
 			} else {
+				view
+					.animate({
+						scale: { x: 0.95, y: 0.95 },
+						opacity: 0.5,
+						backgroundColor: new Color('red'),
+						duration: 400,
+					})
+					.then(() => {
+						view.color = new Color('white');
+						shakeIt();
+					})
+					.catch(() => {});
 			}
 		},
 		up: (view: View) => {
@@ -133,6 +146,24 @@ export class TouchAnimationsModel extends Observable {
 					}
 				);
 			} else {
+				view
+					.animate({
+						scale: { x: 1.2, y: 1.2 },
+						duration: 400,
+					})
+					.then(() => {
+						view.color = new Color('black');
+						view
+							.animate({
+								scale: { x: 1, y: 1 },
+								opacity: 1,
+								backgroundColor: new Color('#aee406'),
+								duration: 200,
+							})
+							.then(() => {})
+							.catch(() => {});
+					})
+					.catch(() => {});
 			}
 		},
 	};
@@ -171,6 +202,80 @@ export class TouchAnimationsModel extends Observable {
 		},
 	};
 
+	touchAnimationBlowAway: TouchAnimationOptions = {
+		down: (view: View) => {
+			let rotate = 3;
+			const shiftAway = (viewInstance: View, delay = 0) => {
+				setTimeout(() => {
+					viewInstance.animate({ translate: { x: 0, y: -10 }, scale: { x: 1.1, y: 1.1 }, opacity: 0.8, rotate, duration: 200, curve: CoreTypes.AnimationCurve.easeInOut }).catch(function () {});
+					rotate = rotate * -1;
+				}, delay);
+			};
+			let cnt = 0;
+			for (const id of this.elementIds) {
+				shiftAway(this.page.getViewById(id), cnt);
+				cnt += 10;
+			}
+			if (global.isIOS) {
+				UIView.animateWithDurationDelayUsingSpringWithDampingInitialSpringVelocityOptionsAnimationsCompletion(
+					0.4,
+					0,
+					0.5,
+					3,
+					UIViewAnimationOptions.CurveEaseInOut,
+					() => {
+						view.ios.transform = CGAffineTransformMakeScale(0.95, 0.95);
+						view.opacity = 0.5;
+					},
+					() => {}
+				);
+			} else {
+				view
+					.animate({
+						scale: { x: 0.95, y: 0.95 },
+						opacity: 0.5,
+						duration: 400,
+					})
+					.catch(() => {});
+			}
+		},
+		up: (view: View) => {
+			const shiftBack = (viewInstance: View, delay = 0) => {
+				setTimeout(() => {
+					viewInstance.animate({ translate: { x: 0, y: 0 }, scale: { x: 1, y: 1 }, opacity: 1, rotate: 0, duration: 200, curve: CoreTypes.AnimationCurve.easeInOut }).catch(function () {});
+				}, delay);
+			};
+			let cnt = 0;
+			for (const id of this.elementIds) {
+				shiftBack(this.page.getViewById(id), cnt);
+				cnt += 10;
+			}
+			if (global.isIOS) {
+				UIView.animateWithDurationDelayUsingSpringWithDampingInitialSpringVelocityOptionsAnimationsCompletion(
+					0.3,
+					0,
+					0.5,
+					3,
+					UIViewAnimationOptions.CurveEaseInOut,
+					() => {
+						view.ios.transform = CGAffineTransformIdentity;
+					},
+					() => {}
+				);
+			} else {
+				view
+					.animate({
+						scale: { x: 1, y: 1 },
+						opacity: 1,
+						duration: 300,
+					})
+					.catch(() => {});
+			}
+		},
+	};
+
+	elementIds = ['label', 'buttonTop', 'grid1', 'buttonShake', 'stack1', 'button2', 'button3', 'button4', 'button5'];
+
 	constructor(private page: Page) {
 		super();
 		TouchManager.enableGlobalTapAnimations = true;
@@ -190,6 +295,17 @@ export class TouchAnimationsModel extends Observable {
 				duration: 150,
 			},
 		};
+	}
+
+	loadedContainer(args) {
+		if (global.isAndroid) {
+			if (args.object.android.setClipToPadding) {
+				args.object.android.setClipToPadding(false);
+			}
+			if (args.object.android.setClipChildren) {
+				args.object.android.setClipChildren(false);
+			}
+		}
 	}
 
 	onTapAnything() {

--- a/apps/toolbox/src/pages/touch-animations.xml
+++ b/apps/toolbox/src/pages/touch-animations.xml
@@ -5,24 +5,25 @@
     </Page.actionBar>
 
     <!-- <ScrollView> -->
-      <StackLayout class="p-20">
-          <Label id="label" tap="{{ onTapAnything }}" text="Tappable label" class="h2 text-center" touchAnimation="{{ touchAnimationLabel }}" />
-          <Button id="buttonTop" text="Tap me for puple vibes" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="{{ touchAnimation }}" />
-          <GridLayout rows="auto" columns="*,auto,auto,*" class="p-10 m-y-10" tap="{{ onTapAnything }}" touchAnimation="{{ touchAnimationLayout }}" borderRadius="8" borderWidth="1" borderColor="#999">
+    
+      <StackLayout class="p-x-20" loaded="{{ loadedContainer }}">
+          <Label id="label" tap="{{ onTapAnything }}" text="Touchable label" class="t-18 c-black text-center m-t-5" touchAnimation="{{ touchAnimationLabel }}" />
+          <Button id="buttonTop" text="Touch me for puple vibes" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="{{ touchAnimation }}" />
+          <GridLayout id="grid1" rows="auto" columns="*,auto,auto,*" class="p-10 m-y-10" tap="{{ onTapAnything }}" touchAnimation="{{ touchAnimationLayout }}" borderRadius="8" borderWidth="1" borderColor="#999">
               <ContentView col="1" backgroundColor="gray" borderRadius="15" width="30" height="30" verticalAlignment="middle" />
-              <Label col="2" text="Tappable GridLayout" class="t-18 m-l-10" verticalAlignment="middle" />
+              <Label col="2" text="Touchable GridLayout" class="t-18 m-l-10" verticalAlignment="middle" />
           </GridLayout>
 
-          <Button text="Tap to shake, rattle n' pop" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-lime" touchAnimation="{{ touchAnimationNative }}" />
-          <StackLayout rows="auto" columns="*,auto,auto,*" class="p-10 m-y-10" tap="{{ onTapAnything }}" touchAnimation="{{ touchAnimationLayout }}" borderRadius="8" borderWidth="1" borderColor="#999">
+          <Button id="buttonShake" text="Tap to shake, rattle n' pop" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-lime" touchAnimation="{{ touchAnimationNative }}" />
+          <StackLayout id="stack1" rows="auto" columns="*,auto,auto,*" class="p-10 m-y-10" tap="{{ onTapAnything }}" touchAnimation="{{ touchAnimationLayout }}" borderRadius="8" borderWidth="1" borderColor="#999">
               <ContentView col="1" backgroundColor="orange" borderRadius="10" width="20" height="20" verticalAlignment="middle" />
-              <Label col="2" text="Tappable StackLayout" class="t-18 text-center" verticalAlignment="middle" />
+              <Label col="2" text="Touchable StackLayout" class="t-18 text-center" verticalAlignment="middle" />
           </StackLayout>
-          <Button id="buttonAnother" text="Auto animation w/ TouchManager" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
-          <Button text="Tap animation ignored" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" ignoreTouchAnimation="true" isEnabled="false" />
-          <Button text="Tap rotate" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-ruby" touchAnimation="{{ touchAnimationRotate }}" />
-          <Button text="Tap grow, slow return" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-forest" touchAnimation="{{ touchAnimationGrow }}" />
-          <Button text="Auto animation w/ TouchManager" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-orange" touchAnimation="true" />
+          <Button id="button2" text="Auto animation w/ TouchManager" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button id="button3" text="Touch animation ignored" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" ignoreTouchAnimation="true" isEnabled="false" />
+          <Button id="button4" text="Touch rotate" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-ruby" touchAnimation="{{ touchAnimationRotate }}" />
+          <Button id="button5" text="Touch grow, slow return" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-forest" touchAnimation="{{ touchAnimationGrow }}" />
+          <Button id="button6" text="Touch me, I'm a lil' shifty!" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-orange" touchAnimation="{{ touchAnimationBlowAway }}" />
 
           <!-- uncomment the following along with ScrollView to test behavior in ScrollView -->
           <!-- <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />

--- a/apps/toolbox/src/pages/touch-animations.xml
+++ b/apps/toolbox/src/pages/touch-animations.xml
@@ -1,0 +1,39 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
+    <Page.actionBar>
+        <ActionBar title="Touch Animations" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+
+    <!-- <ScrollView> -->
+      <StackLayout class="p-20">
+          <Label id="label" tap="{{ onTapAnything }}" text="Tappable label" class="h2 text-center" touchAnimation="{{ touchAnimationLabel }}" />
+          <Button id="buttonTop" text="Tap me for puple vibes" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="{{ touchAnimation }}" />
+          <GridLayout rows="auto" columns="*,auto,auto,*" class="p-10 m-y-10" tap="{{ onTapAnything }}" touchAnimation="{{ touchAnimationLayout }}" borderRadius="8" borderWidth="1" borderColor="#999">
+              <ContentView col="1" backgroundColor="gray" borderRadius="15" width="30" height="30" verticalAlignment="middle" />
+              <Label col="2" text="Tappable GridLayout" class="t-18 m-l-10" verticalAlignment="middle" />
+          </GridLayout>
+
+          <Button text="Tap to shake, rattle n' pop" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-lime" touchAnimation="{{ touchAnimationNative }}" />
+          <StackLayout rows="auto" columns="*,auto,auto,*" class="p-10 m-y-10" tap="{{ onTapAnything }}" touchAnimation="{{ touchAnimationLayout }}" borderRadius="8" borderWidth="1" borderColor="#999">
+              <ContentView col="1" backgroundColor="orange" borderRadius="10" width="20" height="20" verticalAlignment="middle" />
+              <Label col="2" text="Tappable StackLayout" class="t-18 text-center" verticalAlignment="middle" />
+          </StackLayout>
+          <Button id="buttonAnother" text="Auto animation w/ TouchManager" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="Tap animation ignored" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" ignoreTouchAnimation="true" isEnabled="false" />
+          <Button text="Tap rotate" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-ruby" touchAnimation="{{ touchAnimationRotate }}" />
+          <Button text="Tap grow, slow return" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-forest" touchAnimation="{{ touchAnimationGrow }}" />
+          <Button text="Auto animation w/ TouchManager" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo btn-orange" touchAnimation="true" />
+
+          <!-- uncomment the following along with ScrollView to test behavior in ScrollView -->
+          <!-- <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" />
+          <Button text="TAP" tap="{{ onTapAnything }}" class="btn btn-primary btn-view-demo" touchAnimation="true" /> -->
+          
+      </StackLayout>
+    <!-- </ScrollView> -->
+</Page>

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -46,9 +46,15 @@ export class AndroidApplication extends Observable implements AndroidApplication
 	private _systemAppearance: 'light' | 'dark';
 	public paused: boolean;
 	public nativeApp: android.app.Application;
+	/**
+	 * @deprecated Use Utils.android.getApplicationContext() instead.
+	 */
 	public context: android.content.Context;
 	public foregroundActivity: androidx.appcompat.app.AppCompatActivity;
 	public startActivity: androidx.appcompat.app.AppCompatActivity;
+	/**
+	 * @deprecated Use Utils.android.getPackageName() instead.
+	 */
 	public packageName: string;
 	// we are using these property to store the callbacks to avoid early GC collection which would trigger MarkReachableObjects
 	private callbacks: any = {};
@@ -165,7 +171,7 @@ export { androidApp as android };
 let mainEntry: NavigationEntry;
 let started = false;
 
-function ensureNativeApplication() {
+export function ensureNativeApplication() {
 	if (!androidApp) {
 		androidApp = new AndroidApplication();
 		appCommon.setApplication(androidApp);
@@ -207,6 +213,7 @@ export function addCss(cssText: string, attributeScoped?: boolean): void {
 const CALLBACKS = '_callbacks';
 
 export function _resetRootView(entry?: NavigationEntry | string): void {
+	ensureNativeApplication();
 	const activity = androidApp.foregroundActivity || androidApp.startActivity;
 	if (!activity) {
 		throw new Error('Cannot find android activity.');
@@ -225,6 +232,7 @@ export function getMainEntry() {
 }
 
 export function getRootView(): View {
+	ensureNativeApplication();
 	// Use start activity as a backup when foregroundActivity is still not set
 	// in cases when we are getting the root view before activity.onResumed event is fired
 	const activity = androidApp.foregroundActivity || androidApp.startActivity;
@@ -269,14 +277,17 @@ export function getNativeApplication(): android.app.Application {
 }
 
 export function orientation(): 'portrait' | 'landscape' | 'unknown' {
+	ensureNativeApplication();
 	return androidApp.orientation;
 }
 
 export function systemAppearance(): 'dark' | 'light' {
+	ensureNativeApplication();
 	return androidApp.systemAppearance;
 }
 
 global.__onLiveSync = function __onLiveSync(context?: ModuleContext) {
+	ensureNativeApplication();
 	if (androidApp && androidApp.paused) {
 		return;
 	}

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -165,11 +165,15 @@ export { androidApp as android };
 let mainEntry: NavigationEntry;
 let started = false;
 
-export function run(entry?: NavigationEntry | string) {
+function ensureNativeApplication() {
 	if (!androidApp) {
 		androidApp = new AndroidApplication();
 		appCommon.setApplication(androidApp);
 	}
+}
+
+export function run(entry?: NavigationEntry | string) {
+	ensureNativeApplication();
 
 	if (started) {
 		throw new Error('Application is already started.');
@@ -233,6 +237,8 @@ export function getRootView(): View {
 }
 
 export function getNativeApplication(): android.app.Application {
+	ensureNativeApplication();
+
 	// Try getting it from module - check whether application.android.init has been explicitly called
 	let nativeApp = androidApp.nativeApp;
 	if (!nativeApp) {

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -361,6 +361,13 @@ export function systemAppearance(): 'dark' | 'light' | null;
 export let android: AndroidApplication;
 
 /**
+ * Used internally for backwards compatibility, will be removed in the future.
+ * Allowed Application.android.context to work (or Application.ios). Instead use Utils.android.getApplicationContext() or Utils.android.getPackageName()
+ * @internal
+ */
+export function ensureNativeApplication(): void;
+
+/**
  * This is the iOS-specific application object instance.
  * Encapsulates methods and properties specific to the iOS platform.
  * Will be undefined when TargetOS is Android.
@@ -468,6 +475,7 @@ export class AndroidApplication extends Observable {
 
 	/**
 	 * The application's [android Context](http://developer.android.com/reference/android/content/Context.html) object instance.
+	 * @deprecated Use Utils.android.getApplicationContext() instead.
 	 */
 	context: any /* android.content.Context */;
 
@@ -495,6 +503,7 @@ export class AndroidApplication extends Observable {
 
 	/**
 	 * The name of the application package.
+	 * @deprecated Use Utils.android.getPackageName() instead.
 	 */
 	packageName: string;
 

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -353,8 +353,16 @@ let iosApp: iOSApplication;
 /* tslint:enable */
 export { iosApp as ios };
 
+export function ensureNativeApplication() {
+	if (!iosApp) {
+		iosApp = new iOSApplication();
+		setApplication(iosApp);
+	}
+}
+
 // attach on global, so it can be overwritten in NativeScript Angular
 (<any>global).__onLiveSyncCore = function (context?: ModuleContext) {
+	ensureNativeApplication();
 	iosApp._onLivesync(context);
 };
 
@@ -383,15 +391,13 @@ export function getMainEntry() {
 }
 
 export function getRootView() {
+	ensureNativeApplication();
 	return iosApp.rootView;
 }
 
 let started = false;
 export function run(entry?: string | NavigationEntry) {
-	if (!iosApp) {
-		iosApp = new iOSApplication();
-		setApplication(iosApp);
-	}
+	ensureNativeApplication();
 
 	mainEntry = typeof entry === 'string' ? { moduleName: entry } : entry;
 	started = true;
@@ -461,11 +467,13 @@ export function addCss(cssText: string, attributeScoped?: boolean): void {
 }
 
 export function _resetRootView(entry?: NavigationEntry | string) {
+	ensureNativeApplication();
 	mainEntry = typeof entry === 'string' ? { moduleName: entry } : entry;
 	iosApp.setWindowContent();
 }
 
 export function getNativeApplication(): UIApplication {
+	ensureNativeApplication();
 	return iosApp.nativeApp;
 }
 
@@ -506,6 +514,7 @@ function setViewControllerView(view: View): void {
 }
 
 function setRootViewsCssClasses(rootView: View): void {
+	ensureNativeApplication();
 	const deviceType = Device.deviceType.toLowerCase();
 
 	CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${IOS_PLATFORM}`);
@@ -518,6 +527,7 @@ function setRootViewsCssClasses(rootView: View): void {
 }
 
 function setRootViewsSystemAppearanceCssClass(rootView: View): void {
+	ensureNativeApplication();
 	if (majorVersion >= 13) {
 		const systemAppearanceCssClass = `${CSSUtils.CLASS_PREFIX}${iosApp.systemAppearance}`;
 		CSSUtils.pushToSystemCssClasses(systemAppearanceCssClass);
@@ -526,10 +536,12 @@ function setRootViewsSystemAppearanceCssClass(rootView: View): void {
 }
 
 export function orientation(): 'portrait' | 'landscape' | 'unknown' {
+	ensureNativeApplication();
 	return iosApp.orientation;
 }
 
 export function systemAppearance(): 'dark' | 'light' {
+	ensureNativeApplication();
 	return iosApp.systemAppearance;
 }
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,7 +5,7 @@ import './globals';
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
 
-import { fontScaleChangedEvent, launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance, setAutoSystemAppearanceChanged } from './application';
+import { fontScaleChangedEvent, launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance, setAutoSystemAppearanceChanged, ensureNativeApplication } from './application';
 export const Application = {
 	launchEvent,
 	displayedEvent,
@@ -40,9 +40,11 @@ export const Application = {
 	systemAppearance,
 	setAutoSystemAppearanceChanged,
 	get android() {
+		ensureNativeApplication();
 		return appAndroid;
 	},
 	get ios() {
+		ensureNativeApplication();
 		return iosApp;
 	},
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "main": "index",
   "types": "index.d.ts",
   "description": "A JavaScript library providing an easy to use api for interacting with iOS and Android platform APIs.",
-  "version": "8.2.0-alpha.3",
+  "version": "8.2.0-alpha.4",
   "homepage": "https://nativescript.org",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "main": "index",
   "types": "index.d.ts",
   "description": "A JavaScript library providing an easy to use api for interacting with iOS and Android platform APIs.",
-  "version": "8.2.0-alpha.4",
+  "version": "8.2.0-alpha.5",
   "homepage": "https://nativescript.org",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "main": "index",
   "types": "index.d.ts",
   "description": "A JavaScript library providing an easy to use api for interacting with iOS and Android platform APIs.",
-  "version": "8.2.0-alpha.1",
+  "version": "8.2.0-alpha.3",
   "homepage": "https://nativescript.org",
   "repository": {
     "type": "git",

--- a/packages/core/ui/action-bar/index.android.ts
+++ b/packages/core/ui/action-bar/index.android.ts
@@ -7,12 +7,17 @@ import { colorProperty } from '../styling/style-properties';
 import { ImageSource } from '../../image-source';
 import * as application from '../../application';
 import { isAccessibilityServiceEnabled, updateContentDescription } from '../../accessibility';
+import type { Background } from '../styling/background';
+import { Device } from '../../platform';
+import lazy from '../../utils/lazy';
 
 export * from './action-bar-common';
 
 const R_ID_HOME = 0x0102002c;
 const ACTION_ITEM_ID_OFFSET = 10000;
 const DEFAULT_ELEVATION = 4;
+
+const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
 
 let AppCompatTextView;
 let actionItemIdGenerator = ACTION_ITEM_ID_OFFSET;
@@ -59,7 +64,7 @@ function initializeMenuItemClickListener(): void {
 		return;
 	}
 
-	apiLevel = android.os.Build.VERSION.SDK_INT;
+	apiLevel = sdkVersion();
 
 	AppCompatTextView = androidx.appcompat.widget.AppCompatTextView;
 
@@ -214,6 +219,32 @@ export class ActionBar extends ActionBarBase {
 
 		// Set navigation button
 		this._updateNavigationButton();
+	}
+
+	public _applyBackground(background: Background, isBorderDrawable, onlyColor: boolean, backgroundDrawable: any) {
+		const nativeView = this.nativeViewProtected;
+		if (backgroundDrawable && onlyColor && sdkVersion() >= 21) {
+			if (isBorderDrawable && (<any>nativeView)._cachedDrawable) {
+				backgroundDrawable = (<any>nativeView)._cachedDrawable;
+				// we need to duplicate the drawable or we lose the "default" cached drawable
+				const constantState = backgroundDrawable.getConstantState();
+				if (constantState) {
+					try {
+						backgroundDrawable = constantState.newDrawable(nativeView.getResources());
+						// eslint-disable-next-line no-empty
+					} catch {}
+				}
+				nativeView.setBackground(backgroundDrawable);
+			}
+
+			const backgroundColor = ((<any>backgroundDrawable).backgroundColor = background.color.android);
+			backgroundDrawable.mutate();
+			backgroundDrawable.setColorFilter(backgroundColor, android.graphics.PorterDuff.Mode.SRC_IN);
+			backgroundDrawable.invalidateSelf(); // Make sure the drawable is invalidated. Android forgets to invalidate it in some cases: toolbar
+			(<any>backgroundDrawable).backgroundColor = backgroundColor;
+		} else {
+			super._applyBackground(background, isBorderDrawable, onlyColor, backgroundDrawable);
+		}
 	}
 
 	public _onAndroidItemSelected(itemId: number): boolean {

--- a/packages/core/ui/button/index.android.ts
+++ b/packages/core/ui/button/index.android.ts
@@ -7,6 +7,7 @@ import { profile } from '../../profiling';
 import { TouchGestureEventData, GestureTypes, TouchAction } from '../gestures';
 import { Device } from '../../platform';
 import lazy from '../../utils/lazy';
+import type { Background } from 'ui/styling/background';
 
 export * from './button-common';
 
@@ -57,6 +58,32 @@ export class Button extends ButtonBase {
 
 	private _stateListAnimator: any;
 	private _highlightedHandler: (args: TouchGestureEventData) => void;
+
+	public _applyBackground(background: Background, isBorderDrawable, onlyColor: boolean, backgroundDrawable: any) {
+		const nativeView = this.nativeViewProtected;
+		if (backgroundDrawable && onlyColor) {
+			if (isBorderDrawable && (<any>nativeView)._cachedDrawable) {
+				backgroundDrawable = (<any>nativeView)._cachedDrawable;
+				// we need to duplicate the drawable or we lose the "default" cached drawable
+				const constantState = backgroundDrawable.getConstantState();
+				if (constantState) {
+					try {
+						backgroundDrawable = constantState.newDrawable(nativeView.getResources());
+						// eslint-disable-next-line no-empty
+					} catch {}
+				}
+				nativeView.setBackground(backgroundDrawable);
+			}
+
+			const backgroundColor = ((<any>backgroundDrawable).backgroundColor = background.color.android);
+			backgroundDrawable.mutate();
+			backgroundDrawable.setColorFilter(backgroundColor, android.graphics.PorterDuff.Mode.SRC_IN);
+			backgroundDrawable.invalidateSelf(); // Make sure the drawable is invalidated. Android forgets to invalidate it in some cases: toolbar
+			(<any>backgroundDrawable).backgroundColor = backgroundColor;
+		} else {
+			super._applyBackground(background, isBorderDrawable, onlyColor, backgroundDrawable);
+		}
+	}
 
 	@profile
 	public createNativeView() {

--- a/packages/core/ui/core/view-base/index.d.ts
+++ b/packages/core/ui/core/view-base/index.d.ts
@@ -229,6 +229,16 @@ export abstract class ViewBase extends Observable {
 	 */
 	public static unloadedEvent: string;
 
+	/**
+	 * String value used when hooking to creation event
+	 */
+	public static createdEvent: string;
+
+	/**
+	 * String value used when hooking to disposeNativeView event
+	 */
+	public static disposeNativeViewEvent: string;
+
 	public ios: any;
 	public android: any;
 

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -248,7 +248,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 	public static loadedEvent = 'loaded';
 	public static unloadedEvent = 'unloaded';
 	public static createdEvent = 'created';
-	public static disposeNativeView = 'disposeNativeView';
+	public static disposeNativeViewEvent = 'disposeNativeView';
 
 	private _onLoadedCalled = false;
 	private _onUnloadedCalled = false;
@@ -765,7 +765,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 
 	public disposeNativeView() {
 		this.notify({
-			eventName: ViewBase.disposeNativeView,
+			eventName: ViewBase.disposeNativeViewEvent,
 			object: this,
 		});
 	}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -13,8 +13,7 @@ import { EventData } from '../../../data/observable';
 import { perspectiveProperty, visibilityProperty, opacityProperty, horizontalAlignmentProperty, verticalAlignmentProperty, minWidthProperty, minHeightProperty, widthProperty, heightProperty, marginLeftProperty, marginTopProperty, marginRightProperty, marginBottomProperty, rotateProperty, rotateXProperty, rotateYProperty, scaleXProperty, scaleYProperty, translateXProperty, translateYProperty, zIndexProperty, backgroundInternalProperty, androidElevationProperty, androidDynamicElevationOffsetProperty } from '../../styling/style-properties';
 import { CoreTypes } from '../../../core-types';
 
-import { Background, ad as androidBackground } from '../../styling/background';
-import { BackgroundClearFlags, refreshBorderDrawable } from '../../styling/background.android';
+import { Background, BackgroundClearFlags, refreshBorderDrawable } from '../../styling/background';
 import { profile } from '../../../profiling';
 import { topmost } from '../../frame/frame-stack';
 import { Screen } from '../../../platform';

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -1210,11 +1210,13 @@ export class View extends ViewCommon {
 		const topPadding = Math.ceil(this.effectiveBorderTopWidth + this.effectivePaddingTop);
 		const rightPadding = Math.ceil(this.effectiveBorderRightWidth + this.effectivePaddingRight);
 		const bottomPadding = Math.ceil(this.effectiveBorderBottomWidth + this.effectivePaddingBottom);
+
 		if (this._isPaddingRelative) {
 			nativeView.setPaddingRelative(leftPadding, topPadding, rightPadding, bottomPadding);
 		} else {
 			nativeView.setPadding(leftPadding, topPadding, rightPadding, bottomPadding);
 		}
+
 		// reset clear flags
 		background.clearFlags = BackgroundClearFlags.NONE;
 	}

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -8,7 +8,9 @@ import { LinearGradient } from '../../styling/linear-gradient';
 import { AccessibilityLiveRegion, AccessibilityRole, AccessibilityState, AccessibilityTrait, AccessibilityEventOptions } from '../../../accessibility/accessibility-types';
 import { CoreTypes } from '../../../core-types';
 import { CSSShadow } from '../../styling/css-shadow';
+import { ViewCommon } from './view-common';
 
+export * from './view-common';
 // helpers (these are okay re-exported here)
 export * from './view-helper';
 
@@ -99,7 +101,7 @@ export interface ShownModallyData extends EventData {
  * This class is the base class for all UI components.
  * A View occupies a rectangular area on the screen and is responsible for drawing and layouting of all UI components within.
  */
-export abstract class View extends ViewBase {
+export abstract class View extends ViewCommon {
 	/**
 	 * String value used when hooking to layoutChanged event.
 	 */

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -832,6 +832,12 @@ export abstract class View extends ViewCommon {
 	_redrawNativeBackground(value: any): void;
 	/**
 	 * @private
+	 *  method called on Android to apply the background. This allows custom handling
+	 */
+	_applyBackground(background: Background, isBorderDrawable: boolean, onlyColor: boolean, backgroundDrawable: any);
+
+	/**
+	 * @private
 	 */
 	_removeAnimation(animation: Animation): boolean;
 	/**

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -161,7 +161,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		if (!this.isLoaded) {
 			const enableTapAnimations = TouchManager.enableGlobalTapAnimations && (this.hasListeners('tap') || this.hasListeners('tapChange') || this.getGestureObservers(GestureTypes.tap));
 			if (!this.ignoreTouchAnimation && (this.touchAnimation || enableTapAnimations)) {
-				console.log('view:', Object.keys((<any>this)._observers));
+				// console.log('view:', Object.keys((<any>this)._observers));
 				TouchManager.addAnimations(this);
 			}
 		}

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -4,6 +4,7 @@ import { View as ViewDefinition, Point, Size, ShownModallyData } from '.';
 import { booleanConverter, ShowModalOptions, ViewBase } from '../view-base';
 import { getEventOrGestureName } from '../bindable';
 import { layout } from '../../../utils';
+import { isObject } from '../../../utils/types';
 import { Color } from '../../../color';
 import { Property, InheritedProperty } from '../properties';
 import { EventData } from '../../../data/observable';
@@ -13,7 +14,7 @@ import { ViewHelper } from './view-helper';
 
 import { PercentLength } from '../../styling/style-properties';
 
-import { observe as gestureObserve, GesturesObserver, GestureTypes, GestureEventData, fromString as gestureFromString } from '../../gestures';
+import { observe as gestureObserve, GesturesObserver, GestureTypes, GestureEventData, fromString as gestureFromString, TouchManager, TouchAnimationOptions } from '../../gestures';
 
 import { CSSUtils } from '../../../css/system-classes';
 import { Builder } from '../../builder';
@@ -80,6 +81,9 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	public accessibilityLabel: string;
 	public accessibilityValue: string;
 	public accessibilityHint: string;
+
+	public touchAnimation: boolean | TouchAnimationOptions;
+	public ignoreTouchAnimation: boolean;
 
 	protected _closeModalCallback: Function;
 	public _manager: any;
@@ -151,6 +155,17 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		} else if (css !== undefined) {
 			scope.css = css;
 		}
+	}
+
+	onLoaded() {
+		if (!this.isLoaded) {
+			const enableTapAnimations = TouchManager.enableGlobalTapAnimations && (this.hasListeners('tap') || this.hasListeners('tapChange') || this.getGestureObservers(GestureTypes.tap));
+			if (!this.ignoreTouchAnimation && (this.touchAnimation || enableTapAnimations)) {
+				console.log('view:', Object.keys((<any>this)._observers));
+				TouchManager.addAnimations(this);
+			}
+		}
+		super.onLoaded();
 	}
 
 	public _closeAllModalViewsInternal(): boolean {
@@ -399,7 +414,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		};
 	}
 
-	protected abstract _hideNativeModalView(parent: ViewCommon, whenClosedCallback: () => void);
+	protected _hideNativeModalView(parent: ViewCommon, whenClosedCallback: () => void) {}
 
 	protected _raiseLayoutChangedEvent() {
 		const args: EventData = {
@@ -1151,7 +1166,31 @@ export const iosIgnoreSafeAreaProperty = new InheritedProperty({
 	valueConverter: booleanConverter,
 });
 iosIgnoreSafeAreaProperty.register(ViewCommon);
-accessibilityIdentifierProperty.register(ViewCommon);
+
+const touchAnimationProperty = new Property<ViewCommon, boolean | TouchAnimationOptions>({
+	name: 'touchAnimation',
+	valueChanged(view, oldValue, newValue) {
+		view.touchAnimation = newValue;
+	},
+	valueConverter(value) {
+		if (isObject(value)) {
+			return <any>value;
+		} else {
+			return booleanConverter(value);
+		}
+	},
+});
+touchAnimationProperty.register(ViewCommon);
+
+const ignoreTouchAnimationProperty = new Property<ViewCommon, boolean>({
+	name: 'ignoreTouchAnimation',
+	valueChanged(view, oldValue, newValue) {
+		view.ignoreTouchAnimation = newValue;
+	},
+	valueConverter: booleanConverter,
+});
+ignoreTouchAnimationProperty.register(ViewCommon);
+
 accessibilityLabelProperty.register(ViewCommon);
 accessibilityValueProperty.register(ViewCommon);
 accessibilityHintProperty.register(ViewCommon);

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -1191,6 +1191,7 @@ const ignoreTouchAnimationProperty = new Property<ViewCommon, boolean>({
 });
 ignoreTouchAnimationProperty.register(ViewCommon);
 
+accessibilityIdentifierProperty.register(ViewCommon);
 accessibilityLabelProperty.register(ViewCommon);
 accessibilityValueProperty.register(ViewCommon);
 accessibilityHintProperty.register(ViewCommon);

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -1174,7 +1174,7 @@ const touchAnimationProperty = new Property<ViewCommon, boolean | TouchAnimation
 	},
 	valueConverter(value) {
 		if (isObject(value)) {
-			return <any>value;
+			return <TouchAnimationOptions>value;
 		} else {
 			return booleanConverter(value);
 		}

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -1082,6 +1082,9 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	public _redrawNativeBackground(value: any): void {
 		//
 	}
+	public _applyBackground(background, isBorderDrawable: boolean, onlyColor: boolean, backgroundDrawable: any) {
+		//
+	}
 
 	_onAttachedToWindow(): void {
 		//

--- a/packages/core/ui/gestures/gestures-common.ts
+++ b/packages/core/ui/gestures/gestures-common.ts
@@ -1,8 +1,12 @@
 ﻿import { GestureEventData, GesturesObserver as GesturesObserverDefinition } from '.';
 import { View } from '../core/view';
 
+export * from './touch-manager';
+
 export enum GestureEvents {
 	gestureAttached = 'gestureAttached',
+	touchDown = 'touchDown',
+	touchUp = 'touchUp',
 }
 
 export enum GestureTypes {

--- a/packages/core/ui/gestures/index.d.ts
+++ b/packages/core/ui/gestures/index.d.ts
@@ -1,6 +1,8 @@
 import { View } from '../core/view';
 import { EventData } from '../../data/observable';
 
+export * from './touch-manager';
+
 /**
  * Events emitted during gesture lifecycle
  */
@@ -10,6 +12,14 @@ export enum GestureEvents {
 	 * Provides access to the native gesture recognizer for further customization
 	 */
 	gestureAttached = 'gestureAttached',
+	/**
+	 * When a touch down was detected
+	 */
+	touchDown = 'touchDown',
+	/**
+	 * When a touch up was detected
+	 */
+	touchUp = 'touchUp',
 }
 
 /**

--- a/packages/core/ui/gestures/touch-manager.ts
+++ b/packages/core/ui/gestures/touch-manager.ts
@@ -1,0 +1,251 @@
+/**
+ * Provides various helpers for adding easy touch handling animations.
+ * Use when needing to implement more interactivity with your UI regarding touch down/up behavior.
+ */
+import { GestureEventData, GestureEventDataWithState, TouchGestureEventData } from '.';
+import { Animation } from '../animation';
+import { AnimationDefinition } from '../animation/animation-interfaces';
+import { View } from '../core/view';
+import { isObject, isFunction } from '../../utils/types';
+import { GestureEvents, GestureStateTypes, GestureTypes } from './gestures-common';
+
+export type TouchAnimationFn = (view: View) => void;
+export type TouchAnimationOptions = {
+	up?: TouchAnimationFn | AnimationDefinition;
+	down?: TouchAnimationFn | AnimationDefinition;
+};
+export enum TouchAnimationTypes {
+	up = 'up',
+	down = 'down',
+}
+
+/**
+ * Manage interactivity in your apps easily with TouchManager.
+ * Store reusable down/up animation settings for touches as well as optionally enable automatic tap (down/up) animations for your app.
+ */
+export class TouchManager {
+	/**
+	 * Enable animations for all tap bindings in the UI.
+	 */
+	static enableGlobalTapAnimations: boolean;
+	/**
+	 * Define reusable touch animations to use on views with touchAnimation defined or with enableGlobalTapAnimations on.
+	 */
+	static animations: TouchAnimationOptions;
+	/**
+	 * Native Touch handlers (iOS only) registered with the view through the TouchManager.
+	 * The TouchManager uses this internally but makes public for other versatility if needed.
+	 */
+	static touchHandlers: Array<{ view: View; handler: any /* UIGestureRecognizer */ }>;
+	/**
+	 * When using NativeScript AnimationDefinition's for touch animations this will contain any instances for finer grain control of starting/stopping under various circumstances.
+	 * The TouchManager uses this internally but makes public for other versatility if needed.
+	 */
+	static touchAnimationDefinitions: Array<{ view: View; animation: Animation; type: TouchAnimationTypes }>;
+	/**
+	 * The TouchManager uses this internally.
+	 * Adds touch animations to view based upon it's touchAnimation property or TouchManager.animations.
+	 * @param view NativeScript view instance
+	 */
+	static addAnimations(view: View) {
+		// console.log("tapHandler:", tapHandler);
+		const handleDown = (view?.touchAnimation && (<TouchAnimationOptions>view?.touchAnimation).down) || (TouchManager.animations && TouchManager.animations.down);
+		const handleUp = (view?.touchAnimation && (<TouchAnimationOptions>view?.touchAnimation).up) || (TouchManager.animations && TouchManager.animations.up);
+
+		if (global.isIOS) {
+			if (view?.ios?.addTargetActionForControlEvents) {
+				// can use UIControlEvents
+				console.log('added UIControlEvents!');
+				if (!TouchManager.touchHandlers) {
+					TouchManager.touchHandlers = [];
+				}
+				TouchManager.touchHandlers.push({
+					view,
+					handler: TouchControlHandler.initWithOwner(new WeakRef(view)),
+				});
+
+				if (handleDown) {
+					(<UIControl>view.ios).addTargetActionForControlEvents(TouchManager.touchHandlers[TouchManager.touchHandlers.length - 1].handler, GestureEvents.touchDown, UIControlEvents.TouchDown | UIControlEvents.TouchDragEnter);
+					view.on(GestureEvents.touchDown, (args) => {
+						console.log('touchDown {N} event');
+						TouchManager.startAnimationForType(view, TouchAnimationTypes.down);
+					});
+				}
+				if (handleUp) {
+					(<UIControl>view.ios).addTargetActionForControlEvents(TouchManager.touchHandlers[TouchManager.touchHandlers.length - 1].handler, GestureEvents.touchUp, UIControlEvents.TouchDragExit | UIControlEvents.TouchCancel | UIControlEvents.TouchUpInside | UIControlEvents.TouchUpOutside);
+					view.on(GestureEvents.touchUp, (args) => {
+						console.log('touchUp {N} event');
+						TouchManager.startAnimationForType(view, TouchAnimationTypes.up);
+					});
+				}
+			} else {
+				// console.log("use UILongPressGestureRecognizer!");
+				console.log('added longPress to:', view.id);
+
+				if (handleDown || handleUp) {
+					view.on(GestureEvents.gestureAttached, (args: GestureEventData) => {
+						if (args.type === GestureTypes.longPress) {
+							(<UILongPressGestureRecognizer>args.ios).minimumPressDuration = 0;
+						}
+					});
+					view.on(GestureTypes.longPress, (args: GestureEventDataWithState) => {
+						switch (args.state) {
+							case GestureStateTypes.began:
+								if (handleDown) {
+									console.log('longPress began:', args.view.id, args.state);
+									TouchManager.startAnimationForType(<View>args.view, TouchAnimationTypes.down);
+								}
+								break;
+							case GestureStateTypes.cancelled:
+							case GestureStateTypes.ended:
+								if (handleUp) {
+									TouchManager.startAnimationForType(<View>args.view, TouchAnimationTypes.up);
+								}
+								break;
+						}
+					});
+				}
+			}
+		} else {
+			if (handleDown || handleUp) {
+				view.on(GestureTypes.touch, (args: TouchGestureEventData) => {
+					switch (args.action) {
+						case 'down':
+							if (handleDown) {
+								view.notify({
+									eventName: GestureEvents.touchDown,
+									object: view,
+									data: args.android,
+								});
+							}
+							break;
+						case 'up':
+						case 'cancel':
+							if (handleUp) {
+								view.notify({
+									eventName: GestureEvents.touchUp,
+									object: view,
+									data: args.android,
+								});
+							}
+							break;
+					}
+				});
+				if (handleDown) {
+					view.on(GestureEvents.touchDown, (args) => {
+						console.log('touchDown {N} event');
+						TouchManager.startAnimationForType(view, TouchAnimationTypes.down);
+					});
+				}
+				if (handleUp) {
+					view.on(GestureEvents.touchUp, (args) => {
+						console.log('touchUp {N} event');
+						TouchManager.startAnimationForType(view, TouchAnimationTypes.up);
+					});
+				}
+			}
+		}
+
+		view.on(View.disposeNativeViewEvent, (args) => {
+			console.log('calling disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
+			const index = TouchManager.touchHandlers?.findIndex((handler) => handler.view === args.object);
+			if (index > -1) {
+				TouchManager.touchHandlers.splice(index, 1);
+			}
+			TouchManager.touchAnimationDefinitions = TouchManager.touchAnimationDefinitions?.filter((d) => d.view !== args.object);
+			console.log('after clearing with disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
+			console.log('TouchManager.touchAnimationDefinitions.length:', TouchManager.touchAnimationDefinitions.length);
+		});
+	}
+
+	static startAnimationForType(view: View, type: TouchAnimationTypes) {
+		if (view) {
+			const animate = function (definition: AnimationDefinition | TouchAnimationFn) {
+				if (definition) {
+					if (isFunction(definition)) {
+						(<TouchAnimationFn>definition)(view);
+					} else {
+						if (!TouchManager.touchAnimationDefinitions) {
+							TouchManager.touchAnimationDefinitions = [];
+						}
+						// reuse animations for each type
+						let touchAnimation: Animation;
+						// triggering animations should always cancel other animations which may be in progress
+						for (const d of TouchManager.touchAnimationDefinitions) {
+							if (d.view === view && d.animation) {
+								d.animation.cancel();
+								if (d.type === type) {
+									touchAnimation = d.animation;
+								}
+							}
+						}
+
+						if (!touchAnimation) {
+							touchAnimation = new Animation([
+								{
+									target: view,
+									...(<AnimationDefinition>definition),
+								},
+							]);
+							TouchManager.touchAnimationDefinitions.push({
+								view,
+								type,
+								animation: touchAnimation,
+							});
+						}
+						touchAnimation.play().catch(() => {});
+					}
+				}
+			};
+			// always use instance defined animation over global
+			if (isObject(view.touchAnimation) && view.touchAnimation[type]) {
+				animate((<any>view).touchAnimation[type]);
+			} else if (TouchManager.animations?.[type]) {
+				// fallback to globally defined
+				animate(TouchManager.animations?.[type]);
+			}
+		}
+	}
+}
+
+export let TouchControlHandler: {
+	initWithOwner: (owner: WeakRef<View>) => any;
+};
+ensureTouchControlHandlers();
+
+function ensureTouchControlHandlers() {
+	if (global.isIOS) {
+		@NativeClass
+		class TouchHandlerImpl extends NSObject {
+			private _owner: WeakRef<View>;
+			static ObjCExposedMethods = {
+				touchDown: { returns: interop.types.void, params: [interop.types.id] },
+				touchUp: { returns: interop.types.void, params: [interop.types.id] },
+			};
+
+			static initWithOwner(owner: WeakRef<View>): TouchHandlerImpl {
+				const handler = <TouchHandlerImpl>TouchHandlerImpl.new();
+				handler._owner = owner;
+				return handler;
+			}
+
+			touchDown(args) {
+				this._owner?.get?.().notify({
+					eventName: GestureEvents.touchDown,
+					object: this._owner?.get?.(),
+					data: args,
+				});
+			}
+
+			touchUp(args) {
+				this._owner?.get?.().notify({
+					eventName: GestureEvents.touchUp,
+					object: this._owner?.get?.(),
+					data: args,
+				});
+			}
+		}
+
+		TouchControlHandler = TouchHandlerImpl;
+	}
+}

--- a/packages/core/ui/gestures/touch-manager.ts
+++ b/packages/core/ui/gestures/touch-manager.ts
@@ -55,7 +55,7 @@ export class TouchManager {
 		if (global.isIOS) {
 			if (view?.ios?.addTargetActionForControlEvents) {
 				// can use UIControlEvents
-				console.log('added UIControlEvents!');
+				// console.log('added UIControlEvents!');
 				if (!TouchManager.touchHandlers) {
 					TouchManager.touchHandlers = [];
 				}
@@ -67,20 +67,19 @@ export class TouchManager {
 				if (handleDown) {
 					(<UIControl>view.ios).addTargetActionForControlEvents(TouchManager.touchHandlers[TouchManager.touchHandlers.length - 1].handler, GestureEvents.touchDown, UIControlEvents.TouchDown | UIControlEvents.TouchDragEnter);
 					view.on(GestureEvents.touchDown, (args) => {
-						console.log('touchDown {N} event');
+						// console.log('touchDown {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.down);
 					});
 				}
 				if (handleUp) {
 					(<UIControl>view.ios).addTargetActionForControlEvents(TouchManager.touchHandlers[TouchManager.touchHandlers.length - 1].handler, GestureEvents.touchUp, UIControlEvents.TouchDragExit | UIControlEvents.TouchCancel | UIControlEvents.TouchUpInside | UIControlEvents.TouchUpOutside);
 					view.on(GestureEvents.touchUp, (args) => {
-						console.log('touchUp {N} event');
+						// console.log('touchUp {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.up);
 					});
 				}
 			} else {
-				// console.log("use UILongPressGestureRecognizer!");
-				console.log('added longPress to:', view.id);
+				// console.log('added longPress to:', view.id);
 
 				if (handleDown || handleUp) {
 					view.on(GestureEvents.gestureAttached, (args: GestureEventData) => {
@@ -92,7 +91,7 @@ export class TouchManager {
 						switch (args.state) {
 							case GestureStateTypes.began:
 								if (handleDown) {
-									console.log('longPress began:', args.view.id, args.state);
+									// console.log('longPress began:', args.view.id, args.state);
 									TouchManager.startAnimationForType(<View>args.view, TouchAnimationTypes.down);
 								}
 								break;
@@ -133,13 +132,13 @@ export class TouchManager {
 				});
 				if (handleDown) {
 					view.on(GestureEvents.touchDown, (args) => {
-						console.log('touchDown {N} event');
+						// console.log('touchDown {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.down);
 					});
 				}
 				if (handleUp) {
 					view.on(GestureEvents.touchUp, (args) => {
-						console.log('touchUp {N} event');
+						// console.log('touchUp {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.up);
 					});
 				}
@@ -147,14 +146,14 @@ export class TouchManager {
 		}
 
 		view.on(View.disposeNativeViewEvent, (args) => {
-			console.log('calling disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
+			// console.log('calling disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
 			const index = TouchManager.touchHandlers?.findIndex((handler) => handler.view === args.object);
 			if (index > -1) {
 				TouchManager.touchHandlers.splice(index, 1);
 			}
 			TouchManager.touchAnimationDefinitions = TouchManager.touchAnimationDefinitions?.filter((d) => d.view !== args.object);
-			console.log('after clearing with disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
-			console.log('TouchManager.touchAnimationDefinitions.length:', TouchManager.touchAnimationDefinitions.length);
+			// console.log('after clearing with disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
+			// console.log('TouchManager.touchAnimationDefinitions.length:', TouchManager.touchAnimationDefinitions.length);
 		});
 	}
 

--- a/packages/core/ui/gestures/touch-manager.ts
+++ b/packages/core/ui/gestures/touch-manager.ts
@@ -62,14 +62,12 @@ export class TouchManager {
 	 * @param view NativeScript view instance
 	 */
 	static addAnimations(view: View) {
-		// console.log("tapHandler:", tapHandler);
 		const handleDown = (view?.touchAnimation && (<TouchAnimationOptions>view?.touchAnimation).down) || (TouchManager.animations && TouchManager.animations.down);
 		const handleUp = (view?.touchAnimation && (<TouchAnimationOptions>view?.touchAnimation).up) || (TouchManager.animations && TouchManager.animations.up);
 
 		if (global.isIOS) {
 			if (view?.ios?.addTargetActionForControlEvents) {
 				// can use UIControlEvents
-				// console.log('added UIControlEvents!');
 				if (!TouchManager.touchHandlers) {
 					TouchManager.touchHandlers = [];
 				}
@@ -81,20 +79,16 @@ export class TouchManager {
 				if (handleDown) {
 					(<UIControl>view.ios).addTargetActionForControlEvents(TouchManager.touchHandlers[TouchManager.touchHandlers.length - 1].handler, GestureEvents.touchDown, UIControlEvents.TouchDown | UIControlEvents.TouchDragEnter);
 					view.on(GestureEvents.touchDown, (args) => {
-						// console.log('touchDown {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.down);
 					});
 				}
 				if (handleUp) {
 					(<UIControl>view.ios).addTargetActionForControlEvents(TouchManager.touchHandlers[TouchManager.touchHandlers.length - 1].handler, GestureEvents.touchUp, UIControlEvents.TouchDragExit | UIControlEvents.TouchCancel | UIControlEvents.TouchUpInside | UIControlEvents.TouchUpOutside);
 					view.on(GestureEvents.touchUp, (args) => {
-						// console.log('touchUp {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.up);
 					});
 				}
 			} else {
-				// console.log('added longPress to:', view.id);
-
 				if (handleDown || handleUp) {
 					view.on(GestureEvents.gestureAttached, (args: GestureEventData) => {
 						if (args.type === GestureTypes.longPress) {
@@ -105,7 +99,6 @@ export class TouchManager {
 						switch (args.state) {
 							case GestureStateTypes.began:
 								if (handleDown) {
-									// console.log('longPress began:', args.view.id, args.state);
 									TouchManager.startAnimationForType(<View>args.view, TouchAnimationTypes.down);
 								}
 								break;
@@ -146,13 +139,11 @@ export class TouchManager {
 				});
 				if (handleDown) {
 					view.on(GestureEvents.touchDown, (args) => {
-						// console.log('touchDown {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.down);
 					});
 				}
 				if (handleUp) {
 					view.on(GestureEvents.touchUp, (args) => {
-						// console.log('touchUp {N} event');
 						TouchManager.startAnimationForType(view, TouchAnimationTypes.up);
 					});
 				}
@@ -160,14 +151,11 @@ export class TouchManager {
 		}
 
 		view.on(View.disposeNativeViewEvent, (args) => {
-			// console.log('calling disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
 			const index = TouchManager.touchHandlers?.findIndex((handler) => handler.view === args.object);
 			if (index > -1) {
 				TouchManager.touchHandlers.splice(index, 1);
 			}
 			TouchManager.touchAnimationDefinitions = TouchManager.touchAnimationDefinitions?.filter((d) => d.view !== args.object);
-			// console.log('after clearing with disposeNativeView:', args.eventName, 'TouchManager.touchHandlers.length:', TouchManager.touchHandlers.length);
-			// console.log('TouchManager.touchAnimationDefinitions.length:', TouchManager.touchAnimationDefinitions.length);
 		});
 	}
 

--- a/packages/core/ui/gestures/touch-manager.ts
+++ b/packages/core/ui/gestures/touch-manager.ts
@@ -31,6 +31,20 @@ export class TouchManager {
 	/**
 	 * Define reusable touch animations to use on views with touchAnimation defined or with enableGlobalTapAnimations on.
 	 */
+	// Note: In the future, we may expand this to allow an Array of "named" animations to collect an entire suite of custom app animations. Combined with a new 'touch-action' CSS property which could indicate them by name, for example:
+	// .touch-grow {
+	//   touch-action: down-grow up-grow
+	// }
+	// TouchManager.animations = {
+	//   down: [
+	//      { name: grow, (view: View) => { /* animations */ } },
+	//      { name: pop, (view: View) => { /* animations */ } }
+	//   ],
+	//   up: [
+	//      { name: grow, (view: View) => { /* animations */ } },
+	//      { name: pop, (view: View) => { /* animations */ } }
+	//   ]
+	// }
 	static animations: TouchAnimationOptions;
 	/**
 	 * Native Touch handlers (iOS only) registered with the view through the TouchManager.

--- a/packages/core/ui/gestures/touch-manager.ts
+++ b/packages/core/ui/gestures/touch-manager.ts
@@ -199,7 +199,7 @@ export class TouchManager {
 			};
 			// always use instance defined animation over global
 			if (isObject(view.touchAnimation) && view.touchAnimation[type]) {
-				animate((<any>view).touchAnimation[type]);
+				animate(view.touchAnimation[type]);
 			} else if (TouchManager.animations?.[type]) {
 				// fallback to globally defined
 				animate(TouchManager.animations?.[type]);

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -27,8 +27,8 @@ export * from './editable-text-base';
 export { Frame, setActivityCallbacks } from './frame';
 export type { NavigationEntry, NavigationContext, NavigationTransition, BackstackEntry, ViewEntry, AndroidActivityCallbacks } from './frame';
 
-export { GesturesObserver, TouchAction, GestureTypes, GestureStateTypes, SwipeDirection, GestureEvents } from './gestures';
-export type { GestureEventData, GestureEventDataWithState, TapGestureEventData, PanGestureEventData, PinchGestureEventData, RotationGestureEventData, SwipeGestureEventData, TouchGestureEventData } from './gestures';
+export { GesturesObserver, TouchAction, GestureTypes, GestureStateTypes, SwipeDirection, GestureEvents, TouchManager } from './gestures';
+export type { GestureEventData, GestureEventDataWithState, TapGestureEventData, PanGestureEventData, PinchGestureEventData, RotationGestureEventData, SwipeGestureEventData, TouchGestureEventData, TouchAnimationOptions } from './gestures';
 
 export { HtmlView } from './html-view';
 export { Image } from './image';

--- a/packages/core/ui/styling/background-common.ts
+++ b/packages/core/ui/styling/background-common.ts
@@ -1,5 +1,3 @@
-// Deifinitions.
-import { Background as BackgroundDefinition } from './background';
 import { CoreTypes } from '../../core-types';
 import { LinearGradient } from './linear-gradient';
 // Types.
@@ -21,7 +19,7 @@ export const enum BackgroundClearFlags {
 	CLEAR_BOX_SHADOW = 2 << 0,
 }
 
-export class Background implements BackgroundDefinition {
+export class Background {
 	public static default = new Background();
 
 	public color: Color;

--- a/packages/core/ui/styling/background.android.ts
+++ b/packages/core/ui/styling/background.android.ts
@@ -34,7 +34,7 @@ function fromGradient(gradient: LinearGradient): org.nativescript.widgets.Linear
 }
 
 const pattern = /url\(('|")(.*?)\1\)/;
-function refreshBorderDrawable(this: void, view: View, borderDrawable: org.nativescript.widgets.BorderDrawable) {
+export function refreshBorderDrawable(view: View, borderDrawable: org.nativescript.widgets.BorderDrawable) {
 	const nativeView = <android.view.View>view.nativeViewProtected;
 	const context = nativeView.getContext();
 

--- a/packages/core/ui/styling/background.android.ts
+++ b/packages/core/ui/styling/background.android.ts
@@ -1,140 +1,10 @@
 import { View } from '../core/view';
 import { LinearGradient } from './linear-gradient';
-import { CoreTypes } from '../../core-types';
-import { isDataURI, isFileOrResourcePath, layout, RESOURCE_PREFIX, FILE_PREFIX } from '../../utils';
+import { isDataURI, isFileOrResourcePath, RESOURCE_PREFIX, FILE_PREFIX } from '../../utils';
 import { parse } from '../../css-value';
 import { path, knownFolders } from '../../file-system';
 import * as application from '../../application';
-import { profile } from '../../profiling';
-import { CSSShadow } from './css-shadow';
-import { Length } from './style-properties';
-import { BackgroundClearFlags } from './background-common';
 export * from './background-common';
-
-interface AndroidView {
-	_cachedDrawable: android.graphics.drawable.Drawable.ConstantState | android.graphics.drawable.Drawable;
-}
-
-// TODO: Change this implementation to use
-// We are using "ad" here to avoid namespace collision with the global android object
-export namespace ad {
-	let SDK: number;
-	function getSDK() {
-		if (!SDK) {
-			SDK = android.os.Build.VERSION.SDK_INT;
-		}
-
-		return SDK;
-	}
-
-	function isSetColorFilterOnlyWidget(nativeView: android.view.View): boolean {
-		// prettier-ignore
-		return (
-			nativeView instanceof android.widget.Button
-			|| (nativeView instanceof androidx.appcompat.widget.Toolbar && getSDK() >= 21)
-			// There is an issue with the DrawableContainer which was fixed
-			// for API version 21 and above: https://code.google.com/p/android/issues/detail?id=60183
-		);
-	}
-
-	export function onBackgroundOrBorderPropertyChanged(view: View) {
-		const nativeView = <android.view.View>view.nativeViewProtected;
-		if (!nativeView) {
-			return;
-		}
-
-		const background = view.style.backgroundInternal;
-
-		if (background.clearFlags & BackgroundClearFlags.CLEAR_BOX_SHADOW || background.clearFlags & BackgroundClearFlags.CLEAR_BACKGROUND_COLOR) {
-			// clear background if we're clearing the box shadow
-			// or the background has been removed
-			nativeView.setBackground(null);
-		}
-
-		let drawable = nativeView.getBackground();
-		const androidView = (<any>view) as AndroidView;
-		// use undefined as not set. getBackground will never return undefined only Drawable or null;
-		if (androidView._cachedDrawable === undefined && drawable) {
-			const constantState = drawable.getConstantState();
-			androidView._cachedDrawable = constantState || drawable;
-		}
-		const isBorderDrawable = drawable instanceof org.nativescript.widgets.BorderDrawable;
-
-		// prettier-ignore
-		const onlyColor = !background.hasBorderWidth()
-			&& !background.hasBorderRadius()
-			&& !background.hasBoxShadow()
-			&& !background.clipPath
-			&& !background.image
-			&& !!background.color;
-
-		if (!isBorderDrawable && drawable instanceof android.graphics.drawable.ColorDrawable && onlyColor) {
-			drawable.setColor(background.color.android);
-			drawable.invalidateSelf();
-		} else if (isSetColorFilterOnlyWidget(nativeView) && drawable && onlyColor) {
-			if (isBorderDrawable && androidView._cachedDrawable) {
-				if (!(androidView._cachedDrawable instanceof android.graphics.drawable.Drawable.ConstantState)) {
-					return;
-				}
-
-				drawable = androidView._cachedDrawable.newDrawable(nativeView.getResources());
-				nativeView.setBackground(drawable);
-			}
-
-			const backgroundColor = ((<any>drawable).backgroundColor = background.color.android);
-			drawable.mutate();
-			drawable.setColorFilter(backgroundColor, android.graphics.PorterDuff.Mode.SRC_IN);
-			drawable.invalidateSelf(); // Make sure the drawable is invalidated. Android forgets to invalidate it in some cases: toolbar
-			(<any>drawable).backgroundColor = backgroundColor;
-		} else if (!isBorderDrawable && onlyColor) {
-			// this is the fastest way to change only background color
-			nativeView.setBackgroundColor(background.color.android);
-		} else if (!background.isEmpty()) {
-			let backgroundDrawable = drawable;
-
-			if (drawable instanceof org.nativescript.widgets.BoxShadowDrawable) {
-				// if we have BoxShadow's we have to get the underlying drawable
-				backgroundDrawable = drawable.getWrappedDrawable();
-			}
-
-			if (backgroundDrawable instanceof org.nativescript.widgets.BorderDrawable) {
-				refreshBorderDrawable(view, backgroundDrawable);
-			} else {
-				backgroundDrawable = new org.nativescript.widgets.BorderDrawable(layout.getDisplayDensity(), view.toString());
-				refreshBorderDrawable(view, <org.nativescript.widgets.BorderDrawable>backgroundDrawable);
-				nativeView.setBackground(backgroundDrawable);
-			}
-		} else {
-			const cachedDrawable = androidView._cachedDrawable;
-			let defaultDrawable: android.graphics.drawable.Drawable = null;
-			if (cachedDrawable) {
-				if (cachedDrawable instanceof android.graphics.drawable.Drawable.ConstantState) {
-					defaultDrawable = cachedDrawable.newDrawable(nativeView.getResources());
-				} else if (cachedDrawable instanceof android.graphics.drawable.Drawable) {
-					defaultDrawable = cachedDrawable;
-				}
-			}
-
-			nativeView.setBackground(defaultDrawable);
-		}
-
-		if (background.hasBoxShadow()) {
-			drawBoxShadow(nativeView, view, background.getBoxShadow());
-		}
-
-		// TODO: Can we move BorderWidths as separate native setter?
-		// This way we could skip setPadding if borderWidth is not changed.
-		const leftPadding = Math.ceil(view.effectiveBorderLeftWidth + view.effectivePaddingLeft);
-		const topPadding = Math.ceil(view.effectiveBorderTopWidth + view.effectivePaddingTop);
-		const rightPadding = Math.ceil(view.effectiveBorderRightWidth + view.effectivePaddingRight);
-		const bottomPadding = Math.ceil(view.effectiveBorderBottomWidth + view.effectivePaddingBottom);
-
-		nativeView.setPadding(leftPadding, topPadding, rightPadding, bottomPadding);
-
-		// reset clear flags
-		background.clearFlags = BackgroundClearFlags.NONE;
-	}
-}
 
 function fromBase64(source: string): android.graphics.Bitmap {
 	const bytes = android.util.Base64.decode(source, android.util.Base64.DEFAULT);
@@ -251,18 +121,6 @@ function createNativeCSSValueArray(css: string): androidNative.Array<org.natives
 	}
 
 	return nativeArray;
-}
-
-function drawBoxShadow(nativeView: android.view.View, view: View, boxShadow: CSSShadow) {
-	const config = {
-		shadowColor: boxShadow.color.android,
-		cornerRadius: Length.toDevicePixels(view.borderRadius as CoreTypes.LengthType, 0.0),
-		spreadRadius: Length.toDevicePixels(boxShadow.spreadRadius, 0.0),
-		blurRadius: Length.toDevicePixels(boxShadow.blurRadius, 0.0),
-		offsetX: Length.toDevicePixels(boxShadow.offsetX, 0.0),
-		offsetY: Length.toDevicePixels(boxShadow.offsetY, 0.0),
-	};
-	org.nativescript.widgets.Utils.drawBoxShadow(nativeView, JSON.stringify(config));
 }
 
 export enum CacheMode {

--- a/packages/core/ui/styling/background.d.ts
+++ b/packages/core/ui/styling/background.d.ts
@@ -4,72 +4,74 @@ import { BackgroundRepeat } from '../../css/parser';
 import { LinearGradient } from '../styling/linear-gradient';
 import { CSSShadow } from './css-shadow';
 
+export * from './background-common';
+
 export enum CacheMode {
 	none,
 	memory,
 	diskAndMemory,
 }
 
-export declare class Background {
-	public static default: Background;
-	public color: Color;
-	public image: string | LinearGradient;
-	public repeat: BackgroundRepeat;
-	public position: string;
-	public size: string;
-	public borderTopColor: Color;
-	public borderRightColor: Color;
-	public borderBottomColor: Color;
-	public borderLeftColor: Color;
-	public borderTopWidth: number;
-	public borderRightWidth: number;
-	public borderBottomWidth: number;
-	public borderLeftWidth: number;
-	public borderTopLeftRadius: number;
-	public borderTopRightRadius: number;
-	public borderBottomRightRadius: number;
-	public borderBottomLeftRadius: number;
-	public clipPath: string;
-	public boxShadow: string | CSSShadow;
-	public clearFlags: number;
+// export declare class Background {
+// 	public static default: Background;
+// 	public color: Color;
+// 	public image: string | LinearGradient;
+// 	public repeat: BackgroundRepeat;
+// 	public position: string;
+// 	public size: string;
+// 	public borderTopColor: Color;
+// 	public borderRightColor: Color;
+// 	public borderBottomColor: Color;
+// 	public borderLeftColor: Color;
+// 	public borderTopWidth: number;
+// 	public borderRightWidth: number;
+// 	public borderBottomWidth: number;
+// 	public borderLeftWidth: number;
+// 	public borderTopLeftRadius: number;
+// 	public borderTopRightRadius: number;
+// 	public borderBottomRightRadius: number;
+// 	public borderBottomLeftRadius: number;
+// 	public clipPath: string;
+// 	public boxShadow: string | CSSShadow;
+// 	public clearFlags: number;
 
-	public withColor(value: Color): Background;
-	public withImage(value: string | LinearGradient): Background;
-	public withRepeat(value: BackgroundRepeat): Background;
-	public withPosition(value: string): Background;
-	public withSize(value: string): Background;
-	public withBorderTopColor(value: Color): Background;
-	public withBorderRightColor(value: Color): Background;
-	public withBorderBottomColor(value: Color): Background;
-	public withBorderLeftColor(value: Color): Background;
-	public withBorderTopWidth(value: number): Background;
-	public withBorderRightWidth(value: number): Background;
-	public withBorderBottomWidth(value: number): Background;
-	public withBorderLeftWidth(value: number): Background;
-	public withBorderTopLeftRadius(value: number): Background;
-	public withBorderTopRightRadius(value: number): Background;
-	public withBorderBottomRightRadius(value: number): Background;
-	public withBorderBottomLeftRadius(value: number): Background;
-	public withClipPath(value: string): Background;
-	public withBoxShadow(value: CSSShadow): Background;
+// 	public withColor(value: Color): Background;
+// 	public withImage(value: string | LinearGradient): Background;
+// 	public withRepeat(value: BackgroundRepeat): Background;
+// 	public withPosition(value: string): Background;
+// 	public withSize(value: string): Background;
+// 	public withBorderTopColor(value: Color): Background;
+// 	public withBorderRightColor(value: Color): Background;
+// 	public withBorderBottomColor(value: Color): Background;
+// 	public withBorderLeftColor(value: Color): Background;
+// 	public withBorderTopWidth(value: number): Background;
+// 	public withBorderRightWidth(value: number): Background;
+// 	public withBorderBottomWidth(value: number): Background;
+// 	public withBorderLeftWidth(value: number): Background;
+// 	public withBorderTopLeftRadius(value: number): Background;
+// 	public withBorderTopRightRadius(value: number): Background;
+// 	public withBorderBottomRightRadius(value: number): Background;
+// 	public withBorderBottomLeftRadius(value: number): Background;
+// 	public withClipPath(value: string): Background;
+// 	public withBoxShadow(value: CSSShadow): Background;
 
-	public isEmpty(): boolean;
+// 	public isEmpty(): boolean;
 
-	public static equals(value1: Background, value2: Background): boolean;
+// 	public static equals(value1: Background, value2: Background): boolean;
 
-	public hasBorderColor(): boolean;
-	public hasBorderWidth(): boolean;
-	public hasBorderRadius(): boolean;
-	public hasUniformBorderColor(): boolean;
-	public hasUniformBorderWidth(): boolean;
-	public hasUniformBorderRadius(): boolean;
-	public hasUniformBorder(): boolean;
-	public getUniformBorderColor(): Color;
-	public getUniformBorderWidth(): number;
-	public getUniformBorderRadius(): number;
-	public hasBoxShadow(): boolean;
-	public getBoxShadow(): CSSShadow;
-}
+// 	public hasBorderColor(): boolean;
+// 	public hasBorderWidth(): boolean;
+// 	public hasBorderRadius(): boolean;
+// 	public hasUniformBorderColor(): boolean;
+// 	public hasUniformBorderWidth(): boolean;
+// 	public hasUniformBorderRadius(): boolean;
+// 	public hasUniformBorder(): boolean;
+// 	public getUniformBorderColor(): Color;
+// 	public getUniformBorderWidth(): number;
+// 	public getUniformBorderRadius(): number;
+// 	public hasBoxShadow(): boolean;
+// 	public getBoxShadow(): CSSShadow;
+// }
 
 export namespace ios {
 	export function createBackgroundUIColor(view: View, callback: (uiColor: any /* UIColor */) => void, flip?: boolean): void;
@@ -78,3 +80,5 @@ export namespace ios {
 export namespace ad {
 	export function onBackgroundOrBorderPropertyChanged(v: View);
 }
+
+export function refreshBorderDrawable(view: View, borderDrawable: any /* org.nativescript.widgets.BorderDrawable */): void;

--- a/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
@@ -21,13 +21,17 @@
 		android:allowBackup="true"
 		android:icon="@drawable/icon"
 		android:label="@string/app_name"
-		android:theme="@style/AppTheme">
+		android:theme="@style/AppTheme"
+		android:hardwareAccelerated="true">
 
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
 			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
-			android:theme="@style/LaunchScreenTheme">
+			android:theme="@style/LaunchScreenTheme"
+			android:hardwareAccelerated="true"
+      		android:launchMode="singleTask"
+			android:exported="true">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

No easy way to add dynamic touch down/up animations for nice interactivity in the UI.

## What is the new behavior?

Introduces a `TouchManager` with an easy api to enable rich interactivity throughout the UI.
Also adds `touchAnimation` and `ignoreTouchAnimation` properties to views. This allows each view to opt into and define/control it's own touch down/up animations.

`TouchManager.enableGlobalTapAnimations = true` can also be used alongside `TouchManager.animations.{up|down}` animations to define consistent reusable animations for the entire UI by auto detecting and attaching to any view with a `tap` binding.
