### PR TITLE
fix: Apply proper border radius to box shadow and view sublayers

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -726,7 +726,7 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 	cornerRadius = Math.min(Math.min(renderSize.width / 2, renderSize.height / 2), cornerRadius);
 
 	// Apply corner radius to sub layers as clipToBounds and masksToBounds are now set to false
-	if (nativeView.layer.sublayers?.count) {
+	if (nativeView.layer?.sublayers?.count) {
 		const count = nativeView.layer.sublayers.count;
 		for (let i = 0; i < count; i++) {
 			const subLayer = nativeView.layer.sublayers.objectAtIndex(i);
@@ -763,7 +763,7 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 
 function clearBoxShadow(nativeView: NativeScriptUIView) {
 	nativeView.clipsToBounds = true;
-	if (nativeView.layer.sublayers?.count) {
+	if (nativeView.layer?.sublayers?.count) {
 		const count = nativeView.layer.sublayers.count;
 		for (let i = 0; i < count; i++) {
 			const subLayer = nativeView.layer.sublayers.objectAtIndex(i);

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -726,9 +726,11 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 	cornerRadius = Math.min(Math.min(renderSize.width / 2, renderSize.height / 2), cornerRadius);
 
 	// Apply corner radius to sub layers as clipToBounds and masksToBounds are now set to false
-	if (nativeView.layer.sublayers != null) {
-		for (let childLayer of nativeView.layer.sublayers) {
-			childLayer.cornerRadius = cornerRadius;
+	if (nativeView.layer.sublayers?.count) {
+		const count = nativeView.layer.sublayers.count;
+		for (let i = 0; i < count; i++) {
+			const subLayer = nativeView.layer.sublayers.objectAtIndex(i);
+			subLayer.cornerRadius = cornerRadius;
 		}
 	}
 
@@ -761,9 +763,11 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 
 function clearBoxShadow(nativeView: NativeScriptUIView) {
 	nativeView.clipsToBounds = true;
-	if (nativeView.layer.sublayers != null) {
-		for (let childLayer of nativeView.layer.sublayers) {
-			childLayer.cornerRadius = 0.0;
+	if (nativeView.layer.sublayers?.count) {
+		const count = nativeView.layer.sublayers.count;
+		for (let i = 0; i < count; i++) {
+			const subLayer = nativeView.layer.sublayers.objectAtIndex(i);
+			subLayer.cornerRadius = 0.0;
 		}
 	}
 

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -726,11 +726,10 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 	cornerRadius = Math.min(Math.min(renderSize.width / 2, renderSize.height / 2), cornerRadius);
 
 	// Apply corner radius to sub layers as clipToBounds and masksToBounds are now set to false
-	if (nativeView.layer?.sublayers?.count) {
-		const count = nativeView.layer.sublayers.count;
-		for (let i = 0; i < count; i++) {
-			const subLayer = nativeView.layer.sublayers.objectAtIndex(i);
-			subLayer.cornerRadius = cornerRadius;
+	const sublayers = nativeView.layer?.sublayers;
+	if (sublayers) {
+		for (let i = 0; i < sublayers.count; i++) {
+			sublayers.objectAtIndex(i).cornerRadius = cornerRadius;
 		}
 	}
 
@@ -763,11 +762,10 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 
 function clearBoxShadow(nativeView: NativeScriptUIView) {
 	nativeView.clipsToBounds = true;
-	if (nativeView.layer?.sublayers?.count) {
-		const count = nativeView.layer.sublayers.count;
-		for (let i = 0; i < count; i++) {
-			const subLayer = nativeView.layer.sublayers.objectAtIndex(i);
-			subLayer.cornerRadius = 0.0;
+	const sublayers = nativeView.layer?.sublayers;
+	if (sublayers) {
+		for (let i = 0; i < sublayers.count; i++) {
+			sublayers.objectAtIndex(i).cornerRadius = 0.0;
 		}
 	}
 

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -712,6 +712,7 @@ function drawNoRadiusNonUniformBorders(nativeView: NativeScriptUIView, backgroun
 // TODO: use sublayer if its applied to a layout
 function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CSSShadow, background: BackgroundDefinition, useSubLayer: boolean = false) {
 	const layer: CALayer = iOSNativeHelper.getShadowLayer(nativeView, 'ns-box-shadow');
+	const renderSize = view.getActualSize() || { width: 0, height: 0 };
 
 	layer.masksToBounds = false;
 	nativeView.clipsToBounds = false;
@@ -720,10 +721,22 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 	// nativeView.clipsToBounds doesn't work
 	view.setProperty('clipToBounds', false);
 
+	// This should match the view's border radius (only uniform radius is supported for now)
+	let cornerRadius = layout.toDeviceIndependentPixels(background.borderTopLeftRadius);
+	cornerRadius = Math.min(Math.min(renderSize.width / 2, renderSize.height / 2), cornerRadius);
+
+	// Apply corner radius to sub layers as clipToBounds and masksToBounds are now set to false
+	if (nativeView.layer.sublayers != null) {
+		for (let childLayer of nativeView.layer.sublayers) {
+			childLayer.cornerRadius = cornerRadius;
+		}
+	}
+
 	if (!background.color?.a) {
 		// add white background if view has a transparent background
 		layer.backgroundColor = UIColor.whiteColor.CGColor;
 	}
+
 	// shadow opacity is handled on the shadow's color instance
 	layer.shadowOpacity = boxShadow.color?.a ? boxShadow.color?.a / 255 : 1;
 	layer.shadowRadius = Length.toDevicePixels(boxShadow.blurRadius, 0.0);
@@ -734,9 +747,6 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 		Length.toDevicePixels(boxShadow.offsetX, 0.0),
 		Length.toDevicePixels(boxShadow.offsetY, 0.0)
 	);
-
-	// this should match the view's border radius
-	const cornerRadius = Length.toDevicePixels(<CoreTypes.LengthType>view.style.borderRadius, 0.0);
 
 	// apply spreadRadius by expanding shadow layer bounds
 	// prettier-ignore
@@ -751,10 +761,17 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 
 function clearBoxShadow(nativeView: NativeScriptUIView) {
 	nativeView.clipsToBounds = true;
+	if (nativeView.layer.sublayers != null) {
+		for (let childLayer of nativeView.layer.sublayers) {
+			childLayer.cornerRadius = 0.0;
+		}
+	}
+
 	const layer: CALayer = iOSNativeHelper.getShadowLayer(nativeView, 'ns-box-shadow', false);
 	if (!layer) {
 		return;
 	}
+
 	layer.masksToBounds = true;
 	layer.shadowOffset = CGSizeMake(0, 0);
 	layer.shadowColor = UIColor.clearColor.CGColor;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In iOS:
- Border radius is miscalculated for drop-shadow
- Gradient background border radius is miscalculated when there is drop-shadow

I found those problems while using an iPad. Box-shadow radius was probably miscalculated because of a scale factor that may be higher than 1.
![D1C14C66-80AC-4594-A7ED-AC2BA2CE741E](https://user-images.githubusercontent.com/55595100/165373557-1fdb8b0e-c5e6-48f3-a78d-0f67aa7fde13.png)![1FC2E34A-D732-4460-A13B-E4B3265F4F83](https://user-images.githubusercontent.com/55595100/165374332-81bf6172-2f63-41d2-9dc2-b63090cc16c8.png)

## What is the new behavior?
Border radius will be properly calculated for view box-shadow and sublayers. It seems that `toDeviceIndependentPixels` works better and returns the same value as the rest of applied view border-radiuses.
This change will also attempt to apply corner radius to all sublayers. Sublayers will usually consist of a gradient layer and a border layer.
There are also cases that border layer has sublayers but there is a need for a whole refactor to make those look good, that is why we apply radius to top-level layers for now.

This is new shadow radius with gradient background:
![2DD8A8F8-9BCF-4DB4-AB60-8F1D323198BB_1_101_o](https://user-images.githubusercontent.com/55595100/165374960-2ff58dee-fd67-4e74-9eb1-d19703bd69b2.jpeg)

Fixes/Closes #9869 .