### PR TITLE
feat(switch): :checked pseudo and color fixes

### DIFF
--- a/apps/toolbox/src/app.css
+++ b/apps/toolbox/src/app.css
@@ -202,3 +202,23 @@ Button {
 .a11y-demo-page .a11y-state-checked {
   a11y-state: checked;
 }
+
+.switch-demo-page Switch.custom-switch {
+    color: #ddd;
+    background-color: #65adf1;
+}
+
+.switch-demo-page Switch.custom-switch:checked {
+    color: #111;
+    background-color: #65adf1;
+}
+
+.switch-demo-page Switch.custom-switch:disabled {
+    color: #777;
+    background-color: #ddd;
+}
+
+.switch-demo-page Switch.custom-switch:disabled:checked {
+    color: #ddd;
+    background-color: #777;
+}

--- a/apps/toolbox/src/main-page.xml
+++ b/apps/toolbox/src/main-page.xml
@@ -6,15 +6,16 @@
   <StackLayout class="p-20">
     <ScrollView class="h-full">
       <StackLayout>
-        <Button text="list-page" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
-        <Button text="box-shadow" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
-        <Button text="root-layout" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="a11y" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="box-shadow" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="css-playground" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
-        <Button text="visibility-vs-hidden" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="image-async" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
-        <Button text="vector-image" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="list-page" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="root-layout" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="switch" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="touch-animations" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="vector-image" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="visibility-vs-hidden" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
       </StackLayout>
     </ScrollView>
   </StackLayout>

--- a/apps/toolbox/src/pages/switch.ts
+++ b/apps/toolbox/src/pages/switch.ts
@@ -1,0 +1,14 @@
+import { Observable, EventData, Page } from '@nativescript/core';
+
+let page: Page;
+
+export function navigatingTo(args: EventData) {
+	page = <Page>args.object;
+	page.bindingContext = new SwitchModel();
+}
+
+export class SwitchModel extends Observable {
+	constructor() {
+		super();
+	}
+}

--- a/apps/toolbox/src/pages/switch.xml
+++ b/apps/toolbox/src/pages/switch.xml
@@ -1,0 +1,75 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
+    <Page.actionBar>
+        <ActionBar title="Switch" icon="" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+
+    <GridLayout padding="20" class="switch-demo-page">   
+      <ScrollView>
+          <StackLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Default + Checked + Enabled" />
+                <Switch checked="true" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Default + UnChecked + Enabled" />
+                <Switch checked="false" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Default + Checked + Disabled" />
+                <Switch checked="true" isEnabled="false" col="1" />
+            </GridLayout>
+            
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Default + UnChecked + Disabled" />
+                <Switch checked="false" isEnabled="false" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + Checked + Enabled" />
+                <Switch class="custom-switch" checked="true" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + UnChecked + Enabled" />
+                <Switch class="custom-switch" checked="false" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + Checked + Disabled" />
+                <Switch class="custom-switch" checked="true" isEnabled="false" col="1" />
+            </GridLayout>
+            
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + UnChecked + Disabled" />
+                <Switch class="custom-switch" checked="false" isEnabled="false" col="1" />
+            </GridLayout>
+            
+             <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + Checked + Enabled + offBgColor" />
+                <Switch class="custom-switch" checked="true" backgroundColor="blue" offBackgroundColor="red" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + UnChecked + Enabled + offBgColor" />
+                <Switch class="custom-switch" checked="false" offBackgroundColor="red" col="1" />
+            </GridLayout>
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + Checked + Disabled + offBgColor" />
+                <Switch class="custom-switch" checked="true" isEnabled="false" offBackgroundColor="red" col="1" />
+            </GridLayout>
+
+
+            <GridLayout columns="*, auto" marginTop="24">
+                <Label text="Custom + UnChecked + Disabled + offBgColor" />
+                <Switch class="custom-switch" checked="false" isEnabled="false" offBackgroundColor="red" col="1" />
+            </GridLayout>
+
+          </StackLayout>
+      </ScrollView>
+    </GridLayout>
+</Page>

--- a/packages/core/ui/switch/index.android.ts
+++ b/packages/core/ui/switch/index.android.ts
@@ -58,13 +58,16 @@ export class Switch extends SwitchBase {
 
 	private setNativeBackgroundColor(value: string | number | Color) {
 		if (value instanceof Color) {
-			this.nativeViewProtected.getTrackDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+			// todo: use https://developer.android.com/reference/androidx/core/graphics/BlendModeColorFilterCompat
+			this.nativeViewProtected.getTrackDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_OVER);
 		} else {
 			this.nativeViewProtected.getTrackDrawable().clearColorFilter();
 		}
 	}
 
 	_onCheckedPropertyChanged(newValue: boolean) {
+		super._onCheckedPropertyChanged(newValue);
+
 		if (this.offBackgroundColor) {
 			if (!newValue) {
 				this.setNativeBackgroundColor(this.offBackgroundColor);
@@ -86,7 +89,8 @@ export class Switch extends SwitchBase {
 	}
 	[colorProperty.setNative](value: number | Color) {
 		if (value instanceof Color) {
-			this.nativeViewProtected.getThumbDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_IN);
+			// todo: use https://developer.android.com/reference/androidx/core/graphics/BlendModeColorFilterCompat
+			this.nativeViewProtected.getThumbDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_ATOP);
 		} else {
 			this.nativeViewProtected.getThumbDrawable().clearColorFilter();
 		}

--- a/packages/core/ui/switch/index.ios.ts
+++ b/packages/core/ui/switch/index.ios.ts
@@ -111,7 +111,7 @@ export class Switch extends SwitchBase {
 		const color: UIColor = value instanceof Color ? value.ios : value;
 		this.nativeViewProtected.thumbTintColor = color;
 
-		if (this.nativeViewProtected.subviews.count > 0) {
+		if (color && this.nativeViewProtected.subviews.count > 0) {
 			const alpha = new interop.Reference(1.0);
 			const res = color.getRedGreenBlueAlpha(null, null, null, alpha);
 

--- a/packages/core/ui/switch/index.ios.ts
+++ b/packages/core/ui/switch/index.ios.ts
@@ -65,7 +65,7 @@ export class Switch extends SwitchBase {
 			this.nativeViewProtected.onTintColor = null;
 			this.nativeViewProtected.tintColor = null;
 			this.nativeViewProtected.backgroundColor = null;
-			this.nativeViewProtected.layer.cornerRadius = 0; //this.nativeViewProtected.frame.size.height / 2;
+			this.nativeViewProtected.layer.cornerRadius = 0;
 		}
 	}
 

--- a/packages/core/ui/switch/switch-common.ts
+++ b/packages/core/ui/switch/switch-common.ts
@@ -12,7 +12,11 @@ export class SwitchBase extends View implements SwitchDefinition {
 	public offBackgroundColor: Color;
 
 	_onCheckedPropertyChanged(newValue: boolean) {
-		//
+		if (newValue) {
+			this.addPseudoClass('checked');
+		} else {
+			this.deletePseudoClass('checked');
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Switches cannot be styled using the `:checked` pseudo selector.
Switch color behavior differs between iOS and Android.
Android Switch colors are muted and not same as set.

![Screenshot 2022-02-20 at 6 11 13 PM](https://user-images.githubusercontent.com/879060/154855118-b283e9fb-f691-4d00-9648-9ee0a3b4d0fc.png)

## What is the new behavior?

Switches can now be styled with the `:checked` selector.
Switches now have the same behavior across iOS and Android.
Switch colors are exactly as set (no color filters etc applied).

![Screenshot 2022-02-20 at 6 09 16 PM](https://user-images.githubusercontent.com/879060/154855131-2e807bbe-cab0-4ecb-af0e-ae7ae5b72edb.png)

```css
.switch-demo-page Switch.custom-switch {
    color: #ddd;
    background-color: #65adf1;
}

.switch-demo-page Switch.custom-switch:checked {
    color: #111;
    background-color: #65adf1;
}

.switch-demo-page Switch.custom-switch:disabled {
    color: #777;
    background-color: #ddd;
}

.switch-demo-page Switch.custom-switch:disabled:checked {
    color: #ddd;
    background-color: #777;
}
```

BREAKING CHANGES:

Switch `color` now affects both unchecked and checked states on iOS
Switch `backgroundColor` now affects both checked and unchecked states on iOS
Switch colors are now exactly as specified without any color filtering on Android (no more muted colors)

Migration: update `color`, `backgroundColor` and `offBackgroundColor` values (inline or in css) to the desired colors.