### PR TITLE
Disable setting main window content in ios

### DIFF
--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -247,9 +247,8 @@ export class iOSApplication implements iOSApplicationDefinition {
 			cssFile: getCssFileName(),
 		});
 
-		// this._window will be undefined when NS app is embedded in a native one
 		if (this._window) {
-			if (args.root !== null) {
+			if (args.root !== null && !NativeScriptEmbedder.sharedInstance().delegate)
 				this.setWindowContent(args.root);
 			}
 		} else {


### PR DESCRIPTION
When NS app is embedded main window should not be updated because it belongs to the parent app.
