### PR TITLE
feat(core): new autoFillTypes

### DIFF
--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -50,6 +50,9 @@ export namespace CoreTypes {
 	export module AutofillType {
 		export const username = 'username';
 		export const password = 'password';
+		export const newUsername = 'newUsername';
+		export const newPassword = 'newPassword';
+		export const oneTimeCode = 'oneTimeCode';
 		export const none = 'none';
 	}
 

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -269,6 +269,15 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			case 'password':
 				newOptions = 'password'; // android.view.View.AUTOFILL_HINT_PASSWORD
 				break;
+			case 'newPassword':
+				newOptions = 'newPassword'; // android.view.View.AUTOFILL_HINT_NEW_PASSWORD
+				break;
+			case 'newUsername':
+				newOptions = 'newUsername'; // android.view.View.AUTOFILL_HINT_NEW_USERNAME
+				break;
+			case 'oneTimeCode':
+				newOptions = '2faAppOTPCode'; // android.view.View.AUTOFILL_HINT_2FA_APP_OTP
+				break;
 			case 'none':
 				newOptions = null;
 				break;

--- a/packages/core/ui/editable-text-base/index.ios.ts
+++ b/packages/core/ui/editable-text-base/index.ios.ts
@@ -96,6 +96,12 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 			case 'password':
 				newTextContentType = UITextContentTypePassword;
 				break;
+			case 'newPassword':
+				newTextContentType = UITextContentTypeNewPassword;
+				break;
+			case 'oneTimeCode':
+				newTextContentType = UITextContentTypeOneTimeCode;
+				break;
 			case 'none':
 				newTextContentType = null;
 			default:


### PR DESCRIPTION
Add new autoFillTypes:
* for `oneTimeCode` on android i chose `AUTOFILL_HINT_2FA_APP_OTP` but there is also sms and email otp. Not 100% sure which one to choose
* `UITextContentTypeNewPassword` was added in iOS 12. Do we need a check for ios version?