### PR TITLE
feat: delay the launch event until the app becomes active

### DIFF
--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -136,6 +136,7 @@ export class iOSApplication implements iOSApplicationDefinition {
 	private _orientation: 'portrait' | 'landscape' | 'unknown';
 	private _rootView: View;
 	private _systemAppearance: 'light' | 'dark';
+	private launchEventCalled = false;
 
 	constructor() {
 		this._observers = new Array<NotificationObserver>();
@@ -222,11 +223,11 @@ export class iOSApplication implements iOSApplicationDefinition {
 		this._window = UIWindow.alloc().initWithFrame(UIScreen.mainScreen.bounds);
 		// TODO: Expose Window module so that it can we styled from XML & CSS
 		this._window.backgroundColor = this._backgroundColor;
-
-		this.notifyAppStarted(notification);
+		this.launchEventCalled = false;
 	}
 
 	public notifyAppStarted(notification?: NSNotification) {
+		this.launchEventCalled = true;
 		const args: LaunchEventData = {
 			eventName: launchEvent,
 			object: this,
@@ -252,6 +253,9 @@ export class iOSApplication implements iOSApplicationDefinition {
 
 	@profile
 	private didBecomeActive(notification: NSNotification) {
+		if (!this.launchEventCalled) {
+			this.notifyAppStarted(notification);
+		}
 		const ios = UIApplication.sharedApplication;
 		const object = this;
 		notify(<ApplicationEventData>{ eventName: resumeEvent, object, ios });


### PR DESCRIPTION
This is a draft/discussion PR.

According to the iOS docs, the UI should be built on `didBecomeActive` instead of `didFinishLaunchingWithOptions`. This makes a difference when we launch the application due to a fetch event or firebase message, as `didFinishLaunchingWithOptions` will launch with the app in the background and no UI will be shown unless the user opens the app manually in the meantime.

The same scenario on Android delays the launchEvent until the app opens. This PR would make both platforms behave the same.

Checklist:
* [ ] Check if this change introduces a short black screen between the splash and the main screen
* [ ] If the above is true, only delay the launch if we're in a background launch in `didFinishLaunchingWithOptions`
* [ ] Check if this breaks any existing app (it shouldn't)
* [ ] Maybe provide an iOS only event for intercepting `didFinishLaunchingWithOptions`