### PR TITLE
fix(core): iOS app memory leak after using 'showModal' passing any Page as parameter

### DIFF
--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -365,6 +365,12 @@ export class Page extends PageBase {
 		return this.viewController.view;
 	}
 
+	disposeNativeView() {
+		this.viewController = null;
+		this._ios = null;
+		super.disposeNativeView();
+	}
+	
 	// @ts-ignore
 	get ios(): UIViewController {
 		return this._ios;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

The iOS app is leaking always after using the 'showModal' navigation to present any Page. According to the debugging, the entire page presented is leaking.


## What is the new behavior?
<!-- Describe the changes. -->

The page presented by the 'showModal' navigation is being disposed of memory.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

