### PR TITLE
fix(ios): FormattedString and Span a11y font scale

### DIFF
--- a/apps/automated/src/test-runner.ts
+++ b/apps/automated/src/test-runner.ts
@@ -227,6 +227,9 @@ allTests['LISTVIEW'] = listViewTests;
 import * as activityIndicatorTests from './ui/activity-indicator/activity-indicator-tests';
 allTests['ACTIVITY-INDICATOR'] = activityIndicatorTests;
 
+import * as textBaseTests from './ui/text-base/text-base-tests';
+allTests['TEXT-BASE'] = textBaseTests;
+
 import * as textFieldTests from './ui/text-field/text-field-tests';
 allTests['TEXT-FIELD'] = textFieldTests;
 

--- a/apps/automated/src/ui/styling/style-properties-tests.ts
+++ b/apps/automated/src/ui/styling/style-properties-tests.ts
@@ -580,26 +580,6 @@ export function test_setting_font_properties_sets_native_font() {
 	test_native_font('italic', 'bold');
 }
 
-export function test_native_font_size_with_a11y_font_scale() {
-	if (isIOS) {
-		const deviceFontScaleMock = 4.0;
-
-		const page = helper.getCurrentPage();
-		const testView = new Label();
-		const layout = new StackLayout();
-		layout.addChild(testView);
-
-		page.content = layout;
-
-		layout.style.iosAccessibilityAdjustsFontSize = true;
-		layout.style.fontScaleInternal = deviceFontScaleMock;
-
-		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
-		const expectedNativeFontSize = testView.style.fontInternal.fontSize * deviceFontScaleMock;
-		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size does not respect a11y font scaling');
-	}
-}
-
 function test_native_font(style: 'normal' | 'italic', weight: '100' | '200' | '300' | 'normal' | '400' | '500' | '600' | 'bold' | '700' | '800' | '900') {
 	const testView = new Button();
 

--- a/apps/automated/src/ui/text-base/text-base-tests.ts
+++ b/apps/automated/src/ui/text-base/text-base-tests.ts
@@ -1,0 +1,23 @@
+import * as TKUnit from '../../tk-unit';
+import * as helper from '../../ui-helper';
+import { FormattedString, isIOS, Label, Span, StackLayout } from '@nativescript/core';
+
+export function test_native_font_size_with_a11y_font_scale() {
+	if (isIOS) {
+		const deviceFontScaleMock = 4.0;
+
+		const page = helper.getCurrentPage();
+		const testView = new Label();
+		const layout = new StackLayout();
+		layout.addChild(testView);
+
+		page.content = layout;
+
+		layout.style.iosAccessibilityAdjustsFontSize = true;
+		layout.style.fontScaleInternal = deviceFontScaleMock;
+
+		const nativeFontSize = testView.nativeTextViewProtected.font.pointSize;
+		const expectedNativeFontSize = testView.style.fontInternal.fontSize * deviceFontScaleMock;
+		TKUnit.assertEqual(nativeFontSize, expectedNativeFontSize, 'View font size does not respect a11y font scaling');
+	}
+}

--- a/packages/core/ui/text-base/formatted-string.d.ts
+++ b/packages/core/ui/text-base/formatted-string.d.ts
@@ -6,7 +6,7 @@ import { Span } from './span';
 import { ObservableArray } from '../../data/observable-array';
 import { ViewBase } from '../core/view-base';
 import { Color } from '../../color';
-import { FontStyle, FontWeight } from '../styling/font';
+import { FontStyleType, FontWeightType } from '../styling/font';
 import { CoreTypes } from '../../core-types';
 
 /**
@@ -36,12 +36,12 @@ export class FormattedString extends ViewBase {
 	/**
 	 * Gets or sets the font style which will be used for all spans that doesn't have a specific value.
 	 */
-	public fontStyle: FontStyle;
+	public fontStyle: FontStyleType;
 
 	/**
 	 * Gets or sets the font weight which will be used for all spans that doesn't have a specific value.
 	 */
-	public fontWeight: FontWeight;
+	public fontWeight: FontWeightType;
 
 	/**
 	 * Gets or sets text decorations which will be used for all spans that doesn't have a specific value.
@@ -57,4 +57,19 @@ export class FormattedString extends ViewBase {
 	 * Gets or sets the font background color which will be used for all spans that doesn't have a specific value.
 	 */
 	public backgroundColor: Color;
+
+	/**
+	 * Defines whether accessibility font scale should affect font size.
+	 */
+	iosAccessibilityAdjustsFontSize: boolean;
+
+	/**
+	 * Gets or sets the minimum accessibility font scale.
+	 */
+	iosAccessibilityMinFontScale: number;
+
+	/**
+	 * Gets or sets the maximum accessibility font scale.
+	 */
+	iosAccessibilityMaxFontScale: number;
 }

