### PR TITLE
fix(core): WeakRef typings to include deref

### DIFF
--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -354,6 +354,7 @@ declare class WeakRef<T> {
 	constructor(obj: T);
 	get(): T;
 	clear(): void;
+	deref(): T | undefined;
 }
 
 /**


### PR DESCRIPTION


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Using `WeakRef` API `deref` would not pass type checks.

## What is the new behavior?

Using `WeakRef` API `deref` will now pass type checks.