### PR TITLE
fix(core): segmented bar crashes on iOS

### DIFF
--- a/packages/core/ui/segmented-bar/index.ios.ts
+++ b/packages/core/ui/segmented-bar/index.ios.ts
@@ -8,7 +8,7 @@ export * from './segmented-bar-common';
 export class SegmentedBarItem extends SegmentedBarItemBase {
 	public _update() {
 		const parent = <SegmentedBar>this.parent;
-		if (parent) {
+		if (parent?.ios) {
 			const tabIndex = parent.items.indexOf(this);
 			let title = this.title;
 			title = title === null || title === undefined ? '' : title;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
It seems that setting title to `SegmentedBarItem` using binding methods like Angular interpolation will cause SegmentedBar to crash on iOS.

## What is the new behavior?
SegmentedBar will stop crashing. It seems that if we prevent update using a native view validity check, title will still be updated properly.

Fixes/Closes #10009