### PR TITLE
fix(ios): additional safe area insets were miscalculated if already set

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -59,11 +59,15 @@ class UILayoutViewController extends UIViewController {
 
 				if (parent) {
 					const parentPageInsetsTop = parent.nativeViewProtected.safeAreaInsets.top;
-					const currentInsetsTop = this.view.safeAreaInsets.top;
-					const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
-
 					const parentPageInsetsBottom = parent.nativeViewProtected.safeAreaInsets.bottom;
-					const currentInsetsBottom = this.view.safeAreaInsets.bottom;
+
+					let currentInsetsTop = this.view.safeAreaInsets.top;
+					let currentInsetsBottom = this.view.safeAreaInsets.bottom;
+					if (this.additionalSafeAreaInsets) {
+						currentInsetsTop -= this.additionalSafeAreaInsets.top;
+						currentInsetsBottom -= this.additionalSafeAreaInsets.bottom;
+					}
+					const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
 					const additionalInsetsBottom = Math.max(parentPageInsetsBottom - currentInsetsBottom, 0);
 
 					if (additionalInsetsTop > 0 || additionalInsetsBottom > 0) {
@@ -266,7 +270,7 @@ export class IOSHelper {
 			const adjustedFrame = IOSHelper.getFrameFromPosition(position, insets);
 
 			if (Trace.isEnabled()) {
-                Trace.write(`${view} :shrinkToSafeArea: ${JSON.stringify(IOSHelper.getPositionFromFrame(adjustedFrame))}`, Trace.categories.Layout);
+				Trace.write(`${view} :shrinkToSafeArea: ${JSON.stringify(IOSHelper.getPositionFromFrame(adjustedFrame))}`, Trace.categories.Layout);
 			}
 
 			return adjustedFrame;

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -60,13 +60,15 @@ class UILayoutViewController extends UIViewController {
 				if (parent) {
 					const parentPageInsetsTop = parent.nativeViewProtected.safeAreaInsets.top;
 					const parentPageInsetsBottom = parent.nativeViewProtected.safeAreaInsets.bottom;
-
 					let currentInsetsTop = this.view.safeAreaInsets.top;
 					let currentInsetsBottom = this.view.safeAreaInsets.bottom;
+
+					// Safe area insets include additional safe area insets too, so subtract old values
 					if (this.additionalSafeAreaInsets) {
 						currentInsetsTop -= this.additionalSafeAreaInsets.top;
 						currentInsetsBottom -= this.additionalSafeAreaInsets.bottom;
 					}
+
 					const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
 					const additionalInsetsBottom = Math.max(parentPageInsetsBottom - currentInsetsBottom, 0);
 

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -280,13 +280,15 @@ class UIViewControllerImpl extends UIViewController {
 				if (frameParent) {
 					const parentPageInsetsTop = frameParent.nativeViewProtected.safeAreaInsets.top;
 					const parentPageInsetsBottom = frameParent.nativeViewProtected.safeAreaInsets.bottom;
-
 					let currentInsetsTop = this.view.safeAreaInsets.top;
 					let currentInsetsBottom = this.view.safeAreaInsets.bottom;
+
+					// Safe area insets include additional safe area insets too, so subtract old values
 					if (this.additionalSafeAreaInsets) {
 						currentInsetsTop -= this.additionalSafeAreaInsets.top;
 						currentInsetsBottom -= this.additionalSafeAreaInsets.bottom;
 					}
+
 					const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
 					const additionalInsetsBottom = Math.max(parentPageInsetsBottom - currentInsetsBottom, 0);
 

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -279,11 +279,15 @@ class UIViewControllerImpl extends UIViewController {
 
 				if (frameParent) {
 					const parentPageInsetsTop = frameParent.nativeViewProtected.safeAreaInsets.top;
-					const currentInsetsTop = this.view.safeAreaInsets.top;
-					const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
-
 					const parentPageInsetsBottom = frameParent.nativeViewProtected.safeAreaInsets.bottom;
-					const currentInsetsBottom = this.view.safeAreaInsets.bottom;
+
+					let currentInsetsTop = this.view.safeAreaInsets.top;
+					let currentInsetsBottom = this.view.safeAreaInsets.bottom;
+					if (this.additionalSafeAreaInsets) {
+						currentInsetsTop -= this.additionalSafeAreaInsets.top;
+						currentInsetsBottom -= this.additionalSafeAreaInsets.bottom;
+					}
+					const additionalInsetsTop = Math.max(parentPageInsetsTop - currentInsetsTop, 0);
 					const additionalInsetsBottom = Math.max(parentPageInsetsBottom - currentInsetsBottom, 0);
 
 					if (additionalInsetsTop > 0 || additionalInsetsBottom > 0) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
During additional safe area inset calculation, view controllers also included the old additional safe area inset values. Subtracting them from `currentInsetsTop` and `currentInsetsTop` helps calculate proper values for additional insets and fixes problems like tabs infinite loop during rotation.

See https://github.com/NativeScript/NativeScript/pull/9931 for more details by @dgmachado. He has provided a sample and precious information.

## What is the new behavior?
Application will properly calculate insets and operate normally after rotation without problems.

Fixes https://github.com/NativeScript/NativeScript/pull/9931