### PR TITLE
fix: prevent possible crash when accessing actionbar.ios

### DIFF
--- a/packages/core/ui/action-bar/index.ios.ts
+++ b/packages/core/ui/action-bar/index.ios.ts
@@ -93,11 +93,7 @@ export class ActionBar extends ActionBarBase {
 		}
 
 		const viewController = <UIViewController>page.ios;
-		if (viewController.navigationController !== null) {
-			return viewController.navigationController.navigationBar;
-		}
-
-		return null;
+		return viewController?.navigationController?.navigationBar;
 	}
 
 	[accessibilityValueProperty.setNative](value: string): void {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
calling actionbar.ios on an unloaded page results in an error/crash

## What is the new behavior?
actionbar.ios returns null if page is not loaded.
