### PR TITLE
fix: Incorrect font icon size conversion to device pixels.

### DIFF
--- a/packages/core/image-source/index.android.ts
+++ b/packages/core/image-source/index.android.ts
@@ -187,14 +187,12 @@ export class ImageSource implements ImageSourceDefinition {
 			paint.setColor(color.android);
 		}
 
-		let fontSize = layout.toDevicePixels(font.fontSize);
-		if (!fontSize) {
+		let scaledFontSize = layout.toDevicePixels(font.fontSize);
+		if (!scaledFontSize) {
 			// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
-			fontSize = paint.getTextSize();
+			scaledFontSize = layout.toDevicePixels(paint.getTextSize());
 		}
 
-		const density = layout.getDisplayDensity();
-		const scaledFontSize = fontSize * density;
 		paint.setTextSize(scaledFontSize);
 
 		const textBounds = new android.graphics.Rect();

--- a/packages/core/image-source/index.ios.ts
+++ b/packages/core/image-source/index.ios.ts
@@ -180,14 +180,11 @@ export class ImageSource implements ImageSourceDefinition {
 
 	static fromFontIconCodeSync(source: string, font: Font, color: Color): ImageSource {
 		font = font || Font.default;
-		let fontSize = layout.toDevicePixels(font.fontSize);
-		if (!fontSize) {
+		let scaledFontSize = layout.toDevicePixels(font.fontSize);
+		if (!scaledFontSize) {
 			// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
-			fontSize = UIFont.labelFontSize;
+			scaledFontSize = UIFont.labelFontSize;
 		}
-
-		const density = layout.getDisplayDensity();
-		const scaledFontSize = fontSize * density;
 
 		const attributes = {
 			[NSFontAttributeName]: font.getUIFont(UIFont.systemFontOfSize(scaledFontSize)),

--- a/packages/core/image-source/index.ios.ts
+++ b/packages/core/image-source/index.ios.ts
@@ -187,7 +187,7 @@ export class ImageSource implements ImageSourceDefinition {
 		}
 
 		const attributes = {
-			[NSFontAttributeName]: font.getUIFont(UIFont.systemFontOfSize(scaledFontSize)),
+			[NSFontAttributeName]: font.withFontSize(scaledFontSize).getUIFont(UIFont.systemFontOfSize(scaledFontSize)),
 		};
 
 		if (color) {

--- a/packages/core/image-source/index.ios.ts
+++ b/packages/core/image-source/index.ios.ts
@@ -180,14 +180,10 @@ export class ImageSource implements ImageSourceDefinition {
 
 	static fromFontIconCodeSync(source: string, font: Font, color: Color): ImageSource {
 		font = font || Font.default;
-		let scaledFontSize = layout.toDevicePixels(font.fontSize);
-		if (!scaledFontSize) {
-			// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
-			scaledFontSize = layout.toDevicePixels(UIFont.labelFontSize);
-		}
 
+		// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
 		const attributes = {
-			[NSFontAttributeName]: font.withFontSize(scaledFontSize).getUIFont(UIFont.systemFontOfSize(scaledFontSize)),
+			[NSFontAttributeName]: font.getUIFont(UIFont.systemFontOfSize(UIFont.labelFontSize)),
 		};
 
 		if (color) {

--- a/packages/core/image-source/index.ios.ts
+++ b/packages/core/image-source/index.ios.ts
@@ -183,7 +183,7 @@ export class ImageSource implements ImageSourceDefinition {
 		let scaledFontSize = layout.toDevicePixels(font.fontSize);
 		if (!scaledFontSize) {
 			// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
-			scaledFontSize = UIFont.labelFontSize;
+			scaledFontSize = layout.toDevicePixels(UIFont.labelFontSize);
 		}
 
 		const attributes = {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Since NS 6, font icons used with Image, ActionItem, and few more elements have bad sizing between the 2 platforms.
It seems there's been a mistake since the implementation of this feature and font size is multiplied with display density 'twice'.

## What is the new behavior?
Font icons used with Image, ActionItem, and few more elements will have proper size in both platforms.
Note: In iOS, there was a pixel conversion that was wrong and also didn't run so it was dead and was consequently removed.

Fixes #8391.