### PR TITLE
fix(core): FragmentCallbacksImplementation memory leak on Android

### DIFF
--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1031,9 +1031,14 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 		// animation should start between start and resume, so if we have an executing navigation here it probably means the animation was skipped
 		// so we manually set the entry
 		// also, to be compatible with fragments 1.2.x we need this setTimeout as animations haven't run on onResume yet
+		const weakRef = new WeakRef(this);
 		setTimeout(() => {
-			if (frame._executingContext && !(<any>this.entry).isAnimationRunning) {
-				frame.setCurrent(this.entry, frame._executingContext.navigationType);
+			const owner = weakRef.get();
+			if (!owner) {
+				return;
+			}
+			if (frame._executingContext && !(<any>owner.entry).isAnimationRunning) {
+				frame.setCurrent(owner.entry, frame._executingContext.navigationType);
 			}
 		}, 0);
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

The FragmentCallbacksImplementation is having memory leak on Android apps on navigations and when the app enters in foreground.
The memory leak can be verified on the Chrome Dev Tools.

<img width="1577" alt="fragmentCallbacksImplementation - before fix" src="https://user-images.githubusercontent.com/5738416/181227692-5f0e6530-249f-4318-afe0-8ebc3c65cd12.png">


## What is the new behavior?

The FragmentCallbacksImplementation is being disposed properly.

<img width="1571" alt="fragmentCallbacksImplementation - after fix" src="https://user-images.githubusercontent.com/5738416/181227714-f97aaca2-99f3-4cc1-8000-4f284e688178.png">

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

