### PR TITLE
fix(core/platform): fixed types for sdkVersion and osVersion

### DIFF
--- a/packages/core/platform/index.d.ts
+++ b/packages/core/platform/index.d.ts
@@ -46,13 +46,13 @@ export interface IDevice {
 
 	/**
 	 * Gets the OS version.
-	 * For example: 4.4.4(android), 8.1(ios)
+	 * For example: 12(android), 8.1(ios)
 	 */
 	osVersion: number | string;
 
 	/**
 	 * Gets the SDK version.
-	 * For example: 19(android), 8.1(ios).
+	 * For example: 31(android), 8.1(ios).
 	 */
 	sdkVersion: number | string;
 

--- a/packages/core/platform/index.d.ts
+++ b/packages/core/platform/index.d.ts
@@ -48,13 +48,13 @@ export interface IDevice {
 	 * Gets the OS version.
 	 * For example: 4.4.4(android), 8.1(ios)
 	 */
-	osVersion: string;
+	osVersion: number | string;
 
 	/**
 	 * Gets the SDK version.
 	 * For example: 19(android), 8.1(ios).
 	 */
-	sdkVersion: string;
+	sdkVersion: number | string;
 
 	/**
 	 * Gets the type of the current device.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, both `Device.sdkVersion` and `Device.osVersion` return a number in Android. The typings state that this should be a string so expressions like `if (Device.sdkVersion >= 23) {...}` are not possible.

## What is the new behavior?
I added `number | string` to the IDevice interface declaration so these expressions are allowed without the need to add `@ts-ignore`. I also updated the JSDoc to reflect this change.


