### PR TITLE
fix(core): Added item template handling for external renderers

### DIFF
--- a/packages/core/ui/list-view/list-view-common.ts
+++ b/packages/core/ui/list-view/list-view-common.ts
@@ -10,6 +10,7 @@ import { Observable, EventData } from '../../data/observable';
 import { ObservableArray, ChangedData } from '../../data/observable-array';
 import { addWeakEventListener, removeWeakEventListener } from '../core/weak-event-listener';
 import { CoreTypes } from '../../core-types';
+import { isFunction } from '../../utils/types';
 
 const autoEffectiveRowHeight = -1;
 
@@ -28,8 +29,13 @@ export abstract class ListViewBase extends ContainerView implements ListViewDefi
 		key: 'default',
 		createView: () => {
 			if (__UI_USE_EXTERNAL_RENDERER__) {
-			} else if (this.itemTemplate) {
-				return Builder.parse(this.itemTemplate, this);
+				if (isFunction(this.itemTemplate)) {
+					return (<Template>this.itemTemplate)();
+				}
+			} else {
+				if (this.itemTemplate) {
+					return Builder.parse(this.itemTemplate, this);
+				}
 			}
 
 			return undefined;

--- a/packages/core/ui/repeater/index.ts
+++ b/packages/core/ui/repeater/index.ts
@@ -8,6 +8,7 @@ import { ObservableArray, ChangedData } from '../../data/observable-array';
 import { addWeakEventListener, removeWeakEventListener } from '../core/weak-event-listener';
 import { Builder } from '../builder';
 import { profile } from '../../profiling';
+import { isFunction } from '../../utils/types';
 
 export interface ItemsSource {
 	length: number;
@@ -130,7 +131,7 @@ export class Repeater extends CustomLayoutView {
 
 			if (!viewToAdd) {
 				if (__UI_USE_EXTERNAL_RENDERER__) {
-					viewToAdd = this._getDefaultItemContent(i);
+					viewToAdd = isFunction(this.itemTemplate) ? (<Template>this.itemTemplate)() : this._getDefaultItemContent(i);
 				} else {
 					viewToAdd = this.itemTemplate ? Builder.parse(this.itemTemplate, this) : this._getDefaultItemContent(i);
 				}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
ListView and Repeater don't seem to provide template support for external renderers.

## What is the new behavior?
ListView and Repeater will provide template support for external renderers.
By default, we'll be treating `itemTemplate` property as a function according to `Template` interface. This helps ensure that external renderers that rely on vanilla {N} API can make use of single list templates.

Even core itself has an identical handling inside `Builder` module:
https://github.com/NativeScript/NativeScript/blob/main/packages/core/ui/builder/index.ts#L79

@farfromrefug I doubt this has any impact on current functionality or how other frameworks use `ListView` but please feel free to leave comments on this.