### PR TITLE
fix(shared-transition): race condition with interactive updates

### DIFF
--- a/packages/core/ui/transition/shared-transition-helper.ios.ts
+++ b/packages/core/ui/transition/shared-transition-helper.ios.ts
@@ -526,36 +526,39 @@ export class SharedTransitionHelper {
 	}
 
 	static interactiveUpdate(state: SharedTransitionState, interactiveState: PlatformTransitionInteractiveState, type: TransitionNavigationType, percent: number) {
-		if (!interactiveState?.added) {
-			interactiveState.added = true;
-			for (const p of state.instance.sharedElements.presented) {
-				p.view.opacity = 0;
-			}
-			for (const p of state.instance.sharedElements.presenting) {
-				p.snapshot.alpha = p.endOpacity;
-				interactiveState.transitionContext.containerView.addSubview(p.snapshot);
-			}
-
-			const pageStart = state.pageStart;
-
-			const startFrame = getRectFromProps(pageStart, getPageStartDefaultsForType(type));
-			interactiveState.propertyAnimator = UIViewPropertyAnimator.alloc().initWithDurationDampingRatioAnimations(1, 1, () => {
-				for (const p of state.instance.sharedElements.presenting) {
-					p.snapshot.frame = p.startFrame;
-					iOSUtils.copyLayerProperties(p.snapshot, p.view.ios, p.propertiesToMatch as any);
-
-					p.snapshot.alpha = 1;
+		if (interactiveState) {
+			if (!interactiveState.added) {
+				interactiveState.added = true;
+				for (const p of state.instance.sharedElements.presented) {
+					p.view.opacity = 0;
 				}
-				state.instance.presented.view.alpha = isNumber(state.pageReturn?.opacity) ? state.pageReturn?.opacity : 0;
-				state.instance.presented.view.frame = CGRectMake(startFrame.x, startFrame.y, state.instance.presented.view.bounds.size.width, state.instance.presented.view.bounds.size.height);
+				for (const p of state.instance.sharedElements.presenting) {
+					p.snapshot.alpha = p.endOpacity;
+					interactiveState.transitionContext.containerView.addSubview(p.snapshot);
+				}
+
+				const pageStart = state.pageStart;
+
+				const startFrame = getRectFromProps(pageStart, getPageStartDefaultsForType(type));
+				interactiveState.propertyAnimator = UIViewPropertyAnimator.alloc().initWithDurationDampingRatioAnimations(1, 1, () => {
+					for (const p of state.instance.sharedElements.presenting) {
+						p.snapshot.frame = p.startFrame;
+						iOSUtils.copyLayerProperties(p.snapshot, p.view.ios, p.propertiesToMatch as any);
+
+						p.snapshot.alpha = 1;
+					}
+					state.instance.presented.view.alpha = isNumber(state.pageReturn?.opacity) ? state.pageReturn?.opacity : 0;
+					state.instance.presented.view.frame = CGRectMake(startFrame.x, startFrame.y, state.instance.presented.view.bounds.size.width, state.instance.presented.view.bounds.size.height);
+				});
+			}
+
+			interactiveState.propertyAnimator.fractionComplete = percent;
+			SharedTransition.notifyEvent(SharedTransition.interactiveUpdateEvent, {
+				id: state?.instance?.id,
+				type,
+				percent,
 			});
 		}
-		interactiveState.propertyAnimator.fractionComplete = percent;
-		SharedTransition.notifyEvent(SharedTransition.interactiveUpdateEvent, {
-			id: state?.instance?.id,
-			type,
-			percent,
-		});
 	}
 
 	static interactiveCancel(state: SharedTransitionState, interactiveState: PlatformTransitionInteractiveState, type: TransitionNavigationType) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Occasionally when using interactive options for dismissing shared transition, the state may get reset early and cause an error.

## What is the new behavior?

Interactive shared transition dismissals will be stable under broader conditions.

