### PR TITLE
feat(webpack): support webpack profiling when `config.profile=true`

### DIFF
--- a/packages/webpack5/src/bin/index.ts
+++ b/packages/webpack5/src/bin/index.ts
@@ -108,6 +108,10 @@ program
 				// Set the process exit code depending on errors
 				process.exitCode = stats.hasErrors() ? 1 : 0;
 
+				// if webpack profile is enabled we write the stats to a JSON file
+				if (configuration.profile ===  true) {
+					fs.writeFileSync(path.join(process.cwd(), 'webpack.stats.json'), JSON.stringify(stats.toJson()));
+				}
 				console.log(
 					stats.toString({
 						chunks: false,


### PR DESCRIPTION
Enabling profile in webpack is as easy as setting `config.profile=true`
In case we detect it we can write the webpack stats json file as `webpack.stats.json`