### PR TITLE
feat(core): maxLines support for all text components

### DIFF
--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -365,7 +365,6 @@ function initLifecycleCallbacks() {
 		rootView.getViewTreeObserver().addOnGlobalLayoutListener(global.onGlobalLayoutListener);
 	});
 
-
 	let activitiesStarted = 0;
 
 	const lifecycleCallbacks = new android.app.Application.ActivityLifecycleCallbacks(<any>{

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -86,7 +86,7 @@ export namespace CoreTypes {
 		export const nowrap = 'nowrap';
 	}
 
-	export type MaxLinesType = 'none' | number;
+	export type MaxLinesType = number;
 
 	export type OrientationType = 'horizontal' | 'vertical';
 	export module Orientation {

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -86,6 +86,8 @@ export namespace CoreTypes {
 		export const nowrap = 'nowrap';
 	}
 
+	export type MaxLinesType = 'none' | number;
+
 	export type OrientationType = 'horizontal' | 'vertical';
 	export module Orientation {
 		export const horizontal = 'horizontal';

--- a/packages/core/ui/button/index.ios.ts
+++ b/packages/core/ui/button/index.ios.ts
@@ -224,7 +224,7 @@ export class Button extends ButtonBase {
 		switch (value) {
 			case 'normal':
 				nativeView.lineBreakMode = NSLineBreakMode.ByWordWrapping;
-				nativeView.numberOfLines = 0;
+				nativeView.numberOfLines = this.maxLines;
 				break;
 			case 'nowrap':
 			case 'initial':

--- a/packages/core/ui/label/index.ios.ts
+++ b/packages/core/ui/label/index.ios.ts
@@ -117,7 +117,7 @@ export class Label extends TextBase implements LabelDefinition {
 		switch (value) {
 			case 'normal':
 				nativeView.lineBreakMode = NSLineBreakMode.ByWordWrapping;
-				nativeView.numberOfLines = 0;
+				nativeView.numberOfLines = this.maxLines;
 				break;
 			case 'nowrap':
 			case 'initial':

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -146,6 +146,8 @@ export class Style extends Observable implements StyleDefinition {
 	public fontWeight: FontWeight;
 	public font: string;
 
+	public maxLines: number;
+
 	public androidElevation: number;
 	public androidDynamicElevationOffset: number;
 	public zIndex: number;

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -146,7 +146,7 @@ export class Style extends Observable implements StyleDefinition {
 	public fontWeight: FontWeight;
 	public font: string;
 
-	public maxLines: number;
+	public maxLines: CoreTypes.MaxLinesType;
 
 	public androidElevation: number;
 	public androidDynamicElevationOffset: number;

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -462,9 +462,9 @@ export class TextBase extends TextBaseCommon {
 		}
 	}
 
-	[maxLinesProperty.setNative](value: number | string) {
+	[maxLinesProperty.setNative](value: number) {
 		const nativeTextViewProtected = this.nativeTextViewProtected;
-		if (!value || value === 'none') {
+		if (value <= 0) {
 			nativeTextViewProtected.setMaxLines(Number.MAX_SAFE_INTEGER);
 		} else {
 			nativeTextViewProtected.setMaxLines(typeof value === 'string' ? parseInt(value, 10) : value);

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -1,5 +1,5 @@
 // Types
-import { getClosestPropertyValue } from './text-base-common';
+import { getClosestPropertyValue, maxLinesProperty } from './text-base-common';
 import { CSSShadow } from '../styling/css-shadow';
 
 // Requires
@@ -459,6 +459,15 @@ export class TextBase extends TextBaseCommon {
 				this.nativeTextViewProtected.setTag(id, value);
 				this.nativeTextViewProtected.setTag(value);
 			}
+		}
+	}
+
+	[maxLinesProperty.setNative](value: number | string) {
+		const nativeTextViewProtected = this.nativeTextViewProtected;
+		if (!value || value === 'none') {
+			nativeTextViewProtected.setMaxLines(Number.MAX_SAFE_INTEGER);
+		} else {
+			nativeTextViewProtected.setMaxLines(typeof value === 'string' ? parseInt(value, 10) : value);
 		}
 	}
 

--- a/packages/core/ui/text-base/index.d.ts
+++ b/packages/core/ui/text-base/index.d.ts
@@ -64,6 +64,11 @@ export class TextBase extends View implements AddChildFromBuilder {
 	whiteSpace: CoreTypes.WhiteSpaceType;
 
 	/**
+	 * Gets or sets white space style property.
+	 */
+	maxLines: CoreTypes.MaxLinesType;
+
+	/**
 	 * Gets or sets padding style property.
 	 */
 	padding: string | CoreTypes.LengthType;

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -200,7 +200,7 @@ export class TextBase extends TextBaseCommon {
 
 	[maxLinesProperty.setNative](value: CoreTypes.MaxLinesType) {
 		const nativeTextViewProtected = this.nativeTextViewProtected;
-		const numberOfLines: number = value === 'none' ? 0 : value;
+		const numberOfLines = this.whiteSpace === 'normal' ? value : 1;
 		if (nativeTextViewProtected instanceof UITextView) {
 			nativeTextViewProtected.textContainer.maximumNumberOfLines = numberOfLines;
 

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -198,10 +198,11 @@ export class TextBase extends TextBaseCommon {
 		this._setShadow(value);
 	}
 
-	[maxLinesProperty.setNative](value: number) {
+	[maxLinesProperty.setNative](value: CoreTypes.MaxLinesType) {
 		const nativeTextViewProtected = this.nativeTextViewProtected;
+		const numberOfLines: number = value === 'none' ? 0 : value;
 		if (nativeTextViewProtected instanceof UITextView) {
-			nativeTextViewProtected.textContainer.maximumNumberOfLines = value;
+			nativeTextViewProtected.textContainer.maximumNumberOfLines = numberOfLines;
 
 			if (value !== 0) {
 				nativeTextViewProtected.textContainer.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
@@ -209,9 +210,9 @@ export class TextBase extends TextBaseCommon {
 				nativeTextViewProtected.textContainer.lineBreakMode = NSLineBreakMode.ByWordWrapping;
 			}
 		} else if (nativeTextViewProtected instanceof UILabel) {
-			nativeTextViewProtected.numberOfLines = value;
+			nativeTextViewProtected.numberOfLines = numberOfLines;
 		} else if (nativeTextViewProtected instanceof UIButton) {
-			nativeTextViewProtected.titleLabel.numberOfLines = value;
+			nativeTextViewProtected.titleLabel.numberOfLines = numberOfLines;
 		}
 	}
 

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -13,6 +13,7 @@ import { isString, isNullOrUndefined } from '../../utils/types';
 import { iOSNativeHelper } from '../../utils';
 import { Trace } from '../../trace';
 import { CoreTypes } from '../../core-types';
+import { maxLinesProperty } from './text-base-common';
 
 export * from './text-base-common';
 
@@ -195,6 +196,23 @@ export class TextBase extends TextBaseCommon {
 
 	[textShadowProperty.setNative](value: CSSShadow) {
 		this._setShadow(value);
+	}
+
+	[maxLinesProperty.setNative](value: number) {
+		const nativeTextViewProtected = this.nativeTextViewProtected;
+		if (nativeTextViewProtected instanceof UITextView) {
+			nativeTextViewProtected.textContainer.maximumNumberOfLines = value;
+
+			if (value !== 0) {
+				nativeTextViewProtected.textContainer.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
+			} else {
+				nativeTextViewProtected.textContainer.lineBreakMode = NSLineBreakMode.ByWordWrapping;
+			}
+		} else if (nativeTextViewProtected instanceof UILabel) {
+			nativeTextViewProtected.numberOfLines = value;
+		} else if (nativeTextViewProtected instanceof UIButton) {
+			nativeTextViewProtected.titleLabel.numberOfLines = value;
+		}
 	}
 
 	_setColor(color: UIColor): void {

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -90,6 +90,13 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
 		this.style.lineHeight = value;
 	}
 
+	get maxLines(): number {
+		return this.style.maxLines;
+	}
+	set maxLines(value: number) {
+		this.style.maxLines = value;
+	}
+
 	get textAlignment(): CoreTypes.TextAlignmentType {
 		return this.style.textAlignment;
 	}
@@ -309,5 +316,12 @@ export const lineHeightProperty = new InheritedCssProperty<Style, number>({
 	valueConverter: (v) => parseFloat(v),
 });
 lineHeightProperty.register(Style);
+
+export const maxLinesProperty = new CssProperty<Style, number | string>({
+    name: 'maxLines',
+    cssName: 'max-lines',
+	valueConverter: (v) => v === 'none' ? 0 : parseInt(v, 10),
+});
+maxLinesProperty.register(Style);
 
 export const resetSymbol = Symbol('textPropertyDefault');

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -90,10 +90,10 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
 		this.style.lineHeight = value;
 	}
 
-	get maxLines(): number {
+	get maxLines(): CoreTypes.MaxLinesType {
 		return this.style.maxLines;
 	}
-	set maxLines(value: number) {
+	set maxLines(value: CoreTypes.MaxLinesType) {
 		this.style.maxLines = value;
 	}
 
@@ -317,10 +317,10 @@ export const lineHeightProperty = new InheritedCssProperty<Style, number>({
 });
 lineHeightProperty.register(Style);
 
-export const maxLinesProperty = new CssProperty<Style, number | string>({
-    name: 'maxLines',
-    cssName: 'max-lines',
-	valueConverter: (v) => v === 'none' ? 0 : parseInt(v, 10),
+export const maxLinesProperty = new CssProperty<Style, CoreTypes.MaxLinesType>({
+	name: 'maxLines',
+	cssName: 'max-lines',
+	valueConverter: (v) => (v === 'none' ? 0 : parseInt(v, 10)),
 });
 maxLinesProperty.register(Style);
 

--- a/packages/core/ui/text-view/index.android.ts
+++ b/packages/core/ui/text-view/index.android.ts
@@ -1,4 +1,4 @@
-import { TextViewBase as TextViewBaseCommon, maxLinesProperty } from './text-view-common';
+import { TextViewBase as TextViewBaseCommon } from './text-view-common';
 import { CSSType } from '../core/view';
 
 export * from '../text-base';
@@ -13,20 +13,6 @@ export class TextView extends TextViewBaseCommon {
 	public resetNativeView(): void {
 		super.resetNativeView();
 		this.nativeTextViewProtected.setGravity(android.view.Gravity.TOP | android.view.Gravity.START);
-	}
-
-	[maxLinesProperty.getDefault](): number {
-		return 0;
-	}
-
-	[maxLinesProperty.setNative](value: number) {
-		if (value <= 0) {
-			this.nativeTextViewProtected.setMaxLines(Number.MAX_VALUE);
-
-			return;
-		}
-
-		this.nativeTextViewProtected.setMaxLines(value);
 	}
 
 	public _onReturnPress() {

--- a/packages/core/ui/text-view/index.ios.ts
+++ b/packages/core/ui/text-view/index.ios.ts
@@ -1,6 +1,6 @@
 import { ScrollEventData } from '../scroll-view';
 import { textProperty } from '../text-base';
-import { TextViewBase as TextViewBaseCommon, maxLinesProperty } from './text-view-common';
+import { TextViewBase as TextViewBaseCommon } from './text-view-common';
 import { editableProperty, hintProperty, placeholderColorProperty, _updateCharactersInRangeReplacementString } from '../editable-text-base';
 import { CoreTypes } from '../../core-types';
 import { CSSType } from '../core/view';
@@ -407,18 +407,6 @@ export class TextView extends TextViewBaseCommon {
 			bottom: inset.bottom,
 			right: inset.right,
 		};
-	}
-	[maxLinesProperty.getDefault](): number {
-		return 0;
-	}
-	[maxLinesProperty.setNative](value: number) {
-		this.nativeTextViewProtected.textContainer.maximumNumberOfLines = value;
-
-		if (value !== 0) {
-			this.nativeTextViewProtected.textContainer.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
-		} else {
-			this.nativeTextViewProtected.textContainer.lineBreakMode = NSLineBreakMode.ByWordWrapping;
-		}
 	}
 }
 

--- a/packages/core/ui/text-view/text-view-common.ts
+++ b/packages/core/ui/text-view/text-view-common.ts
@@ -1,14 +1,7 @@
 import { TextView as TextViewDefinition } from '.';
 import { EditableTextBase } from '../editable-text-base';
-import { Property } from '../core/properties';
 
 export class TextViewBase extends EditableTextBase implements TextViewDefinition {
 	public static returnPressEvent = 'returnPress';
 	public maxLines: number;
 }
-
-export const maxLinesProperty = new Property<EditableTextBase, number>({
-	name: 'maxLines',
-	valueConverter: parseInt,
-});
-maxLinesProperty.register(EditableTextBase);


### PR DESCRIPTION
This adds `maxLines` property for all `text-base` components.
It supports number + 'none' as specified. It also works correctly with `whiteSpace`