### PR TITLE
fix(ios): Tapping on span does not emit linkTap event

### DIFF
--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -85,6 +85,7 @@
         } ];
     }
     
+    BOOL isLabel = [self isKindOfClass:[UILabel class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         paragraphStyle.lineSpacing = lineHeight;
@@ -96,7 +97,7 @@
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
         }
         
-        if ([self isKindOfClass:[UILabel class]]) {
+        if (isLabel) {
             // make sure a possible previously set line break mode is not lost when line height is specified
             paragraphStyle.lineBreakMode = ((UILabel*)self).lineBreakMode;
         }
@@ -104,14 +105,14 @@
             0,
             attrText.length
         }];
-    } else {
+    } else if (isLabel || [self isKindOfClass:[UITextView class]]) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
 
-        if ([self isKindOfClass:[UITextView class]]) {
-            paragraphStyle.alignment = ((UITextView*)self).textAlignment;
-        } else if ([self isKindOfClass:[UILabel class]]) {
+        if (isLabel) {
             // It's important to set paragraph alignment for link tap to work on multi-line spans as NSTextContainer takes it into account
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
+        } else {
+            paragraphStyle.alignment = ((UITextView*)self).textAlignment;
         }
         [attrText addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:(NSRange){
             0,

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -92,6 +92,7 @@
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
         } else {
+            // Paragraph alignment is also important for tappable spans as NSTextContainer takes it into account
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
         }
         
@@ -103,9 +104,15 @@
             0,
             attrText.length
         }];
