### PR TITLE
fix(Application): getNativeApplication wrong ActivityThread

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -323,7 +323,7 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 		// the getInstance might return null if com.tns.NativeScriptApplication exists but is not the starting app type
 		if (!nativeApp) {
 			// TODO: Should we handle the case when a custom application type is provided and the user has not explicitly initialized the application module?
-			const clazz = java.lang.Class.forName('androidx.appcompat.app.AppCompatActivityThread');
+			const clazz = java.lang.Class.forName('android.app.ActivityThread');
 			if (clazz) {
 				const method = clazz.getMethod('currentApplication', null);
 				if (method) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In some cases when trying to access the native application, an error is thrown:
```
Error: java.lang.ClassNotFoundException: androidx.appcompat.app.AppCompatActivityThread
```

## What is the new behavior?
<!-- Describe the changes. -->
The native application is correctly found/resolved.

fixes #10325

_Note: This line was likely changed by accident in my #10286 PR as I don't recall making this change, or a reason to do so._