### PR TITLE
fix(core 8.2): Parse template literal syntax with nested identifiers as expression

### DIFF
--- a/packages/core/ui/builder/binding-builder.ts
+++ b/packages/core/ui/builder/binding-builder.ts
@@ -1,5 +1,5 @@
 // regex that contains all symbols applicable for expression used to AI detect an expression.
-const expressionSymbolsRegex = /[\+\-\*\/%\?:<>=!\|&\(\)^~]/;
+const expressionSymbolsRegex = /[\+\-\*\/%\?:<>=!\|&\(\)^~]|\$\{.+\}/;
 
 export namespace bindingConstants {
 	export const sourceProperty = 'sourceProperty';


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
This is a change that came up due to expression parser rework and its new features.
NativeScript Core cannot parse XML expression with template literal syntax and nested indentifiers.
Example:
```xml
<Page actionBarHidden="true" xmlns="http://www.nativescript.org/tns.xsd">
    <GridLayout>
        <Label text="{{ 'Hello' + username }}"/> <!-- Works -->
        <Label text="{{ `Hello ${username}` }}"/> <!-- Only identifier 'username' will be parsed -->
    </GridLayout>
</Page>
```

## What is the new behavior?
Template literal syntax that includes identifiers will be parsed as expression.