### PR TITLE
fix(ios/utils): filter out null values from dataSerialize

### DIFF
--- a/packages/core/utils/native-helper.ios.ts
+++ b/packages/core/utils/native-helper.ios.ts
@@ -92,14 +92,15 @@ export function dataSerialize(data: any, wrapPrimitives: boolean = false) {
 			}
 
 			if (Array.isArray(data)) {
-				return NSArray.arrayWithArray((<any>data).map(dataSerialize));
+				return NSArray.arrayWithArray(data.map((el) => dataSerialize(el, wrapPrimitives)).filter((el) => el !== null));
 			}
 
-			let node = {} as any;
-			Object.keys(data).forEach(function (key) {
-				let value = data[key];
-				node[key] = dataSerialize(value, wrapPrimitives);
-			});
+			const node = Object.fromEntries(
+				Object.entries(data)
+					.map(([key, value]) => [key, dataSerialize(value, wrapPrimitives)])
+					.filter(([, value]) => value !== null)
+			);
+
 			return NSDictionary.dictionaryWithDictionary(node);
 		}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`dataSerialize` method fails on iOS when there's an array with null/undefined elements and when objects have null/undefined prop values. 

With this PR the null elements are filtered out of arrays and dictionaries.

This PR also fixes a slight oversight with `data.map(serialize)`, since this syntax causes the second argument to be the element index instead of `wrapPrimitives`, causing the first element not to be wrapped and all the others to be.

```ts
dataSerialize([ null, undefined ]);
// Error: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[0] Error: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]

dataSerialize({ someProp: null, otherProp: undefined });
// Error: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0] Error: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
```

## What is the new behavior?
<!-- Describe the changes. -->

`null`s are filtered out and don't cause exceptions on iOS

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

This is pretty much the same issue as https://github.com/NativeScript/firebase/pull/142