### PR TITLE
feat(ios): allow dynamic ProMotion frame refresh rate changes

### DIFF
--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -29,6 +29,10 @@ const ActivityBackPressed = 'activityBackPressed';
 const ActivityNewIntent = 'activityNewIntent';
 const ActivityRequestPermissions = 'activityRequestPermissions';
 
+export function setMaxRefreshRate(options?: { min?: number; max?: number; preferred?: number }): void {
+	// ignore on android, ios only
+}
+
 export class AndroidApplication extends Observable implements AndroidApplicationDefinition {
 	public static activityCreatedEvent = ActivityCreated;
 	public static activityDestroyedEvent = ActivityDestroyed;

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -77,6 +77,19 @@ export function setAutoSystemAppearanceChanged(value: boolean): void;
 export function systemAppearanceChanged(rootView: View, newSystemAppearance: 'dark' | 'light'): void;
 
 /**
+ * iOS Only
+ * Dynamically change the preferred frame rate
+ * For devices (iOS 15+) which support min/max/preferred frame rate you can specify ranges
+ * For devices (iOS < 15), you can specify the max frame rate
+ * see: https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro
+ * To use, ensure your Info.plist has:
+ *   <key>CADisableMinimumFrameDurationOnPhone</key>
+ *   <true/>
+ * @param options { min?: number; max?: number; preferred?: number }
+ */
+export function setMaxRefreshRate(options?: { min?: number; max?: number; preferred?: number }): void;
+
+/**
  * Event data containing information for the application events.
  */
 export interface ApplicationEventData extends EventData {

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -108,7 +108,6 @@ export function setMaxRefreshRate(options?: { min?: number; max?: number; prefer
 				if (iOSNativeHelper.MajorVersion >= 15) {
 					const min = options?.min || max / 2;
 					const preferred = options?.preferred || max;
-					console.log('min:', min, ' max:', max, ' preferred:', preferred);
 					displayedLink.preferredFrameRateRange = CAFrameRateRangeMake(min, max, preferred);
 				} else {
 					displayedLink.preferredFramesPerSecond = max;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -8,7 +8,7 @@
 export type { NativeScriptConfig } from './config';
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
-import { AndroidApplication, iOSApplication, systemAppearanceChanged, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, systemAppearance, setAutoSystemAppearanceChanged } from './application';
+import { AndroidApplication, iOSApplication, systemAppearanceChanged, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, systemAppearance, setAutoSystemAppearanceChanged, setMaxRefreshRate } from './application';
 export declare const Application: {
 	launchEvent: string;
 	displayedEvent: string;
@@ -22,6 +22,7 @@ export declare const Application: {
 	systemAppearanceChangedEvent: string;
 	fontScaleChangedEvent: string;
 	systemAppearanceChanged: typeof systemAppearanceChanged;
+	setMaxRefreshRate: typeof setMaxRefreshRate;
 	getMainEntry: typeof getMainEntry;
 	getRootView: typeof getRootView;
 	resetRootView: typeof _resetRootView;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,7 +5,7 @@ import './globals';
 export { iOSApplication, AndroidApplication } from './application';
 export type { ApplicationEventData, LaunchEventData, OrientationChangedEventData, UnhandledErrorEventData, DiscardedErrorEventData, CssChangedEventData, LoadAppCSSEventData, AndroidActivityEventData, AndroidActivityBundleEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData, AndroidActivityNewIntentEventData, AndroidActivityBackPressedEventData, SystemAppearanceChangedEventData } from './application';
 
-import { fontScaleChangedEvent, launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance, setAutoSystemAppearanceChanged, ensureNativeApplication } from './application';
+import { fontScaleChangedEvent, launchEvent, displayedEvent, uncaughtErrorEvent, discardedErrorEvent, suspendEvent, resumeEvent, exitEvent, lowMemoryEvent, orientationChangedEvent, systemAppearanceChanged, systemAppearanceChangedEvent, getMainEntry, getRootView, _resetRootView, getResources, setResources, setCssFileName, getCssFileName, loadAppCss, addCss, on, off, notify, hasListeners, run, orientation, getNativeApplication, hasLaunched, android as appAndroid, ios as iosApp, systemAppearance, setAutoSystemAppearanceChanged, ensureNativeApplication, setMaxRefreshRate } from './application';
 export const Application = {
 	launchEvent,
 	displayedEvent,
@@ -19,6 +19,7 @@ export const Application = {
 	systemAppearanceChangedEvent,
 	systemAppearanceChanged,
 	fontScaleChangedEvent,
+	setMaxRefreshRate,
 
 	getMainEntry,
 	getRootView,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?

Currently default frame refresh rates are used on iOS.

## What is the new behavior?

On supported devices users can now dynamically optimize frame refresh rates in accordance to:
see: https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro

```
Application.setMaxRefreshRate({
  min: 80,
  max: 120,
  preferred: 120
});
```

Can be called to dynamically adjust frame refresh rates on newer devices to optimize high impact animations. Other adjustments can be made according to docs under various conditions.
No breaking changes - this was already being setup on app boot with default settings; this just allows user to set it themselves where needed.

