### PR TITLE
fix(core): Unset values for css properties of type Property

### DIFF
--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -575,6 +575,8 @@ export class CssState {
 
 		const valuesToApply = {};
 		const cssExpsProperties = {};
+		const caseRegex = /-([a-z])/g;
+		const replacementFunc = (g) => g[1].toUpperCase();
 
 		for (const property in newPropertyValues) {
 			const value = newPropertyValues[property];
@@ -621,7 +623,8 @@ export class CssState {
 			if (property in view.style) {
 				view.style[`css:${property}`] = unsetValue;
 			} else {
-				// TRICKY: How do we unset local value?
+				const camelCasedProperty = property.replace(caseRegex, replacementFunc);
+				view[camelCasedProperty] = unsetValue;
 			}
 		}
 		// Set new values to the style
@@ -631,9 +634,7 @@ export class CssState {
 				if (property in view.style) {
 					view.style[`css:${property}`] = value;
 				} else {
-					const camelCasedProperty = property.replace(/-([a-z])/g, function (g) {
-						return g[1].toUpperCase();
-					});
+					const camelCasedProperty = property.replace(caseRegex, replacementFunc);
 					view[camelCasedProperty] = value;
 				}
 			} catch (e) {

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -79,6 +79,7 @@ let currentScopeTag: string = null;
 const applicationAdditionalSelectors: RuleSet[] = [];
 const applicationKeyframes: any = {};
 const animationsSymbol = Symbol('animations');
+const kebabCasePattern = /-([a-z])/g;
 const pattern = /('|")(.*?)\1/;
 
 class CSSSource {
@@ -575,7 +576,6 @@ export class CssState {
 
 		const valuesToApply = {};
 		const cssExpsProperties = {};
-		const caseRegex = /-([a-z])/g;
 		const replacementFunc = (g) => g[1].toUpperCase();
 
 		for (const property in newPropertyValues) {
@@ -623,7 +623,7 @@ export class CssState {
 			if (property in view.style) {
 				view.style[`css:${property}`] = unsetValue;
 			} else {
-				const camelCasedProperty = property.replace(caseRegex, replacementFunc);
+				const camelCasedProperty = property.replace(kebabCasePattern, replacementFunc);
 				view[camelCasedProperty] = unsetValue;
 			}
 		}
@@ -634,7 +634,7 @@ export class CssState {
 				if (property in view.style) {
 					view.style[`css:${property}`] = value;
 				} else {
-					const camelCasedProperty = property.replace(caseRegex, replacementFunc);
+					const camelCasedProperty = property.replace(kebabCasePattern, replacementFunc);
 					view[camelCasedProperty] = value;
 				}
 			} catch (e) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
View properties of type `Property` do not get unset if they're updated from a css class selector that no longer targets view.
This is more apparent on ListViews where views are being recycled. View has a css class until it doesn't have it anymore so when class is unset, its effect to the view is still there.
Everything works fine for type `CssProperty`.

## What is the new behavior?
View properties of type `Property` will get unset if they're updated from a css class selector that no longer targets view.
This fix is a continuation of #6889