### PR TITLE
feat(core): make font style, weight, scale params optional

### DIFF
--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -59,7 +59,7 @@ export { Background } from './styling/background';
 export type { CacheMode } from './styling/background';
 export { parseCSSShadow } from './styling/css-shadow';
 export { animationTimingFunctionConverter, timeConverter } from './styling/converters';
-export { Font } from './styling/font';
+export { Font, FontStyle, FontWeight } from './styling/font';
 export { Style } from './styling/style';
 export type { CommonLayoutParams } from './styling/style';
 export * from './styling/style-properties';

--- a/packages/core/ui/styling/font-common.ts
+++ b/packages/core/ui/styling/font-common.ts
@@ -6,6 +6,9 @@ export * from './font-interfaces';
 
 export abstract class Font implements FontDefinition {
 	public static default = undefined;
+	public readonly fontStyle: FontStyleType;
+	public readonly fontWeight: FontWeightType;
+	public readonly fontScale: number;
 
 	get isItalic(): boolean {
 		return this.fontStyle === FontStyle.ITALIC;
@@ -15,7 +18,11 @@ export abstract class Font implements FontDefinition {
 		return this.fontWeight === FontWeight.SEMI_BOLD || this.fontWeight === FontWeight.BOLD || this.fontWeight === '700' || this.fontWeight === FontWeight.EXTRA_BOLD || this.fontWeight === FontWeight.BLACK;
 	}
 
-	protected constructor(public readonly fontFamily: string, public readonly fontSize: number, public readonly fontStyle: FontStyleType, public readonly fontWeight: FontWeightType, public readonly fontScale: number) {}
+	protected constructor(public readonly fontFamily: string, public readonly fontSize: number, fontStyle?: FontStyleType, fontWeight?: FontWeightType, fontScale?: number) {
+		this.fontStyle = fontStyle ?? FontStyle.NORMAL;
+		this.fontWeight = fontWeight ?? FontWeight.NORMAL;
+		this.fontScale = fontScale ?? 1;
+	}
 
 	public abstract getAndroidTypeface(): any; /* android.graphics.Typeface */
 	public abstract getUIFont(defaultFont: any /* UIFont */): any; /* UIFont */

--- a/packages/core/ui/styling/font.android.ts
+++ b/packages/core/ui/styling/font.android.ts
@@ -1,4 +1,4 @@
-import { Font as FontBase, parseFontFamily, genericFontFamilies, FontWeight, FontWeightType } from './font-common';
+import { Font as FontBase, parseFontFamily, genericFontFamilies, FontStyleType, FontWeight, FontWeightType } from './font-common';
 import { Trace } from '../../trace';
 import * as application from '../../application';
 import * as fs from '../../file-system';
@@ -10,11 +10,11 @@ const typefaceCache = new Map<string, android.graphics.Typeface>();
 let appAssets: android.content.res.AssetManager;
 
 export class Font extends FontBase {
-	public static default = new Font(undefined, undefined, 'normal', 'normal');
+	public static default = new Font(undefined, undefined);
 
 	private _typeface: android.graphics.Typeface;
 
-	constructor(family: string, size: number, style: 'normal' | 'italic', weight: FontWeightType) {
+	constructor(family: string, size: number, style?: FontStyleType, weight?: FontWeightType) {
 		super(family, size, style, weight, 1);
 	}
 
@@ -22,7 +22,7 @@ export class Font extends FontBase {
 		return new Font(family, this.fontSize, this.fontStyle, this.fontWeight);
 	}
 
-	public withFontStyle(style: 'normal' | 'italic'): Font {
+	public withFontStyle(style: FontStyleType): Font {
 		return new Font(this.fontFamily, this.fontSize, style, this.fontWeight);
 	}
 

--- a/packages/core/ui/styling/font.d.ts
+++ b/packages/core/ui/styling/font.d.ts
@@ -10,7 +10,7 @@
 	public isBold: boolean;
 	public isItalic: boolean;
 
-	constructor(family: string, size: number, style: FontStyle, weight: FontWeight);
+	constructor(family: string, size: number, style?: FontStyle, weight?: FontWeight, scale?: number);
 
 	public getAndroidTypeface(): any /* android.graphics.Typeface */;
 	public getUIFont(defaultFont: any /* UIFont */): any /* UIFont */;

--- a/packages/core/ui/styling/font.ios.ts
+++ b/packages/core/ui/styling/font.ios.ts
@@ -38,11 +38,9 @@ function getUIFontCached(fontDescriptor: FontDescriptor) {
 }
 
 export class Font extends FontBase {
-	public static default = new Font(undefined, undefined, FontStyle.NORMAL, FontWeight.NORMAL, 1);
+	public static default = new Font(undefined, undefined);
 
-	private _uiFont: UIFont;
-
-	constructor(family: string, size: number, style: FontStyleType, weight: FontWeightType, scale: number) {
+	constructor(family: string, size: number, style?: FontStyleType, weight?: FontWeightType, scale?: number) {
 		super(family, size, style, weight, scale);
 	}
 


### PR DESCRIPTION
Change font style, weight, scale constructor parameters to optional.
Export `FontStyle` and `FontWeight`.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Creating new font instance requires redundant parameters:
```ts
new Font('material-symbols-outlined', 28, 'normal', 'normal')
```

## What is the new behavior?
Style, weight and scale parameters are optional:
```ts
new Font('material-symbols-outlined', 28)
```

