### PR TITLE
fix(core): Frame to Page property propagation

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -43,6 +43,7 @@ export class FrameBase extends CustomLayoutView {
 
 	public actionBarVisibility: 'auto' | 'never' | 'always';
 	public _currentEntry: BackstackEntry;
+	public _childView: Page;
 	public _animationInProgress = false;
 	public _executingContext: NavigationContext;
 	public _isInFrameStack = false;
@@ -238,6 +239,9 @@ export class FrameBase extends CustomLayoutView {
 		// In case we navigated forward to a page that was in the backstack
 		// with clearHistory: true
 		if (!newPage.frame) {
+			// Used for traversing and manipulating DOM
+			this._childView = newPage;
+
 			this._addView(newPage);
 			newPage._frame = this;
 		}
@@ -456,7 +460,6 @@ export class FrameBase extends CustomLayoutView {
 		if (this._currentEntry) {
 			return this._currentEntry.resolvedPage;
 		}
-
 		return null;
 	}
 
@@ -508,7 +511,7 @@ export class FrameBase extends CustomLayoutView {
 	}
 
 	get _childrenCount(): number {
-		if (this.currentPage) {
+		if (this._childView) {
 			return 1;
 		}
 
@@ -516,7 +519,7 @@ export class FrameBase extends CustomLayoutView {
 	}
 
 	public eachChildView(callback: (child: View) => boolean) {
-		const page = this.currentPage;
+		const page = this._childView;
 		if (page) {
 			callback(page);
 		}

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -43,7 +43,10 @@ export class FrameBase extends CustomLayoutView {
 
 	public actionBarVisibility: 'auto' | 'never' | 'always';
 	public _currentEntry: BackstackEntry;
+
+	// Used for traversing and manipulating DOM
 	public _childView: Page;
+
 	public _animationInProgress = false;
 	public _executingContext: NavigationContext;
 	public _isInFrameStack = false;
@@ -239,7 +242,6 @@ export class FrameBase extends CustomLayoutView {
 		// In case we navigated forward to a page that was in the backstack
 		// with clearHistory: true
 		if (!newPage.frame) {
-			// Used for traversing and manipulating DOM
 			this._childView = newPage;
 
 			this._addView(newPage);

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -44,8 +44,12 @@ export class FrameBase extends CustomLayoutView {
 	public actionBarVisibility: 'auto' | 'never' | 'always';
 	public _currentEntry: BackstackEntry;
 
-	// Used for traversing and manipulating DOM
-	public _childView: Page;
+	/**
+	 * A reference of current page that is set earlier than current entry.
+	 * Using this property, methods like 'eachChildView' and '_childrenCount' gain access to page view
+	 * just in time for calls like '_addView' to perform view-tree iterations.
+	 */
+	public _resolvedPage: Page;
 
 	public _animationInProgress = false;
 	public _executingContext: NavigationContext;
@@ -242,7 +246,7 @@ export class FrameBase extends CustomLayoutView {
 		// In case we navigated forward to a page that was in the backstack
 		// with clearHistory: true
 		if (!newPage.frame) {
-			this._childView = newPage;
+			this._resolvedPage = newPage;
 
 			this._addView(newPage);
 			newPage._frame = this;
@@ -513,7 +517,7 @@ export class FrameBase extends CustomLayoutView {
 	}
 
 	get _childrenCount(): number {
-		if (this._childView) {
+		if (this._resolvedPage) {
 			return 1;
 		}
 
@@ -521,7 +525,7 @@ export class FrameBase extends CustomLayoutView {
 	}
 
 	public eachChildView(callback: (child: View) => boolean) {
-		const page = this._childView;
+		const page = this._resolvedPage;
 		if (page) {
 			callback(page);
 		}

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -913,7 +913,7 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 			return null;
 		}
 
-		frame._childView = page;
+		frame._resolvedPage = page;
 
 		if (page.parent === frame) {
 			// If we are navigating to a page that was destroyed

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -913,12 +913,19 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 			return null;
 		}
 
+		// Used for traversing and manipulating DOM
+		frame._childView = page;
+
 		if (page.parent === frame) {
 			// If we are navigating to a page that was destroyed
 			// reinitialize its UI.
 			if (!page._context) {
 				const context = (container && container.getContext()) || (inflater && inflater.getContext());
 				page._setupUI(context);
+			}
+
+			if (frame.isLoaded && !page.isLoaded) {
+				page.callLoaded();
 			}
 		} else {
 			if (!frame._styleScope) {
@@ -927,10 +934,6 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 			}
 
 			frame._addView(page);
-		}
-
-		if (frame.isLoaded && !page.isLoaded) {
-			page.callLoaded();
 		}
 
 		const savedState = entry.viewSavedState;

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -913,7 +913,6 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 			return null;
 		}
 
-		// Used for traversing and manipulating DOM
 		frame._childView = page;
 
 		if (page.parent === frame) {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -120,7 +120,7 @@ class UIViewControllerImpl extends UIViewController {
 			return;
 		}
 
-		const frame = this.navigationController ? (<any>this.navigationController).owner : null;
+		const frame: Frame = this.navigationController ? (<any>this.navigationController).owner : null;
 		const newEntry = this[ENTRY];
 
 		// Don't raise event if currentPage was showing modal page.
@@ -130,14 +130,14 @@ class UIViewControllerImpl extends UIViewController {
 		}
 
 		if (frame) {
+			frame._resolvedPage = owner;
+
 			if (!owner.parent) {
 				owner._frame = frame;
 				if (!frame._styleScope) {
 					// Make sure page will have styleScope even if frame don't.
 					owner._updateStyleScope();
 				}
-
-				frame._childView = owner;
 
 				frame._addView(owner);
 			} else if (owner.parent !== frame) {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -137,7 +137,6 @@ class UIViewControllerImpl extends UIViewController {
 					owner._updateStyleScope();
 				}
 
-				// Used for traversing and manipulating DOM
 				frame._childView = owner;
 
 				frame._addView(owner);

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -137,6 +137,9 @@ class UIViewControllerImpl extends UIViewController {
 					owner._updateStyleScope();
 				}
 
+				// Used for traversing and manipulating DOM
+				frame._childView = owner;
+
 				frame._addView(owner);
 			} else if (owner.parent !== frame) {
 				throw new Error('Page is already shown on another frame.');


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When I attempt to update some inheritable properties programmatically, they won't propagate from Frame to Page during initialization.
The reason seems to be the fact that we append page to frame using `_addView` before setting new frame entry.
Methods like `eachChildView` and `_childrenCount` rely on current entry resolved page and this is the actual problem.

For example, this is a description of how things currently work on iOS:
- Method `viewWillAppear` in Frame view controller will perform an `_addView` call
- Method `viewDidAppear` will assign new current entry

Property `currentPage` is a getter that returns the resolved page of current entry, and this getter is used by `eachChildView` and `_childrenCount`. Since current entry won't be updated until `viewDidAppear` call, we end up with an `_addView` call that tries to iterate Frame's children in order to update their inheritable properties but `eachChildView` has still got zero iterations as `currentPage` returns null.

## What is the new behavior?
We add a new property called `_childView` in order to separate entry navigation logic from view tree logic. Methods like `eachChildView` are considered a DOM thing and we should not make them rely on navigation entries.

Tests seem good in both platforms but we might want to spend some time and see if this change has any bad impact.