### PR TITLE
fix(ios): race conditions with nativeView

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -193,11 +193,13 @@ function setUIColorFromImage(view: View, nativeView: UIView, callback: (uiColor:
 		bitmap = imageSource && imageSource.ios;
 	} else if (imageUri.indexOf('http') !== -1) {
 		style[symbolUrl] = imageUri;
-		ImageSource.fromUrl(imageUri).then((r) => {
-			if (style && style[symbolUrl] === imageUri) {
-				uiColorFromImage(r.ios, view, callback, flip);
-			}
-		});
+		ImageSource.fromUrl(imageUri)
+			.then((r) => {
+				if (style && style[symbolUrl] === imageUri) {
+					uiColorFromImage(r.ios, view, callback, flip);
+				}
+			})
+			.catch(() => {});
 	}
 
 	uiColorFromImage(bitmap, view, callback, flip);
@@ -360,7 +362,7 @@ function getDrawParams(this: void, image: UIImage, background: BackgroundDefinit
 function uiColorFromImage(img: UIImage, view: View, callback: (uiColor: UIColor) => void, flip?: boolean): void {
 	const background = view.style.backgroundInternal;
 
-	if (!img) {
+	if (!img || !view.nativeViewProtected) {
 		callback(background.color && background.color.ios);
 
 		return;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Under various view navigation conditions, anything from background-image css handling to processing of the nativeView can trigger with view bindings at times which lead to race conditions when the nativeView would have been destroyed and crashes such as:

```
  Unhandled Promise rejection: Cannot read property 'frame' of null ; Zone: <root> ; Task: Promise.then ; Value: TypeError: Cannot read property 'frame' of null TypeError: Cannot read property 'frame' of null
  at uiColorFromImage (file: node_modules/@nativescript/core/ui/styling/background.ios.js:317:0)
  at file: node_modules/@nativescript/core/ui/styling/background.ios.js:167:0
```

## What is the new behavior?

iOS stability across broader diverse project/layout binding setups. Under all these types of cases, the existence of `nativeView` does not matter at all and should be ignored.

