### PR TITLE
fix(core/ios): box shadow value border radius

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -736,11 +736,13 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 	);
 
 	// this should match the view's border radius
-    let cornerRadius = view.style.borderRadius;
-    if (typeof view.style.borderRadius !== 'number') {
-        cornerRadius = Length.toDevicePixels(<CoreTypes.LengthType>view.style.borderRadius, 0.0);
-    }
-	
+	let cornerRadius: number;
+	if (typeof view.style.borderRadius !== 'number') {
+		cornerRadius = Length.toDevicePixels(<CoreTypes.LengthType>view.style.borderRadius, 0.0);
+	} else {
+		cornerRadius = view.style.borderRadius;
+	}
+
 	// apply spreadRadius by expanding shadow layer bounds
 	// prettier-ignore
 	const bounds = CGRectInset(nativeView.bounds,

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -736,8 +736,11 @@ function drawBoxShadow(nativeView: NativeScriptUIView, view: View, boxShadow: CS
 	);
 
 	// this should match the view's border radius
-	const cornerRadius = Length.toDevicePixels(<CoreTypes.LengthType>view.style.borderRadius, 0.0);
-
+    let cornerRadius = view.style.borderRadius;
+    if (typeof view.style.borderRadius !== 'number') {
+        cornerRadius = Length.toDevicePixels(<CoreTypes.LengthType>view.style.borderRadius, 0.0);
+    }
+	
 	// apply spreadRadius by expanding shadow layer bounds
 	// prettier-ignore
 	const bounds = CGRectInset(nativeView.bounds,


### PR DESCRIPTION
Without these changes the border with box-shadow was not visible, now the border is clearly visible. The problem when it is a number is that it enters here: https://github.com/NativeScript/NativeScript/blob/main/packages/core/ui/styling/style-properties.ts#L78 and the resulting number is much greater than the edge and the view is lost

Without changes
<img width="443" alt="image" src="https://user-images.githubusercontent.com/15719383/208948189-d8c8ef54-9cb0-49e4-9abd-6d182b416804.png">

<img width="389" alt="image" src="https://user-images.githubusercontent.com/15719383/209018455-b7181dc9-1881-404f-856a-876481e9d0d5.png">



With changes:
<img width="439" alt="image" src="https://user-images.githubusercontent.com/15719383/208948108-8752ad6c-c3a9-43a1-b03d-59b47bbc2233.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/15719383/209018914-20ecac93-9d53-4e68-ae59-d55562634062.png">

