### PR TITLE
feat(text): valueFormatter for easy and flexible input auto-formatting

### DIFF
--- a/apps/toolbox/src/pages/forms.ts
+++ b/apps/toolbox/src/pages/forms.ts
@@ -1,4 +1,4 @@
-import { Page, Observable, EventData } from '@nativescript/core';
+import { Page, Observable, EventData, TextField, PropertyChangeData } from '@nativescript/core';
 
 let page: Page;
 
@@ -9,8 +9,71 @@ export function navigatingTo(args: EventData) {
 
 export class SampleData extends Observable {
 	textInput = '';
-	textChange(args) {
-		console.log(args.object.text);
-		this.notifyPropertyChange('textInput', args.object.text);
+	formattedSSNInput = '';
+	formattedPhoneInput = '';
+	valueFormatterSSN = formatSSN;
+	valueFormatterPhone = formatPhoneNumber;
+
+	textChange(args: PropertyChangeData) {
+		console.log(args.value);
+		this.notifyPropertyChange('textInput', args.value);
 	}
+
+	textChangeSSN(args: PropertyChangeData) {
+		console.log(args.value);
+		this.notifyPropertyChange('formattedSSNInput', args.value);
+	}
+
+	textChangePhone(args: PropertyChangeData) {
+		console.log(args.value);
+		this.notifyPropertyChange('formattedPhoneInput', args.value);
+	}
+}
+
+function formatPhoneNumber(value: string, useParens?: boolean) {
+	value = value.replace(/\D/g, '');
+	var size = value.length;
+	if (useParens) {
+		if (size > 0) {
+			value = '(' + value;
+		}
+		if (size > 3) {
+			value = value.slice(0, 4) + ') ' + value.slice(4, 11);
+		}
+		if (size > 6) {
+			value = value.slice(0, 9) + '-' + value.slice(9);
+		}
+	} else {
+		if (size > 3) {
+			value = value.slice(0, 3) + '-' + value.slice(3, 10);
+		}
+		if (size > 6) {
+			value = value.slice(0, 7) + '-' + value.slice(7);
+		}
+	}
+	return value;
+}
+
+function formatSSN(value: string) {
+	// if input value is falsy eg if the user deletes the input, then just return
+	if (!value) return value;
+
+	// clean the input for any non-digit values
+	const ssn = value.replace(/[^\d]/g, '');
+
+	// ssnLength is used to know when to apply our formatting for the ssn
+	const ssnLength = ssn.length;
+
+	// we need to return the value with no formatting if its less then four digits
+	if (ssnLength < 4) return ssn;
+
+	// if ssnLength is greater than 4 and less the 6 we start to return
+	// the formatted number
+	if (ssnLength < 6) {
+		return `${ssn.slice(0, 3)}-${ssn.slice(3)}`;
+	}
+
+	// finally, if the ssnLength is greater then 6, we add the last
+	// bit of formatting and return it.
+	return `${ssn.slice(0, 3)}-${ssn.slice(3, 5)}-${ssn.slice(5, 9)}`;
 }

--- a/apps/toolbox/src/pages/forms.xml
+++ b/apps/toolbox/src/pages/forms.xml
@@ -1,15 +1,25 @@
 <Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
-    <Page.actionBar>
-        <ActionBar title="Labels and TextView" class="action-bar">
-        </ActionBar>
-    </Page.actionBar>
-    <ScrollView>
-      <StackLayout padding="20">
-        <Label text="TextField:" fontWeight="bold" />
-        <TextField textChange="{{ textChange }}" marginTop="6" backgroundColor="#efefef" padding="8" fontSize="18" keyboardType="url" />
+  <Page.actionBar>
+    <ActionBar title="Labels and TextView" class="action-bar">
+    </ActionBar>
+  </Page.actionBar>
+  <ScrollView>
+    <StackLayout padding="20">
+      <Label text="TextField:" fontWeight="bold" />
+      <TextField textChange="{{ textChange }}" marginTop="6" backgroundColor="#efefef" padding="8" fontSize="18" keyboardType="url" />
 
-		<Label text="{{ textInput }}" marginTop="6" />
-        
-      </StackLayout>
-    </ScrollView>
+      <Label text="{{ textInput }}" marginTop="6" />
+
+      <Label text="SSN Formatted input:" fontWeight="bold" marginTop="12" />
+      <TextField hint="XXX-XX-XXXX" style.placeholderColor="silver" textChange="{{textChangeSSN}}" keyboardType="number" color="black" width="80%" borderColor="silver" borderWidth="1" height="40" textAlignment="center" borderRadius="4" valueFormatter="{{valueFormatterSSN}}" padding="5" maxLength="11">
+      </TextField>
+      <Label text="{{ formattedSSNInput }}" marginTop="6" />
+
+      <Label text="Phone Formatted input:" fontWeight="bold" marginTop="12" />
+      <TextField hint="XXX-XXX-XXXX" style.placeholderColor="silver" textChange="{{textChangePhone}}" keyboardType="number" color="black" width="80%" borderColor="silver" borderWidth="1" height="40" textAlignment="center" borderRadius="4" valueFormatter="{{valueFormatterPhone}}" padding="5" maxLength="12">
+      </TextField>
+      <Label text="{{ formattedPhoneInput }}" marginTop="6" />
+
+    </StackLayout>
+  </ScrollView>
 </Page>

--- a/packages/core/ui/editable-text-base/editable-text-base-common.ts
+++ b/packages/core/ui/editable-text-base/editable-text-base-common.ts
@@ -21,6 +21,7 @@ export abstract class EditableTextBase extends TextBase implements EditableTextB
 	public autocorrect: boolean;
 	public hint: string;
 	public maxLength: number;
+	public valueFormatter: (value: string) => string;
 
 	public abstract dismissSoftInput();
 	public abstract _setInputType(inputType: number): void;

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -493,6 +493,10 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
 	public onTextChanged(text: string, start: number, before: number, count: number): void {
 		// called by android.text.TextWatcher
+		if (this.valueFormatter) {
+			this.text = this.valueFormatter(text.toString());
+			this.android.setSelection((this.text || '').length);
+		}
 		// const owner = this.owner;
 		// let selectionStart = owner.android.getSelectionStart();
 		// owner.android.removeTextChangedListener(owner._editTextListeners);

--- a/packages/core/ui/editable-text-base/index.d.ts
+++ b/packages/core/ui/editable-text-base/index.d.ts
@@ -36,7 +36,7 @@ export class EditableTextBase extends TextBase {
 	/**
 	 * Gets or sets the autofill type.
 	 */
-	 autofillType: CoreTypes.AutofillType;
+	autofillType: CoreTypes.AutofillType;
 
 	/**
 	 * Gets or sets whether the instance is editable.
@@ -57,6 +57,12 @@ export class EditableTextBase extends TextBase {
 	 * Limits input to a certain number of characters.
 	 */
 	maxLength: number;
+
+	/**
+	 * Format input values
+	 * Note: useful for input masking/formatting
+	 */
+	valueFormatter: (value: string) => string;
 
 	/**
 	 * Hides the soft input method, ususally a soft keyboard.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Formatting text, which updates input on the fly in the text input area, while typing on the keyboard was tricky to do properly. 

## What is the new behavior?

Adds a new `valueFormatter` option providing the ability to do all sorts of on-the-fly auto formatting with text entry.

https://github.com/NativeScript/NativeScript/issues/10249

https://user-images.githubusercontent.com/457187/230701381-5f7290a5-bbb6-4f15-8182-528129a01841.mov


https://user-images.githubusercontent.com/457187/230701388-0abeddf7-97c0-4256-b890-5fd3131354f1.mov

