### PR TITLE
ref: Get android device language and region from system configuration

### DIFF
--- a/packages/core/platform/index.android.ts
+++ b/packages/core/platform/index.android.ts
@@ -128,11 +128,23 @@ class DeviceRef {
 	}
 
 	get language(): string {
-		return java.util.Locale.getDefault().getLanguage().replace('_', '-');
+		let defaultNativeLocale;
+		if (android.os.Build.VERSION.SDK_INT >= 24) {
+			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().getLocales().get(0);
+		} else {
+			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().locale;
+		}
+		return defaultNativeLocale.getLanguage().replace('_', '-');
 	}
 
 	get region(): string {
-		return java.util.Locale.getDefault().getCountry();
+		let defaultNativeLocale;
+		if (android.os.Build.VERSION.SDK_INT >= 24) {
+			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().getLocales().get(0);
+		} else {
+			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().locale;
+		}
+		return defaultNativeLocale.getCountry();
 	}
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In android, platform module exposes a `Device` instance that includes `language` and `region` properties.
These getters expose data based on `java.util.Locale` which exposes data from jvm.
Also, `@nativescript/localize` plugin modifies default locale in `java.util.Locale`, resulting in getting a different value from `Device.language` afterwards.

## What is the new behavior?
This patch will expose language and region values from android system configuration, as `java.util.Locale.getDefault()` should be more application-specific than device-specific.