### PR TITLE
fix: don't run layout on viewSafeAreaInsetsDidChange until the first viewDidLayoutSubviews

### DIFF
--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -74,6 +74,7 @@ class UIViewControllerImpl extends UIViewController {
 
 	public isBackstackSkipped: boolean;
 	public isBackstackCleared: boolean;
+	private didFirstLayout: boolean;
 	// this is initialized in initWithOwner since the constructor doesn't run on native classes
 	private _isRunningLayout: number;
 	private get isRunningLayout() {
@@ -84,6 +85,7 @@ class UIViewControllerImpl extends UIViewController {
 	}
 	private finishRunningLayout() {
 		this._isRunningLayout--;
+		this.didFirstLayout = true;
 	}
 	private runLayout(cb: () => void) {
 		try {
@@ -98,6 +100,7 @@ class UIViewControllerImpl extends UIViewController {
 		const controller = <UIViewControllerImpl>UIViewControllerImpl.new();
 		controller._owner = owner;
 		controller._isRunningLayout = 0;
+		controller.didFirstLayout = false;
 
 		return controller;
 	}
@@ -125,7 +128,7 @@ class UIViewControllerImpl extends UIViewController {
 			const isBack = isBackNavigationTo(owner, newEntry);
 			owner.onNavigatingTo(newEntry.entry.context, isBack, newEntry.entry.bindingContext);
 		}
-		
+
 		if (frame) {
 			if (!owner.parent) {
 				owner._frame = frame;
@@ -276,7 +279,7 @@ class UIViewControllerImpl extends UIViewController {
 
 	public viewSafeAreaInsetsDidChange(): void {
 		super.viewSafeAreaInsetsDidChange();
-		if (this.isRunningLayout) {
+		if (this.isRunningLayout || !this.didFirstLayout) {
 			return;
 		}
 		const owner = this._owner?.deref();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
My previous change was specifically to re-layout the views once the safe area insets change. The issue is that `viewSafeAreaInsetsDidChange` fires before `viewDidLayoutSubviews`. This shouldn't be a problem, as we're just doing an extra layout pass, but for some reason is.

## What is the new behavior?
We wait for the first `viewDidLayoutSubviews` to run before dispatching layout calls on `viewSafeAreaInsetsDidChange` 

Fixes #10149.
