### PR TITLE
fix(android): text transform capitalize is capitalizing after apostrophe

### DIFF
--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -505,7 +505,7 @@ export class TextBase extends TextBaseCommon {
 
 function getCapitalizedString(str: string): string {
 	let newString = str.toLowerCase();
-	newString = newString.replace(/(?:^|\s|[-"'([{])+\S/g, (c) => c.toUpperCase());
+	newString = newString.replace(/(?:^|\s'*|[-"([{])+\S/g, (c) => c.toUpperCase());
 	return newString;
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In android, text transform capitalize is capitalizing after apostrophe. That is because regular expression checks for letters after single quote and performs upper-case.

## What is the new behavior?
Regex has been modified so that it performs this operation only on single quotes who are followed by white-space.

Fixes/Implements/Closes #9940.