### PR TITLE
fix: ensure reusable ProxyViewContainer re-adds native children

### DIFF
--- a/packages/core/ui/proxy-view-container/index.ts
+++ b/packages/core/ui/proxy-view-container/index.ts
@@ -66,6 +66,35 @@ export class ProxyViewContainer extends LayoutBase {
 		});
 	}
 
+	_setupUI(context: any, atIndex?: number, parentIsLoaded?: boolean) {
+		let processChildren = false;
+		if (this.reusable && this._context === context) {
+			processChildren = true;
+		}
+		super._setupUI(context, atIndex, parentIsLoaded);
+		if (this.reusable && processChildren) {
+			this.eachChild((child) => {
+				const oldReusable = child.reusable;
+				child.reusable = true;
+				child._setupUI(context);
+				child.reusable = oldReusable;
+				return true;
+			});
+		}
+	}
+	_tearDownUI(force?: boolean) {
+		super._tearDownUI(force);
+		if (this.reusable && !force) {
+			this.eachChild((child) => {
+				const oldReusable = child.reusable;
+				child.reusable = true;
+				child._tearDownUI();
+				child.reusable = oldReusable;
+				return true;
+			});
+		}
+	}
+
 	public _addViewToNativeVisualTree(child: View, atIndex?: number): boolean {
 		if (Trace.isEnabled()) {
 			Trace.write('ProxyViewContainer._addViewToNativeVisualTree for a child ' + child + ' ViewContainer.parent: ' + this.parent, Trace.categories.ViewHierarchy);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
If you set `reusable = true` on a ProxyViewContainer, the children are never re-added to the native visual tree

## What is the new behavior?
reusable ProxyViewContainers will now temporarily set the reusable flag on it's children so that they're not destroyed on _tearDownUI and correctly call _addViewToNativeVisualTree during _setupUI
