### PR TITLE
fix(android): ApplicationSettings not returning precise stored numbers

### DIFF
--- a/packages/core/application-settings/index.android.ts
+++ b/packages/core/application-settings/index.android.ts
@@ -41,7 +41,8 @@ export function getString(key: string, defaultValue?: string): string {
 export function getNumber(key: string, defaultValue?: number): number {
 	verify(key);
 	if (hasKey(key)) {
-		return sharedPreferences.getFloat(key, float(0.0));
+		// SharedPreferences has no getter or setter for double so use long instead
+		return java.lang.Double.longBitsToDouble(sharedPreferences.getLong(key, long(0)));
 	}
 
 	return defaultValue;
@@ -68,7 +69,8 @@ export function setNumber(key: string, value: number): void {
 	verify(key);
 	common.ensureValidValue(value, 'number');
 	const editor = sharedPreferences.edit();
-	editor.putFloat(key, float(value));
+	// SharedPreferences has no getter or setter for double so use long instead
+	editor.putLong(key, java.lang.Double.doubleToRawLongBits(double(value)));
 	editor.apply();
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
`ApplicationSettings.getNumber` does not return the precise value of a stored number. That is because `setNumber` uses `SharedPreferences.putFloat` inside and float is 32-bit.

To reproduce
```js
ApplicationSettings.setNumber("timestamp", 1668478505);
console.log(ApplicationSettings.getNumber("timestamp")); // Returns 1668478464
```
## What is the new behavior?
`ApplicationSettings.setNumber` will store the precise value and return it as double.

Issue: https://discord.com/channels/603595811204366337/828973479343947787/1041908934266589195