### PR TITLE
fix(ios): proper disposal and recreation of iOS native views

### DIFF
--- a/apps/automated/src/ui/lifecycle/lifecycle-tests.ts
+++ b/apps/automated/src/ui/lifecycle/lifecycle-tests.ts
@@ -1,7 +1,7 @@
 import * as helper from '../../ui-helper';
 import * as btnCounter from './pages/button-counter';
 import * as TKUnit from '../../tk-unit';
-import { isIOS, isAndroid } from '@nativescript/core';
+import { isIOS } from '@nativescript/core';
 
 // Integration tests that asser sertain runtime behavior, lifecycle events atc.
 
@@ -163,7 +163,7 @@ export function test_css_sets_properties() {
 	page.content = stack;
 
 	// TODO: The check counts here should be the same as the counts before removing from the page.
-	const expectedNativeSettersAfterReaddedToPage = isAndroid ? [2, 4, 4, 4] : expectedChangesAfterResettingClasses;
+	const expectedNativeSettersAfterReaddedToPage = [2, 4, 4, 4];
 	for (let i = 0; i < buttons.length; i++) {
 		TKUnit.assertEqual(buttons[i].colorSetNativeCount, expectedNativeSettersAfterReaddedToPage[i], `Expected ${buttons[i].id} native set to not be called when added to page.`);
 		TKUnit.assertEqual(buttons[i].colorPropertyChangeCount, expectedChangesAfterResettingClasses[i], `Expected ${buttons[i].id} change notifications for css properties to not occur when added to page.`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/core",
-  "version": "8.2.3",
+  "version": "8.2.4-alpha.0",
   "description": "A JavaScript library providing an easy to use api for interacting with iOS and Android platform APIs.",
   "main": "index",
   "types": "index.d.ts",

--- a/packages/core/ui/animation/animation-interfaces.ts
+++ b/packages/core/ui/animation/animation-interfaces.ts
@@ -69,5 +69,5 @@ export interface AnimationDefinitionInternal extends AnimationDefinition {
 export interface IOSView extends View {
 	_suspendPresentationLayerUpdates();
 	_resumePresentationLayerUpdates();
-	_isPresentationLayerUpdateSuspeneded();
+	_isPresentationLayerUpdateSuspended();
 }

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -909,6 +909,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 
 	public destroyNode(forceDestroyChildren?: boolean): void {
 		this.reusable = false;
+		this.callUnloaded();
 		this._tearDownUI(forceDestroyChildren);
 	}
 
@@ -958,12 +959,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 
 			this._suspendNativeUpdates(SuspendType.UISetup);
 
-			if (global.isAndroid) {
-				this.setNativeView(null);
-				this._androidView = null;
-			}
-
-			// this._iosView = null;
+			this.setNativeView(null);
+			this._androidView = null;
+			this._iosView = null;
 
 			this._context = null;
 		}

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -38,6 +38,7 @@ export class View extends ViewCommon implements ViewDefinition {
 	private _modalAnimatedOptions: Array<boolean>;
 	private _isLaidOut = false;
 	private _hasTransform = false;
+	private _hasPendingTransform = false;
 	private _privateFlags: number = PFLAG_LAYOUT_REQUIRED | PFLAG_FORCE_LAYOUT;
 	private _cachedFrame: CGRect;
 	private _suspendCATransaction = false;
@@ -127,6 +128,10 @@ export class View extends ViewCommon implements ViewDefinition {
 		}
 
 		this.updateBackground(sizeChanged);
+		if (this._hasPendingTransform) {
+			this.updateNativeTransform();
+			this._hasPendingTransform = false;
+		}
 		this._privateFlags &= ~PFLAG_FORCE_LAYOUT;
 	}
 
@@ -371,6 +376,11 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 
 	public updateNativeTransform() {
+		if (!this.isLayoutValid) {
+			this._hasPendingTransform = true;
+			return;
+		}
+
 		const scaleX = this.scaleX || 1e-6;
 		const scaleY = this.scaleY || 1e-6;
 		const perspective = this.perspective || 300;

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -70,6 +70,7 @@ export class View extends ViewCommon implements ViewDefinition {
 		this._cachedFrame = null;
 		this._isLaidOut = false;
 		this._hasTransform = false;
+		this._hasPendingTransform = false;
 	}
 
 	public requestLayout(): void {

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -63,6 +63,14 @@ export class View extends ViewCommon implements ViewDefinition {
 		this.once(View.loadedEvent, () => setupAccessibleView(this));
 	}
 
+	disposeNativeView() {
+		super.disposeNativeView();
+
+		this._cachedFrame = null;
+		this._isLaidOut = false;
+		this._hasTransform = false;
+	}
+
 	public requestLayout(): void {
 		super.requestLayout();
 		this._privateFlags |= PFLAG_FORCE_LAYOUT;

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -37,7 +37,7 @@ export class View extends ViewCommon implements ViewDefinition {
 	 */
 	private _modalAnimatedOptions: Array<boolean>;
 	private _isLaidOut = false;
-	private _hasTransfrom = false;
+	private _hasTransform = false;
 	private _privateFlags: number = PFLAG_LAYOUT_REQUIRED | PFLAG_FORCE_LAYOUT;
 	private _cachedFrame: CGRect;
 	private _suspendCATransaction = false;
@@ -175,7 +175,7 @@ export class View extends ViewCommon implements ViewDefinition {
 			this._cachedFrame = frame;
 			let adjustedFrame = null;
 			let transform = null;
-			if (this._hasTransfrom) {
+			if (this._hasTransform) {
 				// Always set identity transform before setting frame;
 				transform = nativeView.layer.transform;
 				nativeView.layer.transform = CATransform3DIdentity;
@@ -189,7 +189,7 @@ export class View extends ViewCommon implements ViewDefinition {
 				nativeView.frame = adjustedFrame;
 			}
 
-			if (this._hasTransfrom) {
+			if (this._hasTransform) {
 				// re-apply the transform after the frame is adjusted
 				nativeView.layer.transform = transform;
 			}
@@ -378,12 +378,12 @@ export class View extends ViewCommon implements ViewDefinition {
 		transform = iOSNativeHelper.applyRotateTransform(transform, this.rotateX, this.rotateY, this.rotate);
 		transform = CATransform3DScale(transform, scaleX, scaleY, 1);
 		if (!CATransform3DEqualToTransform(this.nativeViewProtected.layer.transform, transform)) {
-			const updateSuspended = this._isPresentationLayerUpdateSuspeneded();
+			const updateSuspended = this._isPresentationLayerUpdateSuspended();
 			if (!updateSuspended) {
 				CATransaction.begin();
 			}
 			this.nativeViewProtected.layer.transform = transform;
-			this._hasTransfrom = this.nativeViewProtected && !CATransform3DEqualToTransform(this.nativeViewProtected.transform3D, CATransform3DIdentity);
+			this._hasTransform = this.nativeViewProtected && !CATransform3DEqualToTransform(this.nativeViewProtected.transform3D, CATransform3DIdentity);
 			if (!updateSuspended) {
 				CATransaction.commit();
 			}
@@ -409,7 +409,7 @@ export class View extends ViewCommon implements ViewDefinition {
 		this._suspendCATransaction = false;
 	}
 
-	public _isPresentationLayerUpdateSuspeneded(): boolean {
+	public _isPresentationLayerUpdateSuspended(): boolean {
 		return this._suspendCATransaction || this._suspendNativeUpdatesCount > 0;
 	}
 
@@ -689,7 +689,7 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 	[opacityProperty.setNative](value: number) {
 		const nativeView = this.nativeViewProtected;
-		const updateSuspended = this._isPresentationLayerUpdateSuspeneded();
+		const updateSuspended = this._isPresentationLayerUpdateSuspended();
 		if (!updateSuspended) {
 			CATransaction.begin();
 		}
@@ -845,7 +845,7 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 
 	_redrawNativeBackground(value: UIColor | Background): void {
-		const updateSuspended = this._isPresentationLayerUpdateSuspeneded();
+		const updateSuspended = this._isPresentationLayerUpdateSuspended();
 		if (!updateSuspended) {
 			CATransaction.begin();
 		}

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -91,7 +91,7 @@ class UILayoutViewController extends UIViewController {
 
 		IOSHelper.updateAutoAdjustScrollInsets(this, owner);
 
-		if (!owner.parent) {
+		if (!owner.isLoaded && !owner.parent) {
 			owner.callLoaded();
 		}
 	}
@@ -99,7 +99,7 @@ class UILayoutViewController extends UIViewController {
 	public viewDidDisappear(animated: boolean): void {
 		super.viewDidDisappear(animated);
 		const owner = this.owner.get();
-		if (owner && !owner.parent) {
+		if (owner && owner.isLoaded && !owner.parent) {
 			owner.callUnloaded();
 		}
 	}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Native iOS views are not disposed and cannot be recreated when their view instances are re-added to the view tree.

## What is the new behavior?

### Native View Disposal

This PR was initially created for the sole purpose of destroying old native views (until more problems showed up in the process).
This is based on Martin's @farfromrefug  PR #9671 which was reverted because of few problems.

@rigor789 If I'm not mistaken, the most common error case was this one:
```
***** Fatal JavaScript exception - application has been terminated. *****
NativeScript encountered a fatal error: Uncaught TypeError: Cannot set property 'delegate' of null
at
onUnloaded(file: src/webpack:/node_modules/@nativescript/core/ui/text-field/index.ios.js:114:0)
at (file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:321:0)
at callFunctionWithSuper(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:312:0)
at callUnloaded(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:321:0)
at unloadView(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:466:0)
at (file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:249:0)
at eachChildView(file: src/webpack:/node_modules/@nativescript/core/ui/layouts/layout-base-common.js:101:0)
at eachChild(file: src/webpack:/node_modules/@nativescript/core/ui/core/view/view-common.js:772:0)
at onUnloaded(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:248:0)
at (file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:321:0)
at callFunctionWithSuper(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:312:0)
at callUnloaded(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:321:0)
at unloadView(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:466:0)
at (file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:249:0)
at eachChildView(file: src/webpack:/node_modules/@nativescript/core/ui/layouts/layout-base-common.js:101:0)
at eachChild(file: src/webpack:/node_modules/@nativescript/core/ui/core/view/view-common.js:772:0)
at onUnloaded(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:248:0)
at (file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:321:0)
at callFunctionWithSuper(file: src/webpack:/node_modules/@nativescript/core/ui/core/view-base/index.js:312:0)
at callUnloaded(file:///app/vend<…>
```

After a bit of research, I concluded the root of this cause is `_tearDownUI` calls being called before the view gets unloaded.
So, what are the cases for a view to get unloaded too late when it's already destroyed?

One case is view controllers which have a `viewDidDisappear` method that is called once owner view is disposed. This method will call `callUnloaded` which will attempt to unload view and all its children in view tree. Let's keep in mind that if a view is disposed by means other than `removeChild`, it's still in view hierarchy.

One primary suspect for this crime is method `destroyNode` in `View` class. I'm not familiar with NS Angular, but its renderer seems to wrap this method inside another `destroyNode`. One of errors mentioned in #9671 has also occured in an Angular app.

I couldn't locate any other error-prone cases and I'm not completely sure all errors have occured because of the flaw in that certain method, but for start I added a missing `callUnloaded` call inside `destroyNode`.
If there are more causes that trigger this issue, I believe we can track them upon further app usage and solve them immediately, since we know what can cause this now. Core has got a dozen of `_tearDownUI` calls that are supposed to get called after view is unloaded but who knows!

Just as @farfromrefug pointed out, perhaps we should make sure those two calls are done in proper order in the future, like adding `callUnloaded` inside `_tearDownUI` for example which needs some refactoring.

So, all these details refer to https://github.com/NativeScript/NativeScript/pull/9879/files#diff-86ce61f77399a980c83c5a14ee2ac54b8c672d375d0280597c217eb17811a076, the change for disposing native views for iOS.

### Re-using iOS view instance (non-reusable native view)

What if one wants to reuse the same NS instance even though its native view is not reusable? Upon re-adding an already removed view instance to the view tree, it should generate a new native view. This leads us to new problems which I'll use an example to describe below.

I'll use a non-reusable animated drawer view of mine embedded in `RootLayout`, in a plain NS app. This is a good example since there is a constant use of `insertChild` and `removeChild` methods, and view will also get transformed it gets hidden to the left side of the screen.

In short, attempting to open drawer will result in calling `insertChild`, while trying to close it will result in calling `removeChild`.

This is how my drawer originally looks like when opening it for first time:
![image](https://user-images.githubusercontent.com/55595100/164916598-a478e68c-409c-4113-93b9-9b1e0b07c78a.png)

If it's removed and re-added to view tree in current NS core version, it will look like this:
![image](https://user-images.githubusercontent.com/55595100/164916702-3261301a-cf05-42b7-b6dc-4856577f3fcf.png)

It looks like this because images undergo a cleanup on disposal since NS 8.2. As view is not currently disposed properly, native view will not be created anew and this results in images not being reloaded.

Now, the following screenshot displays the result of using changes from PR #9671 alone.
![image](https://user-images.githubusercontent.com/55595100/164916821-461b5cfd-4a54-4ad1-974e-19378a15ee3f.png)

View layout seems completely messed up and that is so confusing. This problem occured because view instances keep cache of last used native frame.
And here comes the addition of `disposeNativeView` in the iOS version of `View` class: https://github.com/NativeScript/NativeScript/pull/9879/files#diff-025d8125f2c2388468769424324a18b7a896921f7b44f720db8014eb653b5f84R67

This comes with really good results:
![image](https://user-images.githubusercontent.com/55595100/164916998-5ced8db6-8569-486c-bc10-eeb3b08cf41f.png)

Yet, it seems few children are not aligned properly, and there's no good explanation.
I concluded that the cause of this is the native view `translateX` transform occuring too early. That transform messes up view position in native window, resulting in padding and inset miscalculations.

That is why we should prevent transforms from happening when layout is still invalid, and apply them once view content layout is ready.
See here: https://github.com/NativeScript/NativeScript/pull/9879/files#diff-025d8125f2c2388468769424324a18b7a896921f7b44f720db8014eb653b5f84R132

The final result:
![image](https://user-images.githubusercontent.com/55595100/164917121-c78297e2-294d-43fd-bbe4-ad697f1f2388.png)

The proper disposal of native views works quite well with the few recent additions of GC inside core.
About reuse, I believe this is a really good step for re-using iOS views even when their native instances are not reusable. This has always been possible in android, but it seems we lacked the proper view cleanup to make this work in iOS and that created a bit of confusion.

This PR is a possible candidate for fixing the iOS part of #9820, and its view cleanup is a good solution for my issue described in #9875