### PR TITLE
fix: Close popup views on live-sync

### DIFF
--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -191,31 +191,25 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 			Trace.write(`${this}._onLivesync(${JSON.stringify(context)})`, Trace.categories.Livesync);
 		}
 
-		let hasPopupView = false;
+		let handled = false;
 
 		const rootLayout = global.rootLayout;
 		if (rootLayout != null && rootLayout.topmost() != null) {
 			rootLayout.closeAll();
-			hasPopupView = true;
+			handled = true;
 		}
 
 		if (this._closeAllModalViewsInternal()) {
-			hasPopupView = true;
-		}
-
-		if (hasPopupView) {
-			return true;
+			handled = true;
 		}
 
 		if (this._handleLivesync(context)) {
 			return true;
 		}
 
-		let handled = false;
 		this.eachChildView((child: ViewCommon) => {
 			if (child._onLivesync(context)) {
 				handled = true;
-
 				return false;
 			}
 		});

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -191,7 +191,19 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 			Trace.write(`${this}._onLivesync(${JSON.stringify(context)})`, Trace.categories.Livesync);
 		}
 
+		let hasPopupView = false;
+
+		const rootLayout = global.rootLayout;
+		if (rootLayout != null && rootLayout.topmost() != null) {
+			rootLayout.closeAll();
+			hasPopupView = true;
+		}
+
 		if (this._closeAllModalViewsInternal()) {
+			hasPopupView = true;
+		}
+
+		if (hasPopupView) {
 			return true;
 		}
 

--- a/packages/core/ui/layouts/root-layout/index.d.ts
+++ b/packages/core/ui/layouts/root-layout/index.d.ts
@@ -6,7 +6,7 @@ export class RootLayout extends GridLayout {
 	close(view: View, exitTo: TransitionAnimation): Promise<void>;
 	topmost(): View;
 	bringToFront(view: View, animated?: boolean): Promise<void>;
-	closeAll(): Promise<void>;
+	closeAll(): Promise<void[]>;
 	getShadeCover(): View;
 	openShadeCover(options: ShadeCoverOptions = {}): void;
 	closeShadeCover(shadeCoverOptions: ShadeCoverOptions = {}): Promise<void>;

--- a/packages/core/ui/layouts/root-layout/index.d.ts
+++ b/packages/core/ui/layouts/root-layout/index.d.ts
@@ -3,7 +3,7 @@ import { View } from '../../core/view';
 
 export class RootLayout extends GridLayout {
 	open(view: View, options: RootLayoutOptions = {}): Promise<void>;
-	close(view: View, exitTo: TransitionAnimation): Promise<void>;
+	close(view: View, exitTo?: TransitionAnimation): Promise<void>;
 	topmost(): View;
 	bringToFront(view: View, animated?: boolean): Promise<void>;
 	closeAll(): Promise<void[]>;

--- a/packages/core/ui/layouts/root-layout/index.d.ts
+++ b/packages/core/ui/layouts/root-layout/index.d.ts
@@ -2,14 +2,14 @@ import { GridLayout } from '../grid-layout';
 import { View } from '../../core/view';
 
 export class RootLayout extends GridLayout {
-	open(view: View, options?: RootLayoutOptions): Promise<void>;
-	close(view: View, exitTo?: TransitionAnimation): Promise<void>;
+	open(view: View, options: RootLayoutOptions = {}): Promise<void>;
+	close(view: View, exitTo: TransitionAnimation): Promise<void>;
 	topmost(): View;
 	bringToFront(view: View, animated?: boolean): Promise<void>;
 	closeAll(): Promise<void>;
 	getShadeCover(): View;
-	openShadeCover(options: ShadeCoverOptions): void;
-	closeShadeCover(shadeCoverOptions?: ShadeCoverOptions): Promise<void>;
+	openShadeCover(options: ShadeCoverOptions = {}): void;
+	closeShadeCover(shadeCoverOptions: ShadeCoverOptions = {}): Promise<void>;
 }
 
 export function getRootLayout(): RootLayout;

--- a/packages/core/ui/layouts/root-layout/root-layout-common.ts
+++ b/packages/core/ui/layouts/root-layout/root-layout-common.ts
@@ -65,7 +65,7 @@ export class RootLayoutBase extends GridLayout {
 						resolve();
 					})
 					.catch((ex) => {
-						reject(`Error playing enter animation: ${ex}`);
+						throw new Error(`Error playing enter animation: ${ex}`);
 					});
 			});
 		});
