### PR TITLE
feat(webpack): allow watching node_modules

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -628,3 +628,9 @@ exports[`base configuration for ios 1`] = `
   }
 }"
 `;
+
+exports[`base configuration support env.watchNodeModules 1`] = `
+Object {
+  "managedPaths": Array [],
+}
+`;

--- a/packages/webpack5/__tests__/configuration/base.spec.ts
+++ b/packages/webpack5/__tests__/configuration/base.spec.ts
@@ -22,6 +22,14 @@ describe('base configuration', () => {
 		});
 	}
 
+	it('support env.watchNodeModules', () => {
+		init({
+			ios: true,
+			watchNodeModules: true,
+		});
+		expect(base(new Config()).get('snapshot')).toMatchSnapshot();
+	});
+
 	it('supports dotenv', () => {
 		const fsSpy = jest.spyOn(fs, 'existsSync');
 		fsSpy.mockReturnValue(true);

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -123,6 +123,13 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		],
 	});
 
+	// allow watching node_modules
+	config.when(env.watchNodeModules, (config) => {
+		config.set('snapshot', {
+			managedPaths: [],
+		});
+	});
+
 	// Set up Terser options
 	config.optimization.minimizer('TerserPlugin').use(TerserPlugin, [
 		{

--- a/packages/webpack5/src/index.ts
+++ b/packages/webpack5/src/index.ts
@@ -45,6 +45,7 @@ export interface IWebpackEnv {
 
 	// misc
 	replace?: string[] | string;
+	watchNodeModules?: boolean;
 }
 
 interface IChainEntry {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

-

## What is the new behavior?

Passing `--env.watchNodeModules`, or adding the following to the `webpack.config.js`:

```js
const webpack = require("@nativescript/webpack");

module.exports = (env) => {
  // enable watching node_modules
  env.watchNodeModules = true;
  
  webpack.init(env);
  
  // Learn how to customize:
  // https://docs.nativescript.org/webpack
  
  return webpack.resolveConfig();
};
```

Will trigger a rebuild when something in `node_modules` changes. This is disabled by default as in most cases node_modules shouldn't change, however this is useful when debugging a plugin/core etc right in `node_modules`.