### PR TITLE
chore: refactor

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -897,13 +897,13 @@ export class View extends ViewCommon implements ViewDefinition {
 		if (!updateSuspended) {
 			CATransaction.begin();
 		}
-
-		if (this.nativeViewProtected) {
+		const view = this.nativeViewProtected;
+		if (view) {
 			if (value instanceof UIColor) {
-				this.nativeViewProtected.backgroundColor = value;
+				view.backgroundColor = value;
 			} else {
 				iosBackground.createBackgroundUIColor(this, (color: UIColor) => {
-					this.nativeViewProtected.backgroundColor = color;
+					view.backgroundColor = color;
 				});
 				this._setNativeClipToBounds();
 			}
@@ -917,9 +917,10 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 
 	_setNativeClipToBounds() {
-		if (this.nativeViewProtected) {
+		const view = this.nativeViewProtected;
+		if (view) {
 			const backgroundInternal = this.style.backgroundInternal;
-			this.nativeViewProtected.clipsToBounds = (this.nativeViewProtected instanceof UIScrollView || backgroundInternal.hasBorderWidth() || backgroundInternal.hasBorderRadius()) && !backgroundInternal.hasBoxShadow();
+			view.clipsToBounds = (view instanceof UIScrollView || backgroundInternal.hasBorderWidth() || backgroundInternal.hasBorderRadius()) && !backgroundInternal.hasBoxShadow();
 		}
 	}
 

--- a/packages/core/ui/layouts/layout-base.ios.ts
+++ b/packages/core/ui/layouts/layout-base.ios.ts
@@ -23,8 +23,9 @@ export class LayoutBase extends LayoutBaseCommon {
 
 	_setNativeClipToBounds() {
 		if (this.clipToBounds) {
-			if (this.nativeViewProtected) {
-				this.nativeViewProtected.clipsToBounds = true;
+			const view = this.nativeViewProtected;
+			if (view) {
+				view.clipsToBounds = true;
 			}
 		} else {
 			super._setNativeClipToBounds();

--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -275,8 +275,9 @@ export class ListView extends ListViewBase {
 
 	_setNativeClipToBounds() {
 		// Always set clipsToBounds for list-view
-		if (this.ios) {
-			this.ios.clipsToBounds = true;
+		const view = this.nativeViewProtected;
+		if (view) {
+			view.clipsToBounds = true;
 		}
 	}
 
@@ -286,7 +287,7 @@ export class ListView extends ListViewBase {
 		if (this._isDataDirty) {
 			this.refresh();
 		}
-		this.ios.delegate = this._delegate;
+		this.nativeViewProtected.delegate = this._delegate;
 	}
 
 	// @ts-ignore
@@ -313,7 +314,7 @@ export class ListView extends ListViewBase {
 	}
 
 	private _scrollToIndex(index: number, animated = true) {
-		if (!this.ios) {
+		if (!this.nativeViewProtected) {
 			return;
 		}
 
@@ -326,7 +327,7 @@ export class ListView extends ListViewBase {
 				index = itemsLength - 1;
 			}
 
-			this.ios.scrollToRowAtIndexPathAtScrollPositionAnimated(NSIndexPath.indexPathForItemInSection(index, 0), UITableViewScrollPosition.Top, animated);
+			this.nativeViewProtected.scrollToRowAtIndexPathAtScrollPositionAnimated(NSIndexPath.indexPathForItemInSection(index, 0), UITableViewScrollPosition.Top, animated);
 		} else if (Trace.isEnabled()) {
 			Trace.write(`Cannot scroll listview to index ${index} when listview items not set`, Trace.categories.Binding);
 		}
@@ -341,7 +342,7 @@ export class ListView extends ListViewBase {
 		});
 
 		if (this.isLoaded) {
-			this.ios.reloadData();
+			this.nativeViewProtected.reloadData();
 			this.requestLayout();
 			this._isDataDirty = false;
 		} else {
@@ -350,7 +351,7 @@ export class ListView extends ListViewBase {
 	}
 
 	public isItemAtIndexVisible(itemIndex: number): boolean {
-		const indexes: NSIndexPath[] = Array.from(this.ios.indexPathsForVisibleRows);
+		const indexes: NSIndexPath[] = Array.from(this.nativeViewProtected.indexPathsForVisibleRows);
 
 		return indexes.some((visIndex) => visIndex.row === itemIndex);
 	}
@@ -365,7 +366,7 @@ export class ListView extends ListViewBase {
 
 	public _onRowHeightPropertyChanged(oldValue: CoreTypes.LengthType, newValue: CoreTypes.LengthType) {
 		const value = layout.toDeviceIndependentPixels(this._effectiveRowHeight);
-		const nativeView = this.ios;
+		const nativeView = this.nativeViewProtected;
 		if (value < 0) {
 			nativeView.rowHeight = UITableViewAutomaticDimension;
 			nativeView.estimatedRowHeight = DEFAULT_HEIGHT;
@@ -395,7 +396,7 @@ export class ListView extends ListViewBase {
 		const changed = this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
 		super.measure(widthMeasureSpec, heightMeasureSpec);
 		if (changed) {
-			this.ios.reloadData();
+			this.nativeViewProtected.reloadData();
 		}
 	}
 
@@ -432,7 +433,7 @@ export class ListView extends ListViewBase {
 			return height;
 		}
 
-		return this.ios.estimatedRowHeight;
+		return this.nativeViewProtected.estimatedRowHeight;
 	}
 
 	public _prepareCell(cell: ListViewCell, indexPath: NSIndexPath): number {
@@ -499,10 +500,10 @@ export class ListView extends ListViewBase {
 	}
 
 	[separatorColorProperty.getDefault](): UIColor {
-		return this.ios.separatorColor;
+		return this.nativeViewProtected.separatorColor;
 	}
 	[separatorColorProperty.setNative](value: Color | UIColor) {
-		this.ios.separatorColor = value instanceof Color ? value.ios : value;
+		this.nativeViewProtected.separatorColor = value instanceof Color ? value.ios : value;
 	}
 
 	[itemTemplatesProperty.getDefault](): KeyedTemplate[] {
@@ -512,7 +513,7 @@ export class ListView extends ListViewBase {
 		this._itemTemplatesInternal = new Array<KeyedTemplate>(this._defaultTemplate);
 		if (value) {
 			for (let i = 0, length = value.length; i < length; i++) {
-				this.ios.registerClassForCellReuseIdentifier(ListViewCell.class(), value[i].key);
+				this.nativeViewProtected.registerClassForCellReuseIdentifier(ListViewCell.class(), value[i].key);
 			}
 			this._itemTemplatesInternal = this._itemTemplatesInternal.concat(value);
 		}
@@ -524,7 +525,7 @@ export class ListView extends ListViewBase {
 		return DEFAULT_HEIGHT;
 	}
 	[iosEstimatedRowHeightProperty.setNative](value: CoreTypes.LengthType) {
-		const nativeView = this.ios;
+		const nativeView = this.nativeViewProtected;
 		const estimatedHeight = Length.toDevicePixels(value, 0);
 		nativeView.estimatedRowHeight = estimatedHeight < 0 ? DEFAULT_HEIGHT : estimatedHeight;
 	}


### PR DESCRIPTION
`this.nativeViewProtected` is faster than `this.ios`

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

