### PR TITLE
fix: early access to context and packageName

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -265,6 +265,9 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 	readonly activityRequestPermissionsEvent = AndroidApplication.activityRequestPermissionsEvent;
 
 	private _nativeApp: android.app.Application;
+	private _context: android.content.Context;
+	private _packageName: string;
+
 	// we are using these property to store the callbacks to avoid early GC collection which would trigger MarkReachableObjects
 	private lifecycleCallbacks: NativeScriptLifecycleCallbacks;
 	private componentCallbacks: NativeScriptComponentCallbacks;
@@ -279,6 +282,8 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 		}
 
 		this._nativeApp = nativeApp;
+		this._context = nativeApp.getApplicationContext();
+		this._packageName = nativeApp.getPackageName();
 
 		// we store those callbacks and add a function for clearing them later so that the objects will be eligable for GC
 		this.lifecycleCallbacks = new NativeScriptLifecycleCallbacks();
@@ -381,11 +386,11 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 	}
 
 	get context() {
-		return this.nativeApp.getApplicationContext();
+		return this._context;
 	}
 
 	get packageName() {
-		return this.nativeApp.getPackageName();
+		return this._packageName;
 	}
 
 	public registerBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void): void {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Accessing `Android.application.context` can lead to crashes if called too early:
```
TypeError: Cannot read properties of undefined (reading 'getApplicationContext')
```

## What is the new behavior?
<!-- Describe the changes. -->
Accessing `context` early will be `undefined` but will not crash (if the caller handles it correctly) - this matches behavior prior to 8.5.4.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

