### PR TITLE
fix(core): update metadata filtering for IOS 16

### DIFF
--- a/packages/core/platforms/ios/native-api-usage.json
+++ b/packages/core/platforms/ios/native-api-usage.json
@@ -3,7 +3,8 @@
     "CoreFoundation.CFError:*",
     "CoreFoundation.CFNumber:*",
     "CoreFoundation.CFRunLoop:*",
-
+    "CoreFoundation.CFCGTypes:",
+    
     "CoreGraphics.*:*",
 
     "CoreText.CTFontManager:*",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Enabling metadata filtering crashes a simple app on latest xcode/IOS 16.

## What is the new behavior?
<!-- Describe the changes. -->

Adds an extra entry to allow enabling of metadata filtering in IOS 16.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