--- a/packages/core/ui/text-base/formatted-string.ts
+++ b/packages/core/ui/text-base/formatted-string.ts
@@ -66,6 +66,27 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 		this.style.backgroundColor = value;
 	}
 
+	get iosAccessibilityAdjustsFontSize(): boolean {
+		return this.style.iosAccessibilityAdjustsFontSize;
+	}
+	set iosAccessibilityAdjustsFontSize(value: boolean) {
+		this.style.iosAccessibilityAdjustsFontSize = value;
+	}
+
+	get iosAccessibilityMinFontScale(): number {
+		return this.style.iosAccessibilityMinFontScale;
+	}
+	set iosAccessibilityMinFontScale(value: number) {
+		this.style.iosAccessibilityMinFontScale = value;
+	}
+
+	get iosAccessibilityMaxFontScale(): number {
+		return this.style.iosAccessibilityMaxFontScale;
+	}
+	set iosAccessibilityMaxFontScale(value: number) {
+		this.style.iosAccessibilityMaxFontScale = value;
+	}
+
 	get spans(): ObservableArray<Span> {
 		if (!this._spans) {
 			this._spans = new ObservableArray<Span>();
@@ -135,6 +156,12 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 		style.on('textDecorationChange', this.onPropertyChange, this);
 		style.on('colorChange', this.onPropertyChange, this);
 		style.on('backgroundColorChange', this.onPropertyChange, this);
+
+		// These handlers will trigger font scale update
+		style.on('iosAccessibilityAdjustsFontSizeChange', this.onPropertyChange, this);
+		style.on('iosAccessibilityMinFontScaleChange', this.onPropertyChange, this);
+		style.on('iosAccessibilityMaxFontScaleChange', this.onPropertyChange, this);
+		style.on('fontScaleInternalChange', this.onPropertyChange, this);
 	}
 
 	private removePropertyChangeHandler(span: Span) {
@@ -147,6 +174,11 @@ export class FormattedString extends ViewBase implements FormattedStringDefiniti
 		style.off('textDecorationChange', this.onPropertyChange, this);
 		style.off('colorChange', this.onPropertyChange, this);
 		style.off('backgroundColorChange', this.onPropertyChange, this);
+
+		style.off('iosAccessibilityAdjustsFontSizeChange', this.onPropertyChange, this);
+		style.off('iosAccessibilityMinFontScaleChange', this.onPropertyChange, this);
+		style.off('iosAccessibilityMaxFontScaleChange', this.onPropertyChange, this);
+		style.off('fontScaleInternalChange', this.onPropertyChange, this);
 	}
 
 	private onPropertyChange(data: PropertyChangeData) {

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -194,15 +194,17 @@ export class TextBase extends TextBaseCommon {
 
 	[fontScaleInternalProperty.setNative](value: number) {
 		const nativeView = this.nativeTextViewProtected instanceof UIButton ? this.nativeTextViewProtected.titleLabel : this.nativeTextViewProtected;
-		const currentFont = this.style.fontInternal || Font.default.withFontSize(nativeView.font.pointSize);
+		const font = this.style.fontInternal || Font.default.withFontSize(nativeView.font.pointSize);
 		const finalValue = adjustMinMaxFontScale(value, this);
 
-		const newFont = currentFont.withFontScale(finalValue);
-		this.style.fontInternal = newFont;
-
 		// Request layout on font scale as it's not done automatically
-		if (currentFont.fontScale !== finalValue) {
+		if (font.fontScale !== finalValue) {
+			this.style.fontInternal = font.withFontScale(finalValue);
 			this.requestLayout();
+		} else {
+			if (!this.style.fontInternal) {
+				this.style.fontInternal = font;
+			}
 		}
 	}
 

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -14,7 +14,6 @@ import { isString, isNullOrUndefined } from '../../utils/types';
 import { iOSNativeHelper } from '../../utils';
 import { Trace } from '../../trace';
 import { CoreTypes } from '../../core-types';
-import { ViewBase } from 'ui/core/view-base';
 
 export * from './text-base-common';
 

--- a/packages/core/ui/text-base/span.d.ts
+++ b/packages/core/ui/text-base/span.d.ts
@@ -1,6 +1,6 @@
 ﻿import { Color } from '../../color';
 import { ViewBase } from '../core/view-base';
-import { FontStyle, FontWeight } from '../styling/font';
+import { FontStyleType, FontWeightType } from '../styling/font';
 import { CoreTypes } from '../../core-types';
 
 /**
@@ -20,12 +20,12 @@ export class Span extends ViewBase {
 	/**
 	 * Gets or sets the font style of the span.
 	 */
-	public fontStyle: FontStyle;
+	public fontStyle: FontStyleType;
 
 	/**
 	 * Gets or sets the font weight of the span.
 	 */
-	public fontWeight: FontWeight;
+	public fontWeight: FontWeightType;
 
 	/**
 	 * Gets or sets text decorations for the span.
@@ -41,6 +41,21 @@ export class Span extends ViewBase {
 	 * Gets or sets the font background color of the span.
 	 */
 	public backgroundColor: Color;
+
+	/**
+	 * Defines whether accessibility font scale should affect font size.
+	 */
+	iosAccessibilityAdjustsFontSize: boolean;
+
+	/**
+	 * Gets or sets the minimum accessibility font scale.
+	 */
+	iosAccessibilityMinFontScale: number;
+
+	/**
+	 * Gets or sets the maximum accessibility font scale.
+	 */
+	iosAccessibilityMaxFontScale: number;
 
 	/**
 	 * Gets or sets the text for the span.

--- a/packages/core/ui/text-base/span.ts
+++ b/packages/core/ui/text-base/span.ts
@@ -62,6 +62,27 @@ export class Span extends ViewBase implements SpanDefinition {
 		this.style.backgroundColor = value;
 	}
 
+	get iosAccessibilityAdjustsFontSize(): boolean {
+		return this.style.iosAccessibilityAdjustsFontSize;
+	}
+	set iosAccessibilityAdjustsFontSize(value: boolean) {
+		this.style.iosAccessibilityAdjustsFontSize = value;
+	}
+
+	get iosAccessibilityMinFontScale(): number {
+		return this.style.iosAccessibilityMinFontScale;
+	}
+	set iosAccessibilityMinFontScale(value: number) {
+		this.style.iosAccessibilityMinFontScale = value;
+	}
+
+	get iosAccessibilityMaxFontScale(): number {
+		return this.style.iosAccessibilityMaxFontScale;
+	}
+	set iosAccessibilityMaxFontScale(value: number) {
+		this.style.iosAccessibilityMaxFontScale = value;
+	}
+
 	get text(): string {
 		return this._text;
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
iOS a11y font scale does not affect FormattedStrings and Spans.

## What is the new behavior?
iOS a11y font scale will affect FormattedStrings and Spans.

Fixes #10272 .