### PR TITLE
feat: testID property for use with e2e testing without interfering with a11y

### DIFF
--- a/apps/toolbox/src/pages/a11y.xml
+++ b/apps/toolbox/src/pages/a11y.xml
@@ -7,25 +7,25 @@
     <GridLayout padding="20" class="a11y-demo-page">   
       <ScrollView>
           <StackLayout>
-            <Button text="Open Modal Page" class="view-item" tap="{{openModal}}" />
-            <Button text="Open Normal Page" class="view-item" tap="{{openNormal}}" />
+            <Button testID="openModalPageButton" text="Open Modal Page" class="view-item" tap="{{openModal}}" />
+            <Button testID="openNormalPageButton" text="Open Normal Page" class="view-item" tap="{{openNormal}}" />
 
-            <Label text="Accessible Label" class="view-item a11y text-center" accessibilityLabel="Accessible Label" accessibilityHint="Just a label" accessibilityRole="{{accessibilityRole.StaticText}}" accessibilityValue="Accessible Label" />
-            <Button text="Accessible Button" class="view-item a11y" accessibilityLabel="Accessible Button" accessibilityHint="Tapping this really does nothing" />
+            <Label testID="testLabel1" text="Accessible Label" class="view-item a11y text-center" accessibilityLabel="Accessible Label" accessibilityHint="Just a label" accessibilityRole="{{accessibilityRole.StaticText}}" accessibilityValue="Accessible Label" />
+            <Button testID="testLabel2" text="Accessible Button" class="view-item a11y" accessibilityLabel="Accessible Button" accessibilityHint="Tapping this really does nothing" />
             
-            <Image src="res://icon" width="50" class="view-item a11y" accessibilityLabel="Image with explicit attribute role" accessibilityRole="{{accessibilityRole.Image}}" />
-            <Image src="res://icon" width="50" class="view-item a11y a11y-role-image" accessibilityLabel="Image with css defined role" />
+            <Image testID="testImage1" src="res://icon" width="50" class="view-item a11y" accessibilityLabel="Image with explicit attribute role" accessibilityRole="{{accessibilityRole.Image}}" />
+            <Image testID="testImage2" src="res://icon" width="50" class="view-item a11y a11y-role-image" accessibilityLabel="Image with css defined role" />
             
             
             <Image src="{{ largeImageSrc }}" width="50" class="view-item a11y a11y-role-image" accessibilityLabel="Image with css defined role" />
 
-            <Switch checked="true" class="view-item a11y" accessibilityLabel="Switch with attribute state" accessibilityState="{{accessibilityState.Checked}}" checkedChange="{{checkedChange}}" />
-            <Switch checked="true" class="view-item a11y a11y-state-checked" accessibilityLabel="Switch with css state" checkedChange="{{checkedChange}}" />
+            <Switch testID="testSwitch1" checked="true" class="view-item a11y" accessibilityLabel="Switch with attribute state" accessibilityState="{{accessibilityState.Checked}}" checkedChange="{{checkedChange}}" />
+            <Switch testID="testSwitch2" checked="true" class="view-item a11y a11y-state-checked" accessibilityLabel="Switch with css state" checkedChange="{{checkedChange}}" />
 
-            <TextView hint="TextView" text="{{switchCheckedText}}" class="view-item a11y" accessibilityLabel="TestView with a value" accessibilityLiveRegion="{{accessibilityLiveRegions.Polite}}" />
-            <TextField hint="TextField" class="view-item a11y" accessibilityLabel="Plain jane TextField" accessibilityHint="Tell us your real name Jane" />
+            <TextView testID="testTextView" hint="TextView" text="{{switchCheckedText}}" class="view-item a11y" accessibilityLabel="TestView with a value" accessibilityLiveRegion="{{accessibilityLiveRegions.Polite}}" />
+            <TextField testID="testTextField" hint="TextField" class="view-item a11y" accessibilityLabel="Plain jane TextField" accessibilityHint="Tell us your real name Jane" />
             <TextView hint="TextView" class="view-item a11y" accessibilityLabel="Nice TextView" accessibilityHint="Tell us about yourself Jane" />
