### PR TITLE
fix(core): trace log using a wrong parameter

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -276,7 +276,7 @@ export class IOSHelper {
 			const adjustedFrame = IOSHelper.getFrameFromPosition(position, insets);
 
 			if (Trace.isEnabled()) {
-				Trace.write(this + ' :shrinkToSafeArea: ' + JSON.stringify(IOSHelper.getPositionFromFrame(adjustedFrame)), Trace.categories.Layout);
+                Trace.write(`${view} :shrinkToSafeArea: ${JSON.stringify(IOSHelper.getPositionFromFrame(adjustedFrame))}`, Trace.categories.Layout);
 			}
 
 			return adjustedFrame;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Inside the **shrinkToSafeArea(view, frame)** method the NativeScript trace is writing the entire IOSHelper source code into the log. See the below example:

```
Layout: class IOSHelper {
    static getParentWithViewController(view) {
        while (view && !view.viewController) {
            view = view.parent;
        }
        // Note: Might return undefined if no parent with viewController is found
    ...
    ...
    ...
} :shrinkToSafeArea: {"left":0,"right":828,"top":176,"bottom":342}
``` 

## What is the new behavior?
<!-- Describe the changes. -->

Inside the **shrinkToSafeArea(view, frame)** method the NativeScript trace should log something like below:

```
Layout: SectionedTable<SectionedTable> :shrinkToSafeArea: {"left":0,"right":828,"top":368,"bottom":589}
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

