### PR TITLE
fix(webpack): fix regex for PlatformSuffixPlugin

### DIFF
--- a/packages/webpack5/src/plugins/PlatformSuffixPlugin.ts
+++ b/packages/webpack5/src/plugins/PlatformSuffixPlugin.ts
@@ -34,7 +34,7 @@ export class PlatformSuffixPlugin {
 	}
 
 	apply(compiler: any) {
-		const platformRE = new RegExp(`\.${this.platform}\.`);
+		const platformRE = new RegExp(`\\.${this.platform}\\.`);
 
 		// require.context
 		compiler.hooks.contextModuleFactory.tap(id, (cmf) => {


### PR DESCRIPTION
In this sintax there is the need to escape the backslash in order to escape the . of the regex. In this way '.android.' will be replaced, and not *android* (* stands for character before and after android)

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
`./shared/androidTestClass.ts` will be replaced with `./shared.estClass.ts` (here is the bug)
`./shared/testClass.android` will be replaced with `./shared/testClass.ts` (as it should be)

## What is the new behavior?
`./shared/androidTestClass.ts` will remain `./shared/androidTestClass.ts` (so it's right)
`./shared/testClass.android` will be replaced with `./shared/testClass.ts` (as it was before)

The same is applied to `ios`.

Fixes/Implements/Closes #10168.

