### PR TITLE
feat(webpack): read nativescript.config.ts main if set before package.json

### DIFF
--- a/packages/core/config/config.interface.ts
+++ b/packages/core/config/config.interface.ts
@@ -147,7 +147,7 @@ export interface NativeScriptConfig {
 	 */
 	id?: string;
 	/**
-	 * App's main entry file (currently ignored - set it in package.json main field)
+	 * App's main entry file - this setting overrides the value set in package.json
 	 */
 	main?: string;
 	/**

--- a/packages/webpack5/__tests__/helpers/platform.spec.ts
+++ b/packages/webpack5/__tests__/helpers/platform.spec.ts
@@ -1,0 +1,49 @@
+import { env } from '../../src/';
+import { addPlatform, getEntryPath } from '../../src/helpers/platform';
+
+import { getValue } from '../../src/helpers/config';
+
+describe('getEntryPath', () => {
+	it('uses platform getEntryPath if the platform specifies it', () => {
+		env.platform = 'testPlatform';
+		addPlatform('testPlatform', {
+			getEntryPath() {
+				return 'custom-entry-path';
+			},
+		});
+
+		const res = getEntryPath();
+		expect(res).toEqual('custom-entry-path');
+
+		// cleanup env
+		delete env.platform;
+	});
+
+	it('uses main from nativescript.config.ts if set', () => {
+		env.ios = true;
+
+		// mock getValue
+		const getValueMock = getValue as jest.Mock;
+		const getValueMockImpl = getValueMock.getMockImplementation();
+
+		getValueMock.mockImplementation((key) => {
+			if (key === 'main') {
+				return 'main-from-config';
+			}
+		});
+
+		const res = getEntryPath();
+		expect(res).toEqual('__jest__/main-from-config');
+
+		// reset mock implementation
+		getValueMock.mockImplementation(getValueMockImpl);
+	});
+
+	it('uses main from package.json', () => {
+		env.ios = true;
+
+		const res = getEntryPath();
+		// set in jest.setup.ts mock for package.json...
+		expect(res).toEqual('__jest__/src/app.js');
+	});
+});

--- a/packages/webpack5/scripts/jest.setup.ts
+++ b/packages/webpack5/scripts/jest.setup.ts
@@ -13,10 +13,10 @@ jest.mock('cosmiconfig', () => ({
 	},
 }));
 
+const getValueMock = jest.fn();
+getValueMock.mockImplementation((key, defaultValue) => defaultValue);
 jest.mock('../src/helpers/config.ts', () => ({
-	getValue(key, defaultValue) {
-		return defaultValue;
-	},
+	getValue: getValueMock,
 }));
 
 jest.mock('os', () => {

--- a/packages/webpack5/src/helpers/config.ts
+++ b/packages/webpack5/src/helpers/config.ts
@@ -1,5 +1,5 @@
+import { warnOnce } from './log';
 import { env } from '../index';
-import { error, warnOnce } from './log';
 
 function getCLILib() {
 	if (!env.nativescriptLibPath) {
@@ -28,7 +28,9 @@ export function getValue<T = any>(key: string, defaultValue?: any): T {
 		return defaultValue;
 	}
 
-	return (lib.projectConfigService as {
-		getValue(key: string, defaultValue?: any): T;
-	}).getValue(key, defaultValue);
+	return (
+		lib.projectConfigService as {
+			getValue(key: string, defaultValue?: any): T;
+		}
+	).getValue(key, defaultValue);
 }

--- a/packages/webpack5/src/helpers/platform.ts
+++ b/packages/webpack5/src/helpers/platform.ts
@@ -2,6 +2,7 @@ import { dirname, resolve } from 'path';
 
 import { getPackageJson, getProjectRootPath } from './project';
 import { error, info, warnOnce } from './log';
+import { getValue } from './config';
 import { env } from '../';
 
 import AndroidPlatform from '../platforms/android';
@@ -90,6 +91,13 @@ export function getEntryPath() {
 	// use platform specific entry path
 	if (platform.getEntryPath) {
 		return platform.getEntryPath();
+	}
+
+	// try main from nativescript.config.ts
+	const main = getValue('main');
+
+	if (main) {
+		return resolve(getProjectRootPath(), main);
 	}
 
 	// fallback to main field in package.json


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`main` in `nativescript.config.ts` is ignored.

## What is the new behavior?
<!-- Describe the changes. -->
`main` in `nativescript.config.ts` is read and used instead of `package.json`'s `main` when set.

implements #9658

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGES:

Possibly breaking if a project has a `main` field set in the `nativescript.config.ts` - since after this lands, this value will be used instead of `package.json` `main`. 

The impact is likely very small, the steps to migrate:
1. (Option A) remove `main` from `nativescript.config.ts` if set
2. (Option B) update `main` to the correct path in `nativescript.config.ts` if set incorrectly
