### PR TITLE
Background/foreground events

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -22,6 +22,8 @@ export function hasLaunched(): boolean {
 export const launchEvent = 'launch';
 export const suspendEvent = 'suspend';
 export const displayedEvent = 'displayed';
+export const backgroundEvent = 'background';
+export const foregroundEvent = 'foreground';
 export const resumeEvent = 'resume';
 export const exitEvent = 'exit';
 export const lowMemoryEvent = 'lowMemory';

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -45,6 +45,7 @@ export class AndroidApplication extends Observable implements AndroidApplication
 	private _orientation: 'portrait' | 'landscape' | 'unknown';
 	private _systemAppearance: 'light' | 'dark';
 	public paused: boolean;
+	public backgrounded: boolean;
 	public nativeApp: android.app.Application;
 	public context: android.content.Context;
 	public foregroundActivity: androidx.appcompat.app.AppCompatActivity;
@@ -339,6 +340,9 @@ function initLifecycleCallbacks() {
 		rootView.getViewTreeObserver().addOnGlobalLayoutListener(global.onGlobalLayoutListener);
 	});
 
+
+	let activitiesStarted = 0;
+
 	const lifecycleCallbacks = new android.app.Application.ActivityLifecycleCallbacks(<any>{
 		onActivityCreated: <any>profile('onActivityCreated', function (activity: androidx.appcompat.app.AppCompatActivity, savedInstanceState: android.os.Bundle) {
 			setThemeOnLaunch(activity, undefined, undefined);
@@ -376,7 +380,7 @@ function initLifecycleCallbacks() {
 			if ((<any>activity).isNativeScriptActivity) {
 				androidApp.paused = true;
 				appCommon.notify(<ApplicationEventData>{
-					eventName: appCommon.suspendEvent,
+					eventName: appCommon.backgroundEvent,
 					object: androidApp,
 					android: activity,
 				});
@@ -409,6 +413,15 @@ function initLifecycleCallbacks() {
 		}),
 
 		onActivityStarted: <any>profile('onActivityStarted', function (activity: androidx.appcompat.app.AppCompatActivity) {
+			activitiesStarted++;
+			if (activitiesStarted === 1) {
+				androidApp.backgrounded = true;
+				appCommon.notify(<ApplicationEventData>{
+					eventName: appCommon.foregroundEvent,
+					object: androidApp,
+					android: activity,
+				});
+			}
 			androidApp.notify(<AndroidActivityEventData>{
 				eventName: ActivityStarted,
 				object: androidApp,
@@ -417,6 +430,15 @@ function initLifecycleCallbacks() {
 		}),
 
 		onActivityStopped: <any>profile('onActivityStopped', function (activity: androidx.appcompat.app.AppCompatActivity) {
+			activitiesStarted--;
+			if (activitiesStarted === 0) {
+				androidApp.backgrounded = true;
+				appCommon.notify(<ApplicationEventData>{
+					eventName: appCommon.backgroundEvent,
+					object: androidApp,
+					android: activity,
+				});
+			}
 			androidApp.notify(<AndroidActivityEventData>{
 				eventName: ActivityStopped,
 				object: androidApp,

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -380,7 +380,7 @@ function initLifecycleCallbacks() {
 			if ((<any>activity).isNativeScriptActivity) {
 				androidApp.paused = true;
 				appCommon.notify(<ApplicationEventData>{
-					eventName: appCommon.backgroundEvent,
+					eventName: appCommon.suspendEvent,
 					object: androidApp,
 					android: activity,
 				});

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -35,6 +35,16 @@ export const suspendEvent: string;
 export const resumeEvent: string;
 
 /**
+ * String value used when hooking to foreground event.
+ */
+export const foregroundEvent: string;
+
+/**
+ * String value used when hooking to background event.
+ */
+export const backgroundEvent: string;
+
+/**
  * String value used when hooking to exit event.
  */
 export const exitEvent: string;
@@ -502,6 +512,11 @@ export class AndroidApplication extends Observable {
 	 * True if the main application activity is not running (suspended), false otherwise.
 	 */
 	paused: boolean;
+
+	/**
+	 * True if the main application activity is in background, false otherwise.
+	 */
+	backgrounded: boolean;
 
 	/**
 	 * Initialized the android-specific application object with the native android.app.Application instance.

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -4,7 +4,7 @@ import { ApplicationEventData, CssChangedEventData, LaunchEventData, LoadAppCSSE
 
 // TODO: explain why we need to this or remov it
 // Use requires to ensure order of imports is maintained
-const { displayedEvent, exitEvent, getCssFileName, launchEvent, livesync, lowMemoryEvent, notify, on, orientationChanged, orientationChangedEvent, resumeEvent, setApplication, suspendEvent, systemAppearanceChanged, systemAppearanceChangedEvent } = require('./application-common');
+const { backgroundEvent, displayedEvent, exitEvent, foregroundEvent, getCssFileName, launchEvent, livesync, lowMemoryEvent, notify, on, orientationChanged, orientationChangedEvent, resumeEvent, setApplication, suspendEvent, systemAppearanceChanged, systemAppearanceChangedEvent } = require('./application-common');
 // First reexport so that app module is initialized.
 export * from './application-common';
 
@@ -222,6 +222,7 @@ export class iOSApplication implements iOSApplicationDefinition {
 		const ios = UIApplication.sharedApplication;
 		const object = this;
 		notify(<ApplicationEventData>{ eventName: resumeEvent, object, ios });
+		notify(<ApplicationEventData>{ eventName: foregroundEvent, object, ios });
 		const rootView = this._rootView;
 		if (rootView && !rootView.isLoaded) {
 			rootView.callLoaded();
@@ -229,11 +230,10 @@ export class iOSApplication implements iOSApplicationDefinition {
 	}
 
 	private didEnterBackground(notification: NSNotification) {
-		notify(<ApplicationEventData>{
-			eventName: suspendEvent,
-			object: this,
-			ios: UIApplication.sharedApplication,
-		});
+		const ios = UIApplication.sharedApplication;
+		const object = this;
+		notify(<ApplicationEventData>{ eventName: suspendEvent, object, ios });
+		notify(<ApplicationEventData>{ eventName: backgroundEvent, object, ios });
 		const rootView = this._rootView;
 		if (rootView && rootView.isLoaded) {
 			rootView.callUnloaded();


### PR DESCRIPTION
I recently realised that `suspend` and `resume` events were not doing what we expect on Android:
* iOS: `suspend` and `resume` correspond to app background / foreground
* Android: `suspend` and `resume` correspond to activity state. It means that for example `suspend` will be triggered while a dialog is shown. This can make your app not behave correctly.

This PR fixes this by adding 2 new events `background` and `foreground`. Those events are simple duplicates on iOS but on android they will trigger when the app switches from foreground to background and vice verca