### PR TITLE
feat: `knownFolders.externalDocuments()`

### DIFF
--- a/packages/core/file-system/file-system-access.android.ts
+++ b/packages/core/file-system/file-system-access.android.ts
@@ -224,6 +224,11 @@ export class FileSystemAccess implements IFileSystemAccess {
 
 		return dir.getAbsolutePath();
 	}
+	public getExternalDocumentsFolderPath(): string {
+		const dir = getApplicationContext().getExternalFilesDir(null);
+
+		return dir.getAbsolutePath();
+	}
 
 	public getLogicalRootPath(): string {
 		const dir = getApplicationContext().getFilesDir();

--- a/packages/core/file-system/file-system-access.d.ts
+++ b/packages/core/file-system/file-system-access.d.ts
@@ -101,6 +101,12 @@ export interface IFileSystemAccess {
 	getDocumentsFolderPath(): string;
 
 	/**
+	 * Gets the special documents folder on external storage.
+	 * As there is no external storage on iOS it is the same as getDocumentsFolderPath
+	 */
+	getExternalDocumentsFolderPath(): string;
+
+	/**
 	 * Gets the special temp folder.
 	 * Returns for Android: "/data/data/applicationPackageName/cache", iOS: "/var/mobile/Applications/appID/Library/Caches"
 	 */

--- a/packages/core/file-system/file-system-access.ios.ts
+++ b/packages/core/file-system/file-system-access.ios.ts
@@ -248,6 +248,9 @@ export class FileSystemAccess {
 	public getDocumentsFolderPath(): string {
 		return this.getKnownPath(NSSearchPathDirectory.DocumentDirectory);
 	}
+	public getExternalDocumentsFolderPath(): string {
+		return this.getDocumentsFolderPath();
+	}
 
 	public getTempFolderPath(): string {
 		return this.getKnownPath(NSSearchPathDirectory.CachesDirectory);

--- a/packages/core/file-system/index.d.ts
+++ b/packages/core/file-system/index.d.ts
@@ -218,6 +218,12 @@ export module knownFolders {
 	export function documents(): Folder;
 
 	/**
+	 * Gets the Documents folder available for the current application on an external storage. This Folder is private for the application and not accessible from Users/External apps.
+	 * There is no external storage on iOS os it is the same as `documents()`
+	 */
+	export function externalDocuments(): Folder;
+
+	/**
 	 * Gets the Temporary (Caches) folder available for the current application. This Folder is private for the application and not accessible from Users/External apps.
 	 */
 	export function temp(): Folder;

--- a/packages/core/file-system/index.d.ts
+++ b/packages/core/file-system/index.d.ts
@@ -219,6 +219,7 @@ export module knownFolders {
 
 	/**
 	 * Gets the Documents folder available for the current application on an external storage. This Folder is private for the application and not accessible from Users/External apps.
+	 * On android this requires READ_EXTERNAL_STORAGE/WRITE_EXTERNAL_STORAGE permissions
 	 * There is no external storage on iOS os it is the same as `documents()`
 	 */
 	export function externalDocuments(): Folder;

--- a/packages/core/file-system/index.ts
+++ b/packages/core/file-system/index.ts
@@ -571,7 +571,7 @@ export namespace knownFolders {
 			_externalDocuments._isKnown = true;
 		}
 
-		return _documents;
+		return _externalDocuments;
 	}
 
 	export function temp(): Folder {

--- a/packages/core/file-system/index.ts
+++ b/packages/core/file-system/index.ts
@@ -548,6 +548,7 @@ export class Folder extends FileSystemEntity {
 
 export namespace knownFolders {
 	let _documents: Folder;
+	let _externalDocuments: Folder;
 	let _temp: Folder;
 	let _app: Folder;
 
@@ -563,11 +564,11 @@ export namespace knownFolders {
 	}
 
 	export function externalDocuments(): Folder {
-		if (!_documents) {
+		if (!_externalDocuments) {
 			const path = getFileAccess().getExternalDocumentsFolderPath();
-			_documents = new Folder();
-			_documents._path = path;
-			_documents._isKnown = true;
+			_externalDocuments = new Folder();
+			_externalDocuments._path = path;
+			_externalDocuments._isKnown = true;
 		}
 
 		return _documents;

--- a/packages/core/file-system/index.ts
+++ b/packages/core/file-system/index.ts
@@ -562,6 +562,17 @@ export namespace knownFolders {
 		return _documents;
 	}
 
+	export function externalDocuments(): Folder {
+		if (!_documents) {
+			const path = getFileAccess().getExternalDocumentsFolderPath();
+			_documents = new Folder();
+			_documents._path = path;
+			_documents._isKnown = true;
+		}
+
+		return _documents;
+	}
+
 	export function temp(): Folder {
 		if (!_temp) {
 			const path = getFileAccess().getTempFolderPath();


### PR DESCRIPTION
This PR adds a new `knowFolders` `externalDocuments`. On iOS it will return `documents` but on android it returns the documents folder on external storage.

I added a note to the fact that it requires permissions