### PR TITLE
fix(webpack): close compiler after run

### DIFF
--- a/packages/webpack5/src/bin/index.ts
+++ b/packages/webpack5/src/bin/index.ts
@@ -150,7 +150,14 @@ program
 				webpackCompilationCallback
 			);
 		} else {
-			compiler.run(webpackCompilationCallback);
+			compiler.run((err, status) => {
+				compiler.close((err2) =>
+					webpackCompilationCallback(
+						(err || err2) as webpack.WebpackError,
+						status
+					)
+				);
+			});
 		}
 	});
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Webpack compiler is not closed, this breaks features that rely on the compiler shutdown hook (for example, caching). 

## What is the new behavior?
<!-- Describe the changes. -->

Now the compiler is closed after running, same behaviour as the webpack CLI.

https://github.com/webpack/webpack/blob/main/lib/webpack.js#L146-L150

Relevant comment about this: https://github.com/webpack/webpack/issues/12345#issuecomment-756099417

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

