### PR TITLE
fix(android): Method openUrl failed to handle urls

### DIFF
--- a/packages/core/utils/index.android.ts
+++ b/packages/core/utils/index.android.ts
@@ -22,20 +22,11 @@ export function openUrl(location: string): boolean {
 	const context = ad.getApplicationContext();
 	try {
 		const intent = new android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(location.trim()));
-		const packageManager =  context.getPackageManager();
-
 		intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
-
-		// Handle schemes like mailto, tel, etc
-		if (intent.resolveActivity(packageManager) == null) {
-			Trace.write('Unable to open ' + location + '. Make sure to add queries element(https://developer.android.com/guide/topics/manifest/queries-element) matching the scheme to the AndroidManifest.xml file.', Trace.categories.Error, Trace.messageType.error);
-			return false;
-		}
-
 		context.startActivity(intent);
 	} catch (e) {
-		// We Don't do anything with an error.  We just output it
-		Trace.write('Error in OpenURL', Trace.categories.Error, Trace.messageType.error);
+		// We don't do anything with an error. We just output it
+		Trace.write(`Failed to start activity for handling URL: ${location}`, Trace.categories.Error, Trace.messageType.error);
 
 		return false;
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Method `openUrl` fails to handle certain http/https schemas (e.g. YouTube links).

## What is the new behavior?
This patch partially reverts changes in #10148 as they triggered this problem.
We could start adding checks for http/https schemas but we really don't have to make it too complicated.
@prabudevarrajan You should face no problems as your change in `WebView` is sufficient for fixing your bug. You can also try and let us know.

Fixes: https://discord.com/channels/603595811204366337/603595811720527881/1060924012919799888