### PR TITLE
fix(css): borderColor parse handling for hsl color values

### DIFF
--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -876,7 +876,7 @@ function parseBorderColor(value: string): { top: Color; right: Color; bottom: Co
 		bottom: undefined,
 		left: undefined,
 	};
-	if (value.indexOf('rgb') === 0) {
+	if (value.indexOf('rgb') === 0 || value.indexOf('hsl') === 0) {
 		result.top = result.right = result.bottom = result.left = new Color(value);
 
 		return result;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?

Using `hsl` colors on borderColor would parse incorrectly.

## What is the new behavior?

Using `hsl` colors on borderColor will now parse correctly.