### PR TITLE
Fixed Android back navigation error

### DIFF
--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -672,6 +672,11 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: Backsta
 
 	entries.delete(entry);
 	if (entries.size === 0) {
+		// I had the https://github.com/NativeScript/NativeScript/issues/9096 (similar error but on Android)
+		// during back navigation. The following lines below solved my issue.
+		if (entry.resolvedPage === null) {
+    	return;
+    }
 		const frame = entry.resolvedPage.frame;
 
 		// We have 0 or 1 entry per frameId in completedEntries


### PR DESCRIPTION
Calling js method onTransitionEnd failed TypeError: Cannot read property 'frame' of null

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
During back navigation on Android the app crashes with "Calling js method onTransitionEnd failed TypeError: Cannot read property 'frame' of null". It happens also if the back navigation happens after the app send to background then opened again.

## What is the new behavior?
No error anymore.

Fixes #9912.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

