### PR TITLE
fix(shared-transition): iOS snapshot opacity

### DIFF
--- a/packages/core/utils/native-helper.ios.ts
+++ b/packages/core/utils/native-helper.ios.ts
@@ -368,10 +368,13 @@ export namespace iOSNativeHelper {
 			return view.image;
 		}
 		// console.log('snapshotView view.frame:', printRect(view.frame));
+		const originalOpacity = view.layer.opacity;
+		view.layer.opacity = originalOpacity > 0 ? originalOpacity : 1;
 		UIGraphicsBeginImageContextWithOptions(CGSizeMake(view.frame.size.width, view.frame.size.height), false, scale);
 		view.layer.renderInContext(UIGraphicsGetCurrentContext());
 		const image = UIGraphicsGetImageFromCurrentImageContext();
 		UIGraphicsEndImageContext();
+		view.layer.opacity = originalOpacity;
 		return image;
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In some cases a snapshot might end up being a transparent (empty) image.

## What is the new behavior?
<!-- Describe the changes. -->
The snapshot ensures the layers opacity is non-zero for the snapshot.



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

