### PR TITLE
fix(ios): resilience to nativeView access under edge cases

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -898,13 +898,15 @@ export class View extends ViewCommon implements ViewDefinition {
 			CATransaction.begin();
 		}
 
-		if (value instanceof UIColor) {
-			this.nativeViewProtected.backgroundColor = value;
-		} else {
-			iosBackground.createBackgroundUIColor(this, (color: UIColor) => {
-				this.nativeViewProtected.backgroundColor = color;
-			});
-			this._setNativeClipToBounds();
+		if (this.nativeViewProtected) {
+			if (value instanceof UIColor) {
+				this.nativeViewProtected.backgroundColor = value;
+			} else {
+				iosBackground.createBackgroundUIColor(this, (color: UIColor) => {
+					this.nativeViewProtected.backgroundColor = color;
+				});
+				this._setNativeClipToBounds();
+			}
 		}
 
 		if (!updateSuspended) {
@@ -915,8 +917,10 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 
 	_setNativeClipToBounds() {
-		const backgroundInternal = this.style.backgroundInternal;
-		this.nativeViewProtected.clipsToBounds = (this.nativeViewProtected instanceof UIScrollView || backgroundInternal.hasBorderWidth() || backgroundInternal.hasBorderRadius()) && !backgroundInternal.hasBoxShadow();
+		if (this.nativeViewProtected) {
+			const backgroundInternal = this.style.backgroundInternal;
+			this.nativeViewProtected.clipsToBounds = (this.nativeViewProtected instanceof UIScrollView || backgroundInternal.hasBorderWidth() || backgroundInternal.hasBorderRadius()) && !backgroundInternal.hasBoxShadow();
+		}
 	}
 
 	private _setupPopoverControllerDelegate(controller: UIViewController, parent: View) {

--- a/packages/core/ui/layouts/layout-base.ios.ts
+++ b/packages/core/ui/layouts/layout-base.ios.ts
@@ -23,7 +23,9 @@ export class LayoutBase extends LayoutBaseCommon {
 
 	_setNativeClipToBounds() {
 		if (this.clipToBounds) {
-			this.nativeViewProtected.clipsToBounds = true;
+			if (this.nativeViewProtected) {
+				this.nativeViewProtected.clipsToBounds = true;
+			}
 		} else {
 			super._setNativeClipToBounds();
 		}

--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -275,7 +275,9 @@ export class ListView extends ListViewBase {
 
 	_setNativeClipToBounds() {
 		// Always set clipsToBounds for list-view
-		this.ios.clipsToBounds = true;
+		if (this.ios) {
+			this.ios.clipsToBounds = true;
+		}
 	}
 
 	@profile


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Occasionally varied view binding conditions can cause race conditions on property setters which could end up trying to access the `nativeView` when it is not ready or not created yet.

## What is the new behavior?

iOS will be resilient under these conditions.

