### PR TITLE
fix(android): ensure android application is created before setting listeners

### DIFF
--- a/packages/core/ui/styling/background.android.ts
+++ b/packages/core/ui/styling/background.android.ts
@@ -163,6 +163,7 @@ function onLiveSync(args): void {
 global.NativeScriptGlobals.events.on('livesync', onLiveSync);
 
 global.NativeScriptGlobals.addEventWiring(() => {
+	application.ensureNativeApplication();
 	application.android.on('activityStarted', (args) => {
 		if (!imageFetcher) {
 			initImageCache(args.activity);
@@ -173,6 +174,7 @@ global.NativeScriptGlobals.addEventWiring(() => {
 });
 
 global.NativeScriptGlobals.addEventWiring(() => {
+	application.ensureNativeApplication();
 	application.android.on('activityStopped', (args) => {
 		if (imageFetcher) {
 			imageFetcher.closeCache();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?

Android app boot might fail if listeners are wired prior to bootstrap.

## What is the new behavior?

Android app boot is more resilient under these conditions.

