### PR TITLE
fix: export 'dataSerialize' (imported as 'dataSerialize') was not found

### DIFF
--- a/packages/core/utils/index.android.ts
+++ b/packages/core/utils/index.android.ts
@@ -3,7 +3,7 @@ import { Device } from '../platform';
 import { FileSystemAccess } from '../file-system/file-system-access';
 import { Trace } from '../trace';
 
-export { ad, iOSNativeHelper } from './native-helper';
+export { ad, dataDeserialize, dataSerialize, iOSNativeHelper } from './native-helper';
 export * from './utils-common';
 export { Source } from './debug';
 

--- a/packages/core/utils/index.ios.ts
+++ b/packages/core/utils/index.ios.ts
@@ -1,7 +1,7 @@
 import { iOSNativeHelper } from './native-helper';
 import { Trace } from '../trace';
 
-export { iOSNativeHelper } from './native-helper';
+export { dataDeserialize, dataSerialize, iOSNativeHelper } from './native-helper';
 export * from './utils-common';
 export { Source } from './debug';
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Webpack cannot locate `dataDeserialize` and `dataSerialize` exports.

## What is the new behavior?
Webpack will locate `dataDeserialize` and `dataSerialize` exports.