### PR TITLE
fix(core): Reset frame history when defaultPage is changed.

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -742,7 +742,7 @@ export function _stack(): Array<FrameBase> {
 export const defaultPage = new Property<FrameBase, string>({
 	name: 'defaultPage',
 	valueChanged: (frame: FrameBase, oldValue: string, newValue: string) => {
-		frame.navigate({ moduleName: newValue });
+		frame.navigate({ moduleName: newValue, clearHistory: true });
 	},
 });
 defaultPage.register(FrameBase);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
If one sets Frame's `defaultPage` more than once, Frame will keep old page in navigation history stack.

## What is the new behavior?
If one sets Frame's `defaultPage` more than once, Frame will reset navigation history as a default page is set anew.