### PR TITLE
fix(core): Fix Android navigation crash

### DIFF
--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -672,17 +672,16 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: Backsta
 
 	entries.delete(entry);
 	if (entries.size === 0) {
-		if (!entry.resolvedPage) {
-			return;
-		}
-		const frame = entry.resolvedPage.frame;
-
 		// We have 0 or 1 entry per frameId in completedEntries
 		// So there is no need to make it to Set like waitingQueue
 		const previousCompletedAnimationEntry = completedEntries.get(frameId);
 		completedEntries.delete(frameId);
 		waitingQueue.delete(frameId);
 
+		if (!entry.resolvedPage) {
+			return;
+		}
+		const frame = entry.resolvedPage.frame;
 		const navigationContext = frame._executingContext || {
 			navigationType: NavigationType.back,
 		};

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -679,6 +679,9 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: Backsta
 		waitingQueue.delete(frameId);
 
 		if (!entry.resolvedPage) {
+			if (Trace.isEnabled()) {
+				Trace.write(`Transition completed - Entry ${entry} with unexpected null value for the resolvedPage property.`, Trace.categories.Navigation, Trace.messageType.error);
+			}
 			return;
 		}
 		const frame = entry.resolvedPage.frame;

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -680,7 +680,7 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: Backsta
 
 		if (!entry.resolvedPage) {
 			if (Trace.isEnabled()) {
-				Trace.write(`Transition completed - Entry ${entry} with unexpected null value for the resolvedPage property.`, Trace.categories.Navigation, Trace.messageType.error);
+				Trace.write(`Transition completed - Entry ${entry} with unexpected null value for the resolvedPage property.`, Trace.categories.Transition, Trace.messageType.error);
 			}
 			return;
 		}

--- a/packages/core/ui/frame/fragment.transitions.android.ts
+++ b/packages/core/ui/frame/fragment.transitions.android.ts
@@ -672,6 +672,9 @@ function transitionOrAnimationCompleted(entry: ExpandedEntry, backEntry: Backsta
 
 	entries.delete(entry);
 	if (entries.size === 0) {
+		if (!entry.resolvedPage) {
+			return;
+		}
 		const frame = entry.resolvedPage.frame;
 
 		// We have 0 or 1 entry per frameId in completedEntries


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Android navigation crash when receiving unexpected value on the Entry struct. The entry.resolvedPage is coming null in a Test App and I suppose the root case is that there's memory leak happening on the navigation.

## What is the new behavior?

Fix the Android navigation crash just ignoring the expected value received. It's a defensive programming and that fixes the this crash issue.


