### PR TITLE
fix(ios): label measure correct height when using custom numberOfLines

### DIFF
--- a/packages/core/ui/label/index.ios.ts
+++ b/packages/core/ui/label/index.ios.ts
@@ -104,7 +104,7 @@ export class Label extends TextBase implements LabelDefinition {
 	private _measureNativeView(width: number, widthMode: number, height: number, heightMode: number): { width: number; height: number } {
 		const view = <UILabel>this.nativeTextViewProtected;
 
-		const nativeSize = view.textRectForBoundsLimitedToNumberOfLines(CGRectMake(0, 0, widthMode === 0 /* layout.UNSPECIFIED */ ? Number.POSITIVE_INFINITY : layout.toDeviceIndependentPixels(width), heightMode === 0 /* layout.UNSPECIFIED */ ? Number.POSITIVE_INFINITY : layout.toDeviceIndependentPixels(height)), 0).size;
+		const nativeSize = view.textRectForBoundsLimitedToNumberOfLines(CGRectMake(0, 0, widthMode === 0 /* layout.UNSPECIFIED */ ? Number.POSITIVE_INFINITY : layout.toDeviceIndependentPixels(width), heightMode === 0 /* layout.UNSPECIFIED */ ? Number.POSITIVE_INFINITY : layout.toDeviceIndependentPixels(height)), view.numberOfLines).size;
 
 		nativeSize.width = layout.round(layout.toDevicePixels(nativeSize.width));
 		nativeSize.height = layout.round(layout.toDevicePixels(nativeSize.height));


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Right now, iOS labels include all the lines on the height measurement and do not respect the value specified by the `numberOfLines` property.

## What is the new behavior?
<!-- Describe the changes. -->

The new behavior respects the `numberOfLines` property and properly measures the label height. When the user doesn't specify a custom value for the property it'll be zero and thus all the lines will be considered in the measurement, just as before.

Fixes #6037 
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

