### PR TITLE
fix(android): Webview href schemes threw 'net::ERR_UNKNOWN_URL_SCHEME'

### DIFF
--- a/packages/core/ui/web-view/index.android.ts
+++ b/packages/core/ui/web-view/index.android.ts
@@ -1,6 +1,7 @@
 import { disableZoomProperty, WebViewBase, WebViewClient } from './web-view-common';
 import { Trace } from '../../trace';
 import { knownFolders } from '../../file-system';
+import { openUrl } from '../../utils';
 
 export * from './web-view-common';
 
@@ -19,9 +20,17 @@ function initializeWebViewClient(): void {
 			return global.__native(this);
 		}
 
-		public shouldOverrideUrlLoading(view: android.webkit.WebView, url: any) {
+		public shouldOverrideUrlLoading(view: android.webkit.WebView, target: any) {
+			const url: string = target instanceof android.webkit.WebResourceRequest ? target.getUrl().toString() : target;
+
 			if (Trace.isEnabled()) {
 				Trace.write('WebViewClientClass.shouldOverrideUrlLoading(' + url + ')', Trace.categories.Debug);
+			}
+
+			// Handle schemes like mailto, tel, etc
+			if (!android.webkit.URLUtil.isNetworkUrl(url)) {
+				openUrl(url);
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Android WebView does not handle links with mailto or tel schemes.
WebView for iOS already supports this.
Example:
```html
<a href="mailto:webmaster@example.com">Contact Us</a>
```

## What is the new behavior?
Android WebView will handle any scheme provided there is an app that can handle it.
We make use of existing `openUrl` for this which is pretty convenient.