### PR TITLE
fix: queueGC debounce and throttle with reuse of different settings

### DIFF
--- a/packages/core/utils/utils-common.ts
+++ b/packages/core/utils/utils-common.ts
@@ -155,10 +155,35 @@ export function throttle(fn: any, delay = 300) {
 	};
 }
 
+let throttledGC: Map<number, () => void>;
+let debouncedGC: Map<number, () => void>;
+
 export function queueGC(delay = 900, useThrottle?: boolean) {
+	/**
+	 * developers can use different queueGC settings to optimize their own apps
+	 * each setting is stored in a Map to reuse each time app calls it
+	 */
 	if (useThrottle) {
-		throttle(() => GC(), delay);
+		if (!throttledGC) {
+			throttledGC = new Map();
+		}
+		if (!throttledGC.get(delay)) {
+			throttledGC.set(
+				delay,
+				throttle(() => GC(), delay)
+			);
+		}
+		throttledGC.get(delay)();
 	} else {
-		debounce(() => GC(), delay);
+		if (!debouncedGC) {
+			debouncedGC = new Map();
+		}
+		if (!debouncedGC.get(delay)) {
+			debouncedGC.set(
+				delay,
+				debounce(() => GC(), delay)
+			);
+		}
+		debouncedGC.get(delay)();
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?

Calling `Utils.queueGC()` would not throttle or debounce properly.

## What is the new behavior?

Calling `Utils.queueGC()` behaves properly now.
