### PR TITLE
feat: support importHelpers tsconfig option

### DIFF
--- a/packages/core/globals/index.ts
+++ b/packages/core/globals/index.ts
@@ -1,4 +1,4 @@
-import * as tslibType from 'tslib';
+import type * as tslibType from 'tslib';
 const tslib: typeof tslibType = require('tslib');
 import { Observable } from '../data/observable';
 import { trace as profilingTrace, time, uptime, level as profilingLevel } from '../profiling';
@@ -132,7 +132,7 @@ export function initGlobal() {
 		// Bind the tslib helpers to global scope.
 		// This is needed when we don't use importHelpers, which
 		// breaks extending native-classes
-		for (const fnName of Object.keys(tslib)) {
+		for (const fnName of Object.getOwnPropertyNames(tslib)) {
 			if (typeof tslib[fnName] !== 'function') {
 				continue;
 			}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "acorn": "^8.7.0",
     "css-tree": "^1.1.2",
     "reduce-css-calc": "^2.1.7",
-    "tslib": "~2.0.0"
+    "tslib": "^2.0.0"
   },
   "nativescript": {
     "platforms": {

--- a/packages/core/tslib/index.ts
+++ b/packages/core/tslib/index.ts
@@ -1,0 +1,3 @@
+export * from 'tslib?original';
+import { __extends as tslibExtends } from 'tslib?original';
+export const __extends = global.__extends || tslibExtends;

--- a/packages/core/tslib/references.d.ts
+++ b/packages/core/tslib/references.d.ts
@@ -1,0 +1,3 @@
+declare module 'tslib?original' {
+	export * from 'tslib';
+}

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -1,8 +1,9 @@
-import { extname, resolve } from 'path';
+import { extname, resolve, join } from 'path';
 import {
 	ContextExclusionPlugin,
 	DefinePlugin,
 	HotModuleReplacementPlugin,
+	NormalModuleReplacementPlugin,
 } from 'webpack';
 import Config from 'webpack-chain';
 import { existsSync } from 'fs';
@@ -367,6 +368,13 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	// 		}
 	// 	}
 	// ])
+
+	config
+		.plugin('NormalModuleReplacementPlugin|tslib')
+		.use(NormalModuleReplacementPlugin, [
+			/^tslib$/,
+			'@nativescript/core/tslib',
+		]);
 
 	config.plugin('PlatformSuffixPlugin').use(PlatformSuffixPlugin, [
 		{


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
We're unable to use `importHelpers` because we rely on a custom `__extends` for extending native classes

## What is the new behavior?
We override `tslib` in webpack so it always uses our custom `@nativescript/core/tslib`. This will allow `importHelpers` to  work and we can completely drop `"importHelpers": false` support by NativeScript 9 or 10 while moving tslib to a devDependency
