### PR TITLE
fix(live-sync): navigation history is now maintained

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -616,7 +616,7 @@ export class FrameBase extends CustomLayoutView {
 
 		// Fallback
 		if (!context) {
-			return this.legacyLivesync();
+			return this._onLiveSyncWithoutContext();
 		}
 
 		return false;
@@ -631,7 +631,7 @@ export class FrameBase extends CustomLayoutView {
 		if (this.currentPage && viewMatchesModuleContext(this.currentPage, context, ['markup', 'script'])) {
 			Trace.write(`Change Handled: Replacing page ${context.path}`, Trace.categories.Livesync);
 
-			// replace current page with a default fade transition
+			// Replace current page with a default fade transition
 			this.replacePage({
 				moduleName: context.path,
 				transition: {
@@ -646,12 +646,12 @@ export class FrameBase extends CustomLayoutView {
 		return false;
 	}
 
-	private legacyLivesync(): boolean {
+	private _onLiveSyncWithoutContext(): boolean {
 		// Reset activity/window content when:
 		// + Changes are not handled on View
 		// + There is no ModuleContext
 		if (Trace.isEnabled()) {
-			Trace.write(`${this}._onLivesync()`, Trace.categories.Livesync);
+			Trace.write(`${this}._onLiveSyncWithoutContext()`, Trace.categories.Livesync);
 		}
 
 		if (!this._currentEntry || !this._currentEntry.entry) {
@@ -659,26 +659,26 @@ export class FrameBase extends CustomLayoutView {
 		}
 
 		const currentEntry = this._currentEntry.entry;
-		const newEntry: NavigationEntry = {
-			animated: false,
-			clearHistory: true,
-			context: currentEntry.context,
-			create: currentEntry.create,
-			moduleName: currentEntry.moduleName,
-			backstackVisible: currentEntry.backstackVisible,
-		};
 
 		// If create returns the same page instance we can't recreate it.
 		// Instead of navigation set activity content.
 		// This could happen if current page was set in XML as a Page instance.
-		if (newEntry.create) {
-			const page = newEntry.create();
+		if (currentEntry.create) {
+			const page = currentEntry.create();
 			if (page === this.currentPage) {
 				return false;
 			}
 		}
 
-		this.navigate(newEntry);
+		// Replace current page with a default fade transition
+		this.replacePage({
+			moduleName: currentEntry.moduleName,
+			create: currentEntry.create,
+			transition: {
+				name: 'fade',
+				duration: 100,
+			},
+		});
 
 		return true;
 	}

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -616,7 +616,7 @@ export class FrameBase extends CustomLayoutView {
 
 		// Fallback
 		if (!context) {
-			return this._onLiveSyncWithoutContext();
+			return this._onLivesyncWithoutContext();
 		}
 
 		return false;
@@ -646,12 +646,12 @@ export class FrameBase extends CustomLayoutView {
 		return false;
 	}
 
-	private _onLiveSyncWithoutContext(): boolean {
+	private _onLivesyncWithoutContext(): boolean {
 		// Reset activity/window content when:
 		// + Changes are not handled on View
 		// + There is no ModuleContext
 		if (Trace.isEnabled()) {
-			Trace.write(`${this}._onLiveSyncWithoutContext()`, Trace.categories.Livesync);
+			Trace.write(`${this}._onLivesyncWithoutContext()`, Trace.categories.Livesync);
 		}
 
 		if (!this._currentEntry || !this._currentEntry.entry) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Navigation history is not maintained after live-sync.
This was tested in plain NativeScript and has caused a bit of trouble for some time now during development.
It's related to #9837 and #9839.


## What is the new behavior?
Navigation history will be maintained after live-sync.