### PR TITLE
revert "fix(ios): not responding after rotation (#9931)"

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -37,7 +37,8 @@ class UILayoutViewController extends UIViewController {
 		}
 	}
 
-	private updateAdditionalSafeAreaInsetsIfNeeded(): void {
+	public viewDidLayoutSubviews(): void {
+		super.viewDidLayoutSubviews();
 		const owner = this.owner.get();
 		if (owner) {
 			if (majorVersion >= 11) {
@@ -76,18 +77,7 @@ class UILayoutViewController extends UIViewController {
 					}
 				}
 			}
-		}
-	}
 
-	public viewSafeAreaInsetsDidChange(): void {
-		super.viewSafeAreaInsetsDidChange();
-		this.updateAdditionalSafeAreaInsetsIfNeeded();
-	}
-
-	public viewDidLayoutSubviews(): void {
-		super.viewDidLayoutSubviews();
-		const owner = this.owner.get();
-		if (owner) {
 			IOSHelper.layoutView(this, owner);
 		}
 	}


### PR DESCRIPTION
This reverts commit aee1d0565105158e84b6a752cc05ee0dc0577943.

## What is the current behavior?

The original PR https://github.com/NativeScript/NativeScript/pull/9931 resolved some isolated cases but has some undesired side effects.

## What is the new behavior?

This returns behavior to original and we will redress this differently in subsequent PR.

cc/ @CatchABus 