### PR TITLE
WeakRef.clear() is deprecated

### DIFF
--- a/packages/core/ui/core/bindable/index.ts
+++ b/packages/core/ui/core/bindable/index.ts
@@ -169,7 +169,7 @@ export class Binding {
 		// }
 
 		if (this.sourceOptions) {
-			this.sourceOptions.instance.clear();
+			// this.sourceOptions.instance.clear();
 			this.sourceOptions = undefined;
 		}
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
The console logs are flooded with
`JS: WeakRef.clear() is non-standard and has been deprecated. It does nothing and the call can be safely removed.`

## What is the new behavior?
Console flooding is stopped after this PR is merged

Fixes/Implements/Closes #[Issue Number].
#9756 
