### PR TITLE
fix(core): CSS style not working properly in Android modal pages

### DIFF
--- a/packages/core/ui/styling/css-selector/index.ts
+++ b/packages/core/ui/styling/css-selector/index.ts
@@ -3,7 +3,7 @@ import { isCssVariable } from '../../core/properties';
 import { isNullOrUndefined } from '../../../utils/types';
 
 import * as cssParser from '../../../css';
-import { Combinator as ICombinator , SimpleSelectorSequence as ISimpleSelectorSequence, Selector as ISelector, SimpleSelector as ISimpleSelector, parseSelector} from '../../../css/parser';
+import { Combinator as ICombinator, SimpleSelectorSequence as ISimpleSelectorSequence, Selector as ISelector, SimpleSelector as ISimpleSelector, parseSelector } from '../../../css/parser';
 
 /**
  * An interface describing the shape of a type on which the selectors may apply.
@@ -11,6 +11,7 @@ import { Combinator as ICombinator , SimpleSelectorSequence as ISimpleSelectorSe
  */
 export interface Node {
 	parent?: Node;
+	_modalParent?: Node;
 
 	id?: string;
 	nodeName?: string;
@@ -384,7 +385,7 @@ export class Selector extends SelectorCore {
 				return !!node;
 			} else {
 				let ancestor = node;
-				while ((ancestor = ancestor.parent)) {
+				while ((ancestor = ancestor.parent ?? ancestor._modalParent)) {
 					if ((node = group.match(ancestor))) {
 						return true;
 					}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When app is set with force light mode settings, the styling on modal page is not working if having .ns-light identifier.

Please find the sample app and screen recording attached. (run npm i first)

Steps to reproduce:

    1) Tap on 'MODAL' actionbar item to show a modal page.
    2) Notice the 'Testing: 1' label on the modal page is in grey color even though on app.android.css, the Label type is styled as red color. 

https://user-images.githubusercontent.com/5738416/198552563-16423b62-1484-449c-8769-ea779b7673a1.mov

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

The css is being applied properly. 


Sample app:
[testPopoverModal.zip](https://github.com/NativeScript/NativeScript/files/9887022/testPopoverModal.zip)


