### PR TITLE
fix(android): dialogs activity usage

### DIFF
--- a/apps/toolbox/src/main-page.xml
+++ b/apps/toolbox/src/main-page.xml
@@ -10,6 +10,7 @@
         <Button text="box-shadow" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="css-playground" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="datepicker" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
+        <Button text="dialogs" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="forms" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="image-async" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />
         <Button text="image-handling" tap="{{ viewDemo }}" class="btn btn-primary btn-view-demo" />

--- a/apps/toolbox/src/pages/a11y.xml
+++ b/apps/toolbox/src/pages/a11y.xml
@@ -25,10 +25,10 @@
             <TextView testID="testTextView" hint="TextView" text="{{switchCheckedText}}" class="view-item a11y" accessibilityLabel="TestView with a value" accessibilityLiveRegion="{{accessibilityLiveRegions.Polite}}" />
             <TextField testID="testTextField" hint="TextField" class="view-item a11y" accessibilityLabel="Plain jane TextField" accessibilityHint="Tell us your real name Jane" />
             <TextView hint="TextView" class="view-item a11y" accessibilityLabel="Nice TextView" accessibilityHint="Tell us about yourself Jane" />
-            <GridLayout testID="testGridLayout1" rows="25" columns="*" class="view-item" accessibilityLabel="No can go GridLayout" accessibilityHint="A grid that will not get bigger when increasing accessible text size">
+            <GridLayout testID="testGridLayout1" rows="35" columns="*" class="view-item" accessibilityLabel="No can go GridLayout" accessibilityHint="A grid that will not get bigger when increasing accessible text size">
               <Label text="IN-Accessible Grid" class="view-item text-center" />
             </GridLayout>
-            <GridLayout rows="25,25" columns="*,50" class="view-item a11y" accessibilityLabel="Yes an accessible GridLayout" accessibilityHint="A grid that WILL get bigger dynamically when increasing accessible text size">
+            <GridLayout rows="35,35" columns="*,50" class="view-item a11y" accessibilityLabel="Yes an accessible GridLayout" accessibilityHint="A grid that WILL get bigger dynamically when increasing accessible text size">
               <Label text="Accessible Grid" class="view-item text-center" />
               <Label row="1" text="With another item in a row" class="view-item text-center" />
               <Label rowSpan="2" col="1" text="Hi" />

--- a/apps/toolbox/src/pages/dialogs.ts
+++ b/apps/toolbox/src/pages/dialogs.ts
@@ -1,0 +1,37 @@
+import { Page, Observable, EventData, Dialogs } from '@nativescript/core';
+
+let page: Page;
+
+export function navigatingTo(args: EventData) {
+	page = <Page>args.object;
+	page.bindingContext = new SampleData();
+}
+
+export class SampleData extends Observable {
+	dialogAlert() {
+		Dialogs.alert('Hello');
+	}
+	dialogAlertWithOptions() {
+		Dialogs.alert({
+			title: 'Hello',
+			message: 'Oh hi!',
+			okButtonText: 'Nice',
+		});
+	}
+	dialogConfirm() {
+		Dialogs.confirm('Is it?').then((ok) => {
+			Dialogs.alert('Ok then!');
+		});
+	}
+
+	dialogLogin() {
+		Dialogs.login('Login').then((result) => {
+			console.log(result);
+		});
+	}
+	dialogAction() {
+		Dialogs.action('Actions', 'Cancel', ['Test', 'Testing']).then((result) => {
+			console.log(result);
+		});
+	}
+}

--- a/apps/toolbox/src/pages/dialogs.xml
+++ b/apps/toolbox/src/pages/dialogs.xml
@@ -1,0 +1,16 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
+    <Page.actionBar>
+        <ActionBar title="Dialogs" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+    <ScrollView>
+      <StackLayout padding="20">
+       <Button tap="{{dialogAlert}}" text="Alert" />
+       <Button tap="{{dialogAlertWithOptions}}" text="Alert with Options" />
+       <Button tap="{{dialogConfirm}}" text="Confirm" />
+       <Button tap="{{dialogLogin}}" text="Login" />
+       <Button tap="{{dialogAction}}" text="Actions" />
+        
+      </StackLayout>
+    </ScrollView>
+</Page>

--- a/packages/core/ui/dialogs/index.android.ts
+++ b/packages/core/ui/dialogs/index.android.ts
@@ -3,7 +3,7 @@
  */
 import { DialogOptions, ConfirmOptions, PromptOptions, PromptResult, LoginOptions, LoginResult, ActionOptions } from './dialogs-common';
 import { getLabelColor, getButtonColors, isDialogOptions, inputType, capitalizationType, DialogStrings, parseLoginOptions } from './dialogs-common';
-import { android as androidApp } from '../../application';
+import { ad } from '../../utils/native-helper';
 
 export * from './dialogs-common';
 
