### PR TITLE
fix(webpack): angular 16 build with terser

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -318,7 +318,10 @@ exports[`angular configuration for android 1`] = `
               keep_infinity: true,
               drop_console: false,
               global_defs: {
-                __UGLIFIED__: true
+                __UGLIFIED__: true,
+                ngDevMode: false,
+                ngI18nClosureMode: false,
+                ngJitMode: false
               }
             },
             keep_fnames: true,
@@ -741,7 +744,10 @@ exports[`angular configuration for ios 1`] = `
               keep_infinity: true,
               drop_console: false,
               global_defs: {
-                __UGLIFIED__: true
+                __UGLIFIED__: true,
+                ngDevMode: false,
+                ngI18nClosureMode: false,
+                ngJitMode: false
               }
             },
             keep_fnames: true,

--- a/packages/webpack5/src/configuration/angular.ts
+++ b/packages/webpack5/src/configuration/angular.ts
@@ -13,6 +13,16 @@ import {
 	getPlatformName,
 } from '../helpers/platform';
 import base from './base';
+// until we can switch to async/await on the webpack config, copy this from '@angular/compiler-cli'
+const GLOBAL_DEFS_FOR_TERSER = {
+	ngDevMode: false,
+	ngI18nClosureMode: false,
+};
+
+const GLOBAL_DEFS_FOR_TERSER_WITH_AOT = {
+	...GLOBAL_DEFS_FOR_TERSER,
+	ngJitMode: false,
+};
 
 export default function (config: Config, env: IWebpackEnv = _env): Config {
 	base(config, env);
@@ -268,6 +278,19 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 			/core\/ui\/styling/,
 		])
 	);
+
+	config.optimization.minimizer('TerserPlugin').tap((args) => {
+		args[0].terserOptions ??= {};
+		args[0].terserOptions.compress ??= {};
+		args[0].terserOptions.compress.global_defs ??= {};
+		args[0].terserOptions.compress.global_defs = {
+			...args[0].terserOptions.compress.global_defs,
+			...(disableAOT
+				? GLOBAL_DEFS_FOR_TERSER
+				: GLOBAL_DEFS_FOR_TERSER_WITH_AOT),
+		};
+		return args;
+	});
 
 	// todo: re-visit later, disabling by default now
 	// config.plugin('DefinePlugin').tap((args) => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
We don't add ngDevMode and a few other defines to terser

## What is the new behavior?
we now pass them. Ideally we should get them for `@angular/compiler-cli` but to do that we'd need to convert our webpack config to async (to allow it to import esm), so for now I just copy pasted the values
