### PR TITLE
fix(core): pan gesture on Android

### DIFF
--- a/packages/core/ui/gestures/index.android.ts
+++ b/packages/core/ui/gestures/index.android.ts
@@ -455,10 +455,6 @@ class CustomPanGestureDetector {
 	public onTouchEvent(event: android.view.MotionEvent) {
 		switch (event.getActionMasked()) {
 			case android.view.MotionEvent.ACTION_UP:
-			case android.view.MotionEvent.ACTION_CANCEL:
-				this.trackStop(event, false);
-				break;
-
 			case android.view.MotionEvent.ACTION_DOWN:
 			case android.view.MotionEvent.ACTION_POINTER_DOWN:
 			case android.view.MotionEvent.ACTION_POINTER_UP:


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
Note: I have not created an issue first, but have talked with Igor on Discord about this
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When paning an element, the event.status should be 3 (GestureStateTypes.ended) when the paning is done. On iOS event.status 3 is only fired once when paning is done, but on Android you will receive event.status 3 even when you are not finished paning. It's because it triggers status 3 when Android fires android.view.MotionEvent.ACTION_CANCEL and the paning is not done on this event. The documentation for ACTION_CANCEL says: `The current gesture has been aborted. You will not receive any more points in it. You should treat this as an up event, but not perform any action that you normally would.`. So we should not use this.

## What is the new behavior?
Removing these lines gives us corresponding behavior on both iOS and Android for Paning statuses.

BREAKING CHANGES:
Pan status 3 (GestureStateTypes.ended) will not fire multiple times on Android

