### PR TITLE
fix(core): handle tap and longpress gesture conflict on iOS

### DIFF
--- a/packages/core/ui/gestures/index.ios.ts
+++ b/packages/core/ui/gestures/index.ios.ts
@@ -33,6 +33,9 @@ class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecog
 		if (gestureRecognizer instanceof UITapGestureRecognizer && otherGestureRecognizer instanceof UITapGestureRecognizer && otherGestureRecognizer.numberOfTapsRequired === 2) {
 			return true;
 		}
+		if (gestureRecognizer instanceof UITapGestureRecognizer && otherGestureRecognizer instanceof UILongPressGestureRecognizer) {
+			return true;
+		}
 
 		return false;
 	}


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
on iOS, depending on the time you hold down the finger, it'll fire both longpress and tap events.

## What is the new behavior?
Only tap OR longpress events will be fired. (tap requires longpress to fail, if bound)

Reproduction: https://stackblitz.com/edit/nativescript-stackblitz-templates-s1wsjp
