### PR TITLE
feat: Added proper handling for bindings with invalid converters

### DIFF
--- a/packages/core/ui/core/bindable/bindable-expressions.ts
+++ b/packages/core/ui/core/bindable/bindable-expressions.ts
@@ -91,7 +91,17 @@ const expressionParsers = {
 
 		if (expression.operator == '|') {
 			if (converterExpression.nsRequiresConverter) {
-				return expression.right.nsIsCallable ? right : right?.(left);
+				if (expression.right.nsIsCallable) {
+					return right;
+				}
+
+				if (isFunction(right)) {
+					return right(left);
+				}
+
+				if (isNullOrUndefined(right)) {
+					throw new Error('Cannot perform a call using a null or undefined property');
+				}
 			}
 			throw new Error('Invalid converter syntax');
 		}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Binding of properties with null or undefined converters would silently return an empty value.

## What is the new behavior?
Calling undefined converters (without the use of `()`) should throw error. This gives more freedom of understanding what is wrong inside code.
The following concept also describes how to provide null-safety for such scenarios.

```xml
<Label col="2" row="0" text="{{ dateTime | relativeDateTimeConverter }}" textAlignment="right" class="font-size-small"/> <!-- will throw error in console (this is the case that has bad error handling) -->
<Label col="2" row="0" text="{{ dateTime | relativeDateTimeConverter() }}" textAlignment="right" class="font-size-small"/> <!-- will throw error in console -->
<Label col="2" row="0" text="{{ dateTime | relativeDateTimeConverter?.() }}" textAlignment="right" class="font-size-small"/> <!-- Developer should be able avoid errors using optional chaining -->
```