### PR TITLE
test: use our own http-echo server

### DIFF
--- a/apps/automated/src/fetch/fetch-tests.ts
+++ b/apps/automated/src/fetch/fetch-tests.ts
@@ -8,7 +8,7 @@ export var test_fetch_defined = function () {
 
 export var test_fetch = function (done: (err: Error, res?: string) => void) {
 	// >> fetch-response
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then(function (r) {
 			// Argument (r) is Response!
 			// >> (hide)
@@ -22,7 +22,7 @@ export var test_fetch = function (done: (err: Error, res?: string) => void) {
 
 export var test_fetch_text = function (done: (err: Error, res?: string) => void) {
 	// >> fetch-string
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then((response) => response.text())
 		.then(function (r) {
 			// Argument (r) is string!
@@ -37,7 +37,7 @@ export var test_fetch_text = function (done: (err: Error, res?: string) => void)
 
 export var test_fetch_json = function (done: (err: Error, res?: string) => void) {
 	// >> fetch-json
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then((response) => response.json())
 		.then(function (r) {
 			// Argument (r) is JSON object!
@@ -52,7 +52,7 @@ export var test_fetch_json = function (done: (err: Error, res?: string) => void)
 
 export var test_fetch_formData = function (done: (err: Error, res?: string) => void) {
 	// >> fetch-formdata
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then((response) => response.formData())
 		.then(function (r) {
 			// Argument (r) is FormData object!
@@ -67,7 +67,7 @@ export var test_fetch_formData = function (done: (err: Error, res?: string) => v
 
 export var test_fetch_blob = function (done: (err: Error, res?: string) => void) {
 	// >> fetch-blob
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then((response) => response.blob())
 		.then(function (r) {
 			// Argument (r) is Blob object!
@@ -82,7 +82,7 @@ export var test_fetch_blob = function (done: (err: Error, res?: string) => void)
 
 export var test_fetch_arraybuffer = function (done: (err: Error, res?: string) => void) {
 	// >> fetch-arraybuffer
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then((response) => response.arrayBuffer())
 		.then(function (r) {
 			// Argument (r) is ArrayBuffer object!
@@ -119,7 +119,7 @@ export var test_fetch_fail_invalid_url = function (done) {
 
 export var test_fetch_response_status = function (done) {
 	// >> fetch-status-response
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then(function (response) {
 			// Argument (response) is Response!
 			var statusCode = response.status;
@@ -134,7 +134,7 @@ export var test_fetch_response_status = function (done) {
 
 export var test_fetch_response_headers = function (done) {
 	// >> fetch-headers-response
-	fetch('https://httpbin.org/get')
+	fetch('https://http-echo.nativescript.org/get')
 		.then(function (response) {
 			// Argument (response) is Response!
 			// var all = response.headers.getAll();
@@ -148,7 +148,7 @@ export var test_fetch_response_headers = function (done) {
 };
 
 export var test_fetch_headers_sent = function (done) {
-	fetch('https://httpbin.org/get', {
+	fetch('https://http-echo.nativescript.org/get', {
 		method: 'GET',
 		headers: new Headers({ 'Content-Type': 'application/json' }),
 	})
@@ -165,7 +165,7 @@ export var test_fetch_post_form_data = function (done) {
 	data.append('MyVariableOne', 'ValueOne');
 	data.append('MyVariableTwo', 'ValueTwo');
 
-	fetch('https://httpbin.org/post', {
+	fetch('https://http-echo.nativescript.org/post', {
 		method: 'POST',
 		headers: new Headers({ 'Content-Type': 'application/x-www-form-urlencoded' }),
 		body: data,
@@ -182,7 +182,7 @@ export var test_fetch_post_form_data = function (done) {
 
 export var test_fetch_post_json = function (done) {
 	// >> fetch-post-json
-	fetch('https://httpbin.org/post', {
+	fetch('https://http-echo.nativescript.org/post', {
 		method: 'POST',
 		headers: new Headers({ 'Content-Type': 'application/json' }),
 		body: JSON.stringify({ MyVariableOne: 'ValueOne', MyVariableTwo: 'ValueTwo' }),

--- a/apps/automated/src/http/http-string-worker.ts
+++ b/apps/automated/src/http/http-string-worker.ts
@@ -5,7 +5,7 @@ postMessage('stub');
 //
 // import { getString } from '@nativescript/core/http';
 //
-// getString('https://httpbin.org/get').then(
+// getString('https://http-echo.nativescript.org/get').then(
 // 	function (r) {
 // 		postMessage(r);
 // 	},

--- a/apps/automated/src/http/http-tests.ts
+++ b/apps/automated/src/http/http-tests.ts
@@ -9,7 +9,7 @@ export var test_getString_isDefined = function () {
 };
 
 export var test_getString = function (done: (err: Error, res?: string) => void) {
-	http.getString('https://httpbin.org/get').then(
+	http.getString('https://http-echo.nativescript.org/get').then(
 		function (r) {
 			//// Argument (r) is string!
 			done(null);
@@ -22,7 +22,7 @@ export var test_getString = function (done: (err: Error, res?: string) => void) 
 };
 
 export var test_getString_fail = function (done) {
-	http.getString({ url: 'hgfttp://httpbin.org/get', method: 'GET', timeout: 2000 }).catch(function (e) {
+	http.getString({ url: 'hgfttps://http-echo.nativescript.org/get', method: 'GET', timeout: 2000 }).catch(function (e) {
 		done(null);
 	});
 };
@@ -31,7 +31,7 @@ export var test_getString_fail = function (done) {
 // export var test_getString_fail_when_result_is_not_string = function (done) {
 //     var result;
 
-//     http.getString({ url: "https://httpbin.org/image/png", method: "GET" }).then(function (e) {
+//     http.getString({ url: "https://http-echo.nativescript.org/image/png/logo.png", method: "GET" }).then(function (e) {
 //         result = e;
 //         try {
 //             TKUnit.assert(result instanceof Error, "Result from getString().catch() should be Error! Current type is " + typeof result);
@@ -50,7 +50,7 @@ export var test_getJSON_isDefined = function () {
 export var test_getJSON = function (done) {
 	var result;
 
-	http.getJSON('https://httpbin.org/get').then(
+	http.getJSON('https://http-echo.nativescript.org/get').then(
 		function (r) {
 			//// Argument (r) is JSON!
 			//completed = true;
@@ -74,7 +74,7 @@ export var test_getJSON = function (done) {
 export var test_getJSON_fail = function (done) {
 	var result;
 
-	http.getJSON({ url: 'hgfttp://httpbin.org/get', method: 'GET', timeout: 2000 }).catch(function (e) {
+	http.getJSON({ url: 'hgfttps://http-echo.nativescript.org/', method: 'GET', timeout: 2000 }).catch(function (e) {
 		result = e;
 		try {
 			TKUnit.assert(result instanceof Error, 'Result from getJSON().catch() should be Error! Current type is ' + typeof result);
@@ -88,7 +88,7 @@ export var test_getJSON_fail = function (done) {
 export var test_getJSON_fail_when_result_is_not_JSON = function (done) {
 	var result;
 
-	http.getJSON({ url: 'https://httpbin.org/html', method: 'GET' }).catch(function (e) {
+	http.getJSON({ url: 'https://http-echo.nativescript.org/html', method: 'GET' }).catch(function (e) {
 		result = e;
 		try {
 			TKUnit.assert(result instanceof Error, 'Result from getJSON().catch() should be Error! Current type is ' + typeof result);
@@ -102,7 +102,7 @@ export var test_getJSON_fail_when_result_is_not_JSON = function (done) {
 export var test_getJSONP = function (done) {
 	var result;
 
-	http.getJSON('https://jsfiddle.net/echo/jsonp/').then(
+	http.getJSON('https://http-echo.nativescript.org/jsonp').then(
 		function (r) {
 			result = r;
 			try {
@@ -122,7 +122,7 @@ export var test_getJSONP = function (done) {
 export var test_getJSON_fail_when_result_is_not_JSONP = function (done) {
 	var result;
 
-	http.getJSON({ url: 'https://httpbin.org/html', method: 'GET' }).catch(function (e) {
+	http.getJSON({ url: 'https://http-echo.nativescript.org/html', method: 'GET' }).catch(function (e) {
 		result = e;
 		try {
 			TKUnit.assert(result instanceof Error, 'Result from getJSON().catch() should be Error! Current type is ' + typeof result);
@@ -138,7 +138,7 @@ export var test_gzip_request_explicit = function (done) {
 
 	http
 		.request({
-			url: 'https://postman-echo.com/gzip',
+			url: 'https://http-echo.nativescript.org/gzip',
 			method: 'GET',
 			headers: {
 				'Accept-Encoding': 'gzip',
@@ -165,7 +165,7 @@ export var test_gzip_request_implicit = function (done) {
 
 	http
 		.request({
-			url: 'https://postman-echo.com/gzip',
+			url: 'https://http-echo.nativescript.org/gzip',
 			method: 'GET',
 		})
 		.then(
@@ -191,7 +191,7 @@ export var test_getImage_isDefined = function () {
 export var test_getImage = function (done) {
 	var result;
 
-	http.getImage('https://httpbin.org/image/png').then(
+	http.getImage('https://http-echo.nativescript.org/image/png/logo.png').then(
 		(r) => {
 			// Argument (r) is ImageSource!
 			result = r;
@@ -226,7 +226,7 @@ export var test_getImage_fail = function (done) {
 export var test_getImage_fail_when_result_is_not_image = function (done) {
 	var result;
 
-	http.getImage({ url: 'https://httpbin.org/html', method: 'GET' }).catch(function (e) {
+	http.getImage({ url: 'https://http-echo.nativescript.org/html', method: 'GET' }).catch(function (e) {
 		result = e;
 		try {
 			TKUnit.assert(result instanceof Error, 'Result from getImage().catch() should be Error! Current type is ' + typeof result);
@@ -266,7 +266,7 @@ export var test_getContentAsFile = function (done) {
 	var result;
 
 	var filePath = fs.path.join(fs.knownFolders.documents().path, 'test.png');
-	http.getFile('https://httpbin.org/image/png?testQuery=query&anotherParam=param', filePath).then(
+	http.getFile('https://http-echo.nativescript.org/image/png/logo.png?testQuery=query&anotherParam=param', filePath).then(
 		function (r) {
 			//// Argument (r) is File!
 			result = r;
@@ -332,7 +332,7 @@ export var test_request_requestShouldTimeout = function (done) {
 export var test_request_responseStatusCodeShouldBeDefined = function (done) {
 	var result: http.HttpResponse;
 
-	http.request({ url: 'https://httpbin.org/get', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/get', method: 'GET' }).then(
 		function (response) {
 			//// Argument (response) is HttpResponse!
 			var statusCode = response.statusCode;
@@ -352,7 +352,7 @@ export var test_request_responseStatusCodeShouldBeDefined = function (done) {
 };
 
 export var test_headRequest_responseStatusCodeShouldBeDefined = function (done) {
-	http.request({ url: 'https://httpbin.org/get', method: 'HEAD' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/get', method: 'HEAD' }).then(
 		function (response) {
 			try {
 				TKUnit.assert(typeof response.statusCode !== 'undefined', 'response.statusCode should be defined!');
@@ -370,7 +370,7 @@ export var test_headRequest_responseStatusCodeShouldBeDefined = function (done) 
 export var test_request_responseHeadersShouldBeDefined = function (done) {
 	var result: http.HttpResponse;
 
-	http.request({ url: 'https://httpbin.org/get', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/get', method: 'GET' }).then(
 		function (response) {
 			//// Argument (response) is HttpResponse!
 			//for (var header in response.headers) {
@@ -394,7 +394,7 @@ export var test_request_responseHeadersShouldBeDefined = function (done) {
 export var test_request_responseContentShouldBeDefined = function (done) {
 	var result: http.HttpResponse;
 
-	http.request({ url: 'https://httpbin.org/get', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/get', method: 'GET' }).then(
 		function (response) {
 			//// Argument (response) is HttpResponse!
 			//// Content property of the response is HttpContent!
@@ -416,7 +416,7 @@ export var test_request_responseContentShouldBeDefined = function (done) {
 export var test_request_responseContentToStringShouldReturnString = function (done) {
 	var result;
 
-	http.request({ url: 'https://httpbin.org/get', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/get', method: 'GET' }).then(
 		function (response) {
 			result = response.content.toString();
 			try {
@@ -435,7 +435,7 @@ export var test_request_responseContentToStringShouldReturnString = function (do
 export var test_request_responseContentToJSONShouldReturnJSON = function (done) {
 	var result;
 
-	http.request({ url: 'https://httpbin.org/get', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/get', method: 'GET' }).then(
 		function (response) {
 			result = response.content.toJSON();
 			try {
@@ -454,7 +454,7 @@ export var test_request_responseContentToJSONShouldReturnJSON = function (done) 
 export var test_request_responseContentToImageShouldReturnCorrectImage = function (done) {
 	var result;
 
-	http.request({ url: 'https://httpbin.org/image/png', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/image/png/logo.png', method: 'GET' }).then(
 		function (response) {
 			response.content.toImage().then((source) => {
 				result = source;
@@ -475,7 +475,7 @@ export var test_request_responseContentToImageShouldReturnCorrectImage = functio
 export var test_request_responseContentToFileFromUrlShouldReturnCorrectFile = function (done) {
 	var result;
 
-	http.request({ url: 'https://raw.githubusercontent.com/NativeScript/NativeScript/master/tests/app/logo.png', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/image/png/logo.png', method: 'GET' }).then(
 		function (response) {
 			result = response.content.toFile();
 			try {
@@ -491,9 +491,9 @@ export var test_request_responseContentToFileFromUrlShouldReturnCorrectFile = fu
 	);
 };
 export var test_request_responseContentToFileFromUrlShouldReturnCorrectFileAndCreateDirPathIfNecesary = function (done) {
-	var result;
+	var result: fs.File;
 
-	http.request({ url: 'https://raw.githubusercontent.com/NativeScript/NativeScript/master/tests/app/logo.png', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/image/png/logo.png', method: 'GET' }).then(
 		function (response) {
 			const filePath = fs.path.join(fs.knownFolders.temp().path, 'test', 'some', 'path', 'logo.png');
 			result = response.content.toFile(filePath);
@@ -514,7 +514,7 @@ export var test_request_responseContentToFileFromUrlShouldReturnCorrectFileAndCr
 export var test_request_responseContentToFileFromContentShouldReturnCorrectFile = function (done) {
 	var result;
 
-	http.request({ url: 'https://httpbin.org/image/png?queryString=param&another=anotherParam', method: 'GET' }).then(
+	http.request({ url: 'https://http-echo.nativescript.org/image/png/logo.png?queryString=param&another=anotherParam', method: 'GET' }).then(
 		function (response) {
 			result = response.content.toFile();
 			try {
@@ -535,7 +535,7 @@ export var test_request_headersSentAndReceivedProperly = function (done) {
 
 	http
 		.request({
-			url: 'https://httpbin.org/get',
+			url: 'https://http-echo.nativescript.org/get',
 			method: 'GET',
 			headers: { 'Content-Type': 'application/json' },
 		})
@@ -580,7 +580,7 @@ export var test_request_contentSentAndReceivedProperly = function (done) {
 
 	http
 		.request({
-			url: 'https://httpbin.org/post',
+			url: 'https://http-echo.nativescript.org/post',
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			content: 'MyVariableOne=ValueOne&MyVariableTwo=ValueTwo',
@@ -610,7 +610,7 @@ export var test_request_FormDataContentSentAndReceivedProperly = function (done)
 
 	http
 		.request({
-			url: 'https://httpbin.org/post',
+			url: 'https://http-echo.nativescript.org/post',
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			content: data,
@@ -638,7 +638,7 @@ export var test_request_NonStringHeadersSentAndReceivedProperly = function (done
 
 	http
 		.request({
-			url: 'https://httpbin.org/post',
+			url: 'https://http-echo.nativescript.org/post',
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': postData.length },
 			content: postData,
@@ -664,7 +664,7 @@ export var test_request_jsonAsContentSentAndReceivedProperly = function (done) {
 
 	http
 		.request({
-			url: 'https://httpbin.org/post',
+			url: 'https://http-echo.nativescript.org/post',
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			content: JSON.stringify({ MyVariableOne: 'ValueOne', MyVariableTwo: 'ValueTwo' }),

--- a/apps/automated/src/test-runner.ts
+++ b/apps/automated/src/test-runner.ts
@@ -43,11 +43,13 @@ import * as xhrTests from './xhr/xhr-tests';
 import * as fetchTests from './fetch/fetch-tests';
 import * as timerTests from './timer/timer-tests';
 import * as profilingTests from './profiling/profiling-tests';
+
+allTests['HTTP'] = httpTests;
+allTests['XHR'] = xhrTests;
+allTests['FETCH'] = fetchTests;
+
 // don't run these on CI as they are flaky
 if (!__CI__) {
-	allTests['HTTP'] = httpTests;
-	allTests['XHR'] = xhrTests;
-	allTests['FETCH'] = fetchTests;
 	allTests['TIMER'] = timerTests;
 	allTests['PROFILING'] = profilingTests;
 }

--- a/apps/automated/src/xhr/xhr-tests.ts
+++ b/apps/automated/src/xhr/xhr-tests.ts
@@ -76,7 +76,7 @@ export var test_XMLHttpRequest_readyStateShouldChange = function (done) {
 		// </hide>
 	};
 
-	xhr.open('GET', 'https://httpbin.org/get');
+	xhr.open('GET', 'https://http-echo.nativescript.org/get');
 	xhr.send();
 	// ```
 	// </snippet>
@@ -87,7 +87,7 @@ export var test_XMLHttpRequest_headersSentAndReceivedProperly = function (done) 
 	// ### Send/receive headers
 	// ``` JavaScript
 	let xhr = new XMLHttpRequest();
-	xhr.open('GET', 'https://httpbin.org/get');
+	xhr.open('GET', 'https://http-echo.nativescript.org/get');
 	xhr.setRequestHeader('Content-Type', 'application/json');
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState > 1) {
@@ -112,7 +112,7 @@ export var test_XMLHttpRequest_contentSentAndReceivedProperly = function (done) 
 	// ### Send/receive JSON
 	// ``` JavaScript
 	let xhr = new XMLHttpRequest();
-	xhr.open('POST', 'https://httpbin.org/post');
+	xhr.open('POST', 'https://http-echo.nativescript.org/post');
 	xhr.setRequestHeader('Content-Type', 'application/json');
 	xhr.responseType = 'json';
 	xhr.onreadystatechange = function () {
@@ -137,7 +137,7 @@ export var test_XMLHttpRequest_FormDataContentSentAndReceivedProperly = function
 	// ### Send/receive FormData
 	// ``` JavaScript
 	let xhr = new XMLHttpRequest();
-	xhr.open('POST', 'https://httpbin.org/post');
+	xhr.open('POST', 'https://http-echo.nativescript.org/post');
 	xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState > 3) {
@@ -169,7 +169,7 @@ export var test_XMLHttpRequest_abortShouldCancelonreadystatechange = function (d
 	// ### Abort request
 	// ``` JavaScript
 	let xhr = new XMLHttpRequest();
-	xhr.open('POST', 'https://httpbin.org/post');
+	xhr.open('POST', 'https://http-echo.nativescript.org/post');
 	xhr.setRequestHeader('Content-Type', 'application/json');
 	// <hide>
 	xhr.onreadystatechange = function () {
@@ -186,7 +186,7 @@ export var test_XMLHttpRequest_abortShouldCancelonreadystatechange = function (d
 
 export var test_XMLHttpRequest_requestShouldBePossibleAfterAbortedOpen = function (done) {
 	xhr = new XMLHttpRequest();
-	xhr.open('POST', 'https://httpbin.org/post');
+	xhr.open('POST', 'https://http-echo.nativescript.org/post');
 	xhr.setRequestHeader('Content-Type', 'application/json');
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState > 3) {
@@ -207,7 +207,7 @@ export var test_XMLHttpRequest_requestShouldBePossibleAfterAbortedOpen = functio
 
 export var test_XMLHttpRequest_requestShouldntBePossibleAfterAbortedSentRequest = function () {
 	xhr = new XMLHttpRequest();
-	xhr.open('POST', 'https://httpbin.org/post');
+	xhr.open('POST', 'https://http-echo.nativescript.org/post');
 	xhr.setRequestHeader('Content-Type', 'application/json');
 	xhr.send(JSON.stringify({ MyVariableOne: 'ValueOne', MyVariableTwo: 'ValueTwo' }));
 	xhr.abort();
@@ -217,7 +217,7 @@ export var test_XMLHttpRequest_requestShouldntBePossibleAfterAbortedSentRequest 
 
 export function test_ignore_zero_length_request_body() {
 	let xhr = new XMLHttpRequest();
-	xhr.open('GET', 'https://httpbin.org/get');
+	xhr.open('GET', 'https://http-echo.nativescript.org/get');
 
 	xhr.send('');
 }
@@ -227,7 +227,7 @@ export function test_raises_onload_Event(done) {
 	xhr.onload = () => {
 		done(null);
 	};
-	xhr.open('GET', 'https://httpbin.org/get');
+	xhr.open('GET', 'https://http-echo.nativescript.org/get');
 	xhr.send();
 }
 
@@ -356,7 +356,7 @@ export function test_sets_status_and_statusText(done) {
 			}
 		}
 	};
-	xhr.open('GET', 'https://httpbin.org/get');
+	xhr.open('GET', 'https://http-echo.nativescript.org/get');
 	xhr.send();
 }
 
@@ -365,7 +365,7 @@ export function test_raises_onerror_Event(done) {
 	xhr.onerror = () => {
 		done(null);
 	};
-	xhr.open('GET', 'https://no-such-domain-httpbin.org');
+	xhr.open('GET', 'https://no-such-domain-httpbin.nativescript.org');
 	xhr.send();
 }
 
@@ -405,15 +405,15 @@ export var test_XMLHttpRequest_contentReceivedArrayBufferProperly = function (do
 	// ### Receive Blob
 	// ``` JavaScript
 	let xhr = new XMLHttpRequest();
-	xhr.open('GET', 'https://httpbin.org/image/jpeg');
+	xhr.open('GET', 'https://http-echo.nativescript.org/image/jpeg');
 	xhr.responseType = 'arraybuffer';
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState > 3) {
 			// <hide>
 			try {
-				TKUnit.assertEqual(xhr.getResponseHeader('Content-Length'), '35588');
+				TKUnit.assertEqual(xhr.getResponseHeader('Content-Length'), '7911');
 				TKUnit.assertEqual(xhr.getResponseHeader('Content-Type'), 'image/jpeg');
-				TKUnit.assertEqual((xhr.response as ArrayBuffer).byteLength, 35588);
+				TKUnit.assertEqual((xhr.response as ArrayBuffer).byteLength, 7911);
 				done(null);
 			} catch (err) {
 				done(err);
@@ -431,15 +431,15 @@ export var test_XMLHttpRequest_contentReceivedBlobProperly = function (done) {
 	// ### Receive Blob
 	// ``` JavaScript
 	let xhr = new XMLHttpRequest();
-	xhr.open('GET', 'https://httpbin.org/image/jpeg');
+	xhr.open('GET', 'https://http-echo.nativescript.org/image/jpeg');
 	xhr.responseType = 'blob';
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState > 3) {
 			// <hide>
 			try {
-				TKUnit.assertEqual(xhr.getResponseHeader('Content-Length'), '35588');
+				TKUnit.assertEqual(xhr.getResponseHeader('Content-Length'), '7911');
 				TKUnit.assertEqual(xhr.getResponseHeader('Content-Type'), 'image/jpeg');
-				TKUnit.assertEqual((xhr.response as Blob).size, 35588);
+				TKUnit.assertEqual((xhr.response as Blob).size, 7911);
 				TKUnit.assertEqual((xhr.response as Blob).type, 'image/jpeg');
 				done(null);
 			} catch (err) {

--- a/tools/notes/WritingUnitTests.md
+++ b/tools/notes/WritingUnitTests.md
@@ -77,7 +77,7 @@ Passing an `Error` to the `done()` callback will cause the test to fail:
 
 ```typescript
 export function test_getJSON(done) {
-    http.getJSON("https://httpbin.org/get").then(
+    http.getJSON("https://http-echo.nativescript.org/get").then(
         (result) => { done(); }, // success
         (error) => { done(error); }); // fail
 };


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
We are requesting `httpbin` and various other urls. These are often flaky because of service outages etc.

## What is the new behavior?
<!-- Describe the changes. -->
We request our own echo server: 

source: https://github.com/NativeScript/http-echo
hosted at: https://http-echo.nativescript.org/


