### PR TITLE
fix(listview): remove ios delegate set to null

### DIFF
--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -287,11 +287,6 @@ export class ListView extends ListViewBase {
 		this.ios.delegate = this._delegate;
 	}
 
-	public onUnloaded() {
-		this.ios.delegate = null;
-		super.onUnloaded();
-	}
-
 	// @ts-ignore
 	get ios(): UITableView {
 		return this.nativeViewProtected;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ListView` gets set to null in some cases on iOS. This caused the template to break and white screen.  

## What is the new behavior?
<!-- Describe the changes. -->

The onUnloaded() has been removed as it was the reason ListView was returning null.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

