### PR TITLE
fix: global declarations fix

### DIFF
--- a/apps/automated/src/application/application-tests-common.ts
+++ b/apps/automated/src/application/application-tests-common.ts
@@ -19,7 +19,7 @@ export function testInitialized() {
 
 export function testDisplayedEvent() {
 	// global.isDisplayedEventFired flag is set in app.ts application.displayedEvent handler
-	TKUnit.assert((<any>global).isDisplayedEventFired, 'application.displayedEvent not fired');
+	TKUnit.assert(global.isDisplayedEventFired, 'application.displayedEvent not fired');
 }
 
 export function testOrientation() {

--- a/apps/automated/src/globals/globals-tests.ts
+++ b/apps/automated/src/globals/globals-tests.ts
@@ -6,8 +6,8 @@ export function test_global_system_import() {
 	TKUnit.assert(System, 'System not defined');
 	TKUnit.assert(typeof System.import === 'function', 'System.import not a function');
 
-	TKUnit.assert((<any>global).System, 'global.System not defined');
-	TKUnit.assert(typeof (<any>global).System.import === 'function', 'global.System.import not a function');
+	TKUnit.assert(global.System, 'global.System not defined');
+	TKUnit.assert(typeof global.System.import === 'function', 'global.System.import not a function');
 }
 
 export function test_global_zonedCallback() {

--- a/apps/automated/src/livesync/livesync-tests.ts
+++ b/apps/automated/src/livesync/livesync-tests.ts
@@ -249,7 +249,7 @@ function _test_onLiveSync_ModalViewClosed(context: ModuleContext) {
 }
 
 function livesync(context: ModuleContext) {
-	const ls = (<any>global).__coreModulesLiveSync || global.__onLiveSync;
+	const ls = global.__coreModulesLiveSync || global.__onLiveSync;
 	ls(context);
 }
 

--- a/apps/automated/src/main.ts
+++ b/apps/automated/src/main.ts
@@ -16,7 +16,7 @@ if (Application.ios) {
 
 // Common events for both Android and iOS.
 Application.on(Application.displayedEvent, function (args: ApplicationEventData) {
-	(<any>global).isDisplayedEventFired = true;
+	global.isDisplayedEventFired = true;
 
 	if (args.android) {
 		// For Android applications, args.android is an Android activity class.

--- a/apps/automated/src/xml-declaration/xml-declaration-tests.ts
+++ b/apps/automated/src/xml-declaration/xml-declaration-tests.ts
@@ -130,7 +130,7 @@ export function test_loadWithAttributes() {
 }
 
 export function test_parse_ShouldNotCrashWithoutExports() {
-	const xml = (<any>global).loadModule('xml-declaration/mainPage.xml', true);
+	const xml = global.loadModule('xml-declaration/mainPage.xml', true);
 
 	var v: View = Builder.parse(xml);
 	TKUnit.assert(v instanceof View, 'Expected result: View; Actual result: ' + v + ';');
@@ -826,7 +826,7 @@ export function test_NonExistingElementInTemplateError() {
 }
 
 export function test_EventInTemplate() {
-	var pageCode = (<any>global).loadModule('xml-declaration/template-builder-tests/event-in-template', true);
+	var pageCode = global.loadModule('xml-declaration/template-builder-tests/event-in-template', true);
 	var notified = false;
 	pageCode.test = (args) => {
 		notified = true;
@@ -849,7 +849,7 @@ export function test_EventInTemplate() {
 }
 
 export function test_EventInCodelessFragment() {
-	var pageCode = (<any>global).loadModule('./xml-declaration/template-builder-tests/event-in-codeless-fragment', true);
+	var pageCode = global.loadModule('./xml-declaration/template-builder-tests/event-in-codeless-fragment', true);
 
 	var notified = false;
 	pageCode.setCallback((args) => {

--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -11,7 +11,7 @@ var countResume = 0;
 var countSuspend = 0;
 
 Application.on('displayed', (args) => {
-	const uptime = global.android ? (<any>org).nativescript.Process.getUpTime : (<any>global).__tns_uptime;
+	const uptime = global.android ? (<any>org).nativescript.Process.getUpTime : global.__tns_uptime;
 	console.log('Startup time: ' + uptime() + 'ms.');
 });
 

--- a/apps/ui/src/perf/properties/tests.ts
+++ b/apps/ui/src/perf/properties/tests.ts
@@ -295,9 +295,9 @@ function setup(parent?: LayoutBase): Label {
 
 function time(): number {
 	if (global.android) {
-		return (<any>global).java.lang.System.nanoTime() / 1000000;
+		return global.java.lang.System.nanoTime() / 1000000;
 	} else {
-		return (<any>global).CACurrentMediaTime() * 1000;
+		return global.CACurrentMediaTime() * 1000;
 	}
 }
 

--- a/packages/core/application/index.ios.ts
+++ b/packages/core/application/index.ios.ts
@@ -407,7 +407,7 @@ export function ensureNativeApplication() {
 }
 
 // attach on global, so it can be overwritten in NativeScript Angular
-(<any>global).__onLiveSyncCore = function (context?: ModuleContext) {
+global.__onLiveSyncCore = function (context?: ModuleContext) {
 	ensureNativeApplication();
 	iosApp._onLivesync(context);
 };

--- a/packages/core/fps-meter/fps-native.android.ts
+++ b/packages/core/fps-meter/fps-native.android.ts
@@ -27,7 +27,7 @@ export class FPSCallback implements definition.FPSCallback {
 	}
 
 	private _isNativeFramesSupported() {
-		return typeof (<any>global).__postFrameCallback === 'function' && typeof (<any>global).__removeFrameCallback === 'function';
+		return typeof (global as any).__postFrameCallback === 'function' && typeof global.__removeFrameCallback === 'function';
 	}
 
 	public start() {

--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -17,106 +17,106 @@ declare interface NativeScriptError extends Error {
 }
 
 //Augment the NodeJS global type with our own extensions
-declare namespace NodeJS {
-	interface Global {
-		NativeScriptHasInitGlobal?: boolean;
-		NativeScriptGlobals?: {
-			/**
-			 * Global framework event handling
-			 */
-			events: {
-				[Key in keyof import('data/observable').Observable]: import('data/observable').Observable[Key];
-			};
-			launched: boolean;
-			// used by various classes to setup callbacks to wire up global app event handling when the app instance is ready
-			appEventWiring: Array<any>;
-			// determines if the app instance is ready upon bootstrap
-			appInstanceReady: boolean;
-
-			/**
-			 * Ability for classes to initialize app event handling early even before the app instance is ready during boot cycle avoiding boot race conditions
-			 * @param callback wire up any global event handling inside the callback
-			 */
-			addEventWiring(callback: () => void): void;
+declare module globalThis {
+	var NativeScriptHasInitGlobal: boolean;
+	var NativeScriptGlobals: {
+		/**
+		 * Global framework event handling
+		 */
+		events: {
+			[Key in keyof import('data/observable').Observable]: import('data/observable').Observable[Key];
 		};
-		android?: any;
-		require(id: string): any;
-
-		moduleMerge(sourceExports: any, destExports: any): void;
-
-		registerModule(name: string, loader: (name: string) => any): void;
-		/**
-		 * Register all modules from a webpack context.
-		 * The context is one created using the following webpack utility:
-		 * https://webpack.js.org/guides/dependency-management/#requirecontext
-		 *
-		 * The extension map is optional, modules in the webpack context will have their original file extension (e.g. may be ".ts" or ".scss" etc.),
-		 * while the built-in module builders in {N} will look for ".js", ".css" or ".xml" files. Adding a map such as:
-		 * ```
-		 * { ".ts": ".js" }
-		 * ```
-		 * Will resolve lookups for .js to the .ts file.
-		 * By default scss and ts files are mapped.
-		 */
-		registerWebpackModules(context: { keys(): string[]; (key: string): any }, extensionMap?: { [originalFileExtension: string]: string });
+		launched: boolean;
+		// used by various classes to setup callbacks to wire up global app event handling when the app instance is ready
+		appEventWiring: Array<any>;
+		// determines if the app instance is ready upon bootstrap
+		appInstanceReady: boolean;
 
 		/**
-		 * The NativeScript XML builder, style-scope, application modules use various resources such as:
-		 * app.css, page.xml files and modules during the application life-cycle.
-		 * The moduleResolvers can be used to provide additional mechanisms to locate such resources.
-		 * For example:
-		 * ```
-		 * global.moduleResolvers.unshift(uri => uri === "main-page" ? require("main-page") : null);
-		 * ```
-		 * More advanced scenarios will allow for specific bundlers to integrate their module resolving mechanisms.
-		 * When adding resolvers at the start of the array, avoid throwing and return null instead so subsequent resolvers may try to resolve the resource.
-		 * By default the only member of the array is global.require, as last resort - if it fails to find a module it will throw.
+		 * Ability for classes to initialize app event handling early even before the app instance is ready during boot cycle avoiding boot race conditions
+		 * @param callback wire up any global event handling inside the callback
 		 */
-		readonly moduleResolvers: ModuleResolver[];
+		addEventWiring(callback: () => void): void;
+	};
+	// var android: any;
+	function require(id: string): any;
 
-		/**
-		 *
-		 * @param name Name of the module to be loaded
-		 * @param loadForUI Is this UI module is being loaded for UI from @nativescript/core/ui/builder.
-		 * Xml, css/scss and js/ts modules for pages and custom-components should load with loadForUI=true.
-		 * Passing "true" will enable the HMR mechanics this module. Default value is false.
-		 */
-		loadModule(name: string, loadForUI?: boolean): any;
+	function moduleMerge(sourceExports: any, destExports: any): void;
 
-		/**
-		 * Checks if the module has been registered with `registerModule` or in `registerWebpackModules`
-		 * @param name Name of the module
-		 */
-		moduleExists(name: string): boolean;
+	function registerModule(name: string, loader: (name: string) => any): void;
+	/**
+	 * Register all modules from a webpack context.
+	 * The context is one created using the following webpack utility:
+	 * https://webpack.js.org/guides/dependency-management/#requirecontext
+	 *
+	 * The extension map is optional, modules in the webpack context will have their original file extension (e.g. may be ".ts" or ".scss" etc.),
+	 * while the built-in module builders in {N} will look for ".js", ".css" or ".xml" files. Adding a map such as:
+	 * ```
+	 * { ".ts": ".js" }
+	 * ```
+	 * Will resolve lookups for .js to the .ts file.
+	 * By default scss and ts files are mapped.
+	 */
+	function registerWebpackModules(context: { keys(): string[]; (key: string): any }, extensionMap?: { [originalFileExtension: string]: string });
 
-		getRegisteredModules(): string[];
+	/**
+	 * The NativeScript XML builder, style-scope, application modules use various resources such as:
+	 * app.css, page.xml files and modules during the application life-cycle.
+	 * The moduleResolvers can be used to provide additional mechanisms to locate such resources.
+	 * For example:
+	 * ```
+	 * global.moduleResolvers.unshift(uri => uri === "main-page" ? require("main-page") : null);
+	 * ```
+	 * More advanced scenarios will allow for specific bundlers to integrate their module resolving mechanisms.
+	 * When adding resolvers at the start of the array, avoid throwing and return null instead so subsequent resolvers may try to resolve the resource.
+	 * By default the only member of the array is global.require, as last resort - if it fails to find a module it will throw.
+	 */
+	var moduleResolvers: ModuleResolver[];
 
-		_unregisterModule(name: string): void;
+	/**
+	 *
+	 * @param name Name of the module to be loaded
+	 * @param loadForUI Is this UI module is being loaded for UI from @nativescript/core/ui/builder.
+	 * Xml, css/scss and js/ts modules for pages and custom-components should load with loadForUI=true.
+	 * Passing "true" will enable the HMR mechanics this module. Default value is false.
+	 */
+	function loadModule(name: string, loadForUI?: boolean): any;
 
-		_isModuleLoadedForUI(moduleName: string): boolean;
+	/**
+	 * Checks if the module has been registered with `registerModule` or in `registerWebpackModules`
+	 * @param name Name of the module
+	 */
+	function moduleExists(name: string): boolean;
 
-		onGlobalLayoutListener: any;
-		zonedCallback(callback: Function): Function;
-		Reflect?: any;
-		Deprecated(target: Object, key?: string | symbol, descriptor?: any): any;
-		Experimental(target: Object, key?: string | symbol, descriptor?: any): any;
+	function getRegisteredModules(): string[];
 
-		__native?: any;
-		__inspector?: any;
-		__extends: any;
-		__onLiveSync: (context?: { type: string; path: string }) => void;
-		__onLiveSyncCore: (context?: { type: string; path: string }) => void;
-		__onUncaughtError: (error: NativeScriptError) => void;
-		__onDiscardedError: (error: NativeScriptError) => void;
-		__snapshot?: boolean;
-		TNS_WEBPACK?: boolean;
-		isIOS?: boolean;
-		isAndroid?: boolean;
-		__requireOverride?: (name: string, dir: string) => any;
+	function _unregisterModule(name: string): void;
 
-		// used to get the rootlayout instance to add/remove childviews
-		rootLayout: any;
-	}
+	function _isModuleLoadedForUI(moduleName: string): boolean;
+
+	var onGlobalLayoutListener: any;
+	function zonedCallback(callback: Function): Function;
+	var Reflect: any;
+	function Deprecated(target: Object, key?: string | symbol, descriptor?: any): any;
+	function Experimental(target: Object, key?: string | symbol, descriptor?: any): any;
+
+	var __native: any;
+	var __inspector: any;
+	var __extends: any;
+	var __onLiveSync: (context?: { type: string; path: string }) => void;
+	var __onLiveSyncCore: (context?: { type: string; path: string }) => void;
+	var __onUncaughtError: (error: NativeScriptError) => void;
+	var __onDiscardedError: (error: NativeScriptError) => void;
+	var __snapshot: boolean;
+	var TNS_WEBPACK: boolean;
+	var isIOS: boolean;
+	var isAndroid: boolean;
+	var isDisplayedEventFired: boolean;
+	var autoLoadPolyfills: boolean;
+	var __requireOverride: (name: string, dir: string) => any;
+
+	// used to get the rootlayout instance to add/remove childviews
+	var rootLayout: any;
 }
 declare const __DEV__: boolean;
 declare const __CSS_PARSER__: string;

--- a/packages/core/globals/index.ts
+++ b/packages/core/globals/index.ts
@@ -115,8 +115,8 @@ export function initGlobal() {
 
 		// ts-helpers
 		// Required by V8 snapshot generator
-		if (!(<any>global).__extends) {
-			(<any>global).__extends = function (d, b) {
+		if (!global.__extends) {
+			global.__extends = function (d, b) {
 				for (const p in b) {
 					if (b.hasOwnProperty(p)) {
 						d[p] = b[p];
@@ -160,7 +160,7 @@ export function initGlobal() {
 		};
 
 		// Cast to <any> because moduleResolvers is read-only in definitions
-		(<any>global).moduleResolvers = [global.require];
+		global.moduleResolvers = [global.require];
 
 		global.registerModule = function (name: string, loader: ModuleLoader): void {
 			modules.set(name, { loader, moduleId: name });
@@ -250,7 +250,7 @@ export function initGlobal() {
 				return result;
 			}
 
-			for (const resolver of (<any>global).moduleResolvers) {
+			for (const resolver of global.moduleResolvers) {
 				const result = resolver(name);
 				if (result) {
 					modules.set(name, { moduleId: name, loader: () => result });
@@ -276,19 +276,19 @@ export function initGlobal() {
 		};
 
 		global.zonedCallback = function (callback: Function): Function {
-			if ((<any>global).zone) {
+			if (global.zone) {
 				// Zone v0.5.* style callback wrapping
-				return (<any>global).zone.bind(callback);
+				return global.zone.bind(callback);
 			}
-			if ((<any>global).Zone) {
+			if (global.Zone) {
 				// Zone v0.6.* style callback wrapping
-				return (<any>global).Zone.current.wrap(callback);
+				return global.Zone.current.wrap(callback);
 			} else {
 				return callback;
 			}
 		};
 
-		(<any>global).System = {
+		global.System = {
 			import(path) {
 				return new Promise((resolve, reject) => {
 					try {

--- a/packages/core/profiling/index.ts
+++ b/packages/core/profiling/index.ts
@@ -2,13 +2,13 @@
 declare let __startCPUProfiler: any;
 declare let __stopCPUProfiler: any;
 
-export function uptime() {
-	return global.android ? (<any>org).nativescript.Process.getUpTime() : (<any>global).__tns_uptime();
+export function uptime(): number {
+	return global.android ? (<any>org).nativescript.Process.getUpTime() : global.__tns_uptime();
 }
 
 export function log(message: string, ...optionalParams: any[]): void {
-	if ((<any>global).__nslog) {
-		(<any>global).__nslog('CONSOLE LOG: ' + message);
+	if (global.__nslog) {
+		global.__nslog('CONSOLE LOG: ' + message);
 	}
 	console.log(message, ...optionalParams);
 }
@@ -31,7 +31,7 @@ const timers: { [index: string]: TimerInfo } = {};
 const anyGlobal = <any>global;
 const profileNames: string[] = [];
 
-export const time = (<any>global).__time || Date.now;
+export const time = (global.__time || Date.now) as () => number;
 
 export function start(name: string): void {
 	let info = timers[name];

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -4,7 +4,6 @@
 		"noEmitOnError": true,
 		"noEmitHelpers": true,
 		"declaration": true,
-		"noImplicitAny": false,
 		"noImplicitUseStrict": true,
 		"removeComments": false,
 		"emitDecoratorMetadata": true,

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -34,7 +34,7 @@ class AnimationDelegateImpl extends NSObject implements CAAnimationDelegate {
 	public nextAnimation: Function;
 
 	// The CAAnimationDelegate protocol has been introduced in the iOS 10 SDK
-	static ObjCProtocols = (<any>global).CAAnimationDelegate ? [(<any>global).CAAnimationDelegate] : [];
+	static ObjCProtocols = global.CAAnimationDelegate ? [global.CAAnimationDelegate] : [];
 
 	private _finishedCallback: Function;
 	private _propertyAnimation: PropertyAnimationInfo;

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -597,7 +597,7 @@ export function reloadPage(context?: ModuleContext): void {
 }
 
 // attach on global, so it can be overwritten in NativeScript Angular
-(<any>global).__onLiveSyncCore = Frame.reloadPage;
+global.__onLiveSyncCore = Frame.reloadPage;
 
 function cloneExpandedTransitionListener(expandedTransitionListener: any) {
 	if (!expandedTransitionListener) {

--- a/packages/core/xml/index.ts
+++ b/packages/core/xml/index.ts
@@ -397,7 +397,7 @@ function _generateAmpMap(): any {
 }
 
 // android-specific implementation, which pre-populates the map to get it saved into the heap blob
-if ((<any>global).__snapshot) {
+if (global.__snapshot) {
 	_ampCodes = _generateAmpMap();
 }
 


### PR DESCRIPTION
this changes the way we declare global variables so that it works again as explained here https://stackoverflow.com/questions/59459312/using-globalthis-in-typescript
tsc now picks up the typings and so most fo the any cast are not needed anymore