### PR TITLE
fix(mac): utils for mac catalyst

### DIFF
--- a/packages/core/platforms/ios/src/NativeScriptUtils.m
+++ b/packages/core/platforms/ios/src/NativeScriptUtils.m
@@ -49,8 +49,11 @@
 
             BOOL actualItalic = result.fontDescriptor.symbolicTraits & UIFontDescriptorTraitItalic;
             if ([[font valueForKey:@"isItalic"] boolValue] && !actualItalic) {
+                #if TARGET_OS_MACCATALYST
+                #else
                 // The font we got is not actually italic so emulate that with a matrix
                 result = [UIFont fontWithDescriptor:[descriptor fontDescriptorWithMatrix:CGAffineTransformMake(1, 0, 0.2, 1, 0, 0)] size:size];
+                #endif
             }
 
             // Check if the resolved font has the correct font-family


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Building for Catalyst would throw error on invalid api.

## What is the new behavior?

Building for Catalyst works.

