### PR TITLE
fix: tear down views after a modal is closed

### DIFF
--- a/apps/toolbox/src/pages/a11y.ts
+++ b/apps/toolbox/src/pages/a11y.ts
@@ -35,7 +35,11 @@ export class AccessibilityModel extends Observable {
 	}
 
 	openModal() {
-		page.showModal('pages/sample-modal');
+		page.showModal('pages/sample-modal', {
+			closeCallback(args) {
+				console.log('close modal callback', args);
+			},
+		} as ShowModalOptions);
 	}
 
 	openNormal() {

--- a/apps/toolbox/src/pages/a11y.ts
+++ b/apps/toolbox/src/pages/a11y.ts
@@ -37,4 +37,8 @@ export class AccessibilityModel extends Observable {
 	openModal() {
 		page.showModal('pages/sample-modal');
 	}
+
+	openNormal() {
+		page.frame.navigate('pages/sample-modal');
+	}
 }

--- a/apps/toolbox/src/pages/a11y.xml
+++ b/apps/toolbox/src/pages/a11y.xml
@@ -7,6 +7,9 @@
     <GridLayout padding="20" class="a11y-demo-page">   
       <ScrollView>
           <StackLayout>
+            <Button text="Open Modal Page" class="view-item" tap="{{openModal}}" />
+            <Button text="Open Normal Page" class="view-item" tap="{{openNormal}}" />
+
             <Label text="Accessible Label" class="view-item a11y text-center" accessibilityLabel="Accessible Label" accessibilityHint="Just a label" accessibilityRole="{{accessibilityRole.StaticText}}" accessibilityValue="Accessible Label" />
             <Button text="Accessible Button" class="view-item a11y" accessibilityLabel="Accessible Button" accessibilityHint="Tapping this really does nothing" />
             
@@ -30,7 +33,6 @@
               <Label row="1" text="With another item in a row" class="view-item text-center" />
               <Label rowSpan="2" col="1" text="Hi" />
             </GridLayout>
-            <Button text="Open Modal" class="view-item" tap="{{openModal}}" />
             <Slider value="10" minValue="0" maxValue="100" class="view-item a11y" accessibilityLabel="Slider" accessibilityHint="A smooth slider" accessibilityValue="10" />
           </StackLayout>
       </ScrollView>

--- a/apps/toolbox/src/pages/sample-modal.ts
+++ b/apps/toolbox/src/pages/sample-modal.ts
@@ -3,6 +3,8 @@ import { Page, ShownModallyData, Observable, LoadEventData } from '@nativescript
 let page: Page;
 let closeCallback: Function;
 export function onShownModally(args: ShownModallyData) {
+	console.log('page shown modally');
+
 	closeCallback = args.closeCallback;
 
 	if (args.context) {
@@ -11,6 +13,8 @@ export function onShownModally(args: ShownModallyData) {
 }
 
 export function onLoaded(args: LoadEventData) {
+	console.log('page loaded');
+
 	page = args.object as Page;
 	page.bindingContext = new SampleModal();
 
@@ -31,7 +35,9 @@ export class SampleModal extends Observable {
 		//   (<UIViewController>page.ios).view.accessibilityPerformEscape();
 		// }
 		if (typeof closeCallback === 'function') {
-			closeCallback();
+			closeCallback('data from modal');
+			// reset callback...
+			closeCallback = undefined;
 		} else {
 			// fallback to regular nav back...
 			page.frame.goBack();

--- a/apps/toolbox/src/pages/sample-modal.ts
+++ b/apps/toolbox/src/pages/sample-modal.ts
@@ -1,15 +1,27 @@
-import { Page, ShownModallyData, Observable } from '@nativescript/core';
+import { Page, ShownModallyData, Observable, LoadEventData } from '@nativescript/core';
 
 let page: Page;
 let closeCallback: Function;
 export function onShownModally(args: ShownModallyData) {
-	page = <Page>args.object;
-	page.bindingContext = new SampleModal();
 	closeCallback = args.closeCallback;
 
 	if (args.context) {
 		args.context.shownModally = true;
 	}
+}
+
+export function onLoaded(args: LoadEventData) {
+	page = args.object as Page;
+	page.bindingContext = new SampleModal();
+
+	const disposePage = page.disposeNativeView.bind(page);
+	page.disposeNativeView = () => {
+		console.log('-'.repeat(100));
+		console.log(' [!!] Disposing modal page...');
+		console.log('-'.repeat(100));
+
+		disposePage();
+	};
 }
 
 export class SampleModal extends Observable {
@@ -18,6 +30,11 @@ export class SampleModal extends Observable {
 		// if (global.isIOS) {
 		//   (<UIViewController>page.ios).view.accessibilityPerformEscape();
 		// }
-		closeCallback();
+		if (typeof closeCallback === 'function') {
+			closeCallback();
+		} else {
+			// fallback to regular nav back...
+			page.frame.goBack();
+		}
 	}
 }

--- a/apps/toolbox/src/pages/sample-modal.xml
+++ b/apps/toolbox/src/pages/sample-modal.xml
@@ -1,4 +1,4 @@
-<Page xmlns="http://schemas.nativescript.org/tns.xsd" shownModally="onShownModally" class="page">
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" loaded="onLoaded" shownModally="onShownModally" class="page">
 
     <GridLayout padding="20">   
       <ScrollView>

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -407,6 +407,8 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 					if (typeof options.closeCallback === 'function') {
 						options.closeCallback.apply(undefined, originalArgs);
 					}
+
+					that._tearDownUI(true);
 				};
 
 				that._hideNativeModalView(parent, whenClosedCallback);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Closing a modal will not tear down the views from the modal (GC might eventually, but not reliably)

## What is the new behavior?
<!-- Describe the changes. -->

Closing a modal will fire the `closeCallback` and then tear down the views explicitly.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

