### PR TITLE
fix(android): api17 crash on a11y service

### DIFF
--- a/packages/core/accessibility/accessibility-service.android.ts
+++ b/packages/core/accessibility/accessibility-service.android.ts
@@ -71,19 +71,20 @@ function ensureStateListener(): SharedA11YObservable {
 			}
 		},
 	});
-
-	touchExplorationStateChangeListener = new android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener({
-		onTouchExplorationStateChanged(enabled) {
-			updateAccessibilityState();
-
-			if (Trace.isEnabled()) {
-				Trace.write(`TouchExplorationStateChangeListener state changed to: ${!!enabled}`, Trace.categories.Accessibility);
-			}
-		},
-	});
-
 	accessibilityManager.addAccessibilityStateChangeListener(accessibilityStateChangeListener);
-	accessibilityManager.addTouchExplorationStateChangeListener(touchExplorationStateChangeListener);
+
+	if (android.os.Build.VERSION.SDK_INT >= 19) {
+		touchExplorationStateChangeListener = new android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener({
+			onTouchExplorationStateChanged(enabled) {
+				updateAccessibilityState();
+
+				if (Trace.isEnabled()) {
+					Trace.write(`TouchExplorationStateChangeListener state changed to: ${!!enabled}`, Trace.categories.Accessibility);
+				}
+			},
+		});
+		accessibilityManager.addTouchExplorationStateChangeListener(touchExplorationStateChangeListener);
+	}
 
 	updateAccessibilityState();
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
App crashes on api <19

## What is the new behavior?
App works on api <19
