### PR TITLE
fix(application-settings): use correct storage on Android N and above

### DIFF
--- a/packages/core/application-settings/index.android.ts
+++ b/packages/core/application-settings/index.android.ts
@@ -6,7 +6,7 @@ const DB_KEY = 'prefs.db';
 let sharedPreferences: android.content.SharedPreferences;
 function ensureSharedPreferences() {
 	let context = getNativeApplication().getApplicationContext();
-	if (context && !sharedPreferences) {
+	if (!sharedPreferences) {
 		if (android.os.Build.VERSION.SDK_INT >= 24) {
 			const deviceContext = context.createDeviceProtectedStorageContext();
 			if (deviceContext && !deviceContext.moveSharedPreferencesFrom(context, DB_KEY)) {

--- a/packages/core/application-settings/index.android.ts
+++ b/packages/core/application-settings/index.android.ts
@@ -1,13 +1,16 @@
 import * as common from './application-settings-common';
 import { getNativeApplication } from '../application';
 import { Trace } from '../trace';
+import { Device } from '../platform';
+import lazy from '../utils/lazy';
 
+const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
 const DB_KEY = 'prefs.db';
 let sharedPreferences: android.content.SharedPreferences;
 function ensureSharedPreferences() {
 	let context = getNativeApplication().getApplicationContext();
 	if (!sharedPreferences) {
-		if (android.os.Build.VERSION.SDK_INT >= 24) {
+		if (sdkVersion() >= 24) {
 			const deviceContext = context.createDeviceProtectedStorageContext();
 			if (deviceContext && !deviceContext.moveSharedPreferencesFrom(context, DB_KEY)) {
 				const warnMessage = 'Failed to migrate Application Settings to Device Protected Storage';


### PR DESCRIPTION
Fixes the use of Android Device Storage for Application Settings to avoid runtime error cause by user accessing `SharedPreferances` when the device is locked:

```
Unable to create application com.tns.NativeScriptApplication: com.tns.NativeScriptException: Error calling module function 
Error: java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user is unlocked
```

Logic is based on the snippet from Google Archive here:

https://github.com/googlearchive/android-DirectBoot/blob/737ab9a214debbf3c940360b834077ccc3035ff3/Application/src/main/java/com/example/android/directboot/alarms/AlarmStorage.java#L42

```
// All N devices have split storage areas, but we may need to
// move the existing preferences to the new device protected
// storage area, which is where the data lives from now on.
```