@@ -12,7 +12,7 @@ function isString(value): value is string {
 }
 
 function createAlertDialog(options?: DialogOptions): android.app.AlertDialog.Builder {
-	const alert = new android.app.AlertDialog.Builder(androidApp.foregroundActivity, options.theme ? options.theme : -1);
+	const alert = new android.app.AlertDialog.Builder(ad.getCurrentActivity(), options.theme ? options.theme : -1);
 	alert.setTitle(options && isString(options.title) ? options.title : '');
 	alert.setMessage(options && isString(options.message) ? options.message : '');
 	if (options && options.cancelable === false) {
@@ -202,7 +202,7 @@ export function prompt(...args): Promise<PromptResult> {
 		try {
 			const alert = createAlertDialog(options);
 
-			const input = new android.widget.EditText(androidApp.foregroundActivity);
+			const input = new android.widget.EditText(ad.getCurrentActivity());
 
 			if (options) {
 				if (options.inputType === inputType.password) {
@@ -257,23 +257,21 @@ export function login(...args: any[]): Promise<LoginResult> {
 
 	return new Promise<LoginResult>((resolve, reject) => {
 		try {
-			const context = androidApp.foregroundActivity;
-
 			const alert = createAlertDialog(options);
 
-			const userNameInput = new android.widget.EditText(context);
+			const userNameInput = new android.widget.EditText(ad.getApplicationContext());
 
 			userNameInput.setHint(options.userNameHint ? options.userNameHint : '');
 			userNameInput.setText(options.userName ? options.userName : '');
 
-			const passwordInput = new android.widget.EditText(context);
+			const passwordInput = new android.widget.EditText(ad.getApplicationContext());
 			passwordInput.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
 			passwordInput.setTypeface(android.graphics.Typeface.DEFAULT);
 
 			passwordInput.setHint(options.passwordHint ? options.passwordHint : '');
 			passwordInput.setText(options.password ? options.password : '');
 
-			const layout = new android.widget.LinearLayout(context);
+			const layout = new android.widget.LinearLayout(ad.getApplicationContext());
 			layout.setOrientation(1);
 			layout.addView(userNameInput);
 			layout.addView(passwordInput);
@@ -324,8 +322,7 @@ export function action(...args): Promise<string> {
 
 	return new Promise<string>((resolve, reject) => {
 		try {
-			const activity = androidApp.foregroundActivity || androidApp.startActivity;
-			const alert = new android.app.AlertDialog.Builder(activity, options.theme ? options.theme : -1);
+			const alert = new android.app.AlertDialog.Builder(ad.getCurrentActivity(), options.theme ? options.theme : -1);
 			const message = options && isString(options.message) ? options.message : '';
 			const title = options && isString(options.title) ? options.title : '';
 			if (options && options.cancelable === false) {

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -21,6 +21,7 @@ import { Device } from '../../platform';
 import { profile } from '../../profiling';
 import { android as androidApplication } from '../../application';
 import { setSuspended } from '../../application/application-common';
+import { ad } from '../../utils/native-helper';
 
 export * from './frame-common';
 
@@ -94,7 +95,7 @@ export class Frame extends FrameBase {
 	}
 
 	public static reloadPage(context?: ModuleContext): void {
-		const activity = application.android.foregroundActivity;
+		const activity = ad.getCurrentActivity();
 		const callbacks: AndroidActivityCallbacks = activity[CALLBACKS];
 		if (callbacks) {
 			const rootView: View = callbacks.getRootView();
@@ -147,7 +148,8 @@ export class Frame extends FrameBase {
 
 		// _onAttachedToWindow called from OS again after it was detach
 		// still happens with androidx.fragment:1.3.2
-		const lifecycleState = (androidApplication.foregroundActivity?.getLifecycle?.() || androidApplication.startActivity?.getLifecycle?.())?.getCurrentState() || androidx.lifecycle.Lifecycle.State.CREATED;
+		const activity = ad.getCurrentActivity();
+		const lifecycleState = activity?.getLifecycle?.()?.getCurrentState() || androidx.lifecycle.Lifecycle.State.CREATED;
 		if ((this._manager && this._manager.isDestroyed()) || !lifecycleState.isAtLeast(androidx.lifecycle.Lifecycle.State.CREATED)) {
 			return;
 		}

--- a/packages/core/utils/mainthread-helper.android.ts
+++ b/packages/core/utils/mainthread-helper.android.ts
@@ -1,4 +1,4 @@
-import { android as ad } from '../application';
+import { ad } from './native-helper';
 
 export function dispatchToMainThread(func: () => void) {
 	const runOnMainThread = (global as any).__runOnMainThread;
@@ -20,7 +20,7 @@ export function isMainThread(): boolean {
 }
 
 export function dispatchToUIThread(func: () => void) {
-	const activity: androidx.appcompat.app.AppCompatActivity = ad.foregroundActivity || ad.startActivity;
+	const activity: androidx.appcompat.app.AppCompatActivity = ad.getCurrentActivity();
 	if (activity && func) {
 		activity.runOnUiThread(
 			new java.lang.Runnable({


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Currently Dialogs would crash an app if the dialog is prompted when `foregroundActivity` was not available yet resulting in this crash:
```
Error: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.res.Resources$Theme android.content.Context.getTheme()' on a null object reference
  JS: createAlertDialog(file: src/webpack:/node_modules/@nativescript/core/ui/dialogs/index.android.js:11:0)
```

## What is the new behavior?

Android dialogs are now resilient under all these conditions and will no longer crash but behave properly.

