### PR TITLE
fix(shared-transitions): layer opacity set back to original on next tick

### DIFF
--- a/packages/core/utils/ios/index.ts
+++ b/packages/core/utils/ios/index.ts
@@ -286,7 +286,10 @@ export function snapshotView(view: UIView, scale: number): UIImage {
 	view.layer.renderInContext(UIGraphicsGetCurrentContext());
 	const image = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	view.layer.opacity = originalOpacity;
+	setTimeout(() => {
+		// ensure set back properly on next tick
+		view.layer.opacity = originalOpacity;
+	});
 	return image;
 }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Snapshotting of shared elements during a shared transition won't always set their opacity back to original before animating leading to unexpected shared element transition.

## What is the new behavior?

The snapshot opacity is set back properly on next tick before animation starts. Note: this was affected by the recent async/await share element callbacks.

