### PR TITLE
fix(ios): properties lineHeight and letterSpacing did not apply to spans

### DIFF
--- a/packages/core/platforms/ios/src/UIView+NativeScript.h
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.h
@@ -8,6 +8,6 @@
 
 - (void)nativeScriptSetTextDecorationAndTransform:(NSString*)text textDecoration:(NSString*)textDecoration letterSpacing:(CGFloat)letterSpacing lineHeight:(CGFloat)lineHeight;
 
--(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details;
+-(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details letterSpacing:(CGFloat)letterSpacing lineHeight:(CGFloat)lineHeight;
 
 @end

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -75,9 +75,7 @@
     }
 }
 
--(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details {
-    CGFloat letterSpacing = [[details valueForKey:@"letterSpacing"] doubleValue];
-    CGFloat lineHeight = [[details valueForKey:@"lineHeight"] doubleValue];
+-(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details letterSpacing:(CGFloat)letterSpacing lineHeight:(CGFloat)lineHeight {
     NSMutableAttributedString *attrText = [NativeScriptUtils createMutableStringWithDetails:details];
     if (letterSpacing != 0) {
         NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -87,7 +87,7 @@
     
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.minimumLineHeight = lineHeight;
+        paragraphStyle.lineSpacing = lineHeight;
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -241,12 +241,14 @@ export class TextBase extends TextBaseCommon {
 			return;
 		}
 
+		const letterSpacing = this.style.letterSpacing ? this.style.letterSpacing : 0;
+		const lineHeight = this.style.lineHeight ? this.style.lineHeight : 0;
 		if (this.formattedText) {
-			(<any>this.nativeTextViewProtected).nativeScriptSetFormattedTextDecorationAndTransform(this.getFormattedStringDetails(this.formattedText));
+			(<any>this.nativeTextViewProtected).nativeScriptSetFormattedTextDecorationAndTransformLetterSpacingLineHeight(this.getFormattedStringDetails(this.formattedText), letterSpacing, lineHeight);
 		} else {
 			// console.log('setTextDecorationAndTransform...')
 			const text = getTransformedText(isNullOrUndefined(this.text) ? '' : `${this.text}`, this.textTransform);
-			(<any>this.nativeTextViewProtected).nativeScriptSetTextDecorationAndTransformTextDecorationLetterSpacingLineHeight(text, this.style.textDecoration || '', this.style.letterSpacing !== 0 ? this.style.letterSpacing : 0, this.style.lineHeight ? this.style.lineHeight : 0);
+			(<any>this.nativeTextViewProtected).nativeScriptSetTextDecorationAndTransformTextDecorationLetterSpacingLineHeight(text, this.style.textDecoration || '', letterSpacing, lineHeight);
 
 			if (!this.style?.color && majorVersion >= 13 && UIColor.labelColor) {
 				this._setColor(UIColor.labelColor);
@@ -295,8 +297,6 @@ export class TextBase extends TextBaseCommon {
 			color: span.color ? span.color.ios : null,
 			backgroundColor: backgroundColor ? backgroundColor.ios : null,
 			textDecoration: getClosestPropertyValue(textDecorationProperty, span),
-			letterSpacing: this.letterSpacing || 0,
-			lineHeight: this.lineHeight || 0, //this.style?.lineHeight ? this.style.lineHeight : 0,
 			baselineOffset: this.getBaselineOffset(iosFont, span.style.verticalAlignment),
 			index,
 		};

--- a/packages/types-ios/src/lib/ios/objc-x86_64/objc!UIKit.d.ts
+++ b/packages/types-ios/src/lib/ios/objc-x86_64/objc!UIKit.d.ts
@@ -24018,7 +24018,7 @@ declare class UIView extends UIResponder implements CALayerDelegate, NSCoding, U
 
 	layoutSubviews(): void;
 
-	nativeScriptSetFormattedTextDecorationAndTransform(details: NSDictionary<any, any>): void;
+	nativeScriptSetFormattedTextDecorationAndTransformLetterSpacingLineHeight(details: NSDictionary<any, any>, letterSpacing: number, lineHeight: number): void;
 
 	nativeScriptSetTextDecorationAndTransformTextDecorationLetterSpacingLineHeight(text: string, textDecoration: string, letterSpacing: number, lineHeight: number): void;
 

--- a/packages/types-minimal/src/lib/ios/objc-x86_64/objc!UIKit.d.ts
+++ b/packages/types-minimal/src/lib/ios/objc-x86_64/objc!UIKit.d.ts
@@ -24018,7 +24018,7 @@ declare class UIView extends UIResponder implements CALayerDelegate, NSCoding, U
 
 	layoutSubviews(): void;
 
-	nativeScriptSetFormattedTextDecorationAndTransform(details: NSDictionary<any, any>): void;
+	nativeScriptSetFormattedTextDecorationAndTransformLetterSpacingLineHeight(details: NSDictionary<any, any>, letterSpacing: number, lineHeight: number): void;
 
 	nativeScriptSetTextDecorationAndTransformTextDecorationLetterSpacingLineHeight(text: string, textDecoration: string, letterSpacing: number, lineHeight: number): void;
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
One cannot set `lineHeight` or `letterSpacing` to Labels that consist of spans.
This a feature that got broken in #9761 

## What is the new behavior?
`lineHeight` or `letterSpacing` will apply to spans.