### PR TITLE
Generic events

### DIFF
--- a/packages/core/accessibility/accessibility-common.ts
+++ b/packages/core/accessibility/accessibility-common.ts
@@ -28,7 +28,7 @@ export function notifyAccessibilityFocusState(view: View, receivedFocus: boolean
 		eventName: accessibilityFocusChangedEvent,
 		object: view,
 		value: !!receivedFocus,
-	} as EventDataValue);
+	});
 
 	if (receivedFocus) {
 		if (view.page) {
@@ -38,12 +38,12 @@ export function notifyAccessibilityFocusState(view: View, receivedFocus: boolean
 		view.notify({
 			eventName: accessibilityFocusEvent,
 			object: view,
-		} as EventData);
+		});
 	} else if (lostFocus) {
 		view.notify({
 			eventName: accessibilityBlurEvent,
 			object: view,
-		} as EventData);
+		});
 	}
 }
 

--- a/packages/core/accessibility/accessibility-types.ts
+++ b/packages/core/accessibility/accessibility-types.ts
@@ -1,4 +1,4 @@
-import type { EventData } from '../data/observable';
+import type { EventData, Observable } from '../data/observable';
 
 export enum AccessibilityTrait {
 	/**
@@ -264,7 +264,7 @@ export enum AndroidAccessibilityEvent {
 	ALL_MASK = 'all',
 }
 
-export interface AccessibilityEventPerformEscape extends EventData {
+export interface AccessibilityEventPerformEscape<T extends Observable = Observable> extends EventData<T> {
 	cancel?: boolean;
 }
 

--- a/packages/core/application/application-interfaces.ts
+++ b/packages/core/application/application-interfaces.ts
@@ -1,5 +1,5 @@
 // Types
-import { EventData } from '../data/observable';
+import { EventData, Observable } from '../data/observable';
 import { View } from '../ui/core/view';
 
 /**
@@ -12,7 +12,7 @@ export interface NativeScriptError extends Error {
 	nativeError: any;
 }
 
-export interface ApplicationEventData extends EventData {
+export interface ApplicationEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * UIApplication or undefined, unless otherwise specified. Prefer explicit
 	 * properties where possible.
@@ -34,7 +34,7 @@ export interface ApplicationEventData extends EventData {
 	object: any;
 }
 
-export interface LaunchEventData extends ApplicationEventData {
+export interface LaunchEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	/**
 	 * The value stored into didFinishLaunchingWithOptions notification's
 	 * userInfo under 'UIApplicationLaunchOptionsLocalNotificationKey';
@@ -45,57 +45,57 @@ export interface LaunchEventData extends ApplicationEventData {
 	savedInstanceState?: any /* android.os.Bundle */;
 }
 
-export interface OrientationChangedEventData extends ApplicationEventData {
+export interface OrientationChangedEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	android: any /* globalAndroid.app.Application */;
 	newValue: 'portrait' | 'landscape' | 'unknown';
 }
 
-export interface SystemAppearanceChangedEventData extends ApplicationEventData {
+export interface SystemAppearanceChangedEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	android: any /* globalAndroid.app.Application */;
 	newValue: 'light' | 'dark';
 }
 
-export interface UnhandledErrorEventData extends ApplicationEventData {
+export interface UnhandledErrorEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	ios?: NativeScriptError;
 	android?: NativeScriptError;
 	error: NativeScriptError;
 }
 
-export interface DiscardedErrorEventData extends ApplicationEventData {
+export interface DiscardedErrorEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	error: NativeScriptError;
 }
 
-export interface CssChangedEventData extends ApplicationEventData {
+export interface CssChangedEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	cssFile?: string;
 	cssText?: string;
 }
 
-export interface AndroidActivityEventData extends ApplicationEventData {
+export interface AndroidActivityEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	activity: any /* androidx.appcompat.app.AppCompatActivity */;
 	object: any /* AndroidApplication */;
 }
 
-export interface AndroidActivityBundleEventData extends AndroidActivityEventData {
+export interface AndroidActivityBundleEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	bundle: any /* android.os.Bundle */;
 }
 
-export interface AndroidActivityRequestPermissionsEventData extends AndroidActivityEventData {
+export interface AndroidActivityRequestPermissionsEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	requestCode: number;
 	permissions: Array<string>;
 	grantResults: Array<number>;
 }
 
-export interface AndroidActivityResultEventData extends AndroidActivityEventData {
+export interface AndroidActivityResultEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	requestCode: number;
 	resultCode: number;
 	intent: any /* android.content.Intent */;
 }
 
-export interface AndroidActivityNewIntentEventData extends AndroidActivityEventData {
+export interface AndroidActivityNewIntentEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	intent: any /* android.content.Intent */;
 }
 
-export interface AndroidActivityBackPressedEventData extends AndroidActivityEventData {
+export interface AndroidActivityBackPressedEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	cancel: boolean;
 }
 
@@ -106,6 +106,6 @@ export interface RootViewControllerImpl {
 	contentController: any;
 }
 
-export interface LoadAppCSSEventData extends ApplicationEventData {
+export interface LoadAppCSSEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	cssFile: string;
 }

--- a/packages/core/application/application-interfaces.ts
+++ b/packages/core/application/application-interfaces.ts
@@ -71,8 +71,22 @@ export interface CssChangedEventData<T extends Observable = Observable> extends 
 }
 
 export interface AndroidActivityEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
