### PR TITLE
fix(android): race condition on offBackgroundColor view change detection

### DIFF
--- a/packages/core/ui/switch/index.android.ts
+++ b/packages/core/ui/switch/index.android.ts
@@ -57,11 +57,13 @@ export class Switch extends SwitchBase {
 	}
 
 	private setNativeBackgroundColor(value: string | number | Color) {
-		if (value instanceof Color) {
-			// todo: use https://developer.android.com/reference/androidx/core/graphics/BlendModeColorFilterCompat
-			this.nativeViewProtected.getTrackDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_OVER);
-		} else {
-			this.nativeViewProtected.getTrackDrawable().clearColorFilter();
+		if (this.nativeViewProtected) {
+			if (value instanceof Color) {
+				// todo: use https://developer.android.com/reference/androidx/core/graphics/BlendModeColorFilterCompat
+				this.nativeViewProtected.getTrackDrawable().setColorFilter(value.android, android.graphics.PorterDuff.Mode.SRC_OVER);
+			} else {
+				this.nativeViewProtected.getTrackDrawable().clearColorFilter();
+			}
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?

Various framework integrations, like Angular, may invoke view change detection cycles on property bindings at times when the `nativeView` is not available resulting in errors like:

```
JS: ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'getTrackDrawable' of undefined
JS: TypeError: Cannot read property 'getTrackDrawable' of undefined
JS:     at Switch.setNativeBackgroundColor (file: src/webpack:/app/node_modules/@nativescript/core/ui/switch/index.android.js:48:0)
JS:     at Switch._onCheckedPropertyChanged (file: src/webpack:/app/node_modules/@nativescript/core/ui/switch/index.android.js:61:0)
```

## What is the new behavior?

`Switch` is now resilient to this.