-    } else if ([self isKindOfClass:[UITextView class]]) {
+    } else {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.alignment = ((UITextView*)self).textAlignment;
+
+        if ([self isKindOfClass:[UITextView class]]) {
+            paragraphStyle.alignment = ((UITextView*)self).textAlignment;
+        } else if ([self isKindOfClass:[UILabel class]]) {
+            // It's important to set paragraph alignment for link tap to work on multi-line spans as NSTextContainer takes it into account
+            paragraphStyle.alignment = ((UILabel*)self).textAlignment;
+        }
         [attrText addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:(NSRange){
             0,
             attrText.length

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -33,9 +33,9 @@ class UILabelClickHandlerImpl extends NSObject {
 	public linkTap(tapGesture: UITapGestureRecognizer) {
 		const owner = this._owner.get();
 		if (owner) {
-			// https://stackoverflow.com/a/35789589
 			const label = <UILabel>owner.nativeTextViewProtected;
 
+			// This offset along with setting paragraph style alignment will achieve perfect horizontal alignment for NSTextContainer
 			let offsetXMultiplier: number;
 			switch (owner.textAlignment) {
 				case 'center':

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -37,11 +37,11 @@ class UILabelClickHandlerImpl extends NSObject {
 			const label = <UILabel>owner.nativeTextViewProtected;
 
 			let offsetXMultiplier: number;
-			switch (label.textAlignment) {
-				case NSTextAlignment.Center:
+			switch (owner.textAlignment) {
+				case 'center':
 					offsetXMultiplier = 0.5;
 					break;
-				case NSTextAlignment.Right:
+				case 'right':
 					offsetXMultiplier = 1.0;
 					break;
 				default:

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -35,6 +35,21 @@ class UILabelClickHandlerImpl extends NSObject {
 		if (owner) {
 			// https://stackoverflow.com/a/35789589
 			const label = <UILabel>owner.nativeTextViewProtected;
+
+			let offsetXMultiplier: number;
+			switch (label.textAlignment) {
+				case NSTextAlignment.Center:
+					offsetXMultiplier = 0.5;
+					break;
+				case NSTextAlignment.Right:
+					offsetXMultiplier = 1.0;
+					break;
+				default:
+					offsetXMultiplier = 0.0;
+					break;
+			}
+			const offsetYMultiplier: number = 0.5; // Text is vertically aligned to center
+
 			const layoutManager = NSLayoutManager.alloc().init();
 			const textContainer = NSTextContainer.alloc().initWithSize(CGSizeZero);
 			const textStorage = NSTextStorage.alloc().initWithAttributedString(owner.nativeTextViewProtected['attributedText']);
@@ -51,27 +66,45 @@ class UILabelClickHandlerImpl extends NSObject {
 			const locationOfTouchInLabel = tapGesture.locationInView(label);
 			const textBoundingBox = layoutManager.usedRectForTextContainer(textContainer);
 
-			const textContainerOffset = CGPointMake((labelSize.width - textBoundingBox.size.width) * 0.5 - textBoundingBox.origin.x, (labelSize.height - textBoundingBox.size.height) * 0.5 - textBoundingBox.origin.y);
-
+			const textContainerOffset = CGPointMake((labelSize.width - textBoundingBox.size.width) * offsetXMultiplier - textBoundingBox.origin.x, (labelSize.height - textBoundingBox.size.height) * offsetYMultiplier - textBoundingBox.origin.y);
 			const locationOfTouchInTextContainer = CGPointMake(locationOfTouchInLabel.x - textContainerOffset.x, locationOfTouchInLabel.y - textContainerOffset.y);
 
-			const indexOfCharacter = layoutManager.characterIndexForPointInTextContainerFractionOfDistanceBetweenInsertionPoints(locationOfTouchInTextContainer, textContainer, null);
+			// Check if tap was inside text bounding rect
+			if (CGRectContainsPoint(textBoundingBox, locationOfTouchInTextContainer)) {
+				// According to Apple docs, if no glyph is under point, the nearest glyph is returned
+				const glyphIndex = layoutManager.glyphIndexForPointInTextContainerFractionOfDistanceThroughGlyph(locationOfTouchInTextContainer, textContainer, null);
+				// In order to determine whether the tap point actually lies within the bounds
+				// of the glyph returned, we call the method below and test
+				// whether the point falls in the rectangle returned by that method
+				const glyphRect = layoutManager.boundingRectForGlyphRangeInTextContainer(
+					{
+						location: glyphIndex,
+						length: 1,
+					},
+					textContainer
+				);
 
-			let span: Span = null;
-			// try to find the corresponding span using the spanRanges
-			for (let i = 0; i < owner._spanRanges.length; i++) {
-				const range = owner._spanRanges[i];
-				if (range.location <= indexOfCharacter && range.location + range.length > indexOfCharacter) {
-					if (owner.formattedText && owner.formattedText.spans.length > i) {
-						span = owner.formattedText.spans.getItem(i);
+				// Ensure that an actual glyph was tapped
+				if (CGRectContainsPoint(glyphRect, locationOfTouchInTextContainer)) {
+					const indexOfCharacter = layoutManager.characterIndexForGlyphAtIndex(glyphIndex);
+
+					let span: Span = null;
+					// Try to find the corresponding span using the spanRanges
+					for (let i = 0; i < owner._spanRanges.length; i++) {
+						const range = owner._spanRanges[i];
+						if (range.location <= indexOfCharacter && range.location + range.length > indexOfCharacter) {
+							if (owner.formattedText && owner.formattedText.spans.length > i) {
+								span = owner.formattedText.spans.getItem(i);
+							}
+							break;
+						}
 					}
-					break;
-				}
-			}
 
-			if (span && span.tappable) {
-				// if the span is found and tappable emit the linkTap event
-				span._emit(Span.linkTapEvent);
+					if (span && span.tappable) {
+						// if the span is found and tappable emit the linkTap event
+						span._emit(Span.linkTapEvent);
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In iOS, event `linkTap` is not emitted at all times or happens to emit for wrong tap point.

Issues:
1) Tap point calculations return wrong result if text alignment is not set to center
2) Tap point calculations return wrong result if label is multi-line
3) One can trigger `linkTap` event even if tap occurs outside text bounding area
4) One can trigger `linkTap` event even if tap occurs on a blank point inside text bounding area (method `characterIndexForPointInTextContainerFractionOfDistanceBetweenInsertionPoints` returns first or last character index when no character is found, depending on tap horizontal position)

## What is the new behavior?
An accurate `linkTap` event for iOS that meets the requirements to emulate android native tap for `SpannableStrings`.
It was essential to include paragraph style alignment for tap point calculations to work on multi-line labels.
This PR fixes all issues mentioned above.

It's a good feature when it comes to long, wrapped texts with links inside and there is a good tutorial where Alex introduces its functionality: https://www.youtube.com/watch?v=ACnk_0jOVp0&ab_channel=AlexZiskind

Fixes/Implements/Closes #9189.