### PR TITLE
fix(types): Add missing fields from EventData

### DIFF
--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -12,6 +12,18 @@ export interface EventData {
 	 * The Observable instance that has raised the event.
 	 */
 	object: Observable;
+	/**
+	 * The event-specific data for iOS
+	 */
+	ios: any;
+	 /**
+	 * The event-specific data for Android
+	 */
+	android: any;
+	/**
+	 * Error object if an error occured
+	 */
+	error: any;
 }
 
 export interface EventDataValue extends EventData {


### PR DESCRIPTION
Before:
<img width="519" alt="Skjermbilde 2023-06-12 kl  21 32 25" src="https://github.com/NativeScript/NativeScript/assets/9407896/a49d2760-7b2e-4723-8767-69c2a6b65d0e">
After:
<img width="403" alt="Skjermbilde 2023-06-12 kl  21 32 01" src="https://github.com/NativeScript/NativeScript/assets/9407896/0ada0463-40c5-4852-9228-ac51c2c6f88b">
