### PR TITLE
fix(core): allow View subclass to force onLayoutChangeListener

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -349,7 +349,7 @@ export class View extends ViewCommon {
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 
 		// Remove native listener only if there are no more user listeners for LayoutChanged event
-		if (this.isLoaded && this.layoutChangeListenerIsSet && isLayoutEvent && !this.hasListeners(ViewCommon.layoutChangedEvent)) {
+		if (this.isLoaded && this.layoutChangeListenerIsSet && isLayoutEvent && !this.needsOnLayoutChangeListener()) {
 			this.nativeViewProtected.removeOnLayoutChangeListener(this.layoutChangeListener);
 			this.layoutChangeListenerIsSet = false;
 		}
@@ -468,9 +468,13 @@ export class View extends ViewCommon {
 		super.initNativeView();
 		this._isClickable = this.nativeViewProtected.isClickable();
 
-		if (this.hasListeners(ViewCommon.layoutChangedEvent)) {
+		if (this.needsOnLayoutChangeListener()) {
 			this.setOnLayoutChangeListener();
 		}
+	}
+
+	public needsOnLayoutChangeListener() {
+		return this.hasListeners(ViewCommon.layoutChangedEvent);
 	}
 
 	public disposeNativeView(): void {


### PR DESCRIPTION
This is a simple change allowing views to force the layout change listener to be set without having an event added.
I have some plugins needing this. Thought it would be an easy and good thing to have in the core