### PR TITLE
fix(core): property parentsMatch is invalid or does not exist

### DIFF
--- a/packages/core/ui/builder/binding-builder.ts
+++ b/packages/core/ui/builder/binding-builder.ts
@@ -121,20 +121,7 @@ function getParamsArray(value: string) {
 }
 
 function isExpression(expression: string): boolean {
-	if (expression.search(expressionSymbolsRegex) > -1) {
-		const parentsMatches = expression.match(parentsRegex);
-		if (parentsMatches) {
-			const restOfExpression = expression.substr(expression.indexOf(parentsMatches[0]) + parentsMatches[0].length);
-			// no more expression regognition symbols so it is safe for sourceProperty
-			if (!(restOfExpression.search(expressionSymbolsRegex) > -1)) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	return false;
+	return expression.search(expressionSymbolsRegex) > -1;
 }
 
 export function getBindingOptions(name: string, value: string): any {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
There are times method `isExpression` modifies expression in case there is a parent reference inside while there is no need for such a thing.
This was initially added here: https://github.com/NativeScript/NativeScript/commit/e7156b53bd2cca7eb1f15f6b24a13ab3bdb10495#

On top of that, it performs extra regex calls to test expression in a totally wrong way, resulting in an error with this format when there is a parent inside:
```sh
Binding: Property: '`test-${activeAlerts | parentsMatch' is invalid or does not exist. SourceProperty: '`test-${activeAlerts | $parents['ListView'].fooConverter}`'
```

## What is the new behavior?
The code block responsive for this gets removed. All tests are passing and expressions with parent work as they should.