### PR TITLE
fix (ios-view): resolves race condition when setting preferredContentSize on view controller

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -485,7 +485,7 @@ export class View extends ViewCommon implements ViewDefinition {
 
 						//TODO: only numeric value is supported, percentage value is not supported like Android
 						if (w > 0 && h > 0) {
-							controller.preferredContentSize = CGSizeMake(w, h);
+							this.viewController.preferredContentSize = CGSizeMake(w, h);
 						}
 					}
 

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -479,7 +479,7 @@ export class View extends ViewCommon implements ViewDefinition {
 			} else {
 				//use CSS & attribute width & height if option is not provided
 				const handler = () => {
-					if (controller) {
+					if (this.viewController) {
 						const w = <number>(this.width || this.style.width);
 						const h = <number>(this.height || this.style.height);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
A race condition exists when showing a view modally on ios if that view has been assigned width and height.  In `_showNativeModalView` (@nativescript/core/ui/core/view/index.ios.ts, 459) `const controller` is assigned the value `this.viewController`. In the `handler` callback created on line 481, the width/height from the view are assigned to the `preferredContentSize` of the `controller`. However at the conclusion of `_showNativeModalView`, the `controller` variable is released, creating a race condition for the handler.

## What is the new behavior?
Making the perferredContentSize assignment on `this.viewController` instead of `controller` avoids a race condition.


