### PR TITLE
fix(webpack): use existing runtime version to determine the supported browsers

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -208,7 +208,10 @@ exports[`angular configuration for android 1`] = `
           {
             loader: '@angular-devkit/build-angular/src/babel/webpack-loader',
             options: {
-              aot: true
+              aot: true,
+              supportedBrowsers: [
+                'chrome 83'
+              ]
             }
           }
         ],
@@ -634,7 +637,10 @@ exports[`angular configuration for ios 1`] = `
           {
             loader: '@angular-devkit/build-angular/src/babel/webpack-loader',
             options: {
-              aot: true
+              aot: true,
+              supportedBrowsers: [
+                'chrome 103'
+              ]
             }
           }
         ],

--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -41,6 +41,7 @@
 		"sass": "^1.0.0",
 		"sass-loader": "^13.0.0",
 		"sax": "^1.0.0",
+		"semver": "^7.5.1",
 		"source-map": "^0.7.0",
 		"terser-webpack-plugin": "^5.0.0",
 		"ts-dedent": "^2.0.0",


### PR DESCRIPTION
This is a draft atm. It should correctly detect the runtime version and transform the code (using babel internally), since angular doesn't honor the tsconfig target anymore.