### PR TITLE
fix(core): Added ObservableArray constructor declarations to support multiple arguments

### DIFF
--- a/apps/automated/src/data/observable-array-tests.ts
+++ b/apps/automated/src/data/observable-array-tests.ts
@@ -16,7 +16,8 @@ export const test_ObservableArray_shouldCopySourceArrayItems = function () {
 export const test_ObservableArray_shouldCopyMultipleItemsAsSource = function () {
 	// >> observable-array-arguments
 	const sa = [1, 2, 3];
-	const array = new ObservableArray(...sa);
+	// Avoid appending items using spread operator as it will skip argument type check
+	const array = new ObservableArray(1, 2, 3);
 	// << observable-array-arguments
 
 	TKUnit.assertEqual(array.length, 3, 'ObservableArray length should be 3');

--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -51,9 +51,21 @@ export class ObservableArray<T> extends Observable {
 	private _deleteArgs: ChangedData<T>;
 
 	/**
+	 * Create ObservableArray<T> with specified length.
+	 */
+	constructor(arrayLength?: number);
+
+	/**
 	 * Create ObservableArray<T> from source Array<T>.
 	 */
-	constructor(args?: T[] | number) {
+	constructor(items: T[]);
+
+	/**
+	 * Create ObservableArray<T> from T items.
+	 */
+	constructor(...items: T[]);
+
+	constructor(_args?: any) {
 		super();
 
 		if (arguments.length === 1 && Array.isArray(arguments[0])) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
ObservableArray constructor does not accept multiple arguments because of TypeScript type incompatibility.

Current declaration:
```ts
constructor(args?: T[] | number);
```

Concept:
```ts
const array: ObservableArray<number> = new ObservableArray(1, 2, 3);
```

## What is the new behavior?
ObservableArray constructor will accept multiple arguments.
This was achieved by adding few constructor declarations.

Using multiple types with union operator didn't work so I followed the same approach that was used back in NativeScript 6.x.x: https://github.com/NativeScript/NativeScript/blob/cea2e317c8f83ad4866599527638bf00eb6b6b93/nativescript-core/data/observable-array/observable-array.d.ts#L66

The test for the corresponding case was modified in such a way that the TS argument type will also be checked upon execution.