-	activity: any /* androidx.appcompat.app.AppCompatActivity */;
-	object: any /* AndroidApplication */;
+	/**
+	 * The activity.
+	 * androidx.appcompat.app.AppCompatActivity
+	 */
+	activity: any;
+
+	/**
+	 * The name of the event.
+	 */
+	eventName: string;
+
+	/**
+	 * The instance that has raised the event.
+	 * AndroidApplication
+	 */
+	object: T;
 }
 
 export interface AndroidActivityBundleEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {

--- a/packages/core/application/index.android.ts
+++ b/packages/core/application/index.android.ts
@@ -163,18 +163,18 @@ export class AndroidApplication extends Observable implements AndroidApplication
 // HACK: We declare all these 'on' statements, so that they can appear in the API reference
 // HACK: Do we need this? Is it useful? There are static fields to the AndroidApplication class for the event names.
 export interface AndroidApplication {
-	on(eventNames: string, callback: (data: AndroidActivityEventData) => void, thisArg?: any): void;
-	on(event: 'activityCreated', callback: (args: AndroidActivityBundleEventData) => void, thisArg?: any): void;
-	on(event: 'activityDestroyed', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
-	on(event: 'activityStarted', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
-	on(event: 'activityPaused', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
-	on(event: 'activityResumed', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
-	on(event: 'activityStopped', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
-	on(event: 'saveActivityState', callback: (args: AndroidActivityBundleEventData) => void, thisArg?: any): void;
-	on(event: 'activityResult', callback: (args: AndroidActivityResultEventData) => void, thisArg?: any): void;
-	on(event: 'activityBackPressed', callback: (args: AndroidActivityBackPressedEventData) => void, thisArg?: any): void;
-	on(event: 'activityNewIntent', callback: (args: AndroidActivityNewIntentEventData) => void, thisArg?: any): void;
-	on(event: 'activityRequestPermissions', callback: (args: AndroidActivityRequestPermissionsEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: AndroidActivityEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityCreated', callback: (args: AndroidActivityBundleEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityDestroyed', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityStarted', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityPaused', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityResumed', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityStopped', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'saveActivityState', callback: (args: AndroidActivityBundleEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityResult', callback: (args: AndroidActivityResultEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityBackPressed', callback: (args: AndroidActivityBackPressedEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityNewIntent', callback: (args: AndroidActivityNewIntentEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityRequestPermissions', callback: (args: AndroidActivityRequestPermissionsEventData<T>) => void, thisArg?: any): void;
 }
 
 let androidApp: AndroidApplication;

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -102,7 +102,7 @@ export function setMaxRefreshRate(options?: { min?: number; max?: number; prefer
 /**
  * Event data containing information for the application events.
  */
-export interface ApplicationEventData extends EventData {
+export interface ApplicationEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * Gets the native iOS event arguments. Valid only when running on iOS.
 	 */
@@ -127,7 +127,7 @@ export interface ApplicationEventData extends EventData {
 /**
  * Event data containing information for launch event.
  */
-export interface LaunchEventData extends ApplicationEventData {
+export interface LaunchEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	/**
 	 * The root view for this Window on iOS or Activity for Android.
 	 * If not set a new Frame will be created as a root view in order to maintain backwards compatibility.
@@ -141,7 +141,7 @@ export interface LaunchEventData extends ApplicationEventData {
 /**
  * Event data containing information for orientation changed event.
  */
-export interface OrientationChangedEventData extends ApplicationEventData {
+export interface OrientationChangedEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	/**
 	 * New orientation value.
 	 */
@@ -151,7 +151,7 @@ export interface OrientationChangedEventData extends ApplicationEventData {
 /**
  * Event data containing information for system appearance changed event.
  */
-export interface SystemAppearanceChangedEventData extends ApplicationEventData {
+export interface SystemAppearanceChangedEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	/**
 	 * New system appearance value.
 	 */
@@ -161,7 +161,7 @@ export interface SystemAppearanceChangedEventData extends ApplicationEventData {
 /**
  * Event data containing information for font scale changed event.
  */
-export interface FontScaleChangedEventData extends ApplicationEventData {
+export interface FontScaleChangedEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	/**
 	 * New font scale value.
 	 */
@@ -171,7 +171,7 @@ export interface FontScaleChangedEventData extends ApplicationEventData {
 /**
  * Event data containing information about unhandled application errors.
  */
-export interface UnhandledErrorEventData extends ApplicationEventData {
+export interface UnhandledErrorEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	ios?: NativeScriptError;
 	android?: NativeScriptError;
 	error: NativeScriptError;
@@ -180,14 +180,14 @@ export interface UnhandledErrorEventData extends ApplicationEventData {
 /**
  * Event data containing information about discarded application errors.
  */
-export interface DiscardedErrorEventData extends ApplicationEventData {
+export interface DiscardedErrorEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	error: NativeScriptError;
 }
 
 /**
  * Event data containing information about application css change.
  */
-export interface CssChangedEventData extends EventData {
+export interface CssChangedEventData<T extends Observable = Observable> extends EventData<T> {
 	cssFile?: string;
 	cssText?: string;
 }
@@ -257,7 +257,7 @@ export function _resetRootView(entry?: NavigationEntry | string);
 /**
  * Removes listener for the specified event name.
  */
-export function off(eventNames: string, callback?: (eventData: ApplicationEventData) => void, thisArg?: any): void;
+export function off<T extends Observable = Observable>(eventNames: string, callback?: (eventData: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * Shortcut alias to the removeEventListener method.
@@ -265,7 +265,7 @@ export function off(eventNames: string, callback?: (eventData: ApplicationEventD
  * @param callback - Callback function which will be removed.
  * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
  */
-export function off(eventNames: string, callback?: (eventData: ApplicationEventData) => void, thisArg?: any): void;
+export function off<T extends Observable = Observable>(eventNames: string, callback?: (eventData: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * Notifies all the registered listeners for the event provided in the data.eventName.
@@ -285,78 +285,78 @@ export function hasListeners(eventName: string): boolean;
  * @param callback - Callback function which will be executed when event is raised.
  * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
  */
-export function on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when application css is changed.
  */
-export function on(event: 'cssChanged', callback: (args: CssChangedEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'cssChanged', callback: (args: CssChangedEventData<T>) => void, thisArg?: any): void;
 
 /**
  * Event raised then livesync operation is performed.
  */
-export function on(event: 'livesync', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'livesync', callback: (args: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when application css is changed.
  */
-export function on(event: 'cssChanged', callback: (args: CssChangedEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'cssChanged', callback: (args: CssChangedEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised on application launchEvent.
  */
-export function on(event: 'launch', callback: (args: LaunchEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'launch', callback: (args: LaunchEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised after the application has performed most of its startup actions.
  * Its intent is to be suitable for measuring app startup times.
  * @experimental
  */
-export function on(event: 'displayed', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'displayed', callback: (args: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when the Application is suspended.
  */
-export function on(event: 'suspend', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'suspend', callback: (args: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when the Application is resumed after it has been suspended.
  */
-export function on(event: 'resume', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'resume', callback: (args: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when the Application is about to exit.
  */
-export function on(event: 'exit', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'exit', callback: (args: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when there is low memory on the target device.
  */
-export function on(event: 'lowMemory', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'lowMemory', callback: (args: ApplicationEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when an uncaught error occurs while the application is running.
  */
-export function on(event: 'uncaughtError', callback: (args: UnhandledErrorEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'uncaughtError', callback: (args: UnhandledErrorEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when an discarded error occurs while the application is running.
  */
-export function on(event: 'discardedError', callback: (args: DiscardedErrorEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'discardedError', callback: (args: DiscardedErrorEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when the orientation of the application changes.
  */
-export function on(event: 'orientationChanged', callback: (args: OrientationChangedEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'orientationChanged', callback: (args: OrientationChangedEventData<T>) => void, thisArg?: any): void;
 
 /**
  * This event is raised when the operating system appearance changes
  * between light and dark theme (for Android);
  * between light and dark mode (for iOS) and vice versa.
  */
-export function on(event: 'systemAppearanceChanged', callback: (args: SystemAppearanceChangedEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'systemAppearanceChanged', callback: (args: SystemAppearanceChangedEventData<T>) => void, thisArg?: any): void;
 
-export function on(event: 'fontScaleChanged', callback: (args: FontScaleChangedEventData) => void, thisArg?: any): void;
+export function on<T extends Observable = Observable>(event: 'fontScaleChanged', callback: (args: FontScaleChangedEventData<T>) => void, thisArg?: any): void;
 
 /**
  * Gets the orientation of the application.
@@ -415,7 +415,7 @@ export interface AndroidActivityEventData {
 /**
  * Data for the Android activity events with bundle.
  */
-export interface AndroidActivityBundleEventData extends AndroidActivityEventData {
+export interface AndroidActivityBundleEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	/**
 	 * The bundle.
 	 */
@@ -425,7 +425,7 @@ export interface AndroidActivityBundleEventData extends AndroidActivityEventData
 /**
  * Data for the Android activity onRequestPermissions callback
  */
-export interface AndroidActivityRequestPermissionsEventData extends AndroidActivityEventData {
+export interface AndroidActivityRequestPermissionsEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	/**
 	 * The request code.
 	 */
@@ -445,7 +445,7 @@ export interface AndroidActivityRequestPermissionsEventData extends AndroidActiv
 /**
  * Data for the Android activity result event.
  */
-export interface AndroidActivityResultEventData extends AndroidActivityEventData {
+export interface AndroidActivityResultEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	/**
 	 * The request code.
 	 */
@@ -465,7 +465,7 @@ export interface AndroidActivityResultEventData extends AndroidActivityEventData
 /**
  * Data for the Android activity newIntent event.
  */
-export interface AndroidActivityNewIntentEventData extends AndroidActivityEventData {
+export interface AndroidActivityNewIntentEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	/**
 	 * The intent.
 	 */
@@ -475,7 +475,7 @@ export interface AndroidActivityNewIntentEventData extends AndroidActivityEventD
 /**
  * Data for the Android activity back pressed event.
  */
-export interface AndroidActivityBackPressedEventData extends AndroidActivityEventData {
+export interface AndroidActivityBackPressedEventData<T extends Observable = Observable> extends AndroidActivityEventData<T> {
 	/**
 	 * In the event handler, set this value to true if you want to cancel the back navigation and do something else instead.
 	 */
@@ -548,62 +548,62 @@ export class AndroidApplication extends Observable {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: AndroidActivityEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: AndroidActivityEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityCreated.
 	 */
-	on(event: 'activityCreated', callback: (args: AndroidActivityBundleEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityCreated', callback: (args: AndroidActivityBundleEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityDestroyed.
 	 */
-	on(event: 'activityDestroyed', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityDestroyed', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityStarted.
 	 */
-	on(event: 'activityStarted', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityStarted', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityPaused.
 	 */
-	on(event: 'activityPaused', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityPaused', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityResumed.
 	 */
-	on(event: 'activityResumed', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityResumed', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityStopped.
 	 */
-	on(event: 'activityStopped', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityStopped', callback: (args: AndroidActivityEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application SaveActivityState.
 	 */
-	on(event: 'saveActivityState', callback: (args: AndroidActivityBundleEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'saveActivityState', callback: (args: AndroidActivityBundleEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on android application ActivityResult.
 	 */
-	on(event: 'activityResult', callback: (args: AndroidActivityResultEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityResult', callback: (args: AndroidActivityResultEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised on the back button is pressed in an android application.
 	 */
-	on(event: 'activityBackPressed', callback: (args: AndroidActivityBackPressedEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityBackPressed', callback: (args: AndroidActivityBackPressedEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised when the Android app was launched by an Intent with data.
 	 */
-	on(event: 'activityNewIntent', callback: (args: AndroidActivityNewIntentEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityNewIntent', callback: (args: AndroidActivityNewIntentEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * This event is raised when the Android activity requests permissions.
 	 */
-	on(event: 'activityRequestPermissions', callback: (args: AndroidActivityRequestPermissionsEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'activityRequestPermissions', callback: (args: AndroidActivityRequestPermissionsEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * String value used when hooking to activityCreated event.
@@ -754,6 +754,6 @@ export function getNativeApplication(): any;
  */
 export function hasLaunched(): boolean;
 
-export interface LoadAppCSSEventData extends EventData {
+export interface LoadAppCSSEventData<T extends Observable = Observable> extends EventData<T> {
 	cssFile: string;
 }

--- a/packages/core/application/index.d.ts
+++ b/packages/core/application/index.d.ts
@@ -395,7 +395,7 @@ export let ios: iOSApplication;
 /**
  * Data for the Android activity events.
  */
-export interface AndroidActivityEventData {
+export interface AndroidActivityEventData<T extends Observable = Observable> extends ApplicationEventData<T> {
 	/**
 	 * The activity.
 	 */

--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -13,7 +13,7 @@ export class ChangeType {
 /**
  * Event args for "changed" event.
  */
-export interface ChangedData<T> extends EventData {
+export interface ChangedData<T, O extends Observable = Observable> extends EventData<O> {
 	/**
 	 * Change type.
 	 */
@@ -429,7 +429,7 @@ export interface ObservableArray<T> {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
-	on(event: 'change', callback: (args: ChangedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'change', callback: (args: ChangedData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/data/virtual-array/index.ts
+++ b/packages/core/data/virtual-array/index.ts
@@ -4,7 +4,7 @@ import { ChangedData, ChangeType } from '../observable-array';
 /**
  * Event args for "itemsLoading" event.
  */
-export interface ItemsLoading extends EventData {
+export interface ItemsLoading<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * Start index.
 	 */
@@ -188,13 +188,13 @@ export interface VirtualArray<T> {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<O extends Observable = Observable>(eventNames: string, callback: (data: EventData<O>) => void, thisArg?: any): void;
 	/**
 	 * Raised when still not loaded items are requested.
 	 */
-	on(event: 'itemsLoading', callback: (args: ItemsLoading) => void, thisArg?: any): void;
+	on<O extends Observable = Observable>(event: 'itemsLoading', callback: (args: ItemsLoading<O>) => void, thisArg?: any): void;
 	/**
 	 * Raised when a change occurs.
 	 */
-	on(event: 'change', callback: (args: ChangedData<T>) => void, thisArg?: any): void;
+	on<O extends Observable = Observable>(event: 'change', callback: (args: ChangedData<T, O>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/button/index.d.ts
+++ b/packages/core/ui/button/index.d.ts
@@ -31,10 +31,10 @@ export class Button extends TextBase {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Button>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a tap event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'tap', callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Button>(event: 'tap', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/button/index.d.ts
+++ b/packages/core/ui/button/index.d.ts
@@ -31,10 +31,10 @@ export class Button extends TextBase {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a tap event occurs.
 	 */
-	on(event: 'tap', callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'tap', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -335,14 +335,14 @@ export class View extends ViewCommon {
 	}
 
 	// TODO: Implement unobserve that detach the touchListener.
-	_observe<T extends Observable = Observable>(type: GestureTypes, callback: (args: GestureEventData<T>) => void, thisArg?: any): void {
+	_observe<T extends Observable = View>(type: GestureTypes, callback: (args: GestureEventData<T>) => void, thisArg?: any): void {
 		super._observe(type, callback, thisArg);
 		if (this.isLoaded && !this.touchListenerIsSet) {
 			this.setOnTouchListener();
 		}
 	}
 
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any) {
+	on<T extends Observable = View>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any) {
 		super.on(eventNames, callback, thisArg);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 
@@ -351,7 +351,7 @@ export class View extends ViewCommon {
 		}
 	}
 
-	off<T extends Observable = Observable>(eventNames: string, callback?: (data: EventData<T>) => void, thisArg?: any) {
+	off<T extends Observable = View>(eventNames: string, callback?: (data: EventData<T>) => void, thisArg?: any) {
 		super.off(eventNames, callback, thisArg);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -8,7 +8,7 @@ import { paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingB
 import { layout } from '../../../utils';
 import { Trace } from '../../../trace';
 import { ShowModalOptions, hiddenProperty } from '../view-base';
-import { EventData } from '../../../data/observable';
+import { EventData, Observable } from '../../../data/observable';
 
 import { perspectiveProperty, visibilityProperty, opacityProperty, horizontalAlignmentProperty, verticalAlignmentProperty, minWidthProperty, minHeightProperty, widthProperty, heightProperty, marginLeftProperty, marginTopProperty, marginRightProperty, marginBottomProperty, rotateProperty, rotateXProperty, rotateYProperty, scaleXProperty, scaleYProperty, translateXProperty, translateYProperty, zIndexProperty, backgroundInternalProperty, androidElevationProperty, androidDynamicElevationOffsetProperty } from '../../styling/style-properties';
 import { CoreTypes } from '../../../core-types';
@@ -335,14 +335,14 @@ export class View extends ViewCommon {
 	}
 
 	// TODO: Implement unobserve that detach the touchListener.
-	_observe(type: GestureTypes, callback: (args: GestureEventData) => void, thisArg?: any): void {
+	_observe<T extends Observable = Observable>(type: GestureTypes, callback: (args: GestureEventData<T>) => void, thisArg?: any): void {
 		super._observe(type, callback, thisArg);
 		if (this.isLoaded && !this.touchListenerIsSet) {
 			this.setOnTouchListener();
 		}
 	}
 
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any) {
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any) {
 		super.on(eventNames, callback, thisArg);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 
@@ -351,7 +351,7 @@ export class View extends ViewCommon {
 		}
 	}
 
-	off(eventNames: string, callback?: (data: EventData) => void, thisArg?: any) {
+	off<T extends Observable = Observable>(eventNames: string, callback?: (data: EventData<T>) => void, thisArg?: any) {
 		super.off(eventNames, callback, thisArg);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -83,7 +83,7 @@ export interface Size {
 /**
  * Defines the data for the shownModally event.
  */
-export interface ShownModallyData<T extends Observable = Observable> extends EventData<T> {
+export interface ShownModallyData<T extends Observable = ViewCommon> extends EventData<T> {
 	/**
 	 * The context (optional, may be undefined) passed to the view when shown modally.
 	 */
@@ -585,7 +585,7 @@ export abstract class View extends ViewCommon {
 	 * @param callback An optional parameter pointing to a specific listener. If not defined, all listeners for the event names will be removed.
 	 * @param thisArg An optional parameter which when set will be used to refine search of the correct callback which will be removed as event listener.
 	 */
-	off<T extends Observable = Observable>(eventNames: string | GestureTypes, callback?: (args: EventData<T>) => void, thisArg?: any);
+	off<T extends Observable = View>(eventNames: string | GestureTypes, callback?: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * A basic method signature to hook an event listener (shortcut alias to the addEventListener method).
@@ -593,33 +593,33 @@ export abstract class View extends ViewCommon {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string | GestureTypes, callback: (args: EventData<T>) => void, thisArg?: any);
+	on<T extends Observable = View>(eventNames: string | GestureTypes, callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised when a loaded event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'loaded', callback: (args: EventData<T>) => void, thisArg?: any);
+	on<T extends Observable = View>(event: 'loaded', callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised when an unloaded event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'unloaded', callback: (args: EventData<T>) => void, thisArg?: any);
+	on<T extends Observable = View>(event: 'unloaded', callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised when a back button is pressed.
 	 * This event is raised only for android.
 	 */
-	on<T extends Observable = Observable>(event: 'androidBackPressed', callback: (args: EventData<T>) => void, thisArg?: any);
+	on<T extends Observable = View>(event: 'androidBackPressed', callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised before the view is shown as a modal dialog.
 	 */
-	on<T extends Observable = Observable>(event: 'showingModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = View>(event: 'showingModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised after the view is shown as a modal dialog.
 	 */
-	on<T extends Observable = Observable>(event: 'shownModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any);
+	on<T extends Observable = View>(event: 'shownModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any);
 
 	/**
 	 * Returns the current modal view that this page is showing (is parent of), if any.

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -83,7 +83,7 @@ export interface Size {
 /**
  * Defines the data for the shownModally event.
  */
-export interface ShownModallyData extends EventData {
+export interface ShownModallyData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The context (optional, may be undefined) passed to the view when shown modally.
 	 */
@@ -585,7 +585,7 @@ export abstract class View extends ViewCommon {
 	 * @param callback An optional parameter pointing to a specific listener. If not defined, all listeners for the event names will be removed.
 	 * @param thisArg An optional parameter which when set will be used to refine search of the correct callback which will be removed as event listener.
 	 */
-	off(eventNames: string | GestureTypes, callback?: (args: EventData) => void, thisArg?: any);
+	off<T extends Observable = Observable>(eventNames: string | GestureTypes, callback?: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * A basic method signature to hook an event listener (shortcut alias to the addEventListener method).
@@ -593,33 +593,33 @@ export abstract class View extends ViewCommon {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string | GestureTypes, callback: (args: EventData) => void, thisArg?: any);
+	on<T extends Observable = Observable>(eventNames: string | GestureTypes, callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised when a loaded event occurs.
 	 */
-	on(event: 'loaded', callback: (args: EventData) => void, thisArg?: any);
+	on<T extends Observable = Observable>(event: 'loaded', callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised when an unloaded event occurs.
 	 */
-	on(event: 'unloaded', callback: (args: EventData) => void, thisArg?: any);
+	on<T extends Observable = Observable>(event: 'unloaded', callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised when a back button is pressed.
 	 * This event is raised only for android.
 	 */
-	on(event: 'androidBackPressed', callback: (args: EventData) => void, thisArg?: any);
+	on<T extends Observable = Observable>(event: 'androidBackPressed', callback: (args: EventData<T>) => void, thisArg?: any);
 
 	/**
 	 * Raised before the view is shown as a modal dialog.
 	 */
-	on(event: 'showingModally', callback: (args: ShownModallyData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'showingModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised after the view is shown as a modal dialog.
 	 */
-	on(event: 'shownModally', callback: (args: ShownModallyData) => void, thisArg?: any);
+	on<T extends Observable = Observable>(event: 'shownModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any);
 
 	/**
 	 * Returns the current modal view that this page is showing (is parent of), if any.

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -253,7 +253,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		}
 	}
 
-	_observe<T extends Observable = Observable>(type: GestureTypes, callback: (args: GestureEventData<T>) => void, thisArg?: any): void {
+	_observe<T extends Observable = ViewCommon>(type: GestureTypes, callback: (args: GestureEventData<T>) => void, thisArg?: any): void {
 		if (!this._gestureObservers[type]) {
 			this._gestureObservers[type] = [];
 		}
@@ -265,7 +265,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		return this._gestureObservers[type];
 	}
 
-	public addEventListener<T extends Observable = Observable>(arg: string | GestureTypes, callback: (data: EventData<T>) => void, thisArg?: any) {
+	public addEventListener<T extends Observable = ViewCommon>(arg: string | GestureTypes, callback: (data: EventData<T>) => void, thisArg?: any) {
 		if (typeof arg === 'string') {
 			arg = getEventOrGestureName(arg);
 
@@ -293,7 +293,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		}
 	}
 
-	public removeEventListener<T extends Observable = Observable>(arg: string | GestureTypes, callback?: (data: EventData<T>) => void, thisArg?: any) {
+	public removeEventListener<T extends Observable = ViewCommon>(arg: string | GestureTypes, callback?: (data: EventData<T>) => void, thisArg?: any) {
 		if (typeof arg === 'string') {
 			const gesture = gestureFromString(arg);
 			if (gesture && !this._isEvent(arg)) {

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -7,7 +7,7 @@ import { layout } from '../../../utils';
 import { isObject } from '../../../utils/types';
 import { Color } from '../../../color';
 import { Property, InheritedProperty } from '../properties';
-import { EventData } from '../../../data/observable';
+import { EventData, Observable } from '../../../data/observable';
 import { Trace } from '../../../trace';
 import { CoreTypes } from '../../../core-types';
 import { ViewHelper } from './view-helper';
@@ -253,7 +253,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		}
 	}
 
-	_observe(type: GestureTypes, callback: (args: GestureEventData) => void, thisArg?: any): void {
+	_observe<T extends Observable = Observable>(type: GestureTypes, callback: (args: GestureEventData<T>) => void, thisArg?: any): void {
 		if (!this._gestureObservers[type]) {
 			this._gestureObservers[type] = [];
 		}
@@ -265,7 +265,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		return this._gestureObservers[type];
 	}
 
-	public addEventListener(arg: string | GestureTypes, callback: (data: EventData) => void, thisArg?: any) {
+	public addEventListener<T extends Observable = Observable>(arg: string | GestureTypes, callback: (data: EventData<T>) => void, thisArg?: any) {
 		if (typeof arg === 'string') {
 			arg = getEventOrGestureName(arg);
 
@@ -289,11 +289,11 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 				}
 			}
 		} else if (typeof arg === 'number') {
-			this._observe(<GestureTypes>arg, callback, thisArg);
+			this._observe(arg, callback, thisArg);
 		}
 	}
 
-	public removeEventListener(arg: string | GestureTypes, callback?: (data: EventData) => void, thisArg?: any) {
+	public removeEventListener<T extends Observable = Observable>(arg: string | GestureTypes, callback?: (data: EventData<T>) => void, thisArg?: any) {
 		if (typeof arg === 'string') {
 			const gesture = gestureFromString(arg);
 			if (gesture && !this._isEvent(arg)) {

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -6,7 +6,7 @@ import { Transition } from '../transition';
 
 export * from './frame-interfaces';
 
-export interface NavigationData<T extends Observable = Observable> extends EventData<T> {
+export interface NavigationData<T extends Observable = Frame> extends EventData<T> {
 	entry?: NavigationEntry;
 	fromEntry?: NavigationEntry;
 	isBack?: boolean;
@@ -221,17 +221,17 @@ export class Frame extends FrameBase {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Frame>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has started.
 	 */
-	public on<T extends Observable = Observable>(event: 'navigatingTo', callback: (args: NavigationData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Frame>(event: 'navigatingTo', callback: (args: NavigationData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has finished.
 	 */
-	public on<T extends Observable = Observable>(event: 'navigatedTo', callback: (args: NavigationData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Frame>(event: 'navigatedTo', callback: (args: NavigationData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -6,7 +6,7 @@ import { Transition } from '../transition';
 
 export * from './frame-interfaces';
 
-export interface NavigationData extends EventData {
+export interface NavigationData<T extends Observable = Observable> extends EventData<T> {
 	entry?: NavigationEntry;
 	fromEntry?: NavigationEntry;
 	isBack?: boolean;
@@ -221,17 +221,17 @@ export class Frame extends FrameBase {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has started.
 	 */
-	public on(event: 'navigatingTo', callback: (args: NavigationData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(event: 'navigatingTo', callback: (args: NavigationData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has finished.
 	 */
-	public on(event: 'navigatedTo', callback: (args: NavigationData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(event: 'navigatedTo', callback: (args: NavigationData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/gestures/index.d.ts
+++ b/packages/core/ui/gestures/index.d.ts
@@ -132,7 +132,7 @@ export namespace TouchAction {
 /**
  * Provides gesture event data.
  */
-export interface GestureEventData extends EventData {
+export interface GestureEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * Gets the type of the gesture.
 	 */
@@ -154,7 +154,7 @@ export interface GestureEventData extends EventData {
 /**
  * Provides gesture event data.
  */
-export interface TapGestureEventData extends GestureEventData {
+export interface TapGestureEventData<T extends Observable = Observable> extends GestureEventData<T> {
 	/**
 	 * Gets the number of pointers in the event.
 	 */
@@ -172,7 +172,7 @@ export interface TapGestureEventData extends GestureEventData {
 /**
  * Provides gesture event data.
  */
-export interface TouchGestureEventData extends TapGestureEventData {
+export interface TouchGestureEventData<T extends Observable = Observable> extends TapGestureEventData<T> {
 	/**
 	 * Gets action of the touch. Possible values: 'up', 'move', 'down', 'cancel'
 	 */
@@ -241,14 +241,14 @@ export interface Pointer {
 /**
  * Provides gesture event data.
  */
-export interface GestureEventDataWithState extends GestureEventData {
+export interface GestureEventDataWithState<T extends Observable = Observable> extends GestureEventData<T> {
 	state: number;
 }
 
 /**
  * Provides gesture event data for pinch gesture.
  */
-export interface PinchGestureEventData extends GestureEventDataWithState {
+export interface PinchGestureEventData<T extends Observable = Observable> extends GestureEventDataWithState<T> {
 	scale: number;
 
 	getFocusX(): number;
@@ -258,14 +258,14 @@ export interface PinchGestureEventData extends GestureEventDataWithState {
 /**
  * Provides gesture event data for swipe gesture.
  */
-export interface SwipeGestureEventData extends GestureEventData {
+export interface SwipeGestureEventData<T extends Observable = Observable> extends GestureEventData<T> {
 	direction: SwipeDirection;
 }
 
 /**
  * Provides gesture event data for pan gesture.
  */
-export interface PanGestureEventData extends GestureEventDataWithState {
+export interface PanGestureEventData<T extends Observable = Observable> extends GestureEventDataWithState<T> {
 	deltaX: number;
 	deltaY: number;
 }
@@ -273,32 +273,32 @@ export interface PanGestureEventData extends GestureEventDataWithState {
 /**
  * Provides gesture event data for rotation gesture.
  */
-export interface RotationGestureEventData extends GestureEventDataWithState {
+export interface RotationGestureEventData<T extends Observable = Observable> extends GestureEventDataWithState<T> {
 	rotation: number;
 }
 
 /**
  * Provides options for the GesturesObserver.
  */
-export class GesturesObserver {
+export class GesturesObserver<T extends Observable = Observable> {
 	/**
 	 * Creates an instance of GesturesObserver class.
 	 * @param target - The view for which the observer is created.
 	 * @param callback - A function that will be executed when a gesture is received.
 	 * @param context - default this argument for the callbacks.
 	 */
-	constructor(target: View, callback: (args: GestureEventData) => void, context: any);
+	constructor(target: View, callback: (args: GestureEventData<T>) => void, context: any);
 
 	/**
 	 * Registers a gesture observer to a view and gesture.
 	 * @param type - Type of the gesture.
 	 */
-	observe(type: GestureTypes);
+	observe<T>(type: GestureTypes);
 
 	/**
 	 * Disconnects the gesture observer.
 	 */
-	disconnect();
+	disconnect<T>();
 
 	/**
 	 * Gesture type attached to the observer.
@@ -308,7 +308,7 @@ export class GesturesObserver {
 	/**
 	 * A function that will be executed when a gesture is received.
 	 */
-	callback: (args: GestureEventData) => void;
+	callback: (args: GestureEventData<T>) => void;
 
 	/**
 	 * A context which will be used as `this` in callback execution.
@@ -328,7 +328,7 @@ export class GesturesObserver {
  * @param callback - A function that will be executed when a gesture is received.
  * @param context - this argument for the callback.
  */
-export function observe(target: View, type: GestureTypes, callback: (args: GestureEventData) => void, context?: any): GesturesObserver;
+export function observe<T extends Observable = Observable>(target: View, type: GestureTypes, callback: (args: GestureEventData<T>) => void, context?: any): GesturesObserver<T>;
 
 /**
  * Returns a string representation of a gesture type.

--- a/packages/core/ui/gestures/index.d.ts
+++ b/packages/core/ui/gestures/index.d.ts
@@ -132,7 +132,7 @@ export namespace TouchAction {
 /**
  * Provides gesture event data.
  */
-export interface GestureEventData<T extends Observable = Observable> extends EventData<T> {
+export interface GestureEventData<T extends Observable = View> extends EventData<T> {
 	/**
 	 * Gets the type of the gesture.
 	 */
@@ -154,7 +154,7 @@ export interface GestureEventData<T extends Observable = Observable> extends Eve
 /**
  * Provides gesture event data.
  */
-export interface TapGestureEventData<T extends Observable = Observable> extends GestureEventData<T> {
+export interface TapGestureEventData<T extends Observable = View> extends GestureEventData<T> {
 	/**
 	 * Gets the number of pointers in the event.
 	 */
@@ -172,7 +172,7 @@ export interface TapGestureEventData<T extends Observable = Observable> extends 
 /**
  * Provides gesture event data.
  */
-export interface TouchGestureEventData<T extends Observable = Observable> extends TapGestureEventData<T> {
+export interface TouchGestureEventData<T extends Observable = View> extends TapGestureEventData<T> {
 	/**
 	 * Gets action of the touch. Possible values: 'up', 'move', 'down', 'cancel'
 	 */
@@ -241,14 +241,14 @@ export interface Pointer {
 /**
  * Provides gesture event data.
  */
-export interface GestureEventDataWithState<T extends Observable = Observable> extends GestureEventData<T> {
+export interface GestureEventDataWithState<T extends Observable = View> extends GestureEventData<T> {
 	state: number;
 }
 
 /**
  * Provides gesture event data for pinch gesture.
  */
-export interface PinchGestureEventData<T extends Observable = Observable> extends GestureEventDataWithState<T> {
+export interface PinchGestureEventData<T extends Observable = View> extends GestureEventDataWithState<T> {
 	scale: number;
 
 	getFocusX(): number;
@@ -258,14 +258,14 @@ export interface PinchGestureEventData<T extends Observable = Observable> extend
 /**
  * Provides gesture event data for swipe gesture.
  */
-export interface SwipeGestureEventData<T extends Observable = Observable> extends GestureEventData<T> {
+export interface SwipeGestureEventData<T extends Observable = View> extends GestureEventData<T> {
 	direction: SwipeDirection;
 }
 
 /**
  * Provides gesture event data for pan gesture.
  */
-export interface PanGestureEventData<T extends Observable = Observable> extends GestureEventDataWithState<T> {
+export interface PanGestureEventData<T extends Observable = View> extends GestureEventDataWithState<T> {
 	deltaX: number;
 	deltaY: number;
 }
@@ -273,14 +273,14 @@ export interface PanGestureEventData<T extends Observable = Observable> extends 
 /**
  * Provides gesture event data for rotation gesture.
  */
-export interface RotationGestureEventData<T extends Observable = Observable> extends GestureEventDataWithState<T> {
+export interface RotationGestureEventData<T extends Observable = View> extends GestureEventDataWithState<T> {
 	rotation: number;
 }
 
 /**
  * Provides options for the GesturesObserver.
  */
-export class GesturesObserver<T extends Observable = Observable> {
+export class GesturesObserver<T extends Observable = View> {
 	/**
 	 * Creates an instance of GesturesObserver class.
 	 * @param target - The view for which the observer is created.
@@ -328,7 +328,7 @@ export class GesturesObserver<T extends Observable = Observable> {
  * @param callback - A function that will be executed when a gesture is received.
  * @param context - this argument for the callback.
  */
-export function observe<T extends Observable = Observable>(target: View, type: GestureTypes, callback: (args: GestureEventData<T>) => void, context?: any): GesturesObserver<T>;
+export function observe<T extends Observable = View>(target: View, type: GestureTypes, callback: (args: GestureEventData<T>) => void, context?: any): GesturesObserver<T>;
 
 /**
  * Returns a string representation of a gesture type.

--- a/packages/core/ui/gestures/index.ios.ts
+++ b/packages/core/ui/gestures/index.ios.ts
@@ -2,7 +2,7 @@
 
 import { GestureEventData, TapGestureEventData, GestureEventDataWithState, SwipeGestureEventData, PanGestureEventData, RotationGestureEventData, PinchGestureEventData } from '.';
 import { View } from '../core/view';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
 // Types.
 import { GesturesObserverBase, toString, TouchAction, GestureStateTypes, GestureTypes, SwipeDirection, GestureEvents } from './gestures-common';
@@ -53,7 +53,7 @@ class UIGestureRecognizerImpl extends NSObject {
 	private _callback: Function;
 	private _context: any;
 
-	public static initWithOwnerTypeCallback(owner: WeakRef<GesturesObserver>, type: any, callback?: Function, thisArg?: any): UIGestureRecognizerImpl {
+	public static initWithOwnerTypeCallback<T extends Observable = Observable>(owner: WeakRef<GesturesObserver>, type: any, callback?: (args: GestureEventData<T>) => void, thisArg?: any): UIGestureRecognizerImpl {
 		const handler = <UIGestureRecognizerImpl>UIGestureRecognizerImpl.new();
 		handler._owner = owner;
 		handler._type = type;
@@ -320,7 +320,7 @@ export class GesturesObserver extends GesturesObserverBase {
 	}
 }
 
-function _createUIGestureRecognizerTarget(owner: GesturesObserver, type: GestureTypes, callback?: (args: GestureEventData) => void, context?: any): any {
+function _createUIGestureRecognizerTarget<T extends Observable = Observable>(owner: GesturesObserver, type: GestureTypes, callback?: (args: GestureEventData<T>) => void, context?: any): any {
 	return UIGestureRecognizerImpl.initWithOwnerTypeCallback(new WeakRef(owner), type, callback, context);
 }
 

--- a/packages/core/ui/gestures/index.ios.ts
+++ b/packages/core/ui/gestures/index.ios.ts
@@ -53,7 +53,7 @@ class UIGestureRecognizerImpl extends NSObject {
 	private _callback: Function;
 	private _context: any;
 
-	public static initWithOwnerTypeCallback<T extends Observable = Observable>(owner: WeakRef<GesturesObserver>, type: any, callback?: (args: GestureEventData<T>) => void, thisArg?: any): UIGestureRecognizerImpl {
+	public static initWithOwnerTypeCallback<T extends Observable = View>(owner: WeakRef<GesturesObserver>, type: any, callback?: (args: GestureEventData<T>) => void, thisArg?: any): UIGestureRecognizerImpl {
 		const handler = <UIGestureRecognizerImpl>UIGestureRecognizerImpl.new();
 		handler._owner = owner;
 		handler._type = type;
@@ -320,7 +320,7 @@ export class GesturesObserver extends GesturesObserverBase {
 	}
 }
 
-function _createUIGestureRecognizerTarget<T extends Observable = Observable>(owner: GesturesObserver, type: GestureTypes, callback?: (args: GestureEventData<T>) => void, context?: any): any {
+function _createUIGestureRecognizerTarget<T extends Observable = View>(owner: GesturesObserver, type: GestureTypes, callback?: (args: GestureEventData<T>) => void, context?: any): any {
 	return UIGestureRecognizerImpl.initWithOwnerTypeCallback(new WeakRef(owner), type, callback, context);
 }
 

--- a/packages/core/ui/image-cache/image-cache-common.ts
+++ b/packages/core/ui/image-cache/image-cache-common.ts
@@ -215,7 +215,7 @@ export class Cache extends Observable implements definition.Cache {
 	}
 }
 export interface Cache {
-	on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
-	on(event: 'downloaded', callback: (args: definition.DownloadedData) => void, thisArg?: any): void;
-	on(event: 'downloadError', callback: (args: definition.DownloadError) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'downloaded', callback: (args: definition.DownloadedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'downloadError', callback: (args: definition.DownloadError<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/image-cache/image-cache-common.ts
+++ b/packages/core/ui/image-cache/image-cache-common.ts
@@ -215,7 +215,7 @@ export class Cache extends Observable implements definition.Cache {
 	}
 }
 export interface Cache {
-	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'downloaded', callback: (args: definition.DownloadedData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'downloadError', callback: (args: definition.DownloadError<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Cache>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Cache>(event: 'downloaded', callback: (args: definition.DownloadedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Cache>(event: 'downloadError', callback: (args: definition.DownloadError<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/image-cache/index.d.ts
+++ b/packages/core/ui/image-cache/index.d.ts
@@ -85,17 +85,17 @@ export class Cache extends Observable {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the image has been downloaded.
 	 */
-	on(event: 'downloaded', callback: (args: DownloadedData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'downloaded', callback: (args: DownloadedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised if the image download errors.
 	 */
-	on(event: 'downloadError', callback: (args: DownloadError) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'downloadError', callback: (args: DownloadError<T>) => void, thisArg?: any): void;
 
 	//@private
 	/**
@@ -117,7 +117,7 @@ export class Cache extends Observable {
 /**
  * Provides data for downloaded event.
  */
-export interface DownloadedData extends EventData {
+export interface DownloadedData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * A string indentifier of the cached image.
 	 */
@@ -131,7 +131,7 @@ export interface DownloadedData extends EventData {
 /**
  * Provides data for download error.
  */
-export interface DownloadError extends EventData {
+export interface DownloadError<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * A string indentifier of the cached image.
 	 */

--- a/packages/core/ui/image-cache/index.d.ts
+++ b/packages/core/ui/image-cache/index.d.ts
@@ -85,17 +85,17 @@ export class Cache extends Observable {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Cache>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the image has been downloaded.
 	 */
-	on<T extends Observable = Observable>(event: 'downloaded', callback: (args: DownloadedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Cache>(event: 'downloaded', callback: (args: DownloadedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised if the image download errors.
 	 */
-	on<T extends Observable = Observable>(event: 'downloadError', callback: (args: DownloadError<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Cache>(event: 'downloadError', callback: (args: DownloadError<T>) => void, thisArg?: any): void;
 
 	//@private
 	/**

--- a/packages/core/ui/list-view/index.d.ts
+++ b/packages/core/ui/list-view/index.d.ts
@@ -108,7 +108,7 @@ export class ListView extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a View for the data at the specified index should be created.
@@ -116,23 +116,23 @@ export class ListView extends View {
 	 * Note, that the view property of the event data can be pre-initialized with
 	 * an old instance of a view, so that it can be reused.
 	 */
-	on(event: 'itemLoading', callback: (args: ItemEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when an item inside the ListView is tapped.
 	 */
-	on(event: 'itemTap', callback: (args: ItemEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'itemTap', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the ListView is scrolled so that its last item is visible.
 	 */
-	on(event: 'loadMoreItems', callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'loadMoreItems', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }
 
 /**
  * Event data containing information for the index and the view associated to a list view item.
  */
-export interface ItemEventData extends EventData {
+export interface ItemEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The index of the item, for which the event is raised.
 	 */
@@ -164,8 +164,8 @@ export interface TemplatedItemsView {
 	itemTemplate: string | Template;
 	itemTemplates?: string | Array<KeyedTemplate>;
 	refresh(): void;
-	on(event: 'itemLoading', callback: (args: ItemEventData) => void, thisArg?: any): void;
-	off(event: 'itemLoading', callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	off<T extends Observable = Observable>(event: 'itemLoading', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/list-view/index.d.ts
+++ b/packages/core/ui/list-view/index.d.ts
@@ -108,7 +108,7 @@ export class ListView extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListView>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a View for the data at the specified index should be created.
@@ -116,23 +116,23 @@ export class ListView extends View {
 	 * Note, that the view property of the event data can be pre-initialized with
 	 * an old instance of a view, so that it can be reused.
 	 */
-	on<T extends Observable = Observable>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListView>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when an item inside the ListView is tapped.
 	 */
-	on<T extends Observable = Observable>(event: 'itemTap', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListView>(event: 'itemTap', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the ListView is scrolled so that its last item is visible.
 	 */
-	on<T extends Observable = Observable>(event: 'loadMoreItems', callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListView>(event: 'loadMoreItems', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }
 
 /**
  * Event data containing information for the index and the view associated to a list view item.
  */
-export interface ItemEventData<T extends Observable = Observable> extends EventData<T> {
+export interface ItemEventData<T extends Observable = ListView> extends EventData<T> {
 	/**
 	 * The index of the item, for which the event is raised.
 	 */
@@ -164,8 +164,8 @@ export interface TemplatedItemsView {
 	itemTemplate: string | Template;
 	itemTemplates?: string | Array<KeyedTemplate>;
 	refresh(): void;
-	on<T extends Observable = Observable>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
-	off<T extends Observable = Observable>(event: 'itemLoading', callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListView>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	off<T extends Observable = ListView>(event: 'itemLoading', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/list-view/list-view-common.ts
+++ b/packages/core/ui/list-view/list-view-common.ts
@@ -154,10 +154,10 @@ export abstract class ListViewBase extends ContainerView implements ListViewDefi
 ListViewBase.prototype.recycleNativeView = 'auto';
 
 export interface ListViewBase {
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-	on(event: 'itemLoading', callback: (args: ItemEventData) => void, thisArg?: any): void;
-	on(event: 'itemTap', callback: (args: ItemEventData) => void, thisArg?: any): void;
-	on(event: 'loadMoreItems', callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'itemTap', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'loadMoreItems', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/list-view/list-view-common.ts
+++ b/packages/core/ui/list-view/list-view-common.ts
@@ -154,10 +154,10 @@ export abstract class ListViewBase extends ContainerView implements ListViewDefi
 ListViewBase.prototype.recycleNativeView = 'auto';
 
 export interface ListViewBase {
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'itemTap', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'loadMoreItems', callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListViewBase>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListViewBase>(event: 'itemLoading', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListViewBase>(event: 'itemTap', callback: (args: ItemEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ListViewBase>(event: 'loadMoreItems', callback: (args: EventData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/page/index.d.ts
+++ b/packages/core/ui/page/index.d.ts
@@ -12,7 +12,7 @@ export * from './page-common';
 /**
  * Defines the data for the page navigation events.
  */
-export interface NavigatedData<T extends Observable = Observable> extends EventData<T> {
+export interface NavigatedData<T extends Observable = Page> extends EventData<T> {
 	/**
 	 * The navigation context (optional, may be undefined) passed to the page navigation events method.
 	 */
@@ -116,27 +116,27 @@ export declare class Page extends PageBase {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	public on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Page>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has started.
 	 */
-	public on<T extends Observable = Observable>(event: 'navigatingTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Page>(event: 'navigatingTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has finished.
 	 */
-	public on<T extends Observable = Observable>(event: 'navigatedTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Page>(event: 'navigatedTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation from the page has started.
 	 */
-	public on<T extends Observable = Observable>(event: 'navigatingFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Page>(event: 'navigatingFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation from the page has finished.
 	 */
-	public on<T extends Observable = Observable>(event: 'navigatedFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	public on<T extends Observable = Page>(event: 'navigatedFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 	//@private
 
 	/**

--- a/packages/core/ui/page/index.d.ts
+++ b/packages/core/ui/page/index.d.ts
@@ -12,7 +12,7 @@ export * from './page-common';
 /**
  * Defines the data for the page navigation events.
  */
-export interface NavigatedData extends EventData {
+export interface NavigatedData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The navigation context (optional, may be undefined) passed to the page navigation events method.
 	 */
@@ -116,27 +116,27 @@ export declare class Page extends PageBase {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	public on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has started.
 	 */
-	public on(event: 'navigatingTo', callback: (args: NavigatedData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(event: 'navigatingTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation to the page has finished.
 	 */
-	public on(event: 'navigatedTo', callback: (args: NavigatedData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(event: 'navigatedTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation from the page has started.
 	 */
-	public on(event: 'navigatingFrom', callback: (args: NavigatedData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(event: 'navigatingFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when navigation from the page has finished.
 	 */
-	public on(event: 'navigatedFrom', callback: (args: NavigatedData) => void, thisArg?: any): void;
+	public on<T extends Observable = Observable>(event: 'navigatedFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
 	//@private
 
 	/**

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -12,7 +12,7 @@ import { ActionBar } from '../action-bar';
 import { KeyframeAnimationInfo } from '../animation/keyframe-animation';
 import { profile } from '../../profiling';
 
-interface NavigatedData<T extends Observable = Observable> extends EventData<T> {
+interface NavigatedData<T extends Observable = PageBase> extends EventData<T> {
 	context: any;
 	isBackNavigation: boolean;
 }
@@ -166,13 +166,13 @@ export class PageBase extends ContentView {
 PageBase.prototype.recycleNativeView = 'never';
 
 export interface PageBase {
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'navigatingTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'navigatedTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'navigatingFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'navigatedFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'showingModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'shownModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(event: 'navigatingTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(event: 'navigatedTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(event: 'navigatingFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(event: 'navigatedFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(event: 'showingModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = PageBase>(event: 'shownModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -5,14 +5,14 @@ import { booleanConverter } from '../core/view-base';
 import { Property, CssProperty } from '../core/properties';
 import { Style } from '../styling/style';
 import { Color } from '../../color';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 import type { Frame } from '../frame';
 import { isFrame } from '../frame/frame-helpers';
 import { ActionBar } from '../action-bar';
 import { KeyframeAnimationInfo } from '../animation/keyframe-animation';
 import { profile } from '../../profiling';
 
-interface NavigatedData extends EventData {
+interface NavigatedData<T extends Observable = Observable> extends EventData<T> {
 	context: any;
 	isBackNavigation: boolean;
 }
@@ -166,13 +166,13 @@ export class PageBase extends ContentView {
 PageBase.prototype.recycleNativeView = 'never';
 
 export interface PageBase {
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-	on(event: 'navigatingTo', callback: (args: NavigatedData) => void, thisArg?: any): void;
-	on(event: 'navigatedTo', callback: (args: NavigatedData) => void, thisArg?: any): void;
-	on(event: 'navigatingFrom', callback: (args: NavigatedData) => void, thisArg?: any): void;
-	on(event: 'navigatedFrom', callback: (args: NavigatedData) => void, thisArg?: any): void;
-	on(event: 'showingModally', callback: (args: ShownModallyData) => void, thisArg?: any): void;
-	on(event: 'shownModally', callback: (args: ShownModallyData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'navigatingTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'navigatedTo', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'navigatingFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'navigatedFrom', callback: (args: NavigatedData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'showingModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'shownModally', callback: (args: ShownModallyData<T>) => void, thisArg?: any): void;
 }
 
 /**

--- a/packages/core/ui/placeholder/index.android.ts
+++ b/packages/core/ui/placeholder/index.android.ts
@@ -21,6 +21,6 @@ export class Placeholder extends View {
 	}
 }
 export interface Placeholder {
-	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Placeholder>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Placeholder>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/placeholder/index.android.ts
+++ b/packages/core/ui/placeholder/index.android.ts
@@ -1,6 +1,6 @@
 import { CreateViewEventData } from './placeholder-common';
 import { View, CSSType } from '../core/view';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
 export * from './placeholder-common';
 
@@ -21,6 +21,6 @@ export class Placeholder extends View {
 	}
 }
 export interface Placeholder {
-	on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
-	on(event: 'creatingView', callback: (args: CreateViewEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/placeholder/index.d.ts
+++ b/packages/core/ui/placeholder/index.d.ts
@@ -1,5 +1,5 @@
 ﻿import { View } from '../core/view';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
 export * from './placeholder-common';
 
@@ -18,18 +18,18 @@ export class Placeholder extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a creatingView event occurs.
 	 */
-	on(event: 'creatingView', callback: (args: CreateViewEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
 }
 
 /**
  * Event data containing information for creating a native view that will be added to the visual tree.
  */
-export interface CreateViewEventData extends EventData {
+export interface CreateViewEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The native view that should be added to the visual tree.
 	 */

--- a/packages/core/ui/placeholder/index.d.ts
+++ b/packages/core/ui/placeholder/index.d.ts
@@ -18,18 +18,18 @@ export class Placeholder extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Placeholder>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a creatingView event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Placeholder>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
 }
 
 /**
  * Event data containing information for creating a native view that will be added to the visual tree.
  */
-export interface CreateViewEventData<T extends Observable = Observable> extends EventData<T> {
+export interface CreateViewEventData<T extends Observable = Placeholder> extends EventData<T> {
 	/**
 	 * The native view that should be added to the visual tree.
 	 */

--- a/packages/core/ui/placeholder/index.ts
+++ b/packages/core/ui/placeholder/index.ts
@@ -1,6 +1,6 @@
 import { View } from '../core/view';
 import { CreateViewEventData } from './placeholder-common';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
 export * from './placeholder-common';
 
@@ -20,6 +20,6 @@ export class Placeholder extends View {
 	}
 }
 export interface Placeholder {
-	on(eventNames: string, callback: (args: EventData) => void, thisArg?: any): void;
-	on(event: 'creatingView', callback: (args: CreateViewEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/placeholder/index.ts
+++ b/packages/core/ui/placeholder/index.ts
@@ -20,6 +20,6 @@ export class Placeholder extends View {
 	}
 }
 export interface Placeholder {
-	on<T extends Observable = Observable>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Placeholder>(eventNames: string, callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Placeholder>(event: 'creatingView', callback: (args: CreateViewEventData<T>) => void, thisArg?: any): void;
 }

--- a/packages/core/ui/placeholder/placeholder-common.ts
+++ b/packages/core/ui/placeholder/placeholder-common.ts
@@ -1,6 +1,6 @@
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
-export interface CreateViewEventData extends EventData {
+export interface CreateViewEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The native view that should be added to the visual tree.
 	 */

--- a/packages/core/ui/scroll-view/index.d.ts
+++ b/packages/core/ui/scroll-view/index.d.ts
@@ -67,17 +67,17 @@ export class ScrollView extends ContentView {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ScrollView>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a scroll event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'scroll', callback: (args: ScrollEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ScrollView>(event: 'scroll', callback: (args: ScrollEventData<T>) => void, thisArg?: any): void;
 
 	_onOrientationChanged(): void;
 }
 
-export interface ScrollEventData<T extends Observable = Observable> extends EventData<T> {
+export interface ScrollEventData<T extends Observable = ScrollView> extends EventData<T> {
 	scrollX: number;
 	scrollY: number;
 }

--- a/packages/core/ui/scroll-view/index.d.ts
+++ b/packages/core/ui/scroll-view/index.d.ts
@@ -67,17 +67,17 @@ export class ScrollView extends ContentView {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a scroll event occurs.
 	 */
-	on(event: 'scroll', callback: (args: ScrollEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'scroll', callback: (args: ScrollEventData<T>) => void, thisArg?: any): void;
 
 	_onOrientationChanged(): void;
 }
 
-export interface ScrollEventData extends EventData {
+export interface ScrollEventData<T extends Observable = Observable> extends EventData<T> {
 	scrollX: number;
 	scrollY: number;
 }

--- a/packages/core/ui/scroll-view/scroll-view-common.ts
+++ b/packages/core/ui/scroll-view/scroll-view-common.ts
@@ -4,7 +4,7 @@ import { profile } from '../../profiling';
 import { Property, makeParser, makeValidator } from '../core/properties';
 import { CSSType } from '../core/view';
 import { booleanConverter } from '../core/view-base';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 import { CoreTypes } from '../../core-types';
 
 @CSSType('ScrollView')
@@ -16,7 +16,7 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 	public scrollBarIndicatorVisible: boolean;
 	public isScrollEnabled: boolean;
 
-	public addEventListener(arg: string, callback: (data: EventData) => void, thisArg?: any): void {
+	public addEventListener<T extends Observable = Observable>(arg: string, callback: (data: EventData<T>) => void, thisArg?: any): void {
 		super.addEventListener(arg, callback, thisArg);
 
 		if (arg === ScrollViewBase.scrollEvent) {
@@ -25,7 +25,7 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 		}
 	}
 
-	public removeEventListener(arg: string, callback?: (data: EventData) => void, thisArg?: any): void {
+	public removeEventListener<T extends Observable = Observable>(arg: string, callback?: (data: EventData<T>) => void, thisArg?: any): void {
 		super.removeEventListener(arg, callback, thisArg);
 
 		if (arg === ScrollViewBase.scrollEvent) {
@@ -87,8 +87,8 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 	public abstract _onOrientationChanged();
 }
 export interface ScrollViewBase {
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-	on(event: 'scroll', callback: (args: ScrollEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'scroll', callback: (args: ScrollEventData<T>) => void, thisArg?: any): void;
 }
 
 const converter = makeParser<CoreTypes.OrientationType>(makeValidator(CoreTypes.Orientation.horizontal, CoreTypes.Orientation.vertical));

--- a/packages/core/ui/scroll-view/scroll-view-common.ts
+++ b/packages/core/ui/scroll-view/scroll-view-common.ts
@@ -87,8 +87,8 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 	public abstract _onOrientationChanged();
 }
 export interface ScrollViewBase {
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'scroll', callback: (args: ScrollEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ScrollViewBase>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = ScrollViewBase>(event: 'scroll', callback: (args: ScrollEventData<T>) => void, thisArg?: any): void;
 }
 
 const converter = makeParser<CoreTypes.OrientationType>(makeValidator(CoreTypes.Orientation.horizontal, CoreTypes.Orientation.vertical));

--- a/packages/core/ui/search-bar/index.d.ts
+++ b/packages/core/ui/search-bar/index.d.ts
@@ -53,17 +53,17 @@ export class SearchBar extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = SearchBar>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a search bar search is submitted.
 	 */
-	on<T extends Observable = Observable>(event: 'submit', callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = SearchBar>(event: 'submit', callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a search bar search is closed.
 	 */
-	on<T extends Observable = Observable>(event: 'close', callback: (args: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = SearchBar>(event: 'close', callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Hides the soft input method, usually a soft keyboard.

--- a/packages/core/ui/search-bar/index.d.ts
+++ b/packages/core/ui/search-bar/index.d.ts
@@ -53,17 +53,17 @@ export class SearchBar extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a search bar search is submitted.
 	 */
-	on(event: 'submit', callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'submit', callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a search bar search is closed.
 	 */
-	on(event: 'close', callback: (args: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'close', callback: (args: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Hides the soft input method, usually a soft keyboard.

--- a/packages/core/ui/segmented-bar/index.d.ts
+++ b/packages/core/ui/segmented-bar/index.d.ts
@@ -18,7 +18,7 @@ export class SegmentedBarItem extends ViewBase {
 /**
  * Defines the data for the SegmentedBar.selectedIndexChanged event.
  */
-export interface SelectedIndexChangedEventData<T extends Observable = Observable> extends EventData<T> {
+export interface SelectedIndexChangedEventData<T extends Observable = SegmentedBar> extends EventData<T> {
 	/**
 	 * The old selected index.
 	 */
@@ -60,12 +60,12 @@ export class SegmentedBar extends View implements AddChildFromBuilder, AddArrayF
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = SegmentedBar>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the selected index changes.
 	 */
-	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = SegmentedBar>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Called for every child element declared in xml.

--- a/packages/core/ui/segmented-bar/index.d.ts
+++ b/packages/core/ui/segmented-bar/index.d.ts
@@ -18,7 +18,7 @@ export class SegmentedBarItem extends ViewBase {
 /**
  * Defines the data for the SegmentedBar.selectedIndexChanged event.
  */
-export interface SelectedIndexChangedEventData extends EventData {
+export interface SelectedIndexChangedEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The old selected index.
 	 */
@@ -60,12 +60,12 @@ export class SegmentedBar extends View implements AddChildFromBuilder, AddArrayF
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the selected index changes.
 	 */
-	on(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Called for every child element declared in xml.

--- a/packages/core/ui/segmented-bar/segmented-bar-common.ts
+++ b/packages/core/ui/segmented-bar/segmented-bar-common.ts
@@ -4,7 +4,7 @@ import { ViewBase } from '../core/view-base';
 import { Property, CoercibleProperty, InheritedCssProperty } from '../core/properties';
 import { Color } from '../../color';
 import { Style } from '../styling/style';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
 @CSSType('SegmentedBarItem')
 export abstract class SegmentedBarItemBase extends ViewBase implements SegmentedBarItemDefinition {
@@ -89,8 +89,8 @@ export abstract class SegmentedBarBase extends View implements SegmentedBarDefin
 }
 
 export interface SegmentedBarBase {
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-	on(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 }
 
 SegmentedBarBase.prototype.recycleNativeView = 'auto';

--- a/packages/core/ui/slider/index.d.ts
+++ b/packages/core/ui/slider/index.d.ts
@@ -61,12 +61,12 @@ export const maxValueProperty: CoercibleProperty<Slider, number>;
  */
 export const accessibilityStepProperty: Property<SliderBase, number>;
 
-interface AccessibilityIncrementEventData<T extends Observable = Observable> extends EventData<T> {
+interface AccessibilityIncrementEventData<T extends Observable = Slider> extends EventData<T> {
 	object: Slider;
 	value?: number;
 }
 
-interface AccessibilityDecrementEventData<T extends Observable = Observable> extends EventData<T> {
+interface AccessibilityDecrementEventData<T extends Observable = Slider> extends EventData<T> {
 	object: Slider;
 	value?: number;
 }

--- a/packages/core/ui/slider/index.d.ts
+++ b/packages/core/ui/slider/index.d.ts
@@ -61,12 +61,12 @@ export const maxValueProperty: CoercibleProperty<Slider, number>;
  */
 export const accessibilityStepProperty: Property<SliderBase, number>;
 
-interface AccessibilityIncrementEventData extends EventData {
+interface AccessibilityIncrementEventData<T extends Observable = Observable> extends EventData<T> {
 	object: Slider;
 	value?: number;
 }
 
-interface AccessibilityDecrementEventData extends EventData {
+interface AccessibilityDecrementEventData<T extends Observable = Observable> extends EventData<T> {
 	object: Slider;
 	value?: number;
 }

--- a/packages/core/ui/tab-view/index.d.ts
+++ b/packages/core/ui/tab-view/index.d.ts
@@ -42,7 +42,7 @@ export class TabViewItem extends ViewBase {
 /**
  * Defines the data for the TabView.selectedIndexChanged event.
  */
-export interface SelectedIndexChangedEventData extends EventData {
+export interface SelectedIndexChangedEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * The old selected index.
 	 */
@@ -150,12 +150,12 @@ export class TabView extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the selected index changes.
 	 */
-	on(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 }
 
 export const itemsProperty: Property<TabView, TabViewItem[]>;

--- a/packages/core/ui/tab-view/index.d.ts
+++ b/packages/core/ui/tab-view/index.d.ts
@@ -42,7 +42,7 @@ export class TabViewItem extends ViewBase {
 /**
  * Defines the data for the TabView.selectedIndexChanged event.
  */
-export interface SelectedIndexChangedEventData<T extends Observable = Observable> extends EventData<T> {
+export interface SelectedIndexChangedEventData<T extends Observable = TabView> extends EventData<T> {
 	/**
 	 * The old selected index.
 	 */
@@ -150,12 +150,12 @@ export class TabView extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = TabView>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when the selected index changes.
 	 */
-	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = TabView>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 }
 
 export const itemsProperty: Property<TabView, TabViewItem[]>;

--- a/packages/core/ui/tab-view/tab-view-common.ts
+++ b/packages/core/ui/tab-view/tab-view-common.ts
@@ -2,7 +2,7 @@ import { TabView as TabViewDefinition, TabViewItem as TabViewItemDefinition, Sel
 import { View, AddArrayFromBuilder, AddChildFromBuilder, CSSType } from '../core/view';
 import { ViewBase, booleanConverter } from '../core/view-base';
 import { Style } from '../styling/style';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 import { Color } from '../../color';
 import { Property, CssProperty, CoercibleProperty } from '../core/properties';
 import { CoreTypes } from '../../core-types';
@@ -205,8 +205,8 @@ export class TabViewBase extends View implements TabViewDefinition, AddChildFrom
 }
 
 export interface TabViewBase {
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-	on(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 }
 
 export function traceMissingIcon(icon: string) {

--- a/packages/core/ui/tab-view/tab-view-common.ts
+++ b/packages/core/ui/tab-view/tab-view-common.ts
@@ -205,8 +205,8 @@ export class TabViewBase extends View implements TabViewDefinition, AddChildFrom
 }
 
 export interface TabViewBase {
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = TabViewBase>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = TabViewBase>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
 }
 
 export function traceMissingIcon(icon: string) {

--- a/packages/core/ui/text-base/span.ts
+++ b/packages/core/ui/text-base/span.ts
@@ -81,12 +81,12 @@ export class Span extends ViewBase implements SpanDefinition {
 		return this._tappable;
 	}
 
-	addEventListener<T extends Observable = Observable>(arg: string, callback: (data: EventData<T>) => void, thisArg?: any): void {
+	addEventListener<T extends Observable = Span>(arg: string, callback: (data: EventData<T>) => void, thisArg?: any): void {
 		super.addEventListener(arg, callback, thisArg);
 		this._setTappable(this.hasListeners(Span.linkTapEvent));
 	}
 
-	removeEventListener<T extends Observable = Observable>(arg: string, callback?: (data: EventData<T>) => void, thisArg?: any): void {
+	removeEventListener<T extends Observable = Span>(arg: string, callback?: (data: EventData<T>) => void, thisArg?: any): void {
 		super.removeEventListener(arg, callback, thisArg);
 		this._setTappable(this.hasListeners(Span.linkTapEvent));
 	}

--- a/packages/core/ui/text-base/span.ts
+++ b/packages/core/ui/text-base/span.ts
@@ -3,7 +3,7 @@ import { Span as SpanDefinition } from './span';
 import { ViewBase } from '../core/view-base';
 import { FontStyleType, FontWeightType } from '../styling/font';
 import { CoreTypes } from '../../core-types';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 import { isNullOrUndefined, isString } from '../../utils/types';
 
 export class Span extends ViewBase implements SpanDefinition {
@@ -81,12 +81,12 @@ export class Span extends ViewBase implements SpanDefinition {
 		return this._tappable;
 	}
 
-	addEventListener(arg: string, callback: (data: EventData) => void, thisArg?: any): void {
+	addEventListener<T extends Observable = Observable>(arg: string, callback: (data: EventData<T>) => void, thisArg?: any): void {
 		super.addEventListener(arg, callback, thisArg);
 		this._setTappable(this.hasListeners(Span.linkTapEvent));
 	}
 
-	removeEventListener(arg: string, callback?: (data: EventData) => void, thisArg?: any): void {
+	removeEventListener<T extends Observable = Observable>(arg: string, callback?: (data: EventData<T>) => void, thisArg?: any): void {
 		super.removeEventListener(arg, callback, thisArg);
 		this._setTappable(this.hasListeners(Span.linkTapEvent));
 	}

--- a/packages/core/ui/web-view/index.d.ts
+++ b/packages/core/ui/web-view/index.d.ts
@@ -92,23 +92,23 @@ export class WebView extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = WebView>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a loadFinished event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'loadFinished', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = WebView>(event: 'loadFinished', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a loadStarted event occurs.
 	 */
-	on<T extends Observable = Observable>(event: 'loadStarted', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = WebView>(event: 'loadStarted', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
 }
 
 /**
  * Event data containing information for the loading events of a WebView.
  */
-export interface LoadEventData<T extends Observable = Observable> extends EventData<T> {
+export interface LoadEventData<T extends Observable = WebView> extends EventData<T> {
 	/**
 	 * Gets the url of the web-view.
 	 */

--- a/packages/core/ui/web-view/index.d.ts
+++ b/packages/core/ui/web-view/index.d.ts
@@ -92,23 +92,23 @@ export class WebView extends View {
 	 * @param callback - Callback function which will be executed when event is raised.
 	 * @param thisArg - An optional parameter which will be used as `this` context for callback execution.
 	 */
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a loadFinished event occurs.
 	 */
-	on(event: 'loadFinished', callback: (args: LoadEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'loadFinished', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
 
 	/**
 	 * Raised when a loadStarted event occurs.
 	 */
-	on(event: 'loadStarted', callback: (args: LoadEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'loadStarted', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
 }
 
 /**
  * Event data containing information for the loading events of a WebView.
  */
-export interface LoadEventData extends EventData {
+export interface LoadEventData<T extends Observable = Observable> extends EventData<T> {
 	/**
 	 * Gets the url of the web-view.
 	 */

--- a/packages/core/ui/web-view/web-view-common.ts
+++ b/packages/core/ui/web-view/web-view-common.ts
@@ -29,7 +29,7 @@ export abstract class WebViewBase extends ContainerView {
 			error: error,
 		};
 
-		this.notify(<any>args);
+		this.notify(args);
 	}
 
 	public _onLoadStarted(url: string, navigationType: WebViewNavigationType) {
@@ -41,7 +41,7 @@ export abstract class WebViewBase extends ContainerView {
 			error: undefined,
 		};
 
-		this.notify(<any>args);
+		this.notify(args);
 	}
 
 	abstract _loadUrl(src: string): void;
@@ -101,9 +101,9 @@ export abstract class WebViewBase extends ContainerView {
 // HACK: We declare all these 'on' statements, so that they can appear in the API reference
 // HACK: Do we need this? Is it useful? There are static fields to the WebViewBase class for the event names.
 export interface WebViewBase {
-	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'loadFinished', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
-	on<T extends Observable = Observable>(event: 'loadStarted', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = WebViewBase>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = WebViewBase>(event: 'loadFinished', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = WebViewBase>(event: 'loadStarted', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
 }
 
 srcProperty.register(WebViewBase);

--- a/packages/core/ui/web-view/web-view-common.ts
+++ b/packages/core/ui/web-view/web-view-common.ts
@@ -1,7 +1,7 @@
 import { LoadEventData, WebViewNavigationType } from './web-view-interfaces';
 import { ContainerView, CSSType } from '../core/view';
 import { Property } from '../core/properties';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 import { knownFolders } from '../../file-system';
 import { booleanConverter } from '../core/view-base';
 
@@ -101,9 +101,9 @@ export abstract class WebViewBase extends ContainerView {
 // HACK: We declare all these 'on' statements, so that they can appear in the API reference
 // HACK: Do we need this? Is it useful? There are static fields to the WebViewBase class for the event names.
 export interface WebViewBase {
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
-	on(event: 'loadFinished', callback: (args: LoadEventData) => void, thisArg?: any): void;
-	on(event: 'loadStarted', callback: (args: LoadEventData) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(eventNames: string, callback: (data: EventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'loadFinished', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
+	on<T extends Observable = Observable>(event: 'loadStarted', callback: (args: LoadEventData<T>) => void, thisArg?: any): void;
 }
 
 srcProperty.register(WebViewBase);

--- a/packages/core/ui/web-view/web-view-interfaces.ts
+++ b/packages/core/ui/web-view/web-view-interfaces.ts
@@ -1,9 +1,9 @@
 ﻿import { WebView } from '.';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
 
 export type WebViewNavigationType = 'linkClicked' | 'formSubmitted' | 'backForward' | 'reload' | 'formResubmitted' | 'other' | undefined;
 
-export interface LoadEventData extends EventData {
+export interface LoadEventData<T extends Observable = Observable> extends EventData<T> {
 	url: string;
 	navigationType: WebViewNavigationType;
 	error: string;

--- a/packages/core/ui/web-view/web-view-interfaces.ts
+++ b/packages/core/ui/web-view/web-view-interfaces.ts
@@ -1,9 +1,10 @@
-﻿import { WebView } from '.';
+﻿import { WebViewBase } from './web-view-common';
+import { WebView } from '.';
 import { EventData, Observable } from '../../data/observable';
 
 export type WebViewNavigationType = 'linkClicked' | 'formSubmitted' | 'backForward' | 'reload' | 'formResubmitted' | 'other' | undefined;
 
-export interface LoadEventData<T extends Observable = Observable> extends EventData<T> {
+export interface LoadEventData<T extends Observable = WebViewBase> extends EventData<T> {
 	url: string;
 	navigationType: WebViewNavigationType;
 	error: string;


### PR DESCRIPTION
With this PR, EventData and methods for adding/removing listeners will now be generic:

```ts
// This event is inherited from View, so eventData.object is
// inferred to be a View.
new Button().on("loaded", (eventData) => {
  eventData.object; // TypeScript infers this to be a View
});

// You can, however, explicitly pass the generic to narrow
// that down to Button:
new Button().on<Button>("loaded", (eventData) => {
  eventData.object; // TypeScript infers this to be a Button
});

// Button-specific events don't require passing the generic:
new Button().on("tap", (eventData) => {
  eventData.object; // TypeScript infers this to be a Button
});
```

Please do give comment on the discussion points I've posted and (once we've reviewed it and prepared a build of it) a try on your projects, as I fully expect it'll result in some TypeScript grumbles.

## PR Checklist

- [ ] The PR title follows our [guidelines](https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages) - TODO: I'm keeping them as individual commits for review, but we can rename upon squash.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are [included](https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md) - It's largely a typings change, so no new tests to add.

## What is the current behavior?

Types for EventData and adding/removing listeners are non-generic, so we always have to write `eventData.object as Button` if we want anything more specific than an Observable.

## What is the new behavior?

Improved inference in most cases. The events in Application have always been *very* messy though, so I've left those as defaulting to Observable even though some could be narrowed to View, as I simply can't get my head round them.

Note that this PR would introduce breaking changes for library authors. As although we do provide default args for each generic, if they've extended `on` anywhere, they'll have to add the generic, as demonstrated in this [playground](https://www.typescriptlang.org/play?ssl=13&ssc=1&pln=1&pc=1#code/JYOwLgpgTgZghgYwgAgKIDcLgCJzHAHgBVkIAPSEAEwGdkB5AIxunTkYBsUBeB519lwB8yAN4AoAJARM4AHJwAthABcyGmCigA5gG4pAe0YArCAjBqi+gL7jxVMxzhQUCJzTpMWUNpxQTkQOQDEGJSCixaPm9fLmReLwE-IQAKGSwLdU0dABpkBDgODkZEAGs1FKo8ODUMDNx8YiEASniRdANgKjywAAtgGgBBKG0AfjU4EABPZrUOrps7NzgPZABlA2UABQ4AV21QcMooxJ9Bf3Eg4JA02UyNLRBtPIKikoRy5Erq2ruGuFa3HanW6yD6A2GYwm01aolstiAA):

<img width="899" alt="image" src="https://user-images.githubusercontent.com/14055146/213916731-17607127-d938-431c-b807-64574e90eb99.png">

## For discussion

### What should the generics be?

The generics implemented in this PR are "better than nothing", but still not ideal. See what I ideally wanted to implement vs. what I was able to get working:

```ts
// What I wanted:
export abstract class View extends ViewCommon {
  on<T extends View = this>(event: 'loaded', callback: (args: EventData<T>) => void, thisArg?: any);
}

// The only thing I could get to work:
export abstract class View extends ViewCommon {
  on<T extends Observable = View>(event: 'loaded', callback: (args: EventData<T>) => void, thisArg?: any);
}
```

The former is more strictly correct, but I just couldn't get TypeScript to accept it 🤷

### Should we narrow the default generic for EventData in the first place?

Although I think it *is* correct for the methods for adding/removing event listeners to have more narrow generic defaults than just `Observable`, e.g.:

```ts
export class SegmentedBar extends View implements AddChildFromBuilder, AddArrayFromBuilder {
  on<T extends Observable = SegmentedBar>(event: 'selectedIndexChanged', callback: (args: SelectedIndexChangedEventData<T>) => void, thisArg?: any): void;
}
```

... I am unsure about whether the EventData interfaces should behave the same:

```ts
// Would we prefer a narrow default?
export interface SelectedIndexChangedEventData<T extends Observable = SegmentedBar> extends EventData<T> {
  oldIndex: number;
  newIndex: number;
}

// ... or just stick to Observable?
export interface SelectedIndexChangedEventData<T extends Observable = Observable> extends EventData<T> {
  oldIndex: number;
  newIndex: number;
}
```

Mainly because we don't know whether others might repurpose the same event (SelectedIndexChangedEvent can be used for more than just SegmentedBar, and indeed there are duplicates of this interface across the codebase). Of course consumers can just specify the generic explicitly if they want to override the assumed default of SegmentedBar, so it's not the end of the world whichever choice we go with.