### PR TITLE
fix(core): Errors get swallowed if thrown inside async event functions

### DIFF
--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -303,7 +303,7 @@ export class Observable implements ObservableDefinition {
 			}
 
 			// This ensures errors thrown inside asynchronous functions do not get swallowed
-			if (call instanceof Promise) {
+			if (call && call instanceof Promise) {
 				call.catch((err) => {
 					console.error(err);
 				});

--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -294,10 +294,19 @@ export class Observable implements ObservableDefinition {
 			if (entry.once) {
 				observers.splice(i, 1);
 			}
+
+			let call;
 			if (entry.thisArg) {
-				entry.callback.apply(entry.thisArg, [data]);
+				call = entry.callback.apply(entry.thisArg, [data]);
 			} else {
-				entry.callback(data);
+				call = entry.callback(data);
+			}
+
+			// This ensures errors thrown inside asynchronous functions do not get swallowed
+			if (call instanceof Promise) {
+				call.catch((err) => {
+					console.error(err);
+				});
 			}
 		}
 	}

--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -295,16 +295,16 @@ export class Observable implements ObservableDefinition {
 				observers.splice(i, 1);
 			}
 
-			let call;
+			let returnValue;
 			if (entry.thisArg) {
-				call = entry.callback.apply(entry.thisArg, [data]);
+				returnValue = entry.callback.apply(entry.thisArg, [data]);
 			} else {
-				call = entry.callback(data);
+				returnValue = entry.callback(data);
 			}
 
 			// This ensures errors thrown inside asynchronous functions do not get swallowed
-			if (call && call instanceof Promise) {
-				call.catch((err) => {
+			if (returnValue && returnValue instanceof Promise) {
+				returnValue.catch((err) => {
 					console.error(err);
 				});
 			}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Here is a small scenario. I have this `Page` event callback.
```js
function onNavigatedTo(args) {
    // For a reason, I wish to navigate elsewhere
    Frame.topmost().navigate({moduleName: "I accidentally put an invalid path"});
}
```
There is faulty code inside it that returns a blank page and throws error in console.
```sh
Error: Failed to load component from module: I accidentally put an invalid path
```

So far so good. What if I want to use an asynchronous callback though? Let's say that I would like to use async-await because I like it more than promises.

My callback will look like this:
```js
async function onNavigatedTo(args) {
    var response = await axios.get(...);

    // For a reason, I wish to navigate elsewhere
    Frame.topmost().navigate({moduleName: "I accidentally put an invalid path"});
}
```
Even though the result is the same, error thrown by `Frame.topmost().navigate` will be shallowed because it's thrown inside an asynchronous function.
One would use try-catch to handle this problem in his own custom code, but this problem occurs even with N calls.
As a result, one gets a blank page but has no idea what is happening.

## What is the new behavior?
Depending on whether event callback execution is asynchronous or not, we append a promise `catch` to it and print the error that gets swallowed.

I couldn't think of a better solution to this matter. What I'm sure of is that we have to be informed about throws as error messages usually lead us to the cause of the problem.
I'm open to suggestions on improving this if any.