### PR TITLE
fix(animation): avoid uncaught reject on cancel

### DIFF
--- a/packages/core/ui/animation/index.android.ts
+++ b/packages/core/ui/animation/index.android.ts
@@ -248,7 +248,7 @@ export class Animation extends AnimationBase {
 	private _onAndroidAnimationCancel() {
 		// tslint:disable-line
 		this._propertyResetCallbacks.forEach((v) => v());
-		this._rejectAnimationFinishedPromise();
+		this._resolveAnimationFinishedPromise();
 
 		if (this._target) {
 			this._target._removeAnimation(this);

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -7,7 +7,7 @@ import { AnimationBase, Properties, CubicBezierAnimationCurve } from './animatio
 import { Trace } from '../../trace';
 import { opacityProperty, backgroundColorProperty, rotateProperty, rotateXProperty, rotateYProperty, translateXProperty, translateYProperty, scaleXProperty, scaleYProperty, heightProperty, widthProperty, PercentLength } from '../styling/style-properties';
 
-import { iOSNativeHelper } from '../../utils/native-helper';
+import { ios as iosHelper } from '../../utils/native-helper';
 
 import { Screen } from '../../platform';
 
@@ -168,33 +168,28 @@ export class Animation extends AnimationBase {
 			this._mergedPropertyAnimations = this._propertyAnimations;
 		}
 
-		const that = this;
 		const animationFinishedCallback = (cancelled: boolean) => {
-			if (that._playSequentially) {
+			if (this._playSequentially) {
 				// This function will be called by the last animation when done or by another animation if the user cancels them halfway through.
-				if (cancelled) {
-					that._rejectAnimationFinishedPromise();
-				} else {
-					that._resolveAnimationFinishedPromise();
-				}
+				this._resolveAnimationFinishedPromise();
 			} else {
 				// This callback will be called by each INDIVIDUAL animation when it finishes or is cancelled.
 				if (cancelled) {
-					that._cancelledAnimations++;
+					this._cancelledAnimations++;
 				} else {
-					that._finishedAnimations++;
+					this._finishedAnimations++;
 				}
 
-				if (that._cancelledAnimations > 0 && that._cancelledAnimations + that._finishedAnimations === that._mergedPropertyAnimations.length) {
+				if (this._cancelledAnimations > 0 && this._cancelledAnimations + this._finishedAnimations === this._mergedPropertyAnimations.length) {
 					if (Trace.isEnabled()) {
-						Trace.write(that._cancelledAnimations + ' animations cancelled.', Trace.categories.Animation);
+						Trace.write(this._cancelledAnimations + ' animations cancelled.', Trace.categories.Animation);
 					}
-					that._rejectAnimationFinishedPromise();
-				} else if (that._finishedAnimations === that._mergedPropertyAnimations.length) {
+					this._resolveAnimationFinishedPromise();
+				} else if (this._finishedAnimations === this._mergedPropertyAnimations.length) {
 					if (Trace.isEnabled()) {
-						Trace.write(that._finishedAnimations + ' animations finished.', Trace.categories.Animation);
+						Trace.write(this._finishedAnimations + ' animations finished.', Trace.categories.Animation);
 					}
-					that._resolveAnimationFinishedPromise();
+					this._resolveAnimationFinishedPromise();
 				}
 			}
 		};
@@ -719,7 +714,7 @@ function calculateTransform(view: View): CATransform3D {
 	}
 
 	expectedTransform = CATransform3DTranslate(expectedTransform, view.translateX, view.translateY, 0);
-	expectedTransform = iOSNativeHelper.applyRotateTransform(expectedTransform, view.rotateX, view.rotateY, view.rotate);
+	expectedTransform = iosHelper.applyRotateTransform(expectedTransform, view.rotateX, view.rotateY, view.rotate);
 	expectedTransform = CATransform3DScale(expectedTransform, scaleX, scaleY, 1);
 
 	return expectedTransform;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Currently any in-flight animation can be auto cancelled by any number of user interactions - navigation, tap to interact with screens, or explicit cancels. All will reject the promise of which don't need to be caught but still cause numerous uncaught errors. These can manifest into UI bugs when uncaught under various conditions.

```ts
Error: Animation cancelled. Error: Animation cancelled.
      at Animation._rejectAnimationFinishedPromise (file: src/webpack:/myp/node_modules/@nativescript/core/ui/animation/animation-common.js:102:0)
      at AnimationDelegateImpl.animationFinishedCallback [as _finishedCallback] (file: src/webpack:/myp/node_modules/@nativescript/core/ui/animation/index.ios.js:158:0)
      at AnimationDelegateImpl.animationDidStopFinished (file: src/webpack:/myp/node_modules/@nativescript/core/ui/animation/index.ios.js:79:0)
  Unhandled Promise rejection: Animation cancelled. ; Zone: <root> ; Task: Promise.then ; Value: Error: Animation cancelled. Error: Animation cancelled.
      at Animation._rejectAnimationFinishedPromise (file: src/webpack:/myp/node_modules/@nativescript/core/ui/animation/animation-common.js:102:0)
      at AnimationDelegateImpl.animationFinishedCallback [as _finishedCallback] (file: src/webpack:/myp/node_modules/@nativescript/core/ui/animation/index.ios.js:158:0)
      at AnimationDelegateImpl.animationDidStopFinished (file: src/webpack:/myp/node_modules/@nativescript/core/ui/animation/index.ios.js:79:0)
```

## What is the new behavior?

Animation cancellations resolve and no longer pose a threat to apps stability.

