### PR TITLE
fix(core): android wrong background state + current value accessors

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -170,6 +170,16 @@ export function systemAppearanceChanged(rootView: View, newSystemAppearance: 'da
 	});
 }
 
+export let inBackground = false;
+export let suspended = false;
+
+export function setInBackground(value: boolean): void {
+	inBackground = value;
+}
+export function setSuspended(value: boolean): void {
+	suspended = value;
+}
+
 global.__onUncaughtError = function (error: NativeScriptError) {
 	global.NativeScriptGlobals.events.notify(<UnhandledErrorEventData>{
 		eventName: uncaughtErrorEvent,

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -20,6 +20,7 @@ import { profile } from '../profiling';
 import { iOSNativeHelper } from '../utils';
 import { initAccessibilityCssHelper } from '../accessibility/accessibility-css-helper';
 import { initAccessibilityFontScale } from '../accessibility/font-scale';
+import { setInBackground, setSuspended } from './application-common';
 
 const IOS_PLATFORM = 'ios';
 
@@ -254,6 +255,8 @@ export class iOSApplication implements iOSApplicationDefinition {
 	private didBecomeActive(notification: NSNotification) {
 		const ios = UIApplication.sharedApplication;
 		const object = this;
+		setInBackground(false);
+		setSuspended(false);
 		notify(<ApplicationEventData>{ eventName: resumeEvent, object, ios });
 		notify(<ApplicationEventData>{ eventName: foregroundEvent, object, ios });
 		const rootView = this._rootView;
@@ -265,6 +268,8 @@ export class iOSApplication implements iOSApplicationDefinition {
 	private didEnterBackground(notification: NSNotification) {
 		const ios = UIApplication.sharedApplication;
 		const object = this;
+		setInBackground(true);
+		setSuspended(true);
 		notify(<ApplicationEventData>{ eventName: suspendEvent, object, ios });
 		notify(<ApplicationEventData>{ eventName: backgroundEvent, object, ios });
 		const rootView = this._rootView;

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1204,7 +1204,6 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 				android: activity,
 			};
 			application.notify(args);
-			application.android.paused = false;
 		}
 	}
 

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -20,6 +20,7 @@ import { CSSUtils } from '../../css/system-classes';
 import { Device } from '../../platform';
 import { profile } from '../../profiling';
 import { android as androidApplication } from '../../application';
+import { setSuspended } from '../../application/application-common';
 
 export * from './frame-common';
 
@@ -1196,6 +1197,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 		// and raising the application resume event there causes issues like
 		// https://github.com/NativeScript/NativeScript/issues/6708
 		if ((<any>activity).isNativeScriptActivity) {
+			setSuspended(false);
 			const args = <application.ApplicationEventData>{
 				eventName: application.resumeEvent,
 				object: application.android,


### PR DESCRIPTION
This fixes a bug with my recent addition of `backgroung/foreground` events.
It also adds getters `inBackground` and `suspended` in `application-common` to query the current value for both iOS/Android