-            <GridLayout rows="25" columns="*" class="view-item" accessibilityLabel="No can go GridLayout" accessibilityHint="A grid that will not get bigger when increasing accessible text size">
+            <GridLayout testID="testGridLayout1" rows="25" columns="*" class="view-item" accessibilityLabel="No can go GridLayout" accessibilityHint="A grid that will not get bigger when increasing accessible text size">
               <Label text="IN-Accessible Grid" class="view-item text-center" />
             </GridLayout>
             <GridLayout rows="25,25" columns="*,50" class="view-item a11y" accessibilityLabel="Yes an accessible GridLayout" accessibilityHint="A grid that WILL get bigger dynamically when increasing accessible text size">
@@ -33,7 +33,7 @@
               <Label row="1" text="With another item in a row" class="view-item text-center" />
               <Label rowSpan="2" col="1" text="Hi" />
             </GridLayout>
-            <Slider value="10" minValue="0" maxValue="100" class="view-item a11y" accessibilityLabel="Slider" accessibilityHint="A smooth slider" accessibilityValue="10" />
+            <Slider testID="testSlider" value="10" minValue="0" maxValue="100" class="view-item a11y" accessibilityLabel="Slider" accessibilityHint="A smooth slider" accessibilityValue="10" />
           </StackLayout>
       </ScrollView>
     </GridLayout>

