### PR TITLE
fix(ios): prevent transitionCoordinator usage during modal presentation

### DIFF
--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -118,7 +118,9 @@ export class Frame extends FrameBase {
 		if (!this._currentEntry) {
 			// Update action-bar with disabled animations before the initial navigation.
 			this._updateActionBar(backstackEntry.resolvedPage, true);
-			this.pushViewControllerAnimated(viewController, animated);
+			// Core defaults modalPresentationStyle to 1 for standard frame navigation
+			// for all others, it's modal presentation
+			this.pushViewControllerAnimated(viewController, animated, this._ios?.controller?.modalPresentationStyle !== 1);
 			if (Trace.isEnabled()) {
 				Trace.write(`${this}.pushViewControllerAnimated(${viewController}, ${animated}); depth = ${navDepth}`, Trace.categories.Navigation);
 			}
@@ -180,13 +182,14 @@ export class Frame extends FrameBase {
 		}
 	}
 
-	private pushViewControllerAnimated(viewController: UIViewController, animated: boolean) {
+	private pushViewControllerAnimated(viewController: UIViewController, animated: boolean, isModal: boolean) {
 		let transitionCoordinator = this._ios.controller.transitionCoordinator;
-		if (transitionCoordinator) {
+		if (!isModal && transitionCoordinator) {
 			transitionCoordinator.animateAlongsideTransitionCompletion(null, () => {
 				this._ios.controller.pushViewControllerAnimated(viewController, animated);
 			});
 		} else {
+			// modal should always push immediately without transition coordinator
 			this._ios.controller.pushViewControllerAnimated(viewController, animated);
 		}
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Frame usage within a modal would cause content to be blank until fully opened.

## What is the new behavior?

Frame usage within a modal now works as expected.

closes https://github.com/NativeScript/NativeScript/issues/10115