### PR TITLE
fix(core): FormattedString.spans threw error in markup.

### DIFF
--- a/packages/core/ui/text-base/formatted-string.ts
+++ b/packages/core/ui/text-base/formatted-string.ts
@@ -76,8 +76,8 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 
 	public toString(): string {
 		let result = '';
-		for (let i = 0, length = this._spans.length; i < length; i++) {
-			result += this._spans.getItem(i).text;
+		for (let span of this.spans) {
+			result += span.text;
 		}
 
 		return result;
@@ -85,7 +85,7 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 
 	public _addArrayFromBuilder(name: string, value: Array<any>) {
 		if (name === 'spans') {
-			this.spans.push(value);
+			this.spans.push(...value);
 		}
 	}
 

--- a/packages/core/ui/text-base/formatted-string.ts
+++ b/packages/core/ui/text-base/formatted-string.ts
@@ -76,8 +76,8 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 
 	public toString(): string {
 		let result = '';
-		for (let span of this.spans) {
-			result += span.text;
+		for (let i = 0, length = this._spans.length; i < length; i++) {
+			result += this._spans.getItem(i).text;
 		}
 
 		return result;

--- a/packages/core/ui/text-base/formatted-string.ts
+++ b/packages/core/ui/text-base/formatted-string.ts
@@ -76,8 +76,8 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 
 	public toString(): string {
 		let result = '';
-		for (let i = 0, length = this._spans.length; i < length; i++) {
-			result += this._spans.getItem(i).text;
+		for (let i = 0, length = this.spans.length; i < length; i++) {
+			result += this.spans.getItem(i).text;
 		}
 
 		return result;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Span items throw `is not a valid View instance` markup error. This is related to few ObservableArray changes in 8.3.

## What is the new behavior?
Span items will render without problems.