### PR TITLE
feat(ios): Added new a11y properties for managing font scale

### DIFF
--- a/apps/automated/src/accessibility/accessibility-properties-tests.ts
+++ b/apps/automated/src/accessibility/accessibility-properties-tests.ts
@@ -2,7 +2,7 @@ import * as TKUnit from '../tk-unit';
 import * as helper from '../ui-helper';
 import { isIOS, Label, StackLayout } from '@nativescript/core';
 
-export function test_iOSAccessibilityAdjustsFontSize_property() {
+export function test_iosAccessibilityAdjustsFontSize_property() {
 	if (isIOS) {
 		const deviceFontScaleMock = 4.0;
 
@@ -13,19 +13,19 @@ export function test_iOSAccessibilityAdjustsFontSize_property() {
 
 		page.content = layout;
 
-		layout.style.iOSAccessibilityAdjustsFontSize = false;
+		layout.style.iosAccessibilityAdjustsFontSize = false;
 		layout.style.fontScaleInternal = deviceFontScaleMock;
 
 		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
-		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.iosAccessibilityAdjustsFontSize = true;
 		const nativeFontSizeWithAdjust = testView.nativeTextViewProtected.font.pointSize;
 
-		TKUnit.assertEqual(nativeFontSize, testView.style.fontInternal.fontSize, 'View font size was scaled even though iOSAccessibilityAdjustsFontSize is disabled');
-		TKUnit.assertEqual(nativeFontSizeWithAdjust, testView.style.fontInternal.fontSize * deviceFontScaleMock, 'View font size was not scaled even though iOSAccessibilityAdjustsFontSize is enabled');
+		TKUnit.assertEqual(nativeFontSize, testView.style.fontInternal.fontSize, 'View font size was scaled even though iosAccessibilityAdjustsFontSize is disabled');
+		TKUnit.assertEqual(nativeFontSizeWithAdjust, testView.style.fontInternal.fontSize * deviceFontScaleMock, 'View font size was not scaled even though iosAccessibilityAdjustsFontSize is enabled');
 	}
 }
 
-export function test_iOSAccessibilityMinFontScale_property() {
+export function test_iosAccessibilityMinFontScale_property() {
 	if (isIOS) {
 		const deviceFontScaleMock = 1.0;
 
@@ -36,18 +36,18 @@ export function test_iOSAccessibilityMinFontScale_property() {
 
 		page.content = layout;
 
-		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.iosAccessibilityAdjustsFontSize = true;
 		layout.style.fontScaleInternal = deviceFontScaleMock;
 
-		testView.style.iOSAccessibilityMinFontScale = 2.0;
+		testView.style.iosAccessibilityMinFontScale = 2.0;
 
 		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
-		const expectedNativeFontSize = testView.style.fontInternal.fontSize * testView.style.iOSAccessibilityMinFontScale;
-		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size scaling does not respect iOSAccessibilityMinFontScale');
+		const expectedNativeFontSize = testView.style.fontInternal.fontSize * testView.style.iosAccessibilityMinFontScale;
+		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size scaling does not respect iosAccessibilityMinFontScale');
 	}
 }
 
-export function test_iOSAccessibilityMaxFontScale_property() {
+export function test_iosAccessibilityMaxFontScale_property() {
 	if (isIOS) {
 		const deviceFontScaleMock = 4.0;
 
@@ -58,13 +58,13 @@ export function test_iOSAccessibilityMaxFontScale_property() {
 
 		page.content = layout;
 
-		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.iosAccessibilityAdjustsFontSize = true;
 		layout.style.fontScaleInternal = deviceFontScaleMock;
 
-		testView.style.iOSAccessibilityMaxFontScale = 2.0;
+		testView.style.iosAccessibilityMaxFontScale = 2.0;
 
 		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
-		const expectedNativeFontSize = testView.style.fontInternal.fontSize * testView.style.iOSAccessibilityMaxFontScale;
-		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size scaling does not respect iOSAccessibilityMaxFontScale');
+		const expectedNativeFontSize = testView.style.fontInternal.fontSize * testView.style.iosAccessibilityMaxFontScale;
+		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size scaling does not respect iosAccessibilityMaxFontScale');
 	}
 }

--- a/apps/automated/src/accessibility/accessibility-properties-tests.ts
+++ b/apps/automated/src/accessibility/accessibility-properties-tests.ts
@@ -1,0 +1,70 @@
+import * as TKUnit from '../tk-unit';
+import * as helper from '../ui-helper';
+import { isIOS, Label, StackLayout } from '@nativescript/core';
+
+export function test_iOSAccessibilityAdjustsFontSize_property() {
+	if (isIOS) {
+		const deviceFontScaleMock = 4.0;
+
+		const page = helper.getCurrentPage();
+		const testView = new Label();
+		const layout = new StackLayout();
+		layout.addChild(testView);
+
+		page.content = layout;
+
+		layout.style.iOSAccessibilityAdjustsFontSize = false;
+		layout.style.fontScaleInternal = deviceFontScaleMock;
+
+		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
+		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		const nativeFontSizeWithAdjust = testView.nativeTextViewProtected.font.pointSize;
+
+		TKUnit.assertEqual(nativeFontSize, testView.style.fontInternal.fontSize, 'View font size was scaled even though iOSAccessibilityAdjustsFontSize is disabled');
+		TKUnit.assertEqual(nativeFontSizeWithAdjust, testView.style.fontInternal.fontSize * deviceFontScaleMock, 'View font size was not scaled even though iOSAccessibilityAdjustsFontSize is enabled');
+	}
+}
+
+export function test_iOSAccessibilityMinFontScale_property() {
+	if (isIOS) {
+		const deviceFontScaleMock = 1.0;
+
+		const page = helper.getCurrentPage();
+		const testView = new Label();
+		const layout = new StackLayout();
+		layout.addChild(testView);
+
+		page.content = layout;
+
+		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.fontScaleInternal = deviceFontScaleMock;
+
+		testView.style.iOSAccessibilityMinFontScale = 2.0;
+
+		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
+		const expectedNativeFontSize = testView.style.fontInternal.fontSize * testView.style.iOSAccessibilityMinFontScale;
+		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size scaling does not respect iOSAccessibilityMinFontScale');
+	}
+}
+
+export function test_iOSAccessibilityMaxFontScale_property() {
+	if (isIOS) {
+		const deviceFontScaleMock = 4.0;
+
+		const page = helper.getCurrentPage();
+		const testView = new Label();
+		const layout = new StackLayout();
+		layout.addChild(testView);
+
+		page.content = layout;
+
+		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.fontScaleInternal = deviceFontScaleMock;
+
+		testView.style.iOSAccessibilityMaxFontScale = 2.0;
+
+		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
+		const expectedNativeFontSize = testView.style.fontInternal.fontSize * testView.style.iOSAccessibilityMaxFontScale;
+		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size scaling does not respect iOSAccessibilityMaxFontScale');
+	}
+}

--- a/apps/automated/src/test-runner.ts
+++ b/apps/automated/src/test-runner.ts
@@ -54,6 +54,9 @@ if (!__CI__) {
 	allTests['PROFILING'] = profilingTests;
 }
 
+import * as a11yPropertiesTests from './accessibility/accessibility-properties-tests';
+allTests['A11Y-PROPERTIES'] = a11yPropertiesTests;
+
 import * as appSettingsTests from './application-settings/application-settings-tests';
 allTests['APPLICATION-SETTINGS'] = appSettingsTests;
 

--- a/apps/automated/src/ui/styling/style-properties-tests.ts
+++ b/apps/automated/src/ui/styling/style-properties-tests.ts
@@ -582,13 +582,17 @@ export function test_setting_font_properties_sets_native_font() {
 
 export function test_native_font_size_with_a11y_font_scale() {
 	if (isIOS) {
-		const page = helper.getCurrentPage();
-		const testView = new Label();
 		const deviceFontScaleMock = 4.0;
 
-		page.content = testView;
+		const page = helper.getCurrentPage();
+		const testView = new Label();
+		const layout = new StackLayout();
+		layout.addChild(testView);
 
-		testView.style._fontScale = deviceFontScaleMock;
+		page.content = layout;
+
+		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.fontScaleInternal = deviceFontScaleMock;
 
 		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
 		const expectedNativeFontSize = testView.style.fontInternal.fontSize * deviceFontScaleMock;

--- a/apps/automated/src/ui/styling/style-properties-tests.ts
+++ b/apps/automated/src/ui/styling/style-properties-tests.ts
@@ -591,7 +591,7 @@ export function test_native_font_size_with_a11y_font_scale() {
 
 		page.content = layout;
 
-		layout.style.iOSAccessibilityAdjustsFontSize = true;
+		layout.style.iosAccessibilityAdjustsFontSize = true;
 		layout.style.fontScaleInternal = deviceFontScaleMock;
 
 		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;

--- a/packages/core/accessibility/accessibility-css-helper.ts
+++ b/packages/core/accessibility/accessibility-css-helper.ts
@@ -52,10 +52,10 @@ function applyFontScaleToRootViews(): void {
 
 	const fontScale = getCurrentFontScale();
 
-	rootView.style._fontScale = fontScale;
+	rootView.style.fontScaleInternal = fontScale;
 
 	const rootModalViews = <Array<View>>rootView._getRootModalViews();
-	rootModalViews.forEach((rootModalView) => (rootModalView.style._fontScale = fontScale));
+	rootModalViews.forEach((rootModalView) => (rootModalView.style.fontScaleInternal = fontScale));
 }
 
 export function initAccessibilityCssHelper(): void {

--- a/packages/core/accessibility/accessibility-properties.ts
+++ b/packages/core/accessibility/accessibility-properties.ts
@@ -31,29 +31,29 @@ export const accessibilityEnabledProperty = new CssProperty<Style, boolean>({
 });
 accessibilityEnabledProperty.register(Style);
 
-export const iOSAccessibilityAdjustsFontSizeProperty = new InheritedCssProperty<Style, boolean>({
+export const iosAccessibilityAdjustsFontSizeProperty = new InheritedCssProperty<Style, boolean>({
 	defaultValue: false,
-	name: 'iOSAccessibilityAdjustsFontSize',
+	name: 'iosAccessibilityAdjustsFontSize',
 	cssName: 'ios-a11y-adjusts-font-size',
 	valueConverter: booleanConverter,
 });
-iOSAccessibilityAdjustsFontSizeProperty.register(Style);
+iosAccessibilityAdjustsFontSizeProperty.register(Style);
 
-export const iOSAccessibilityMinFontScaleProperty = new InheritedCssProperty<Style, number>({
+export const iosAccessibilityMinFontScaleProperty = new InheritedCssProperty<Style, number>({
 	defaultValue: 0,
-	name: 'iOSAccessibilityMinFontScale',
+	name: 'iosAccessibilityMinFontScale',
 	cssName: 'ios-a11y-min-font-scale',
 	valueConverter: parseFloat,
 });
-iOSAccessibilityMinFontScaleProperty.register(Style);
+iosAccessibilityMinFontScaleProperty.register(Style);
 
-export const iOSAccessibilityMaxFontScaleProperty = new InheritedCssProperty<Style, number>({
+export const iosAccessibilityMaxFontScaleProperty = new InheritedCssProperty<Style, number>({
 	defaultValue: 0,
-	name: 'iOSAccessibilityMaxFontScale',
+	name: 'iosAccessibilityMaxFontScale',
 	cssName: 'ios-a11y-max-font-scale',
 	valueConverter: parseFloat,
 });
-iOSAccessibilityMaxFontScaleProperty.register(Style);
+iosAccessibilityMaxFontScaleProperty.register(Style);
 
 export const accessibilityHiddenProperty = new (global.isIOS ? InheritedCssProperty : CssProperty)({
 	name: 'accessibilityHidden',

--- a/packages/core/accessibility/accessibility-properties.ts
+++ b/packages/core/accessibility/accessibility-properties.ts
@@ -31,6 +31,30 @@ export const accessibilityEnabledProperty = new CssProperty<Style, boolean>({
 });
 accessibilityEnabledProperty.register(Style);
 
+export const iOSAccessibilityAdjustsFontSizeProperty = new InheritedCssProperty<Style, boolean>({
+	defaultValue: false,
+	name: 'iOSAccessibilityAdjustsFontSize',
+	cssName: 'ios-a11y-adjusts-font-size',
+	valueConverter: booleanConverter,
+});
+iOSAccessibilityAdjustsFontSizeProperty.register(Style);
+
+export const iOSAccessibilityMinFontScaleProperty = new InheritedCssProperty<Style, number>({
+	defaultValue: 0,
+	name: 'iOSAccessibilityMinFontScale',
+	cssName: 'ios-a11y-min-font-scale',
+	valueConverter: parseFloat,
+});
+iOSAccessibilityMinFontScaleProperty.register(Style);
+
+export const iOSAccessibilityMaxFontScaleProperty = new InheritedCssProperty<Style, number>({
+	defaultValue: 0,
+	name: 'iOSAccessibilityMaxFontScale',
+	cssName: 'ios-a11y-max-font-scale',
+	valueConverter: parseFloat,
+});
+iOSAccessibilityMaxFontScaleProperty.register(Style);
+
 export const accessibilityHiddenProperty = new (global.isIOS ? InheritedCssProperty : CssProperty)({
 	name: 'accessibilityHidden',
 	cssName: 'a11y-hidden',

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -285,17 +285,17 @@ export abstract class View extends ViewCommon {
 	/**
 	 * Defines whether accessibility font scale should affect font size.
 	 */
-	iOSAccessibilityAdjustsFontSize: boolean;
+	iosAccessibilityAdjustsFontSize: boolean;
 
 	/**
 	 * Gets or sets the minimum accessibility font scale.
 	 */
-	iOSAccessibilityMinFontScale: number;
+	iosAccessibilityMinFontScale: number;
 
 	/**
 	 * Gets or sets the maximum accessibility font scale.
 	 */
-	iOSAccessibilityMaxFontScale: number;
+	iosAccessibilityMaxFontScale: number;
 
 	/**
 	 * Internal use only. This is used to limit the number of updates to android.view.View.setContentDescription()

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -283,6 +283,21 @@ export abstract class View extends ViewCommon {
 	accessibilityMediaSession: boolean;
 
 	/**
+	 * Defines whether accessibility font scale should affect font size.
+	 */
+	iOSAccessibilityAdjustsFontSize: boolean;
+
+	/**
+	 * Gets or sets the minimum accessibility font scale.
+	 */
+	iOSAccessibilityMinFontScale: number;
+
+	/**
+	 * Gets or sets the maximum accessibility font scale.
+	 */
+	iOSAccessibilityMaxFontScale: number;
+
+	/**
 	 * Internal use only. This is used to limit the number of updates to android.view.View.setContentDescription()
 	 */
 	_androidContentDescriptionUpdated?: boolean;

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -405,7 +405,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		modalRootViewCssClasses.forEach((c) => this.cssClasses.add(c));
 
 		parent._modal = this;
-		this.style._fontScale = getCurrentFontScale();
+		this.style.fontScaleInternal = getCurrentFontScale();
 		this._modalParent = parent;
 		this._modalContext = options.context;
 		this._closeModalCallback = (...originalArgs) => {
@@ -857,6 +857,27 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	}
 	set accessibilityMediaSession(value: boolean) {
 		this.style.accessibilityMediaSession = value;
+	}
+
+	get iOSAccessibilityAdjustsFontSize(): boolean {
+		return this.style.iOSAccessibilityAdjustsFontSize;
+	}
+	set iOSAccessibilityAdjustsFontSize(value: boolean) {
+		this.style.iOSAccessibilityAdjustsFontSize = value;
+	}
+
+	get iOSAccessibilityMinFontScale(): number {
+		return this.style.iOSAccessibilityMinFontScale;
+	}
+	set iOSAccessibilityMinFontScale(value: number) {
+		this.style.iOSAccessibilityMinFontScale = value;
+	}
+
+	get iOSAccessibilityMaxFontScale(): number {
+		return this.style.iOSAccessibilityMaxFontScale;
+	}
+	set iOSAccessibilityMaxFontScale(value: number) {
+		this.style.iOSAccessibilityMaxFontScale = value;
 	}
 
 	get automationText(): string {

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -859,25 +859,25 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		this.style.accessibilityMediaSession = value;
 	}
 
-	get iOSAccessibilityAdjustsFontSize(): boolean {
-		return this.style.iOSAccessibilityAdjustsFontSize;
+	get iosAccessibilityAdjustsFontSize(): boolean {
+		return this.style.iosAccessibilityAdjustsFontSize;
 	}
-	set iOSAccessibilityAdjustsFontSize(value: boolean) {
-		this.style.iOSAccessibilityAdjustsFontSize = value;
-	}
-
-	get iOSAccessibilityMinFontScale(): number {
-		return this.style.iOSAccessibilityMinFontScale;
-	}
-	set iOSAccessibilityMinFontScale(value: number) {
-		this.style.iOSAccessibilityMinFontScale = value;
+	set iosAccessibilityAdjustsFontSize(value: boolean) {
+		this.style.iosAccessibilityAdjustsFontSize = value;
 	}
 
-	get iOSAccessibilityMaxFontScale(): number {
-		return this.style.iOSAccessibilityMaxFontScale;
+	get iosAccessibilityMinFontScale(): number {
+		return this.style.iosAccessibilityMinFontScale;
 	}
-	set iOSAccessibilityMaxFontScale(value: number) {
-		this.style.iOSAccessibilityMaxFontScale = value;
+	set iosAccessibilityMinFontScale(value: number) {
+		this.style.iosAccessibilityMinFontScale = value;
+	}
+
+	get iosAccessibilityMaxFontScale(): number {
+		return this.style.iosAccessibilityMaxFontScale;
+	}
+	set iosAccessibilityMaxFontScale(value: number) {
+		this.style.iosAccessibilityMaxFontScale = value;
 	}
 
 	get automationText(): string {

--- a/packages/core/ui/styling/style-properties.d.ts
+++ b/packages/core/ui/styling/style-properties.d.ts
@@ -2,8 +2,8 @@ import { TransformFunctionsInfo } from '../animation';
 import { CoreTypes } from '../../core-types';
 import { Color } from '../../color';
 import { CssProperty, CssAnimationProperty, ShorthandProperty, InheritedCssProperty } from '../core/properties';
-import { Style } from '../styling/style';
-import { Font, FontStyle, FontWeight } from './font';
+import { Style } from './style';
+import { Font, FontStyleType, FontWeightType } from './font';
 import { Background } from './background';
 
 export namespace Length {
@@ -95,11 +95,12 @@ export const verticalAlignmentProperty: CssProperty<Style, CoreTypes.VerticalAli
 
 export const fontSizeProperty: InheritedCssProperty<Style, number>;
 export const fontFamilyProperty: InheritedCssProperty<Style, string>;
-export const fontStyleProperty: InheritedCssProperty<Style, FontStyle>;
-export const fontWeightProperty: InheritedCssProperty<Style, FontWeight>;
+export const fontStyleProperty: InheritedCssProperty<Style, FontStyleType>;
+export const fontWeightProperty: InheritedCssProperty<Style, FontWeightType>;
 
 export const backgroundInternalProperty: CssProperty<Style, Background>;
 export const fontInternalProperty: InheritedCssProperty<Style, Font>;
+export const fontScaleInternalProperty: InheritedCssProperty<Style, number>;
 
 export const androidElevationProperty: CssProperty<Style, number>;
 export const androidDynamicElevationOffsetProperty: CssProperty<Style, number>;

--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -1,12 +1,12 @@
 // Types
 import { unsetValue, CssProperty, CssAnimationProperty, ShorthandProperty, InheritedCssProperty } from '../core/properties';
-import { Style } from '../styling/style';
+import { Style } from './style';
 import { Transformation, TransformationValue, TransformFunctionsInfo } from '../animation';
 
 import { Color } from '../../color';
-import { Font, parseFont, FontStyle, FontStyleType, FontWeight, FontWeightType, FontVariationSettings, FontVariationSettingsType } from '../../ui/styling/font';
+import { Font, parseFont, FontStyle, FontStyleType, FontWeight, FontWeightType, FontVariationSettings, FontVariationSettingsType } from './font';
+import { Background } from './background';
 import { layout, hasDuplicates } from '../../utils';
-import { Background } from '../../ui/styling/background';
 
 import { radiansToDegrees } from '../../utils/number-utils';
 
@@ -1326,13 +1326,13 @@ export const fontFamilyProperty = new InheritedCssProperty<Style, string>({
 });
 fontFamilyProperty.register(Style);
 
-export const fontScaleProperty = new InheritedCssProperty<Style, number>({
-	name: '_fontScale',
-	cssName: '_fontScale',
+export const fontScaleInternalProperty = new InheritedCssProperty<Style, number>({
+	name: 'fontScaleInternal',
+	cssName: '_fontScaleInternal',
 	defaultValue: 1.0,
 	valueConverter: (v) => parseFloat(v),
 });
-fontScaleProperty.register(Style);
+fontScaleInternalProperty.register(Style);
 
 export const fontSizeProperty = new InheritedCssProperty<Style, number>({
 	name: 'fontSize',

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -233,9 +233,9 @@ export class Style extends Observable implements StyleDefinition {
 	public accessibilityLanguage: string;
 	public accessibilityMediaSession: boolean;
 	public accessibilityStep: number;
-	public iOSAccessibilityAdjustsFontSize: boolean;
-	public iOSAccessibilityMinFontScale: number;
-	public iOSAccessibilityMaxFontScale: number;
+	public iosAccessibilityAdjustsFontSize: boolean;
+	public iosAccessibilityMinFontScale: number;
+	public iosAccessibilityMaxFontScale: number;
 
 	public PropertyBag: {
 		new (): { [property: string]: string };

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -108,7 +108,7 @@ export class Style extends Observable implements StyleDefinition {
 	/**
 	 * This property ensures inheritance of a11y scale among views.
 	 */
-	public _fontScale: number;
+	public fontScaleInternal: number;
 	public backgroundInternal: Background;
 
 	public rotate: number;
@@ -233,6 +233,9 @@ export class Style extends Observable implements StyleDefinition {
 	public accessibilityLanguage: string;
 	public accessibilityMediaSession: boolean;
 	public accessibilityStep: number;
+	public iOSAccessibilityAdjustsFontSize: boolean;
+	public iOSAccessibilityMinFontScale: number;
+	public iOSAccessibilityMaxFontScale: number;
 
 	public PropertyBag: {
 		new (): { [property: string]: string };

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -4,7 +4,7 @@ import { CSSShadow } from '../styling/css-shadow';
 
 // Requires
 import { Font } from '../styling/font';
-import { iOSAccessibilityAdjustsFontSizeProperty, iOSAccessibilityMaxFontScaleProperty, iOSAccessibilityMinFontScaleProperty } from '../../accessibility/accessibility-properties';
+import { iosAccessibilityAdjustsFontSizeProperty, iosAccessibilityMaxFontScaleProperty, iosAccessibilityMinFontScaleProperty } from '../../accessibility/accessibility-properties';
 import { TextBaseCommon, textProperty, formattedTextProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, letterSpacingProperty, lineHeightProperty, maxLinesProperty, resetSymbol } from './text-base-common';
 import { Color } from '../../color';
 import { FormattedString } from './formatted-string';
@@ -197,14 +197,14 @@ export class TextBase extends TextBaseCommon {
 		const currentFont = this.style.fontInternal || Font.default.withFontSize(nativeView.font.pointSize);
 
 		let finalValue;
-		if (this.iOSAccessibilityAdjustsFontSize) {
+		if (this.iosAccessibilityAdjustsFontSize) {
 			finalValue = value;
 
-			if (this.iOSAccessibilityMinFontScale && this.iOSAccessibilityMinFontScale > value) {
-				finalValue = this.iOSAccessibilityMinFontScale;
+			if (this.iosAccessibilityMinFontScale && this.iosAccessibilityMinFontScale > value) {
+				finalValue = this.iosAccessibilityMinFontScale;
 			}
-			if (this.iOSAccessibilityMaxFontScale && this.iOSAccessibilityMaxFontScale < value) {
-				finalValue = this.iOSAccessibilityMaxFontScale;
+			if (this.iosAccessibilityMaxFontScale && this.iosAccessibilityMaxFontScale < value) {
+				finalValue = this.iosAccessibilityMaxFontScale;
 			}
 		} else {
 			finalValue = 1.0;
@@ -219,15 +219,15 @@ export class TextBase extends TextBaseCommon {
 		}
 	}
 
-	[iOSAccessibilityAdjustsFontSizeProperty.setNative](value: boolean) {
+	[iosAccessibilityAdjustsFontSizeProperty.setNative](value: boolean) {
 		this[fontScaleInternalProperty.setNative](this.style.fontScaleInternal);
 	}
 
-	[iOSAccessibilityMinFontScaleProperty.setNative](value: number) {
+	[iosAccessibilityMinFontScaleProperty.setNative](value: number) {
 		this[fontScaleInternalProperty.setNative](this.style.fontScaleInternal);
 	}
 
-	[iOSAccessibilityMaxFontScaleProperty.setNative](value: number) {
+	[iosAccessibilityMaxFontScaleProperty.setNative](value: number) {
 		this[fontScaleInternalProperty.setNative](this.style.fontScaleInternal);
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
As of NativeScript 8.5, we added missing support for scaling font size on iOS using accessibility settings by default.
This caused problems for a number of developers as they don't want this feature or want to put limits to it.

## What is the new behavior?
This PR adds the following new properties for iOS:

- iOSAccessibilityAdjustsFontSize (default: false)
- iOSAccessibilityMinFontScale
- iOSAccessibilityMaxFontScale

All of them are inherited css properties and inline properties at the same time.
Assigned one to root view is enough for affecting entire view tree.

BREAKING CHANGES:

This PR ensures accessibility font scale is disabled by default on iOS.
It has minor to almost no impact as scaling was not available before 8.5.