### PR TITLE
chore(core): refactor android sdk version use

### DIFF
--- a/packages/core/accessibility/accessibility-service.android.ts
+++ b/packages/core/accessibility/accessibility-service.android.ts
@@ -73,7 +73,7 @@ function ensureStateListener(): SharedA11YObservable {
 	});
 	accessibilityManager.addAccessibilityStateChangeListener(accessibilityStateChangeListener);
 
-	if (android.os.Build.VERSION.SDK_INT >= 19) {
+	if (Utils.SDK_VERSION >= 19) {
 		touchExplorationStateChangeListener = new android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener({
 			onTouchExplorationStateChanged(enabled) {
 				updateAccessibilityState();

--- a/packages/core/accessibility/index.android.ts
+++ b/packages/core/accessibility/index.android.ts
@@ -1,5 +1,6 @@
 import * as Application from '../application';
 import { Trace } from '../trace';
+import { SDK_VERSION } from '../utils';
 import type { View } from '../ui/core/view';
 import { GestureTypes } from '../ui/gestures';
 import { notifyAccessibilityFocusState } from './accessibility-common';
@@ -52,7 +53,7 @@ function accessibilityEventHelper(view: Partial<View>, eventType: number) {
 			 * Android API >= 26 handles accessibility tap-events by converting them to TYPE_VIEW_CLICKED
 			 * These aren't triggered for custom tap events in NativeScript.
 			 */
-			if (android.os.Build.VERSION.SDK_INT >= 26) {
+			if (SDK_VERSION >= 26) {
 				// Find all tap gestures and trigger them.
 				for (const tapGesture of view.getGestureObservers(GestureTypes.tap) ?? []) {
 					tapGesture.callback({
@@ -169,7 +170,7 @@ function ensureNativeClasses() {
 			if (accessibilityRole) {
 				const androidClassName = RoleTypeMap.get(accessibilityRole);
 				if (androidClassName) {
-					const oldClassName = info.getClassName() || (android.os.Build.VERSION.SDK_INT >= 28 && host.getAccessibilityClassName()) || null;
+					const oldClassName = info.getClassName() || (SDK_VERSION >= 28 && host.getAccessibilityClassName()) || null;
 					info.setClassName(androidClassName);
 
 					if (Trace.isEnabled()) {
@@ -189,7 +190,7 @@ function ensureNativeClasses() {
 					info.setClickable(true);
 				}
 
-				if (android.os.Build.VERSION.SDK_INT >= 28) {
+				if (SDK_VERSION >= 28) {
 					if (accessibilityRole === AccessibilityRole.Header) {
 						if (Trace.isEnabled()) {
 							Trace.write(`onInitializeAccessibilityNodeInfo ${view} - set heading role=${accessibilityRole}`, Trace.categories.Accessibility);

--- a/packages/core/connectivity/index.android.ts
+++ b/packages/core/connectivity/index.android.ts
@@ -1,4 +1,5 @@
 import { android as androidApp, getNativeApplication } from '../application';
+import { SDK_VERSION } from '../utils';
 
 export enum connectionType {
 	none = 0,
@@ -69,7 +70,7 @@ function parseNetworkCapabilities(capabilities?: android.net.NetworkCapabilities
 }
 
 export function getConnectionType(): number {
-	if (android.os.Build.VERSION.SDK_INT >= 28) {
+	if (SDK_VERSION >= 28) {
 		return getNetworkCapabilities();
 	} else {
 		const activeNetworkInfo = getActiveNetworkInfo();
@@ -117,7 +118,7 @@ let networkCallback;
 let notifyCallback;
 
 export function startMonitoring(connectionTypeChangedCallback: (newConnectionType: number) => void): void {
-	if (android.os.Build.VERSION.SDK_INT >= 28) {
+	if (SDK_VERSION >= 28) {
 		const manager = getConnectivityManager();
 		if (manager) {
 			notifyCallback = (network: android.net.Network, networkCapabilities: android.net.NetworkCapabilities) => {
@@ -162,7 +163,7 @@ export function startMonitoring(connectionTypeChangedCallback: (newConnectionTyp
 }
 
 export function stopMonitoring(): void {
-	if (android.os.Build.VERSION.SDK_INT >= 28) {
+	if (SDK_VERSION >= 28) {
 		// @ts-ignore
 		const manager = getConnectivityManager();
 		if (manager && callback) {

--- a/packages/core/file-system/index.ts
+++ b/packages/core/file-system/index.ts
@@ -1,5 +1,6 @@
 import { IFileSystemAccess, FileSystemAccess, FileSystemAccess29 } from './file-system-access';
 import { Device } from '../platform';
+import { SDK_VERSION } from '../utils';
 // The FileSystemAccess implementation, used through all the APIs.
 let fileAccess: IFileSystemAccess;
 
@@ -9,7 +10,7 @@ let fileAccess: IFileSystemAccess;
  */
 export function getFileAccess(): IFileSystemAccess {
 	if (!fileAccess) {
-		if (global.isAndroid && parseInt(Device.sdkVersion) >= 29) {
+		if (global.isAndroid && SDK_VERSION >= 29) {
 			fileAccess = new FileSystemAccess29();
 		} else {
 			fileAccess = new FileSystemAccess();

--- a/packages/core/fps-meter/fps-native.android.ts
+++ b/packages/core/fps-meter/fps-native.android.ts
@@ -1,19 +1,17 @@
 import * as definition from './fps-native';
-import { Device } from '../platform';
+import { SDK_VERSION } from '../utils';
 
 export class FPSCallback implements definition.FPSCallback {
 	private impl: android.view.Choreographer.FrameCallback | ((nanos: number) => void);
 	private onFrame: (currentTimeMillis: number) => void;
 
 	public running: boolean;
-	sdkVersion: number;
 	nativeFramesSupported: boolean;
 	constructor(onFrame: (currentTimeMillis: number) => void) {
 		this.running = false;
 		this.onFrame = onFrame;
 
-		this.sdkVersion = parseInt(Device.sdkVersion);
-		this.nativeFramesSupported = this.sdkVersion >= 24 && this._isNativeFramesSupported();
+		this.nativeFramesSupported = SDK_VERSION >= 24 && this._isNativeFramesSupported();
 
 		if (this.nativeFramesSupported) {
 			this.impl = (nanos: number) => {

--- a/packages/core/platform/index.android.ts
+++ b/packages/core/platform/index.android.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:class-name */
 import { getNativeApplication, on, orientationChangedEvent, android as AndroidApplication } from '../application';
+import { SDK_VERSION } from '../utils';
 
 const MIN_TABLET_PIXELS = 600;
 
@@ -129,7 +130,7 @@ class DeviceRef {
 
 	get language(): string {
 		let defaultNativeLocale;
-		if (android.os.Build.VERSION.SDK_INT >= 24) {
+		if (SDK_VERSION >= 24) {
 			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().getLocales().get(0);
 		} else {
 			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().locale;
@@ -139,7 +140,7 @@ class DeviceRef {
 
 	get region(): string {
 		let defaultNativeLocale;
-		if (android.os.Build.VERSION.SDK_INT >= 24) {
+		if (SDK_VERSION >= 24) {
 			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().getLocales().get(0);
 		} else {
 			defaultNativeLocale = android.content.res.Resources.getSystem().getConfiguration().locale;

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"noEmitOnError": true,
+		"noEmitOnError": false,
 		"noEmitHelpers": true,
 		"declaration": true,
 		"noImplicitAny": false,

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"noEmitOnError": false,
+		"noEmitOnError": true,
 		"noEmitHelpers": true,
 		"declaration": true,
 		"noImplicitAny": false,

--- a/packages/core/ui/action-bar/index.android.ts
+++ b/packages/core/ui/action-bar/index.android.ts
@@ -8,16 +8,13 @@ import { ImageSource } from '../../image-source';
 import * as application from '../../application';
 import { isAccessibilityServiceEnabled, updateContentDescription } from '../../accessibility';
 import type { Background } from '../styling/background';
-import { Device } from '../../platform';
-import lazy from '../../utils/lazy';
+import { SDK_VERSION } from '../../utils';
 
 export * from './action-bar-common';
 
 const R_ID_HOME = 0x0102002c;
 const ACTION_ITEM_ID_OFFSET = 10000;
 const DEFAULT_ELEVATION = 4;
-
-const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
 
 let AppCompatTextView;
 let actionItemIdGenerator = ACTION_ITEM_ID_OFFSET;
@@ -64,8 +61,6 @@ function initializeMenuItemClickListener(): void {
 		return;
 	}
 
-	apiLevel = sdkVersion();
-
 	AppCompatTextView = androidx.appcompat.widget.AppCompatTextView;
 
 	@NativeClass
@@ -87,8 +82,6 @@ function initializeMenuItemClickListener(): void {
 	MenuItemClickListener = MenuItemClickListenerImpl;
 	appResources = application.android.context.getResources();
 }
-
-let apiLevel: number;
 
 export class ActionItem extends ActionItemBase {
 	private _androidPosition: AndroidActionItemSettings = {
@@ -223,7 +216,7 @@ export class ActionBar extends ActionBarBase {
 
 	public _applyBackground(background: Background, isBorderDrawable, onlyColor: boolean, backgroundDrawable: any) {
 		const nativeView = this.nativeViewProtected;
-		if (backgroundDrawable && onlyColor && sdkVersion() >= 21) {
+		if (backgroundDrawable && onlyColor && SDK_VERSION >= 21) {
 			if (isBorderDrawable && (<any>nativeView)._cachedDrawable) {
 				backgroundDrawable = (<any>nativeView)._cachedDrawable;
 				// we need to duplicate the drawable or we lose the "default" cached drawable
@@ -472,13 +465,13 @@ export class ActionBar extends ActionBarBase {
 	}
 
 	[androidContentInsetLeftProperty.setNative]() {
-		if (apiLevel >= 21) {
+		if (SDK_VERSION >= 21) {
 			this.nativeViewProtected.setContentInsetsAbsolute(this.effectiveContentInsetLeft, this.effectiveContentInsetRight);
 		}
 	}
 
 	[androidContentInsetRightProperty.setNative]() {
-		if (apiLevel >= 21) {
+		if (SDK_VERSION >= 21) {
 			this.nativeViewProtected.setContentInsetsAbsolute(this.effectiveContentInsetLeft, this.effectiveContentInsetRight);
 		}
 	}
@@ -493,9 +486,9 @@ export class ActionBar extends ActionBarBase {
 			return;
 		}
 
-		const originalFocusableState = android.os.Build.VERSION.SDK_INT >= 26 && nativeView.getFocusable();
+		const originalFocusableState = SDK_VERSION >= 26 && nativeView.getFocusable();
 		const originalImportantForAccessibility = nativeView.getImportantForAccessibility();
-		const originalIsAccessibilityHeading = android.os.Build.VERSION.SDK_INT >= 28 && nativeView.isAccessibilityHeading();
+		const originalIsAccessibilityHeading = SDK_VERSION >= 28 && nativeView.isAccessibilityHeading();
 
 		try {
 			nativeView.setFocusable(false);
@@ -513,7 +506,7 @@ export class ActionBar extends ActionBarBase {
 				childView.setFocusable(true);
 				if (childView instanceof androidx.appcompat.widget.AppCompatTextView) {
 					announceView = childView;
-					if (android.os.Build.VERSION.SDK_INT >= 28) {
+					if (SDK_VERSION >= 28) {
 						announceView.setAccessibilityHeading(true);
 					}
 				}
@@ -538,11 +531,11 @@ export class ActionBar extends ActionBarBase {
 					return;
 				}
 
-				if (android.os.Build.VERSION.SDK_INT >= 28) {
+				if (SDK_VERSION >= 28) {
 					nativeView.setAccessibilityHeading(originalIsAccessibilityHeading);
 				}
 
-				if (android.os.Build.VERSION.SDK_INT >= 26) {
+				if (SDK_VERSION >= 26) {
 					localNativeView.setFocusable(originalFocusableState);
 				}
 

--- a/packages/core/ui/animation/index.android.ts
+++ b/packages/core/ui/animation/index.android.ts
@@ -7,7 +7,7 @@ import { AnimationBase, Properties, CubicBezierAnimationCurve } from './animatio
 import { Color } from '../../color';
 import { Trace } from '../../trace';
 import { opacityProperty, backgroundColorProperty, rotateProperty, rotateXProperty, rotateYProperty, translateXProperty, translateYProperty, scaleXProperty, scaleYProperty, heightProperty, widthProperty, PercentLength } from '../styling/style-properties';
-import { layout } from '../../utils';
+import { SDK_VERSION, layout } from '../../utils';
 import { Device, Screen } from '../../platform';
 import lazy from '../../utils/lazy';
 
@@ -207,8 +207,8 @@ export class Animation extends AnimationBase {
 		return _resolveAnimationCurve(curve);
 	}
 
-	private _play(): void {
-		if (Device.sdkVersion <= '23') {
+	protected _play(): void {
+		if (SDK_VERSION <= 23) {
 			this._animatorSet = new android.animation.AnimatorSet();
 			this._animatorSet.addListener(this._animatorListener);
 		}

--- a/packages/core/ui/button/index.android.ts
+++ b/packages/core/ui/button/index.android.ts
@@ -6,19 +6,17 @@ import { CoreTypes } from '../../core-types';
 import { profile } from '../../profiling';
 import { TouchGestureEventData, GestureTypes, TouchAction } from '../gestures';
 import { Device } from '../../platform';
+import { SDK_VERSION } from '../../utils';
 import lazy from '../../utils/lazy';
 import type { Background } from '../styling/background';
 
 export * from './button-common';
-
-const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
 
 interface ClickListener {
 	new (owner: Button): android.view.View.OnClickListener;
 }
 
 let ClickListener: ClickListener;
-let APILEVEL: number;
 let AndroidButton: typeof android.widget.Button;
 
 function initializeClickListener(): void {
@@ -48,13 +46,6 @@ function initializeClickListener(): void {
 
 export class Button extends ButtonBase {
 	nativeViewProtected: android.widget.Button;
-
-	constructor() {
-		super();
-		if (!APILEVEL) {
-			APILEVEL = android.os.Build.VERSION.SDK_INT;
-		}
-	}
 
 	private _stateListAnimator: any;
 	private _highlightedHandler: (args: TouchGestureEventData) => void;
@@ -113,7 +104,7 @@ export class Button extends ButtonBase {
 	public resetNativeView(): void {
 		super.resetNativeView();
 
-		if (this._stateListAnimator && APILEVEL >= 21) {
+		if (this._stateListAnimator && SDK_VERSION >= 21) {
 			(<any>this.nativeViewProtected).setStateListAnimator(this._stateListAnimator);
 			this._stateListAnimator = undefined;
 		}
@@ -182,8 +173,7 @@ export class Button extends ButtonBase {
 	}
 
 	[zIndexProperty.setNative](value: number) {
-		// API >= 21
-		if (APILEVEL >= 21) {
+		if (SDK_VERSION >= 21) {
 			const nativeView = this.nativeViewProtected;
 			if (!this._stateListAnimator) {
 				this._stateListAnimator = (<any>nativeView).getStateListAnimator();
@@ -201,7 +191,7 @@ export class Button extends ButtonBase {
 	}
 
 	protected getDefaultElevation(): number {
-		if (sdkVersion() < 21) {
+		if (SDK_VERSION < 21) {
 			return 0;
 		}
 
@@ -212,7 +202,7 @@ export class Button extends ButtonBase {
 	}
 
 	protected getDefaultDynamicElevationOffset(): number {
-		if (sdkVersion() < 21) {
+		if (SDK_VERSION < 21) {
 			return 0;
 		}
 

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -50,8 +50,6 @@ const GRAVITY_FILL_HORIZONTAL = 7; // android.view.Gravity.FILL_HORIZONTAL
 const GRAVITY_CENTER_VERTICAL = 16; // android.view.Gravity.CENTER_VERTICAL
 const GRAVITY_FILL_VERTICAL = 112; // android.view.Gravity.FILL_VERTICAL
 
-const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
-
 const modalMap = new Map<number, DialogOptions>();
 
 let TouchListener: TouchListener;
@@ -848,7 +846,7 @@ export class View extends ViewCommon {
 		this.accessibilityRole = value;
 		updateAccessibilityProperties(this);
 
-		if (android.os.Build.VERSION.SDK_INT >= 28) {
+		if (Utils.SDK_VERSION >= 28) {
 			this.nativeViewProtected?.setAccessibilityHeading(value === AccessibilityRole.Header);
 		}
 	}
@@ -906,7 +904,7 @@ export class View extends ViewCommon {
 		return this.getDefaultElevation();
 	}
 	[androidElevationProperty.setNative](value: number) {
-		if (sdkVersion() < 21) {
+		if (Utils.SDK_VERSION < 21) {
 			return;
 		}
 
@@ -917,7 +915,7 @@ export class View extends ViewCommon {
 		return this.getDefaultDynamicElevationOffset();
 	}
 	[androidDynamicElevationOffsetProperty.setNative](value: number) {
-		if (sdkVersion() < 21) {
+		if (Utils.SDK_VERSION < 21) {
 			return;
 		}
 
@@ -925,7 +923,7 @@ export class View extends ViewCommon {
 	}
 
 	protected getDefaultElevation(): number {
-		if (sdkVersion() < 21) {
+		if (Utils.SDK_VERSION < 21) {
 			return 0;
 		}
 

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -1,14 +1,12 @@
 import { EditableTextBase as EditableTextBaseCommon, autofillTypeProperty, keyboardTypeProperty, returnKeyTypeProperty, editableProperty, autocapitalizationTypeProperty, autocorrectProperty, hintProperty, placeholderColorProperty, maxLengthProperty } from './editable-text-base-common';
 import { textTransformProperty, textProperty, resetSymbol } from '../text-base';
 import { Color } from '../../color';
-import { ad } from '../../utils';
+import { SDK_VERSION, ad } from '../../utils';
 import { CoreTypes } from '../../core-types';
 import { Device } from '../../platform';
 import lazy from '../../utils/lazy';
 
 export * from './editable-text-base-common';
-
-const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
 
 //https://github.com/NativeScript/NativeScript/issues/2942
 export let dismissKeyboardTimeoutId: NodeJS.Timer;
@@ -300,7 +298,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 	}
 
 	[autofillTypeProperty.setNative](value: CoreTypes.AutofillType) {
-		if (sdkVersion() < 26) {
+		if (SDK_VERSION < 26) {
 			return;
 		}
 		let newOptions;

--- a/packages/core/ui/html-view/index.android.ts
+++ b/packages/core/ui/html-view/index.android.ts
@@ -1,4 +1,5 @@
 ﻿import { Color } from '../../color';
+import { SDK_VERSION } from '../../utils';
 import { Font } from '../styling/font';
 import { colorProperty, fontSizeProperty, fontInternalProperty } from '../styling/style-properties';
 import { HtmlViewBase, htmlProperty, selectableProperty, linkColorProperty } from './html-view-common';
@@ -41,8 +42,7 @@ export class HtmlView extends HtmlViewBase {
 			mask = 0;
 		}
 		this.nativeViewProtected.setAutoLinkMask(mask);
-		const apiLevel = android.os.Build.VERSION.SDK_INT;
-		if (apiLevel >= 24) {
+		if (SDK_VERSION >= 24) {
 			this.nativeViewProtected.setText(<any>android.text.Html.fromHtml(value, android.text.Html.FROM_HTML_MODE_LEGACY));
 		} else {
 			this.nativeViewProtected.setText(<any>android.text.Html.fromHtml(value));

--- a/packages/core/ui/list-picker/index.android.ts
+++ b/packages/core/ui/list-picker/index.android.ts
@@ -6,8 +6,6 @@ import lazy from '../../utils/lazy';
 
 export * from './list-picker-common';
 
-const sdkVersion = lazy(() => parseInt(Device.sdkVersion));
-
 interface Formatter {
 	new (owner: ListPicker): android.widget.NumberPicker.Formatter;
 }

--- a/packages/core/ui/page/index.android.ts
+++ b/packages/core/ui/page/index.android.ts
@@ -4,7 +4,7 @@ import { View } from '../core/view';
 import { Color } from '../../color';
 import { ActionBar } from '../action-bar';
 import { GridLayout } from '../layouts/grid-layout';
-import { Device } from '../../platform';
+import { SDK_VERSION } from '../../utils';
 import { profile } from '../../profiling';
 import { AndroidAccessibilityEvent, getLastFocusedViewOnPage, isAccessibilityServiceEnabled } from '../../accessibility';
 
@@ -91,7 +91,7 @@ export class Page extends PageBase {
 		color: number;
 		systemUiVisibility: number;
 	} {
-		if (Device.sdkVersion >= '21') {
+		if (SDK_VERSION >= 21) {
 			const window = this.getClosestWindow();
 			const decorView = window.getDecorView();
 
@@ -104,7 +104,7 @@ export class Page extends PageBase {
 		return null;
 	}
 	[statusBarStyleProperty.setNative](value: 'dark' | 'light' | { color: number; systemUiVisibility: number }) {
-		if (Device.sdkVersion >= '21') {
+		if (SDK_VERSION >= 21) {
 			const window = this.getClosestWindow();
 			const decorView = window.getDecorView();
 
@@ -122,7 +122,7 @@ export class Page extends PageBase {
 	}
 
 	[androidStatusBarBackgroundProperty.getDefault](): number {
-		if (Device.sdkVersion >= '21') {
+		if (SDK_VERSION >= 21) {
 			const window = this.getClosestWindow();
 			return (<any>window).getStatusBarColor();
 		}
@@ -130,7 +130,7 @@ export class Page extends PageBase {
 		return null;
 	}
 	[androidStatusBarBackgroundProperty.setNative](value: number | Color) {
-		if (Device.sdkVersion >= '21') {
+		if (SDK_VERSION >= 21) {
 			const window = this.getClosestWindow();
 			const color = value instanceof Color ? value.android : value;
 			(<any>window).setStatusBarColor(color);

--- a/packages/core/ui/segmented-bar/index.android.ts
+++ b/packages/core/ui/segmented-bar/index.android.ts
@@ -3,7 +3,7 @@ import { SegmentedBarItemBase, SegmentedBarBase, selectedIndexProperty, itemsPro
 import { isEnabledProperty } from '../core/view';
 import { colorProperty, fontInternalProperty, fontSizeProperty } from '../styling/style-properties';
 import { Color } from '../../color';
-import { layout } from '../../utils';
+import { SDK_VERSION, layout } from '../../utils';
 
 export * from './segmented-bar-common';
 
@@ -24,7 +24,6 @@ interface TabHost {
 	new (context: android.content.Context, attrs: android.util.AttributeSet): android.widget.TabHost;
 }
 
-let apiLevel: number;
 let selectedIndicatorThickness: number;
 
 let TabHost: TabHost;
@@ -37,9 +36,8 @@ function initializeNativeClasses(): void {
 		return;
 	}
 
-	apiLevel = android.os.Build.VERSION.SDK_INT;
 	// Indicator thickness for material - 2dip. For pre-material - 5dip.
-	selectedIndicatorThickness = layout.toDevicePixels(apiLevel >= 21 ? 2 : 5);
+	selectedIndicatorThickness = layout.toDevicePixels(SDK_VERSION >= 21 ? 2 : 5);
 
 	@NativeClass
 	@Interfaces([android.widget.TabHost.OnTabChangeListener])
@@ -164,7 +162,7 @@ export class SegmentedBarItem extends SegmentedBarItemBase {
 		if (value instanceof Color) {
 			const color = value.android;
 			const backgroundDrawable = viewGroup.getBackground();
-			if (apiLevel > 21 && backgroundDrawable) {
+			if (SDK_VERSION > 21 && backgroundDrawable) {
 				const newDrawable = tryCloneDrawable(backgroundDrawable, nativeView.getResources());
 				newDrawable.setColorFilter(color, android.graphics.PorterDuff.Mode.SRC_IN);
 				viewGroup.setBackground(newDrawable);

--- a/packages/core/ui/styling/font.android.ts
+++ b/packages/core/ui/styling/font.android.ts
@@ -1,5 +1,6 @@
 import { Font as FontBase, parseFontFamily, genericFontFamilies, FontStyleType, FontWeight, FontWeightType } from './font-common';
 import { Trace } from '../../trace';
+import { SDK_VERSION } from '../../utils';
 import * as application from '../../application';
 import * as fs from '../../file-system';
 
@@ -144,10 +145,10 @@ function getFontWeightSuffix(fontWeight: FontWeightType): string {
 	}
 	switch (fontWeight) {
 		case FontWeight.THIN:
-			return android.os.Build.VERSION.SDK_INT >= 16 ? '-thin' : '';
+			return SDK_VERSION >= 16 ? '-thin' : '';
 		case FontWeight.EXTRA_LIGHT:
 		case FontWeight.LIGHT:
-			return android.os.Build.VERSION.SDK_INT >= 16 ? '-light' : '';
+			return SDK_VERSION >= 16 ? '-light' : '';
 		case FontWeight.NORMAL:
 		case '400':
 		case undefined:
@@ -155,13 +156,13 @@ function getFontWeightSuffix(fontWeight: FontWeightType): string {
 			return '';
 		case FontWeight.MEDIUM:
 		case FontWeight.SEMI_BOLD:
-			return android.os.Build.VERSION.SDK_INT >= 21 ? '-medium' : '';
+			return SDK_VERSION >= 21 ? '-medium' : '';
 		case FontWeight.BOLD:
 		case '700':
 		case FontWeight.EXTRA_BOLD:
 			return '';
 		case FontWeight.BLACK:
-			return android.os.Build.VERSION.SDK_INT >= 21 ? '-black' : '';
+			return SDK_VERSION >= 21 ? '-black' : '';
 		default:
 			throw new Error(`Invalid font weight: "${fontWeight}"`);
 	}

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -11,7 +11,7 @@ import { colorProperty, fontSizeProperty, fontInternalProperty, paddingLeftPrope
 import { FormattedString } from './formatted-string';
 import { Span } from './span';
 import { CoreTypes } from '../../core-types';
-import { layout } from '../../utils';
+import { SDK_VERSION, layout } from '../../utils';
 import { isString, isNullOrUndefined } from '../../utils/types';
 import { accessibilityIdentifierProperty } from '../../accessibility/accessibility-properties';
 import * as Utils from '../../utils';
@@ -298,7 +298,7 @@ export class TextBase extends TextBaseCommon {
 				this.nativeTextViewProtected.setGravity(android.view.Gravity.START | verticalGravity);
 				break;
 		}
-		if (android.os.Build.VERSION.SDK_INT >= 26) {
+		if (SDK_VERSION >= 26) {
 			if (value === 'justify') {
 				this.nativeTextViewProtected.setJustificationMode(android.text.Layout.JUSTIFICATION_MODE_INTER_WORD);
 			} else {

--- a/packages/core/ui/time-picker/index.android.ts
+++ b/packages/core/ui/time-picker/index.android.ts
@@ -1,4 +1,5 @@
 import { TimePickerBase, getValidTime, timeProperty, hourProperty, minuteProperty } from './time-picker-common';
+import { SDK_VERSION } from '../../utils';
 
 export * from './time-picker-common';
 
@@ -12,8 +13,6 @@ function initializeTimeChangedListener(): void {
 	if (TimeChangedListener) {
 		return;
 	}
-
-	apiLevel = android.os.Build.VERSION.SDK_INT;
 
 	@NativeClass
 	@Interfaces([android.widget.TimePicker.OnTimeChangedListener])
@@ -37,8 +36,6 @@ function initializeTimeChangedListener(): void {
 
 	TimeChangedListener = TimeChangedListenerImpl;
 }
-
-let apiLevel: number;
 
 export class TimePicker extends TimePickerBase {
 	nativeViewProtected: android.widget.TimePicker;
@@ -69,7 +66,7 @@ export class TimePicker extends TimePickerBase {
 	[minuteProperty.setNative](value: number) {
 		this.updatingNativeValue = true;
 		try {
-			if (apiLevel >= 23) {
+			if (SDK_VERSION >= 23) {
 				(<any>this.nativeViewProtected).setMinute(value);
 			} else {
 				this.nativeViewProtected.setCurrentMinute(new java.lang.Integer(value));
@@ -82,7 +79,7 @@ export class TimePicker extends TimePickerBase {
 	[hourProperty.setNative](value: number) {
 		this.updatingNativeValue = true;
 		try {
-			if (apiLevel >= 23) {
+			if (SDK_VERSION >= 23) {
 				(<any>this.nativeViewProtected).setHour(value);
 			} else {
 				this.nativeViewProtected.setCurrentHour(new java.lang.Integer(value));

--- a/packages/core/utils/index.android.ts
+++ b/packages/core/utils/index.android.ts
@@ -1,5 +1,5 @@
 import { ad } from './native-helper';
-import { Device } from '../platform';
+import { SDK_VERSION } from '../utils';
 import { FileSystemAccess } from '../file-system/file-system-access';
 import { Trace } from '../trace';
 
@@ -114,16 +114,15 @@ Applications cannot access internal storage of other application on Android (see
 		chooserIntent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
 
 		// Android SDK <28 only requires starting the chooser Intent straight forwardly
-		const sdkVersion = parseInt(Device.sdkVersion, 10);
-		if (sdkVersion && sdkVersion < MIN_URI_SHARE_RESTRICTED_APK_VERSION) {
-			Trace.write(`detected sdk version ${sdkVersion} (< ${MIN_URI_SHARE_RESTRICTED_APK_VERSION}), using simple openFile`, Trace.categories.Debug);
+		if (SDK_VERSION < MIN_URI_SHARE_RESTRICTED_APK_VERSION) {
+			Trace.write(`detected sdk version ${SDK_VERSION} (< ${MIN_URI_SHARE_RESTRICTED_APK_VERSION}), using simple openFile`, Trace.categories.Debug);
 			intent.setDataAndType(android.net.Uri.fromFile(new java.io.File(filePath)), mimeType);
 			context.startActivity(chooserIntent);
 
 			return true;
 		}
 
-		Trace.write(`detected sdk version ${sdkVersion} (>= ${MIN_URI_SHARE_RESTRICTED_APK_VERSION}), using URI openFile`, Trace.categories.Debug);
+		Trace.write(`detected sdk version ${SDK_VERSION} (>= ${MIN_URI_SHARE_RESTRICTED_APK_VERSION}), using URI openFile`, Trace.categories.Debug);
 
 		// Android SDK 24+ introduced file system permissions changes that disallow
 		// exposing URIs between applications

--- a/packages/core/utils/index.d.ts
+++ b/packages/core/utils/index.d.ts
@@ -9,6 +9,8 @@ export * from './native-helper';
 export const RESOURCE_PREFIX: string;
 export const FILE_PREFIX: string;
 
+export const SDK_VERSION: number;
+
 //@private
 /**
  * Used by various android event listener implementations.

--- a/packages/core/utils/layout-helper/index.android.ts
+++ b/packages/core/utils/layout-helper/index.android.ts
@@ -12,7 +12,7 @@ export function makeMeasureSpec(size: number, mode: number): number {
 	if (sdkVersion === undefined) {
 		// check whether the old layout is needed
 		sdkVersion = ad.getApplicationContext().getApplicationInfo().targetSdkVersion;
-		useOldMeasureSpec = sdkVersion <= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
+		useOldMeasureSpec = sdkVersion <= 17;
 	}
 
 	if (useOldMeasureSpec) {

--- a/packages/core/utils/utils-common.ts
+++ b/packages/core/utils/utils-common.ts
@@ -4,6 +4,7 @@ import { sanitizeModuleName } from '../ui/builder/module-name-sanitizer';
 import * as layout from './layout-helper';
 
 import { GC } from './index';
+import { Device } from '../platform';
 
 export { layout };
 export * from './mainthread-helper';
@@ -191,3 +192,5 @@ export function queueGC(delay = 900, useThrottle?: boolean) {
 		debouncedGC.get(delay)();
 	}
 }
+
+export const SDK_VERSION = parseInt(Device.sdkVersion, 10);


### PR DESCRIPTION
I refactored it all so that we always use the same variable and stop constantly accessing `android.os.Build`
On change i made also was to not use lazy. I did not see any issue locally but maybe i missed something. I dont know why we were using it here