### PR TITLE
fix(ios): app stopped responding after screen rotation

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -266,7 +266,7 @@ export class IOSHelper {
 			const adjustedFrame = IOSHelper.getFrameFromPosition(position, insets);
 
 			if (Trace.isEnabled()) {
-                Trace.write(`${view} :shrinkToSafeArea: ${JSON.stringify(IOSHelper.getPositionFromFrame(adjustedFrame))}`, Trace.categories.Layout);
+				Trace.write(`${view} :shrinkToSafeArea: ${JSON.stringify(IOSHelper.getPositionFromFrame(adjustedFrame))}`, Trace.categories.Layout);
 			}
 
 			return adjustedFrame;
@@ -288,11 +288,11 @@ export class IOSHelper {
 
 		const adjustedPosition = position;
 
-		if (position.left && inWindowPosition.left <= safeAreaPosition.left) {
+		if (position.left && inWindowPosition.left < safeAreaPosition.left) {
 			adjustedPosition.left = fullscreenPosition.left;
 		}
 
-		if (position.top && inWindowPosition.top <= safeAreaPosition.top) {
+		if (position.top && inWindowPosition.top < safeAreaPosition.top) {
 			adjustedPosition.top = fullscreenPosition.top;
 		}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
The iOS app isn't responding after rotation. The issue is only reproducible on the iOS phone. Cannot be reproduced on an iOS tablet.

The issue can be reproduced immediately (after the first rotation) on the nested tabs scenario.

See #9931 for more details by @dgmachado. He has provided a sample and precious information.

If needed, NS view controllers will modify their own insets when they layout subviews. This seemed to cause problems in a rotation scenario due to wrong checks inside core during children insets calculation.

## What is the new behavior?
Application will operate normally after rotation without problems.

Fixes #9931 