### PR TITLE
fix(android) Connectivity reporting none on resume

### DIFF
--- a/packages/core/connectivity/index.android.ts
+++ b/packages/core/connectivity/index.android.ts
@@ -133,7 +133,6 @@ export function startMonitoring(connectionTypeChangedCallback: (newConnectionTyp
 				@NativeClass
 				class NetworkCallbackImpl extends ConnectivityManager.NetworkCallback {
 					onCapabilitiesChanged(network: android.net.Network, networkCapabilities: android.net.NetworkCapabilities) {
-						console.log('NetworkCallbackImpl.onCapabilitiesChanged');
 						if (notifyCallback) {
 							notifyCallback(network, networkCapabilities);
 						}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On some android phones, (Google Pixel 5 & Galaxy s20+ running android 12) the final state reported when subscribing to ````Connectivity.startMonitoring```` would report incorrectly report no connectivity.

This happened when the app was in the foreground, and the phone was locked and then unlocked ( i.e. hit power button)
This was because the call to the methods on ConnectivityManager.getActiveNetwork returned null, the documentation seems to suggest that calling any of the syncronus methods on ConnectivityManager is not advised during these callbacks.
https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback

## What is the new behavior?

The new behaviour is to rely on the network capabilities passed to the callback to determine the status, or to report no connectivity when lost is triggered.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

