### PR TITLE
ci: fix automated app CI workflow

### DIFF
--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: '11'
 
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
 
       - name: Install NativeScript
         run: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: Start iOS Simulator
         if: ${{ always() && !cancelled() }} # run iOS tests even if Android tests failed
-        uses: futureware-tech/simulator-action@v1
+        uses: futureware-tech/simulator-action@v2
         with:
           model: 'iPhone 13 Pro Max'
           os_version: '>=15.0'

--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -51,8 +51,8 @@ jobs:
       - run: |
           ls -al
           npm i
-          ls -al
-          ls -al node_modules
+          ls -al node_modules/@nativescript
+          ls -al node_modules/@nativescript/core
         working-directory: apps/automated
 
       - name: Test (Android)

--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -48,18 +48,6 @@ jobs:
       - name: Create Emulator
         uses: rigor789/action-create-emulator@main
 
-      - run: |
-          npm -v
-          node -v
-          ls -al packages/core
-
-      - run: |
-          ls -al
-          npm i
-          ls -al node_modules/@nativescript
-          ls -al node_modules/@nativescript/core
-        working-directory: apps/automated
-
       - name: Test (Android)
         run: node tools/scripts/run-automated.js android
 

--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Create Emulator
         uses: rigor789/action-create-emulator@main
 
-			- run: |
-					ls -al
-					ls -al node_modules
-					npm i
-					ls -al
-					ls -al node_modules
-				working-directory: apps/automated
+      - run: |
+          ls -al
+          ls -al node_modules
+          npm i
+          ls -al
+          ls -al node_modules
+        working-directory: apps/automated
 
       - name: Test (Android)
         run: node tools/scripts/run-automated.js android

--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -50,7 +50,6 @@ jobs:
 
       - run: |
           ls -al
-          ls -al node_modules
           npm i
           ls -al
           ls -al node_modules

--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -49,6 +49,11 @@ jobs:
         uses: rigor789/action-create-emulator@main
 
       - run: |
+          npm -v
+          node -v
+          ls -al packages/core
+
+      - run: |
           ls -al
           npm i
           ls -al node_modules/@nativescript

--- a/.github/workflows/apps_automated.yml
+++ b/.github/workflows/apps_automated.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Create Emulator
         uses: rigor789/action-create-emulator@main
 
+			- run: |
+					ls -al
+					ls -al node_modules
+					npm i
+					ls -al
+					ls -al node_modules
+				working-directory: apps/automated
+
       - name: Test (Android)
         run: node tools/scripts/run-automated.js android
 

--- a/apps/automated/.npmrc
+++ b/apps/automated/.npmrc
@@ -1,2 +1,6 @@
 legacy-peer-deps=true
+
+# npm 9+ this defaults to `true` meaning `file:` dependencies are packed and then installed
+# but since we want to link the source files in this case, we disable this behavior and
+# opt to link the dependency as-is instead. (eg. @nativescript/core)
 install-links=false

--- a/apps/automated/.npmrc
+++ b/apps/automated/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+install-links=false

--- a/tools/scripts/run-automated.js
+++ b/tools/scripts/run-automated.js
@@ -17,7 +17,7 @@ const spawned_process = spawn(
 		"nx",
 		"run",
 		`apps-automated:${platform}`,
-		// "--log=trace",
+		"--log=trace",
 		"--timeout=600" // 10 minutes, booting avds on CI is very slow...
 	],
 	{

--- a/tools/scripts/run-automated.js
+++ b/tools/scripts/run-automated.js
@@ -17,7 +17,8 @@ const spawned_process = spawn(
 		"nx",
 		"run",
 		`apps-automated:${platform}`,
-		"--log=trace",
+		// "--log=trace",
+		`--flags="--log=trace"`,
 		"--timeout=600" // 10 minutes, booting avds on CI is very slow...
 	],
 	{

--- a/tools/scripts/run-automated.js
+++ b/tools/scripts/run-automated.js
@@ -18,7 +18,7 @@ const spawned_process = spawn(
 		"run",
 		`apps-automated:${platform}`,
 		// "--log=trace",
-		`--flags="--log=trace"`,
+		// `--flags="--log=trace"`,
 		"--timeout=600" // 10 minutes, booting avds on CI is very slow...
 	],
 	{


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The CI action for the Automated app fails with a bunch of errors like these ones:

```
 ERROR in ./src/main.ts 8:0-69
Module not found: Error: Can't resolve '@nativescript/core' in '/Users/runner/work/NativeScript/NativeScript/apps/automated/src'
```

(example build: https://github.com/NativeScript/NativeScript/actions/runs/4204462364/jobs/7311437908)

## What is the new behavior?

The workflow has been updated to use latest version of each action (bundled in here, but unrelated to the failing workflow).

We are setting the `install-links=false` flag to force linking `file:` referenced packages.

---

Background of the issue:
 - npm 9.0 changed `install-links` value to be `true` by default
 - GitHub Actions updated the macos environment from npm 8.9 to 9.3.1 recently

About the `install-links` flag from the NPM docs:
> When set file: protocol dependencies will be packed and installed as regular dependencies instead of creating a symlink. This option has no effect on workspaces.

So essentially, we were running `npm pack` in `packages/core` and then installing the pack into `apps/automated`, however this pack didn't contain neither the `.ts` files (they are not part of the public package) nor `.js` files, since we are not building core in this workflow - we instead rely on the source files (`.ts` files) which are only included when we link the dependency instead of packing it.