### PR TITLE
fix(android): default Label to vertical-align middle

### DIFF
--- a/apps/toolbox/src/pages/labels.xml
+++ b/apps/toolbox/src/pages/labels.xml
@@ -5,7 +5,16 @@
     </Page.actionBar>
     <ScrollView>
       <StackLayout padding="20">
-        <Label text="maxLines 2" fontWeight="bold" />
+	  	<GridLayout borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
+			<Label text="Test Label 1: should be aligned middle" />
+		</GridLayout>
+		<GridLayout marginTop="10" borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
+			<Label text="Test Label 2: should be aligned bottom" verticalAlignment="bottom" />
+		</GridLayout>
+		<GridLayout marginTop="10" borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
+			<Label text="Test Label 3: should be aligned top" verticalAlignment="top" />
+		</GridLayout>
+        <Label text="maxLines 2" fontWeight="bold" marginTop="10" />
         <Label
 				text="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 				textWrap="true"

--- a/packages/core/ui/label/index.android.ts
+++ b/packages/core/ui/label/index.android.ts
@@ -39,6 +39,7 @@ export class Label extends TextBase implements LabelDefinition {
 		const textView = this.nativeTextViewProtected;
 		textView.setSingleLine(true);
 		textView.setEllipsize(android.text.TextUtils.TruncateAt.END);
+		textView.setGravity(android.view.Gravity.CENTER_VERTICAL);
 	}
 
 	[whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

All Android `Label`'s defaulted to vertical-align `top` which never matched iOS. This has been broadly complained about and a PR was even submitted by an excellent contributor @Logikgate https://github.com/NativeScript/NativeScript/pull/8216 which properly addressed the issue but was closed years ago citing breaking changes.

## What is the new behavior?

All Android `Label`'s will default to vertical-align `middle` now to match iOS default. This is a long desired breaking change.

closes https://github.com/NativeScript/NativeScript/issues/3829 
References:
https://github.com/NativeScript/NativeScript/issues/5977 
https://github.com/NativeScript/NativeScript/pull/8216

BREAKING CHANGES:

All Android `Label`'s will default to vertical-align `middle` now to match iOS default. If you preferred the previous default `top`, you can just explicitly set it.

