### PR TITLE
fix(core): Font icons had incorrect fallback size in android

### DIFF
--- a/packages/core/image-source/index.android.ts
+++ b/packages/core/image-source/index.android.ts
@@ -187,13 +187,11 @@ export class ImageSource implements ImageSourceDefinition {
 			paint.setColor(color.android);
 		}
 
-		let scaledFontSize = layout.toDevicePixels(font.fontSize);
-		if (!scaledFontSize) {
-			// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
-			scaledFontSize = layout.toDevicePixels(paint.getTextSize());
+		// TODO: Consider making 36 font size as default for optimal look on TabView and ActionBar
+		const scaledFontSize = layout.toDevicePixels(font.fontSize);
+		if (scaledFontSize) {
+			paint.setTextSize(scaledFontSize);
 		}
-
-		paint.setTextSize(scaledFontSize);
 
 		const textBounds = new android.graphics.Rect();
 		paint.getTextBounds(source, 0, source.length, textBounds);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
The font icon size that works as a fallback value is incorrect.

## What is the new behavior?
The font icon size that works as a fallback value will be incorrect.