### PR TITLE
perf(webpack): Attempt to resolve namespaces before module names

### DIFF
--- a/packages/webpack5/src/loaders/xml-namespace-loader/index.ts
+++ b/packages/webpack5/src/loaders/xml-namespace-loader/index.ts
@@ -72,13 +72,14 @@ async function parseXML(content: string): Promise<ParseResult> {
 		const localNamespacePath = join(this.rootContext, namespace);
 		const localModulePath = join(localNamespacePath, elementName);
 
+		// Check namespaces before module names as a folder may contain an index file with exports
 		const resolvePaths = [
 			localNamespacePath,
 			localModulePath,
-			moduleName,
 			namespace,
-			`~/${moduleName}`,
+			moduleName,
 			`~/${namespace}`,
+			`~/${moduleName}`,
 		];
 
 		// fallbacks for codeless namespaces


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
XML namespace loader attempts to resolve module paths based on element name before namespaces.

## What is the new behavior?
XML namespace loader attempts to resolve module paths based on element name after namespaces.

I have a directory with an index.js that exports all my components. In some cases, loader attempted to resolve a path based on element name and this results in case-sensitivity problems.

For example, my index.js exported `Select` component from `./select.js`. XML loader attempts to load a module using `mypath/Select.js` as a module name. Method `resolve` happens to be case insensitive in MacOs, and results in conflict between Select.js and select.js.

This change in order helps get rid of such issues as loader will attempt to load namespace as a module first.