### PR TITLE
fix(core): Added handling for unsupported '!important' css rule

### DIFF
--- a/packages/core/ui/styling/css-animation-parser.ts
+++ b/packages/core/ui/styling/css-animation-parser.ts
@@ -4,6 +4,7 @@ import { KeyframeAnimationInfo, KeyframeDeclaration, KeyframeInfo, UnparsedKeyfr
 import { timeConverter, animationTimingFunctionConverter } from '../styling/converters';
 
 import { transformConverter } from '../styling/style-properties';
+import { Trace } from '../../trace';
 
 const ANIMATION_PROPERTY_HANDLERS = Object.freeze({
 	'animation-name': (info: any, value: any) => (info.name = value),
@@ -125,6 +126,11 @@ function keyframeAnimationsFromCSSProperty(value: any, animations: KeyframeAnima
 export function parseKeyframeDeclarations(unparsedKeyframeDeclarations: KeyframeDeclaration[]): KeyframeDeclaration[] {
 	const declarations = unparsedKeyframeDeclarations.reduce((declarations, { property: unparsedProperty, value: unparsedValue }) => {
 		const property = CssAnimationProperty._getByCssName(unparsedProperty);
+		const indexOfImportantOccurence: number = unparsedValue.indexOf('!important');
+		if (indexOfImportantOccurence >= 0) {
+			unparsedValue = unparsedValue.substring(0, indexOfImportantOccurence).trim();
+			Trace.write(`The !important css rule is currently not supported. Property: ${property.cssLocalName}`, Trace.categories.Style, Trace.messageType.warn);
+		}
 
 		if (typeof unparsedProperty === 'string' && property && property._valueConverter) {
 			declarations[property.name] = property._valueConverter(<string>unparsedValue);

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -563,7 +563,6 @@ export class CssState {
 		const view = this.viewRef.get();
 		if (!view) {
 			Trace.write(`${matchingSelectors} not set to view's property because ".viewRef" is cleared`, Trace.categories.Style, Trace.messageType.warn);
-
 			return;
 		}
 
@@ -579,7 +578,13 @@ export class CssState {
 		const replacementFunc = (g) => g[1].toUpperCase();
 
 		for (const property in newPropertyValues) {
-			const value = newPropertyValues[property];
+			let value = newPropertyValues[property];
+			const indexOfImportantOccurence: number = value.indexOf('!important');
+			if (indexOfImportantOccurence >= 0) {
+				value = value.substring(0, indexOfImportantOccurence).trim();
+				Trace.write(`The !important css rule is currently not supported. Property: ${property}`, Trace.categories.Style, Trace.messageType.warn);
+			}
+
 			const isCssExp = isCssVariableExpression(value) || isCssCalcExpression(value);
 
 			if (isCssExp) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
A number of css properties throw error if value contains `!important` rule.

## What is the new behavior?
Added handling for missing `!important` rule to prevent it from throwing errors.

It partially fixes #4969 as PR is not actually implementing the rule.