--- a/packages/core/accessibility/index.android.ts
+++ b/packages/core/accessibility/index.android.ts
@@ -645,7 +645,9 @@ function applyContentDescription(view: Partial<View>, forceUpdate?: boolean) {
 
 	const contentDescription = contentDescriptionBuilder.join('. ').trim().replace(/^\.$/, '');
 
-	if (contentDescription) {
+	if (view.testID) {
+		// todo:?
+	} else if (contentDescription) {
 		if (Trace.isEnabled()) {
 			Trace.write(`${cls} - set to "${contentDescription}"`, Trace.categories.Accessibility);
 		}

--- a/packages/core/accessibility/index.android.ts
+++ b/packages/core/accessibility/index.android.ts
@@ -645,7 +645,7 @@ function applyContentDescription(view: Partial<View>, forceUpdate?: boolean) {
 
 	const contentDescription = contentDescriptionBuilder.join('. ').trim().replace(/^\.$/, '');
 
-	if (view.testID) {
+	if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__ && view.testID) {
 		// todo:?
 	} else if (contentDescription) {
 		if (Trace.isEnabled()) {

--- a/packages/core/accessibility/index.android.ts
+++ b/packages/core/accessibility/index.android.ts
@@ -648,7 +648,9 @@ function applyContentDescription(view: Partial<View>, forceUpdate?: boolean) {
 	if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__ && view.testID) {
 		// ignore when testID is enabled
 		return;
-	} else if (contentDescription) {
+	}
+
+	if (contentDescription) {
 		if (Trace.isEnabled()) {
 			Trace.write(`${cls} - set to "${contentDescription}"`, Trace.categories.Accessibility);
 		}

--- a/packages/core/accessibility/index.android.ts
+++ b/packages/core/accessibility/index.android.ts
@@ -646,7 +646,8 @@ function applyContentDescription(view: Partial<View>, forceUpdate?: boolean) {
 	const contentDescription = contentDescriptionBuilder.join('. ').trim().replace(/^\.$/, '');
 
 	if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__ && view.testID) {
-		// todo:?
+		// ignore when testID is enabled
+		return;
 	} else if (contentDescription) {
 		if (Trace.isEnabled()) {
 			Trace.write(`${cls} - set to "${contentDescription}"`, Trace.categories.Accessibility);

--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -133,6 +133,7 @@ declare const __CSS_PARSER__: string;
 declare const __NS_WEBPACK__: boolean;
 declare const __UI_USE_EXTERNAL_RENDERER__: boolean;
 declare const __UI_USE_XML_PARSER__: boolean;
+declare const __USE_TEST_ID__: boolean | undefined;
 declare const __ANDROID__: boolean;
 declare const __IOS__: boolean;
 

--- a/packages/core/platforms/android/res/values/ids.xml
+++ b/packages/core/platforms/android/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="nativescript_accessibility_id"/>
+</resources>

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -797,7 +797,20 @@ export class View extends ViewCommon {
 	}
 
 	[testIDProperty.setNative](value: string) {
-		this.nativeViewProtected.setContentDescription(value);
+		this.setTestID(this.nativeViewProtected, value);
+	}
+
+	setTestID(view, value) {
+		if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__) {
+			const id = Utils.ad.resources.getId(':id/nativescript_accessibility_id');
+
+			if (id) {
+				view.setTag(id, value);
+				view.setTag(value);
+			}
+
+			view.setContentDescription(value);
+		}
 	}
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {
@@ -807,11 +820,15 @@ export class View extends ViewCommon {
 	}
 
 	[accessibilityIdentifierProperty.setNative](value: string): void {
-		const id = Utils.ad.resources.getId(':id/nativescript_accessibility_id');
+		if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__ && this.testID) {
+			// ignore when using testID;
+		} else {
+			const id = Utils.ad.resources.getId(':id/nativescript_accessibility_id');
 
-		if (id) {
-			this.nativeViewProtected.setTag(id, value);
-			this.nativeViewProtected.setTag(value);
+			if (id) {
+				this.nativeViewProtected.setTag(id, value);
+				this.nativeViewProtected.setTag(value);
+			}
 		}
 	}
 

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -3,7 +3,7 @@ import type { Point, CustomLayoutView as CustomLayoutViewDefinition } from '.';
 import type { GestureTypes, GestureEventData } from '../../gestures';
 
 // Types.
-import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, isUserInteractionEnabledProperty } from './view-common';
+import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, isUserInteractionEnabledProperty, testIDProperty } from './view-common';
 import { paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length } from '../../styling/style-properties';
 import { layout } from '../../../utils';
 import { Trace } from '../../../trace';
@@ -794,6 +794,10 @@ export class View extends ViewCommon {
 	}
 	[opacityProperty.setNative](value: number) {
 		this.nativeViewProtected.setAlpha(float(value));
+	}
+
+	[testIDProperty.setNative](value: string) {
+		this.nativeViewProtected.setContentDescription(value);
 	}
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -2,7 +2,7 @@
 import { Point, View as ViewDefinition } from '.';
 
 // Requires
-import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, isUserInteractionEnabledProperty } from './view-common';
+import { ViewCommon, isEnabledProperty, originXProperty, originYProperty, isUserInteractionEnabledProperty, testIDProperty } from './view-common';
 import { ShowModalOptions, hiddenProperty } from '../view-base';
 import { Trace } from '../../../trace';
 import { layout, iOSNativeHelper } from '../../../utils';
@@ -570,6 +570,10 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 	[originYProperty.setNative](value: number) {
 		this.updateOriginPoint(this.originX, value);
+	}
+
+	[testIDProperty.setNative](value: string) {
+		this.nativeViewProtected.accessibilityIdentifier = value;
 	}
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -573,7 +573,13 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 
 	[testIDProperty.setNative](value: string) {
-		this.nativeViewProtected.accessibilityIdentifier = value;
+		this.setTestID(this.nativeViewProtected, value);
+	}
+
+	public setTestID(view: any, value: string): void {
+		if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__) {
+			view.accessibilityIdentifier = value;
+		}
 	}
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {
@@ -585,8 +591,13 @@ export class View extends ViewCommon implements ViewDefinition {
 	[accessibilityIdentifierProperty.getDefault](): string {
 		return this.nativeViewProtected.accessibilityLabel;
 	}
+
 	[accessibilityIdentifierProperty.setNative](value: string): void {
-		this.nativeViewProtected.accessibilityIdentifier = value;
+		if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__ && this.testID) {
+			// ignore when using testID
+		} else {
+			this.nativeViewProtected.accessibilityIdentifier = value;
+		}
 	}
 
 	[accessibilityRoleProperty.setNative](value: AccessibilityRole): void {

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -1121,6 +1121,10 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	public accessibilityScreenChanged(): void {
 		return;
 	}
+
+	public setTestID(view: any, value: string) {
+		return;
+	}
 }
 
 export const originXProperty = new Property<ViewCommon, number>({

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -82,6 +82,8 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	public accessibilityValue: string;
 	public accessibilityHint: string;
 
+	public testID: string;
+
 	public touchAnimation: boolean | TouchAnimationOptions;
 	public ignoreTouchAnimation: boolean;
 
@@ -1195,6 +1197,11 @@ const ignoreTouchAnimationProperty = new Property<ViewCommon, boolean>({
 	valueConverter: booleanConverter,
 });
 ignoreTouchAnimationProperty.register(ViewCommon);
+
+export const testIDProperty = new Property<ViewCommon, string>({
+	name: 'testID',
+});
+testIDProperty.register(ViewCommon);
 
 accessibilityIdentifierProperty.register(ViewCommon);
 accessibilityLabelProperty.register(ViewCommon);

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -15,6 +15,7 @@ import { layout } from '../../utils';
 import { isString, isNullOrUndefined } from '../../utils/types';
 import { accessibilityIdentifierProperty } from '../../accessibility/accessibility-properties';
 import * as Utils from '../../utils';
+import { testIDProperty } from '../../ui/core/view';
 
 export * from './text-base-common';
 
@@ -443,13 +444,21 @@ export class TextBase extends TextBaseCommon {
 		org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeTextViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
 	}
 
-	[accessibilityIdentifierProperty.setNative](value: string): void {
-		// we override the default setter to apply it on nativeTextViewProtected
-		const id = Utils.ad.resources.getId(':id/nativescript_accessibility_id');
+	[testIDProperty.setNative](value: string): void {
+		this.setTestID(this.nativeTextViewProtected, value);
+	}
 
-		if (id) {
-			this.nativeTextViewProtected.setTag(id, value);
-			this.nativeTextViewProtected.setTag(value);
+	[accessibilityIdentifierProperty.setNative](value: string): void {
+		if (typeof __USE_TEST_ID__ !== 'undefined' && __USE_TEST_ID__ && this.testID) {
+			// ignore when using testID;
+		} else {
+			// we override the default setter to apply it on nativeTextViewProtected
+			const id = Utils.ad.resources.getId(':id/nativescript_accessibility_id');
+
+			if (id) {
+				this.nativeTextViewProtected.setTag(id, value);
+				this.nativeTextViewProtected.setTag(value);
+			}
 		}
 	}
 

--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -351,7 +351,8 @@ exports[`angular configuration for android 1`] = `
         __IOS__: false,
         'global.isAndroid': true,
         'global.isIOS': false,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */
@@ -774,7 +775,8 @@ exports[`angular configuration for ios 1`] = `
         __IOS__: true,
         'global.isAndroid': false,
         'global.isIOS': true,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -262,7 +262,8 @@ exports[`base configuration for android 1`] = `
         __IOS__: false,
         'global.isAndroid': true,
         'global.isIOS': false,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */
@@ -582,7 +583,8 @@ exports[`base configuration for ios 1`] = `
         __IOS__: true,
         'global.isAndroid': false,
         'global.isIOS': true,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -262,7 +262,8 @@ exports[`javascript configuration for android 1`] = `
         __IOS__: false,
         'global.isAndroid': true,
         'global.isIOS': false,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */
@@ -591,7 +592,8 @@ exports[`javascript configuration for ios 1`] = `
         __IOS__: true,
         'global.isAndroid': false,
         'global.isIOS': true,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
@@ -285,6 +285,7 @@ exports[`react configuration > android > adds ReactRefreshWebpackPlugin when HMR
         'global.isAndroid': true,
         'global.isIOS': false,
         process: 'global.process',
+        __USE_TEST_ID__: false,
         __TEST__: false,
         'process.env.NODE_ENV': '\\"development\\"'
       }
@@ -616,6 +617,7 @@ exports[`react configuration > android > base config 1`] = `
         'global.isAndroid': true,
         'global.isIOS': false,
         process: 'global.process',
+        __USE_TEST_ID__: false,
         __TEST__: false,
         'process.env.NODE_ENV': '\\"development\\"'
       }
@@ -954,6 +956,7 @@ exports[`react configuration > ios > adds ReactRefreshWebpackPlugin when HMR ena
         'global.isAndroid': false,
         'global.isIOS': true,
         process: 'global.process',
+        __USE_TEST_ID__: false,
         __TEST__: false,
         'process.env.NODE_ENV': '\\"development\\"'
       }
@@ -1286,6 +1289,7 @@ exports[`react configuration > ios > base config 1`] = `
         'global.isAndroid': false,
         'global.isIOS': true,
         process: 'global.process',
+        __USE_TEST_ID__: false,
         __TEST__: false,
         'process.env.NODE_ENV': '\\"development\\"'
       }

--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -289,7 +289,8 @@ exports[`svelte configuration for android 1`] = `
         __IOS__: false,
         'global.isAndroid': true,
         'global.isIOS': false,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */
@@ -630,7 +631,8 @@ exports[`svelte configuration for ios 1`] = `
         __IOS__: true,
         'global.isAndroid': false,
         'global.isIOS': true,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -262,7 +262,8 @@ exports[`typescript configuration for android 1`] = `
         __IOS__: false,
         'global.isAndroid': true,
         'global.isIOS': false,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */
@@ -591,7 +592,8 @@ exports[`typescript configuration for ios 1`] = `
         __IOS__: true,
         'global.isAndroid': false,
         'global.isIOS': true,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */

--- a/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
@@ -302,7 +302,8 @@ exports[`vue configuration for android 1`] = `
         __IOS__: false,
         'global.isAndroid': true,
         'global.isIOS': false,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */
@@ -656,7 +657,8 @@ exports[`vue configuration for ios 1`] = `
         __IOS__: true,
         'global.isAndroid': false,
         'global.isIOS': true,
-        process: 'global.process'
+        process: 'global.process',
+        __USE_TEST_ID__: false
       }
     ),
     /* config.plugin('CopyWebpackPlugin') */

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -420,6 +420,9 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			/* for compat only */ 'global.isIOS': platform === 'ios',
 			process: 'global.process',
 
+			// enable testID when using --env.e2e
+			__USE_TEST_ID__: !!env.e2e,
+
 			// todo: ?!?!
 			// profile: '() => {}',
 		},

--- a/packages/webpack5/src/index.ts
+++ b/packages/webpack5/src/index.ts
@@ -46,6 +46,7 @@ export interface IWebpackEnv {
 	// misc
 	replace?: string[] | string;
 	watchNodeModules?: boolean;
+	e2e?: boolean;
 }
 
 interface IChainEntry {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Using `automationText` for e2e testing interferes with a11y.

## What is the new behavior?

Adds a new `testID` property matching what the [React Native community adopted](https://reactnativetesting.io/component/testing.html#testing-text), also [reference api here](https://reactnative.dev/docs/view#testid) which helps discern e2e testing id's apart from anything specific to a11y.

* [x] confirm when set if it should modify any other behavior to achieve what's needed for clear e2e testing