### PR TITLE
feat: Binding expression parser additions and improvements

### DIFF
--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -97,7 +97,7 @@ const expressionParsers = {
 
 		if (expression.requiresConverter) {
 			if (isFunction(callback)) {
-				callback = {toView: callback};
+				callback = { toView: callback };
 			} else if (!isObject(callback) || !isFunction(callback.toModel) && !isFunction(callback.toView)) {
 				throw new Error('Invalid converter call');
 			}

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -98,7 +98,11 @@ const expressionParsers = {
 			let value = convertExpressionToValue(argument, model, isBackConvert, changedModel);
 			argument.type == 'SpreadElement' ? parsedArgs.push(...value) : parsedArgs.push(value);
 		}
-		return isConverter ? getConverter(callback, object, parsedArgs, isBackConvert) : callback.apply(object, parsedArgs);
+
+		if (isConverter) {
+			return getConverter(callback, object, parsedArgs, isBackConvert);
+		}
+		return expression.optional ? object[property]?.(...parsedArgs) : object[property](...parsedArgs);
 	},
 	'ChainExpression': (expression: ASTExpression, model, isBackConvert: boolean, changedModel) => {
 		return convertExpressionToValue(expression.expression, model, isBackConvert, changedModel);

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -81,15 +81,12 @@ const expressionParsers = {
 		const { object, property } = convertExpressionToValue(expression.callee, model, isBackConvert, changedModel);
 
 		let callback;
-		if (expression.callee.optional) {
-			callback = object?.[property];
+		if (object == '$forceChain') {
+			callback = undefined;
 		} else {
-			if (object == '$forceChain') {
-				callback = undefined;
-			} else {
-				callback = object[property];
-			}
+			callback = expression.callee.optional ? object?.[property] : object[property];
 		}
+			
 
 		if ((!expression.optional || expression.requiresConverter) && isNullOrUndefined(callback)) {
 			throw new Error('Cannot perform a call using a null or undefined property');

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -113,6 +113,16 @@ const expressionParsers = {
 	},
 	'Identifier': (expression: ASTExpression, model, isBackConvert: boolean, changedModel) => {
 		const context = getContext(expression.name, model, changedModel);
+		/**
+		 * Certain components do not load context in time, resulting in warnings.
+		 * To get rid of this issue, first expression identifier will throw error in case it's undefined.
+		 * Later, this will be handled in bindable's main file to prevent warnings.
+		 */
+		if (!(expression.name in context)) {
+			let error = new Error();
+			error.name = 'FirstIdentifierUndefinedError';
+			throw error;
+		}
 		return context[expression.name];
 	},
 	'Literal': (expression: ASTExpression, model, isBackConvert: boolean, changedModel) => {

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -86,7 +86,6 @@ const expressionParsers = {
 		} else {
 			callback = expression.callee.optional ? object?.[property] : object[property];
 		}
-			
 
 		if ((!expression.optional || expression.requiresConverter) && isNullOrUndefined(callback)) {
 			throw new Error('Cannot perform a call using a null or undefined property');

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -8,6 +8,8 @@ interface ASTExpression {
 
 const expressionsCache = {};
 
+const FORCED_CHAIN_VALUE = Symbol('forcedChain');
+
 // prettier-ignore
 const unaryOperators = {
 	'+': (v) => +v,
@@ -81,7 +83,7 @@ const expressionParsers = {
 		const { object, property } = convertExpressionToValue(expression.callee, model, isBackConvert, changedModel);
 
 		let callback;
-		if (object == '$forceChain') {
+		if (object == FORCED_CHAIN_VALUE) {
 			callback = undefined;
 		} else {
 			callback = expression.callee.optional ? object?.[property] : object[property];
@@ -158,9 +160,9 @@ const expressionParsers = {
 		 * if context is not ready.
 		 */
 		if (object === undefined && expression.object.type == 'Identifier') {
-			return expression.isChained ? '$forceChain' : object;
+			return expression.isChained ? FORCED_CHAIN_VALUE : object;
     }
-    if (object == '$forceChain') {
+    if (object == FORCED_CHAIN_VALUE) {
 			return expression.isChained ? object : undefined;
     }
 		return expression.optional ? object?.[property] : object[property];

--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -160,8 +160,8 @@ const expressionParsers = {
 		if (object === undefined && expression.object.type == 'Identifier') {
 			return expression.isChained ? '$forceChain' : object;
     }
-    if (object == '$forceChain' && !expression.isChained) {
-			return;
+    if (object == '$forceChain') {
+			return expression.isChained ? object : undefined;
     }
 		return expression.optional ? object?.[property] : object[property];
 	},

--- a/packages/core/ui/core/bindable/index.ts
+++ b/packages/core/ui/core/bindable/index.ts
@@ -373,7 +373,7 @@ export class Binding {
 	}
 
 	private _getExpressionValue(expression: string, isBackConvert: boolean, changedModel: any): any {
-		let result: any = '';
+		let result: any = null;
 
 		if (!__UI_USE_EXTERNAL_RENDERER__) {
 			let context;

--- a/packages/core/ui/core/bindable/index.ts
+++ b/packages/core/ui/core/bindable/index.ts
@@ -356,7 +356,10 @@ export class Binding {
 			const updateExpression = this.prepareExpressionForUpdate();
 			this.prepareContextForExpression(targetInstance, changedModel, updateExpression);
 
-			// Wait for 'prepareContextForExpression' to assign keys first, in order to avoid circular references
+			/**
+			 * Wait for 'prepareContextForExpression' to assign keys first and override any possible occurences.
+			 * For example, 'bindingValueKey' key can result in a circular reference if it's set in both cases.
+			 */
 			changedModel[bc.bindingValueKey] = value;
 			changedModel[bc.newPropertyValueKey] = value;
 			if (sourcePropertyName !== '') {

--- a/packages/core/ui/core/bindable/index.ts
+++ b/packages/core/ui/core/bindable/index.ts
@@ -377,6 +377,7 @@ export class Binding {
 
 		if (!__UI_USE_EXTERNAL_RENDERER__) {
 			let context;
+			const targetInstance = this.target.get();
 			const addedProps = [];
 			try {
 				let exp;
@@ -400,13 +401,12 @@ export class Binding {
 					if (this.prepareContextForExpression(context, expression, addedProps)) {
 						result = convertExpressionToValue(exp, context, isBackConvert, changedModel ? changedModel : context);
 					} else {
-						const targetInstance = this.target.get();
 						targetInstance.off('loaded', this.loadedHandlerVisualTreeBinding, this);
 						targetInstance.on('loaded', this.loadedHandlerVisualTreeBinding, this);
 					}
 				}
 			} catch (e) {
-				result = new Error('Run-time error occured in file: ' + e.sourceURL + ' at line: ' + e.line + ' and column: ' + e.column);
+				result = new Error('Run-time error occured on: ' + targetInstance + ' for expression: ' + expression);
 			}
 
 			// Clear added props

--- a/packages/core/ui/core/bindable/index.ts
+++ b/packages/core/ui/core/bindable/index.ts
@@ -406,8 +406,9 @@ export class Binding {
 					}
 				}
 			} catch (e) {
-				const errorMessage = 'Run-time error occured in file: ' + e.sourceURL + ' at line: ' + e.line + ' and column: ' + e.column;
-				result = new Error(errorMessage);
+				if (e.name != 'FirstIdentifierUndefinedError') {
+					result = new Error('Run-time error occured in file: ' + e.sourceURL + ' at line: ' + e.line + ' and column: ' + e.column);
+				}
 			}
 
 			// Clear added props

--- a/packages/core/ui/core/bindable/index.ts
+++ b/packages/core/ui/core/bindable/index.ts
@@ -406,9 +406,7 @@ export class Binding {
 					}
 				}
 			} catch (e) {
-				if (e.name != 'FirstIdentifierUndefinedError') {
-					result = new Error('Run-time error occured in file: ' + e.sourceURL + ' at line: ' + e.line + ' and column: ' + e.column);
-				}
+				result = new Error('Run-time error occured in file: ' + e.sourceURL + ' at line: ' + e.line + ' and column: ' + e.column);
 			}
 
 			// Clear added props


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the new behavior?
The follow additions are included in this patch:
- Better error reporting for binding expression parsing failure
- Added missing optional chaining support for callbacks
- Using a safer approach to recognize converters
- Fixed an issue that caused a circular reference for `$value` key in certain cases of two-way binding
- Re-added lost converters feature according to docs: `Since the usual operation is converting data from model to view, if a function is provided as converter, it acts as a toView function.`
- If a property caller is undefined (e.g. caller.property1.property2), parser will return undefined instead of throwing error. This is similar to old behaviour and is an attempt to fix issues similar to #9785 

@felixkrautschuk This patch includes changes that should help with your issues. Once this is merged in an alpha version, I would like you to give me some feedback regarding its functionality.

Fixes #9785 .

