### PR TITLE
fix(ios): embedder usage of window

### DIFF
--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -166,7 +166,7 @@ export class iOSApplication implements iOSApplicationDefinition {
 
 	get rootController(): UIViewController {
 		if (NativeScriptEmbedder.sharedInstance().delegate && !this._window) {
-			this._window = UIApplication.sharedApplication.delegate.window;
+			this._window = UIApplication.sharedApplication.keyWindow;
 		}
 		return this._window.rootViewController;
 	}
@@ -254,7 +254,7 @@ export class iOSApplication implements iOSApplicationDefinition {
 				this.setWindowContent(args.root);
 			}
 		} else {
-			this._window = UIApplication.sharedApplication.delegate.window;
+			this._window = UIApplication.sharedApplication.keyWindow;
 		}
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Embedding NativeScript into existing native project will use the wrong root window.

## What is the new behavior?

Embedding NativeScript into existing native project will use the correct root window.

@tdermendjiev 
