### PR TITLE
docs: Fix a few typos

### DIFF
--- a/apps/automated/src/ui/web-view/web-view.md
+++ b/apps/automated/src/ui/web-view/web-view.md
@@ -34,4 +34,4 @@ Using a WebView requires the web-view module.
 
 {%snippet web-view-loaded%}
 
->Note: to be able to use gestures in `WebView` component on Android, we should first disabled the zoom control. To do that we could access the `android` property and with the help of  `setDisplayZoomControls` to set this controll to `false`.
+>Note: to be able to use gestures in `WebView` component on Android, we should first disabled the zoom control. To do that we could access the `android` property and with the help of  `setDisplayZoomControls` to set this control to `false`.

--- a/tools/notes/DevelopmentWorkflow.md
+++ b/tools/notes/DevelopmentWorkflow.md
@@ -48,7 +48,7 @@ npx nx run core:test --watch
 
 ### Isolate tests by name
 
-Run a single test by it's decribe name, for example to run just the `xml/index.spec.ts`, the describe block is named `XmlParser` therefore:
+Run a single test by it's describe name, for example to run just the `xml/index.spec.ts`, the describe block is named `XmlParser` therefore:
 
 ```
 npx nx run core:test --watch -t 'XmlParser' 


### PR DESCRIPTION
There are small typos in:
- apps/automated/src/ui/web-view/web-view.md
- tools/notes/DevelopmentWorkflow.md

Fixes:
- Should read `describe` rather than `decribe`.
- Should read `control` rather than `controll`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md