### PR TITLE
fix type src of Image

### DIFF
--- a/packages/core/ui/image/image-common.ts
+++ b/packages/core/ui/image/image-common.ts
@@ -14,7 +14,7 @@ import { Trace } from '../../trace';
 @CSSType('Image')
 export abstract class ImageBase extends View implements ImageDefinition {
 	public imageSource: ImageSource;
-	public src: string | ImageSource;
+	public src: string | ImageSource | ImageAsset;
 	public isLoading: boolean;
 	public stretch: CoreTypes.ImageStretchType;
 	public loadMode: 'sync' | 'async';
@@ -134,7 +134,7 @@ export const imageSourceProperty = new Property<ImageBase, ImageSource>({
 });
 imageSourceProperty.register(ImageBase);
 
-export const srcProperty = new Property<ImageBase, any>({ name: 'src' });
+export const srcProperty = new Property<ImageBase, string | ImageSource | ImageAsset>({ name: 'src' });
 srcProperty.register(ImageBase);
 
 export const loadModeProperty = new Property<ImageBase, 'sync' | 'async'>({

--- a/packages/core/ui/image/index.android.ts
+++ b/packages/core/ui/image/index.android.ts
@@ -186,7 +186,7 @@ export class Image extends ImageBase {
 	[srcProperty.getDefault](): any {
 		return undefined;
 	}
-	[srcProperty.setNative](value: any) {
+	[srcProperty.setNative](value: string | ImageSource | ImageAsset) {
 		this._createImageSourceFromSrc(value);
 	}
 }

--- a/packages/core/ui/image/index.d.ts
+++ b/packages/core/ui/image/index.d.ts
@@ -1,6 +1,7 @@
 ﻿import { View } from '../core/view';
 import { Style } from '../styling/style';
 import { ImageSource } from '../../image-source';
+import { ImageAsset } from '../../image-asset';
 import { Color } from '../../color';
 import { Property, InheritedCssProperty } from '../core/properties';
 import { CoreTypes } from '../../core-types';
@@ -27,7 +28,7 @@ export class Image extends View {
 	/**
 	 * Gets or sets the source of the Image. This can be either an URL string or a native image instance.
 	 */
-	src: any;
+	src: string | ImageSource | ImageAsset;
 
 	/**
 	 * Gets a value indicating if the image is currently loading.
@@ -66,7 +67,7 @@ export class Image extends View {
 }
 
 export const imageSourceProperty: Property<Image, ImageSource>;
-export const srcProperty: Property<Image, any>;
+export const srcProperty: Property<Image, string | ImageSource | ImageAsset>;
 export const isLoadingProperty: Property<Image, string>;
 export const loadMode: Property<Image, 'sync' | 'async'>;
 export const stretchProperty: Property<Image, CoreTypes.ImageStretchType>;

--- a/packages/core/ui/image/index.ios.ts
+++ b/packages/core/ui/image/index.ios.ts
@@ -1,5 +1,6 @@
 import { ImageBase, stretchProperty, imageSourceProperty, tintColorProperty, srcProperty } from './image-common';
 import { ImageSource } from '../../image-source';
+import { ImageAsset } from '../../image-asset';
 import { Color } from '../../color';
 import { Trace } from '../../trace';
 import { layout, queueGC } from '../../utils';
@@ -190,7 +191,7 @@ export class Image extends ImageBase {
 		this._setNativeImage(value ? value.ios : null);
 	}
 
-	[srcProperty.setNative](value: any) {
+	[srcProperty.setNative](value: string | ImageSource | ImageAsset) {
 		this._createImageSourceFromSrc(value);
 	}
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
The src types of the image class are `any` or `string | imageSource` but the image creation method accepts `string | ImageSource | ImageAsset`
https://github.com/NativeScript/NativeScript/blob/main/packages/core/ui/image/index.android.ts#L81

## What is the new behavior?
now the type is: `string | ImageSource | ImageAsset`



