### PR TITLE
fix(core): unhandled error typings

### DIFF
--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -7,13 +7,21 @@ interface ModuleResolver {
 }
 
 /**
- * An extended JavaScript Error which will have the nativeError property initialized in case the error is caused by executing platform-specific code.
+ * An extended JavaScript Error which will have the nativeException property initialized in case the error is caused by executing platform-specific code.
  */
 declare interface NativeScriptError extends Error {
 	/**
 	 * Represents the native error object.
 	 */
-	nativeError: any;
+	nativeException?: any;
+	/**
+	 * The native stack trace.
+	 */
+	stackTrace?: string;
+	/**
+	 * Javascript portion of stack trace.
+	 */
+	stack?: string;
 }
 
 //Augment the NodeJS global type with our own extensions


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
8.5 introduced strong typing on the Application event args, but the typings in the UnhandledErrorEventData type do not match what is returned in the handler from native.

## What is the new behavior?
Updated to match reality. So existing code compiles with 8.5.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


BREAKING CHANGES:

Will cause code written against the incorrect typing to not compile, but code would not have worked anyway.

<!-- 
[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

