### PR TITLE
fix: do not convert tap data to device pixels twice

### DIFF
--- a/packages/core/ui/gestures/index.ios.ts
+++ b/packages/core/ui/gestures/index.ios.ts
@@ -389,8 +389,8 @@ function _getTapData(args: GestureEventData): TapGestureEventData {
 		eventName: args.eventName,
 		object: args.object,
 		getPointerCount: () => recognizer.numberOfTouches,
-		getX: () => layout.toDeviceIndependentPixels(center.x),
-		getY: () => layout.toDeviceIndependentPixels(center.y),
+		getX: () => center.x,
+		getY: () => center.y,
 	};
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
we convert the position to DIP, but the position is already in DIP

## What is the new behavior?
we return the position as is


BREAKING CHANGES:

tapData.getX() and tapData.getY() will now return correctly in DIP, so any extra conversions (like calling toDevicePixels) twice must be changed.
