### PR TITLE
fix(dialogs/iOS): do not use view controllers that are being dismissed

### DIFF
--- a/packages/core/ui/dialogs/index.ios.ts
+++ b/packages/core/ui/dialogs/index.ios.ts
@@ -45,9 +45,9 @@ function raiseCallback(callback, result) {
 }
 
 function showUIAlertController(alertController: UIAlertController) {
-	let viewController = ios.rootController;
+	let viewController = ios.rootController as UIViewController;
 
-	while (viewController && viewController.presentedViewController) {
+	while (viewController && viewController.presentedViewController && !viewController.presentedViewController.beingDismissed) {
 		viewController = viewController.presentedViewController;
 	}
 
@@ -60,7 +60,7 @@ function showUIAlertController(alertController: UIAlertController) {
 	if (alertController.popoverPresentationController) {
 		alertController.popoverPresentationController.sourceView = viewController.view;
 		alertController.popoverPresentationController.sourceRect = CGRectMake(viewController.view.bounds.size.width / 2.0, viewController.view.bounds.size.height / 2.0, 1.0, 1.0);
-		alertController.popoverPresentationController.permittedArrowDirections = 0;
+		alertController.popoverPresentationController.permittedArrowDirections = 0 as UIPopoverArrowDirection;
 	}
 
 	const color = getButtonColors().color;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A dialog will not show up on iOS when invoked shortly after a modal has been closed, as the view controller will be playing the dismiss animation and will dismiss the dialog along with it.

## What is the new behavior?
Do not use UIControllers that have the `beingDismissed` flag as the `sourceView` for dialogs.

Alternatively, we could use an async approach like this:
```ts
function getViewController(): Promise<UIViewController> {
	let viewController = ios.rootController as UIViewController;

	while (viewController && viewController.presentedViewController) {
		viewController = viewController.presentedViewController;
	}

	if (viewController.beingDismissed) {
		const dismiss = new Promise<void>((resolve) => viewController.dismissViewControllerAnimatedCompletion(false, () => resolve()));
		return dismiss.then(() => getViewController());
	} else {
		return Promise.resolve(viewController);
	}
}
```
The reason why I didn't use this method is simply that I couldn't find any documentation of the side effects of calling `dismissViewController` in a controller that is already being dismissed.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

