### PR TITLE
fix(Connectivity): androidApp is not defined on SDK <28

### DIFF
--- a/packages/core/connectivity/index.android.ts
+++ b/packages/core/connectivity/index.android.ts
@@ -109,8 +109,7 @@ function startMonitoringLegacy(connectionTypeChangedCallback) {
 		connectionTypeChangedCallback(newConnectionType);
 	};
 	const zoneCallback = zonedCallback(onReceiveCallback);
-	// @ts-ignore
-	androidApp.registerBroadcastReceiver(android.net.ConnectivityManager.CONNECTIVITY_ACTION, zoneCallback);
+	Application.android.registerBroadcastReceiver(android.net.ConnectivityManager.CONNECTIVITY_ACTION, zoneCallback);
 }
 
 let callback;

--- a/packages/core/global-types.d.ts
+++ b/packages/core/global-types.d.ts
@@ -103,7 +103,7 @@ declare module globalThis {
 	function _isModuleLoadedForUI(moduleName: string): boolean;
 
 	var onGlobalLayoutListener: any;
-	function zonedCallback(callback: Function): Function;
+	function zonedCallback<T = Function>(callback: T): T;
 	var Reflect: any;
 	function Deprecated(target: Object, key?: string | symbol, descriptor?: any): any;
 	function Experimental(target: Object, key?: string | symbol, descriptor?: any): any;
@@ -358,7 +358,7 @@ declare function fail(data: any): void;
  */
 // declare function clearInterval(id: number): void;
 
-declare function zonedCallback(callback: Function): Function;
+declare function zonedCallback<T = Function>(callback: T): T;
 
 /**
  * Create a Java long from a number


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

On SDK <28 the app crashes when startMonitoring is called with:
```
ReferenceError: androidApp is not defined
```

## What is the new behavior?
<!-- Describe the changes. -->
The app no longer crashes, and calls the correct Application method to register a broadcast receiver.

Bonus: added generic type to `zonedCallback` to not need a `@ts-ignore` comment due to the wrapped function type being changed to `Function`.

fixes #10323

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

