### PR TITLE
fix: android boolean keyboardType should not set inputType

### DIFF
--- a/packages/core/ui/text-field/index.android.ts
+++ b/packages/core/ui/text-field/index.android.ts
@@ -30,7 +30,7 @@ export class TextField extends TextFieldBase {
 
 		// Check for a passed in Number value
 		const value = +this.keyboardType;
-		if (!isNaN(value)) {
+		if (typeof this.keyboardType !== 'boolean' && !isNaN(value)) {
 			this._setInputType(value);
 			return;
 		}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Binding the `keyboardType` to `false/true` prevents the `secure` text-field from working.

## What is the new behavior?

Setting the keyboardType to a boolean should not set the `inputType`.