@@ -114,7 +114,7 @@ export class RootLayoutBase extends GridLayout {
 					.play()
 					.then(cleanupAndFinish.bind(this))
 					.catch((ex) => {
-						reject(`Error playing exit animation: ${ex}`);
+						throw new Error(`Error playing exit animation: ${ex}`);
 					});
 			} else {
 				cleanupAndFinish();
@@ -210,7 +210,7 @@ export class RootLayoutBase extends GridLayout {
 									this.applyDefaultState(view);
 								})
 								.catch((ex) => {
-									reject(`Error playing enter animation: ${ex}`);
+									throw new Error(`Error playing enter animation: ${ex}`);
 								});
 						} else {
 							this.applyDefaultState(view);
@@ -218,7 +218,7 @@ export class RootLayoutBase extends GridLayout {
 					})
 					.catch((ex) => {
 						this._bringToFront(view);
-						reject(`Error playing exit animation: ${ex}`);
+						throw new Error(`Error playing exit animation: ${ex}`);
 					});
 			} else {
 				this._bringToFront(view);

--- a/packages/core/ui/layouts/root-layout/root-layout-common.ts
+++ b/packages/core/ui/layouts/root-layout/root-layout-common.ts
@@ -197,7 +197,6 @@ export class RootLayoutBase extends GridLayout {
 
 			const exitAnimation = this.getViewExitState(view);
 			if (animated && exitAnimation) {
-				let error = null;
 				this.getExitAnimation(view, exitAnimation)
 					.play()
 					.then(() => {
@@ -211,7 +210,7 @@ export class RootLayoutBase extends GridLayout {
 									this.applyDefaultState(view);
 								})
 								.catch((ex) => {
-									error = new Error(`Error playing enter animation: ${ex}`);
+									reject(new Error(`Error playing enter animation: ${ex}`));
 								});
 						} else {
 							this.applyDefaultState(view);
@@ -219,12 +218,8 @@ export class RootLayoutBase extends GridLayout {
 					})
 					.catch((ex) => {
 						this._bringToFront(view);
-						error = new Error(`Error playing exit animation: ${ex}`);
+						reject(new Error(`Error playing exit animation: ${ex}`));
 					});
-
-				if (error != null) {
-					return reject(error);
-				}
 			} else {
 				this._bringToFront(view);
 			}

--- a/packages/core/ui/layouts/root-layout/root-layout-common.ts
+++ b/packages/core/ui/layouts/root-layout/root-layout-common.ts
@@ -15,60 +15,59 @@ export class RootLayoutBase extends GridLayout {
 	constructor() {
 		super();
 		global.rootLayout = this;
-		this.on('loaded', () => {
-			// get actual content count of rootLayout (elements between the <RootLayout> tags in the template).
-			// All popups will be inserted dynamically at a higher index
-			this.staticChildCount = this.getChildrenCount();
-		});
 	}
 
-	// ability to add any view instance to compositie views like layers
-	open(view: View, options?: RootLayoutOptions): Promise<void> {
+	public onLoaded() {
+		// get actual content count of rootLayout (elements between the <RootLayout> tags in the template).
+		// All popups will be inserted dynamically at a higher index
+		this.staticChildCount = this.getChildrenCount();
+
+		super.onLoaded();
+	}
+
+	// ability to add any view instance to composite views like layers
+	open(view: View, options: RootLayoutOptions = {}): Promise<void> {
 		return new Promise((resolve, reject) => {
-			try {
-				if (this.hasChild(view)) {
-					if (Trace.isEnabled()) {
-						Trace.write(`${view} has already been added`, Trace.categories.Layout);
-					}
+			if (!(view instanceof View)) {
+				throw new Error(`Invalid open view: ${view}`);
+			}
+
+			if (this.hasChild(view)) {
+				throw new Error(`${view} has already been added`);
+			}
+
+			const enterAnimationDefinition = options.animation ? options.animation.enterFrom : null;
+
+			// keep track of the views locally to be able to use their options later
+			this.popupViews.push({ view: view, options: options });
+
+			if (options.shadeCover) {
+				// perf optimization note: we only need 1 layer of shade cover
+				// we just update properties if needed by additional overlaid views
+				if (this.shadeCover) {
+					// overwrite current shadeCover options if topmost popupview has additional shadeCover configurations
+					this.updateShadeCover(this.shadeCover, options.shadeCover);
 				} else {
-					// keep track of the views locally to be able to use their options later
-					this.popupViews.push({ view: view, options: options });
-
-					if (options?.shadeCover) {
-						// perf optimization note: we only need 1 layer of shade cover
-						// we just update properties if needed by additional overlaid views
-						if (this.shadeCover) {
-							// overwrite current shadeCover options if topmost popupview has additional shadeCover configurations
-							this.updateShadeCover(this.shadeCover, options.shadeCover);
-						} else {
-							this.openShadeCover(options.shadeCover);
-						}
-					}
-
-					view.opacity = 0; // always begin with view invisible when adding dynamically
-					this.insertChild(view, this.getChildrenCount() + 1);
-
-					setTimeout(() => {
-						// only apply initial state and animate after the first tick - ensures safe areas and other measurements apply correctly
-						this.applyInitialState(view, options.animation ? options.animation.enterFrom : null);
-						this.getEnterAnimation(view, options.animation ? options.animation.enterFrom : null)
-							.play()
-							.then(() => {
-								this.applyDefaultState(view);
-								resolve();
-							})
-							.catch((ex) => {
-								if (Trace.isEnabled()) {
-									Trace.write(`Error playing enter animation: ${ex}`, Trace.categories.Layout, Trace.messageType.error);
-								}
-							});
-					});
-				}
-			} catch (ex) {
-				if (Trace.isEnabled()) {
-					Trace.write(`Error opening popup (${view}): ${ex}`, Trace.categories.Layout, Trace.messageType.error);
+					this.openShadeCover(options.shadeCover);
 				}
 			}
+
+			view.opacity = 0; // always begin with view invisible when adding dynamically
+			this.insertChild(view, this.getChildrenCount() + 1);
+
+			setTimeout(() => {
+				// only apply initial state and animate after the first tick - ensures safe areas and other measurements apply correctly
+				this.applyInitialState(view, enterAnimationDefinition);
+				this.getEnterAnimation(view, enterAnimationDefinition)
+					.play()
+					.then(() => {
+						this.applyDefaultState(view);
+						resolve();
+					})
+					.catch((ex) => {
+						reject(`Error playing enter animation: ${ex}`);
+					});
+			});
 		});
 	}
 
@@ -76,81 +75,67 @@ export class RootLayoutBase extends GridLayout {
 	// ability to remove any view instance from composite views
 	close(view: View, exitTo?: TransitionAnimation): Promise<void> {
 		return new Promise((resolve, reject) => {
-			if (this.hasChild(view)) {
-				const cleanupAndFinish = () => {
-					this.removeChild(view);
-					resolve();
-				};
+			if (!(view instanceof View)) {
+				throw new Error(`Invalid close view: ${view}`);
+			}
 
-				try {
-					const popupIndex = this.getPopupIndex(view);
-					const poppedView = this.popupViews[popupIndex];
-					// use exitAnimation that is passed in and fallback to the exitAnimation passed in when opening
-					const exitAnimationDefinition = exitTo || poppedView?.options?.animation?.exitTo;
+			if (!this.hasChild(view)) {
+				throw new Error(`Unable to close popup. ${view} not found`);
+			}
 
-					// Remove view from tracked popupviews
-					this.popupViews.splice(popupIndex, 1);
+			const popupIndex = this.getPopupIndex(view);
+			const poppedView = this.popupViews[popupIndex];
+			const cleanupAndFinish = () => {
+				this.removeChild(view);
+				resolve();
+			};
+			// use exitAnimation that is passed in and fallback to the exitAnimation passed in when opening
+			const exitAnimationDefinition = exitTo || poppedView?.options?.animation?.exitTo;
 
-					if (this.shadeCover) {
-						// update shade cover with the topmost popupView options (if not specifically told to ignore)
-						if (!poppedView?.options?.shadeCover.ignoreShadeRestore) {
-							const shadeCoverOptions = this.popupViews[this.popupViews.length - 1]?.options?.shadeCover;
-							if (shadeCoverOptions) {
-								this.updateShadeCover(this.shadeCover, shadeCoverOptions);
-							}
-						}
-						// remove shade cover animation if this is the last opened popup view
-						if (this.popupViews.length === 0) {
-							this.closeShadeCover(poppedView.options.shadeCover);
-						}
-					}
+			// Remove view from tracked popupviews
+			this.popupViews.splice(popupIndex, 1);
 
-					if (exitAnimationDefinition) {
-						this.getExitAnimation(view, exitAnimationDefinition)
-							.play()
-							.then(cleanupAndFinish.bind(this))
-							.catch((ex) => {
-								if (Trace.isEnabled()) {
-									Trace.write(`Error playing exit animation: ${ex}`, Trace.categories.Layout, Trace.messageType.error);
-								}
-							});
-					} else {
-						cleanupAndFinish();
-					}
-				} catch (ex) {
-					if (Trace.isEnabled()) {
-						Trace.write(`Error closing popup (${view}): ${ex}`, Trace.categories.Layout, Trace.messageType.error);
+			if (this.shadeCover) {
+				// update shade cover with the topmost popupView options (if not specifically told to ignore)
+				if (!poppedView?.options?.shadeCover.ignoreShadeRestore) {
+					const shadeCoverOptions = this.popupViews[this.popupViews.length - 1]?.options?.shadeCover;
+					if (shadeCoverOptions) {
+						this.updateShadeCover(this.shadeCover, shadeCoverOptions);
 					}
 				}
+				// remove shade cover animation if this is the last opened popup view
+				if (this.popupViews.length === 0) {
+					this.closeShadeCover(poppedView.options.shadeCover);
+				}
+			}
+
+			if (exitAnimationDefinition) {
+				this.getExitAnimation(view, exitAnimationDefinition)
+					.play()
+					.then(cleanupAndFinish.bind(this))
+					.catch((ex) => {
+						reject(`Error playing exit animation: ${ex}`);
+					});
 			} else {
-				if (Trace.isEnabled()) {
-					Trace.write(`Unable to close popup. ${view} not found`, Trace.categories.Layout);
-				}
+				cleanupAndFinish();
 			}
 		});
 	}
 
-	closeAll(): Promise<void> {
-		return new Promise((resolve, reject) => {
-			try {
-				while (this.popupViews.length > 0) {
-					// remove all children in the popupViews array
-					this.close(this.popupViews[this.popupViews.length - 1].view);
-				}
-				resolve();
-			} catch (ex) {
-				if (Trace.isEnabled()) {
-					Trace.write(`Error closing popups: ${ex}`, Trace.categories.Layout, Trace.messageType.error);
-				}
-			}
-		});
+	closeAll(): Promise<void[]> {
+		const toClose = [];
+		// Close all views at the same time and wait for all of them
+		while (this.popupViews.length > 0) {
+			toClose.push(this.close(this.popupViews[this.popupViews.length - 1].view));
+		}
+		return Promise.all(toClose);
 	}
 
 	getShadeCover(): View {
 		return this.shadeCover;
 	}
 
-	openShadeCover(options: ShadeCoverOptions) {
+	openShadeCover(options: ShadeCoverOptions = {}) {
 		if (this.shadeCover) {
 			if (Trace.isEnabled()) {
 				Trace.write(`RootLayout shadeCover already open.`, Trace.categories.Layout, Trace.messageType.warn);
@@ -163,7 +148,7 @@ export class RootLayoutBase extends GridLayout {
 		}
 	}
 
-	closeShadeCover(shadeCoverOptions?: ShadeCoverOptions): Promise<void> {
+	closeShadeCover(shadeCoverOptions: ShadeCoverOptions = {}): Promise<void> {
 		return new Promise((resolve) => {
 			// if shade cover is displayed and the last popup is closed, also close the shade cover
 			if (this.shadeCover) {
@@ -191,67 +176,60 @@ export class RootLayoutBase extends GridLayout {
 	// bring any view instance open on the rootlayout to front of all the children visually
 	bringToFront(view: View, animated: boolean = false): Promise<void> {
 		return new Promise((resolve, reject) => {
-			try {
-				const popupIndex = this.getPopupIndex(view);
-				// popupview should be present and not already the topmost view
-				if (popupIndex > -1 && popupIndex !== this.popupViews.length - 1) {
-					// keep the popupViews array in sync with the stacking of the views
-					const currentView = this.popupViews[this.getPopupIndex(view)];
-					this.popupViews.splice(this.getPopupIndex(view), 1);
-					this.popupViews.push(currentView);
+			if (!(view instanceof View)) {
+				throw new Error(`Invalid bringToFront view: ${view}`);
+			}
 
-					if (this.hasChild(view)) {
-						const exitAnimation = this.getViewExitState(view);
-						if (animated && exitAnimation) {
-							this.getExitAnimation(view, exitAnimation)
+			if (!this.hasChild(view)) {
+				throw new Error(`${view} not found or already at topmost`);
+			}
+
+			const popupIndex = this.getPopupIndex(view);
+			// popupview should be present and not already the topmost view
+			if (popupIndex < 0 || popupIndex == this.popupViews.length - 1) {
+				throw new Error(`${view} not found or already at topmost`);
+			}
+
+			// keep the popupViews array in sync with the stacking of the views
+			const currentView = this.popupViews[this.getPopupIndex(view)];
+			this.popupViews.splice(this.getPopupIndex(view), 1);
+			this.popupViews.push(currentView);
+
+			const exitAnimation = this.getViewExitState(view);
+			if (animated && exitAnimation) {
+				this.getExitAnimation(view, exitAnimation)
+					.play()
+					.then(() => {
+						this._bringToFront(view);
+						const initialState = this.getViewInitialState(currentView.view);
+						if (initialState) {
+							this.applyInitialState(view, initialState);
+							this.getEnterAnimation(view, initialState)
 								.play()
 								.then(() => {
-									this._bringToFront(view);
-									const initialState = this.getViewInitialState(currentView.view);
-									if (initialState) {
-										this.applyInitialState(view, initialState);
-										this.getEnterAnimation(view, initialState)
-											.play()
-											.then(() => {
-												this.applyDefaultState(view);
-											})
-											.catch((ex) => {
-												if (Trace.isEnabled()) {
-													Trace.write(`Error playing enter animation: ${ex}`, Trace.categories.Layout, Trace.messageType.error);
-												}
-											});
-									} else {
-										this.applyDefaultState(view);
-									}
+									this.applyDefaultState(view);
 								})
 								.catch((ex) => {
-									if (Trace.isEnabled()) {
-										Trace.write(`Error playing exit animation: ${ex}`, Trace.categories.Layout, Trace.messageType.error);
-									}
-									this._bringToFront(view);
+									reject(`Error playing enter animation: ${ex}`);
 								});
 						} else {
-							this._bringToFront(view);
+							this.applyDefaultState(view);
 						}
-					}
-
-					// update shadeCover to reflect topmost's shadeCover options
-					const shadeCoverOptions = currentView?.options?.shadeCover;
-					if (shadeCoverOptions) {
-						this.updateShadeCover(this.shadeCover, shadeCoverOptions);
-					}
-
-					resolve();
-				} else {
-					if (Trace.isEnabled()) {
-						Trace.write(`${view} not found or already at topmost`, Trace.categories.Layout);
-					}
-				}
-			} catch (ex) {
-				if (Trace.isEnabled()) {
-					Trace.write(`Error in bringing view to front: ${ex}`, Trace.categories.Layout, Trace.messageType.error);
-				}
+					})
+					.catch((ex) => {
+						this._bringToFront(view);
+						reject(`Error playing exit animation: ${ex}`);
+					});
+			} else {
+				this._bringToFront(view);
 			}
+
+			// update shadeCover to reflect topmost's shadeCover options
+			const shadeCoverOptions = currentView?.options?.shadeCover;
+			if (shadeCoverOptions) {
+				this.updateShadeCover(this.shadeCover, shadeCoverOptions);
+			}
+			resolve();
 		});
 	}
 
@@ -337,7 +315,7 @@ export class RootLayoutBase extends GridLayout {
 		};
 	}
 
-	private createShadeCover(shadeOptions: ShadeCoverOptions): View {
+	private createShadeCover(shadeOptions: ShadeCoverOptions = {}): View {
 		const shadeCover = new GridLayout();
 		shadeCover.verticalAlignment = 'bottom';
 		shadeCover.on('loaded', () => {
@@ -347,7 +325,7 @@ export class RootLayoutBase extends GridLayout {
 		return shadeCover;
 	}
 
-	private updateShadeCover(shade: View, shadeOptions: ShadeCoverOptions): void {
+	private updateShadeCover(shade: View, shadeOptions: ShadeCoverOptions = {}): void {
 		if (shadeOptions.tapToClose !== undefined && shadeOptions.tapToClose !== null) {
 			shade.off('tap');
 			if (shadeOptions.tapToClose) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
RootLayout popup views will not update or close during live-sync.

## What is the new behavior?
RootLayout popup views will close during live-sync.

During my work on this, I took the liberty to do few more important improvements.

1) Method `closeAll` of `RootLayout` will now use Promise.all so that developers can await for all simultaneous popup dismissals.

2) Fixed a small issue that caused live-sync not to reload changes in current page if a `Modal` was shown atop of it. This was a minor bug that occured during early NativeScript 6 updates.

3) Regarding error handling, promise-based methods of `RootLayout` have also gotten few improvements.
The old approach was using try clauses inside promises which caused a promise never to reject in case of error.
There were few trace messages in case trace was enabled but that still didn't handle the errors at all.
These clauses were removed as errors will automatically reject the promise they are thrown into.

4) Validation check for given view was also added in case view was not a valid instance (e.g. undefined).


I believe `RootLayout` is in need of few improvements and this patch is a good start.