### PR TITLE
perf: Improved live-sync functionality for RootLayout

### DIFF
--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -193,12 +193,6 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 
 		let handled = false;
 
-		const rootLayout = global.rootLayout;
-		if (rootLayout != null && rootLayout.topmost() != null) {
-			rootLayout.closeAll();
-			handled = true;
-		}
-
 		if (this._closeAllModalViewsInternal()) {
 			handled = true;
 		}

--- a/packages/core/ui/layouts/root-layout/root-layout-common.ts
+++ b/packages/core/ui/layouts/root-layout/root-layout-common.ts
@@ -25,6 +25,21 @@ export class RootLayoutBase extends GridLayout {
 		super.onLoaded();
 	}
 
+	public _onLivesync(context?: ModuleContext): boolean {
+		let handled = false;
+
+		if (this.popupViews.length > 0) {
+			this.closeAll();
+			handled = true;
+		}
+
+		if (super._onLivesync(context)) {
+			handled = true;
+		}
+
+		return handled;
+	}
+
 	// ability to add any view instance to composite views like layers
 	open(view: View, options: RootLayoutOptions = {}): Promise<void> {
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the new behavior?
This is a performance improvement for RootLayout live-sync. It's also a cleaner approach.
Using the old approach, parents of RootLayout could also close popups during live-sync. Now, RootLayout will handle its own views.