### PR TITLE
fix(core): unhandled error typings

### DIFF
--- a/apps/automated/src/main.ts
+++ b/apps/automated/src/main.ts
@@ -80,14 +80,14 @@ Application.on(Application.lowMemoryEvent, function (args: ApplicationEventData)
 // Error events.
 Application.on(Application.uncaughtErrorEvent, function (args: UnhandledErrorEventData) {
 	console.log('NativeScriptError:', args.error);
-	console.log((<any>args.error).nativeException ?? (<any>args.error).nativeError);
-	console.log((<any>args.error).stackTrace ?? (<any>args.error).stack);
+	console.log(args.error.nativeException ?? (<any>args.error).nativeError);
+	console.log(args.error.stackTrace ?? args.error.stack);
 });
 
 Application.on(Application.discardedErrorEvent, function (args: DiscardedErrorEventData) {
 	console.log('[Discarded] NativeScriptError:', args.error);
-	console.log((<any>args.error).nativeException ?? (<any>args.error).nativeError);
-	console.log((<any>args.error).stackTrace ?? (<any>args.error).stack);
+	console.log(args.error.nativeException ?? (<any>args.error).nativeError);
+	console.log(args.error.stackTrace ?? args.error.stack);
 });
 
 // Android activity events.

--- a/packages/core/application/application-interfaces.ts
+++ b/packages/core/application/application-interfaces.ts
@@ -9,7 +9,15 @@ export interface NativeScriptError extends Error {
 	/**
 	 * Represents the native error object.
 	 */
-	nativeError: any;
+	nativeException?: any;
+	/**
+	 * The native stack trace.
+	 */
+	stackTrace?: string;
+	/**
+	 * Javascript portion of stack trace.
+	 */
+	stack?: string;
 }
 
 /**


### PR DESCRIPTION
NativeScriptError type def used to come from packages/core/global-types.d.ts now comes from packages/core/application/application-interfaces.ts, so fixed there now.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`NativeScriptError` type def previously came from from `packages/core/global-types.d.ts` now comes from `packages/core/application/application-interfaces.ts`, which has the incorrect typeing.


## What is the new behavior?
<!-- Describe the changes. -->
Fixed the type to match what is set by native code.



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

