### PR TITLE
fix: Output from rgbToHsv and rgbToHsl was incorrect

### DIFF
--- a/packages/core/color/color-common.ts
+++ b/packages/core/color/color-common.ts
@@ -466,8 +466,12 @@ function argbFromHsvOrHsva(value: string): number {
 // *Assumes:* r, g, and b are contained in [0, 255]
 // *Returns:* { h, s, l } in [0,360] and [0,100]
 function rgbToHsl(r, g, b) {
-	const max = Math.max(r, g, b) / 255,
-		min = Math.min(r, g, b) / 255;
+	r /= 255;
+	g /= 255;
+	b /= 255;
+
+	const max = Math.max(r, g, b),
+		min = Math.min(r, g, b);
 	let h, s;
 	const l = (max + min) / 2;
 
@@ -478,13 +482,13 @@ function rgbToHsl(r, g, b) {
 		s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
 		switch (max) {
 			case r:
-				h = (g - b) / 255 / d + (g < b ? 6 : 0);
+				h = (g - b) / d + (g < b ? 6 : 0);
 				break;
 			case g:
-				h = (b - r) / 255 / d + 2;
+				h = (b - r) / d + 2;
 				break;
 			case b:
-				h = (r - g) / 255 / d + 4;
+				h = (r - g) / d + 4;
 				break;
 		}
 
@@ -530,8 +534,12 @@ function hslToRgb(h1, s1, l1) {
 // *Assumes:* r, g, and b are contained in the set [0, 255]
 // *Returns:* { h, s, v } in [0,360] and [0,100]
 function rgbToHsv(r, g, b) {
-	const max = Math.max(r, g, b) / 255,
-		min = Math.min(r, g, b) / 255;
+	r /= 255;
+	g /= 255;
+	b /= 255;
+
+	const max = Math.max(r, g, b),
+		min = Math.min(r, g, b);
 	let h;
 	const v = max;
 
@@ -543,13 +551,13 @@ function rgbToHsv(r, g, b) {
 	} else {
 		switch (max) {
 			case r:
-				h = (g - b) / 255 / d + (g < b ? 6 : 0);
+				h = (g - b) / d + (g < b ? 6 : 0);
 				break;
 			case g:
-				h = (b - r) / 255 / d + 2;
+				h = (b - r) / d + 2;
 				break;
 			case b:
-				h = (r - g) / 255 / d + 4;
+				h = (r - g) / d + 4;
 				break;
 		}
 		h /= 6;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Methods `rgbToHsv` and `rgbToHsl` generate wrong output.

## What is the new behavior?
Methods `rgbToHsv` and `rgbToHsl` generate correct output.
@farfromrefug this is a continuation for https://github.com/NativeScript/NativeScript/commit/5452b8973520b7657ee59499b8e413e3c54b2817
The problem is that r, g, b variables were missing division in switch statement cases.
With this patch, function arguments are re-assigned and perform division on top. Let me know if we are good with this change.

Fixes/Implements/Closes #9918 .