### PR TITLE
fix(webpack): unit test runner with node 18+

### DIFF
--- a/packages/webpack5/src/helpers/host.ts
+++ b/packages/webpack5/src/helpers/host.ts
@@ -5,9 +5,9 @@ export function getIPS() {
 	return Object.keys(interfaces)
 		.map((name) => {
 			return interfaces[name].filter(
-				(binding: any) => binding.family === 'IPv4'
+				(binding: any) => binding.family === 'IPv4' || binding.family === 4
 			)[0];
 		})
-		.filter(Boolean)
+		.filter((binding) => !!binding)
 		.map((binding) => binding.address);
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).

## What is the current behavior?

Usage of unit test runner v3+ with Node 18 would fail.

## What is the new behavior?

Usage of unit test runner v3+ with Node 18 will operate normally.