### PR TITLE
fix(webpack5): NativeClass decorator should run after angular transformers in AOT mode

### DIFF
--- a/packages/webpack5/src/configuration/angular.ts
+++ b/packages/webpack5/src/configuration/angular.ts
@@ -152,9 +152,15 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			if (!transformers.before) {
 				transformers.before = [];
 			}
-			transformers.before.unshift(
-				require('../transformers/NativeClass').default
-			);
+			if (this.pluginOptions.jitMode) {
+				transformers.before.unshift(
+					require('../transformers/NativeClass').default
+				);
+			} else {
+				transformers.before.push(
+					require('../transformers/NativeClass').default
+				);
+			}
 			args[1] = transformers;
 			return originalCreateFileEmitter.apply(this, args);
 		};
@@ -256,7 +262,8 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			// Additional rules to suppress warnings that are safe to ignore
 			{
 				module: /@angular\/core\/(__ivy_ngcc__\/)?fesm2015\/core.js/,
-				message: /Critical dependency: the request of a dependency is an expression/,
+				message:
+					/Critical dependency: the request of a dependency is an expression/,
 			},
 			/core\/profiling/,
 			/core\/ui\/styling/,


### PR DESCRIPTION
This is needed because otherwise the webpack build will correctly transpile the class to es5 but you're unable to use imported symbols in it:

Example:

```
// JIT + current config:

console.log(_nativescript_core__WEBPACK_IMPORTED_MODULE_8__.GridLayout);

// AOT + current config
console.log(GridLayout);

// AOT + new config
console.log(_nativescript_core__WEBPACK_IMPORTED_MODULE_8__.GridLayout);
```