### PR TITLE
fix(ios): guard against no nativeView in createBackgroundUIColor

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -33,6 +33,10 @@ export namespace ios {
 		const background = view.style.backgroundInternal;
 		const nativeView = <NativeScriptUIView>view.nativeViewProtected;
 
+		if (!nativeView) {
+			return;
+		}
+
 		if (background.clearFlags & BackgroundClearFlags.CLEAR_BOX_SHADOW) {
 			// clear box shadow if it has been removed!
 			view.setProperty('clipToBounds', true);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In some (rare) cases `createBackgroundUIColor` might be called with a `view` who's `.nativeView` is `null` or `undefined` resulting in a (non-fatal usually) error like:
```
TypeError: Cannot read property 'hasNonUniformBorder' of null
```

## What is the new behavior?
We return early in case there's no `nativeView`.

