### PR TITLE
fix(core): RootLayout view and shade cover should animate in parallel

### DIFF
--- a/packages/core/ui/layouts/root-layout/index.d.ts
+++ b/packages/core/ui/layouts/root-layout/index.d.ts
@@ -8,7 +8,7 @@ export class RootLayout extends GridLayout {
 	bringToFront(view: View, animated?: boolean): Promise<void>;
 	closeAll(): Promise<void[]>;
 	getShadeCover(): View;
-	openShadeCover(options: ShadeCoverOptions = {}): void;
+	openShadeCover(options: ShadeCoverOptions = {}): Promise<void>;
 	closeShadeCover(shadeCoverOptions: ShadeCoverOptions = {}): Promise<void>;
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
RootLayout view and shade cover don't animate in parallel.

## What is the new behavior?
This fixes animation problems caused by #10228, makes few of checks more obvious, and adds a bit more of a missing promise functionality for method `openShadeCover`.

BREAKING CHANGES:

Method `openShadeCover` return type changes from `void` to `Promise<void>`.