### PR TITLE
fix(application): restore AndroidApplication.on etc.

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -126,6 +126,28 @@ export class ApplicationCommon {
 	readonly loadAppCssEvent = 'loadAppCss';
 	readonly cssChangedEvent = 'cssChanged';
 
+	// Expose statically for backwards compat on AndroidApplication.on etc.
+	/**
+	 * @deprecated Use `Application.android.on()` instead.
+	 */
+	static on: ApplicationEvents['on'] = globalEvents.on.bind(globalEvents);
+	/**
+	 * @deprecated Use `Application.android.once()` instead.
+	 */
+	static once: ApplicationEvents['on'] = globalEvents.once.bind(globalEvents);
+	/**
+	 * @deprecated Use `Application.android.off()` instead.
+	 */
+	static off: ApplicationEvents['off'] = globalEvents.off.bind(globalEvents);
+	/**
+	 * @deprecated Use `Application.android.notify()` instead.
+	 */
+	static notify: ApplicationEvents['notify'] = globalEvents.notify.bind(globalEvents);
+	/**
+	 * @deprecated Use `Application.android.hasListeners()` instead.
+	 */
+	static hasListeners: ApplicationEvents['hasListeners'] = globalEvents.hasListeners.bind(globalEvents);
+
 	// Application events go through the global events.
 	on: ApplicationEvents['on'] = globalEvents.on.bind(globalEvents);
 	once: ApplicationEvents['on'] = globalEvents.once.bind(globalEvents);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#10286 didn't account for usage of the AndroidApplication in the following scenario:
```ts
AndroidApplication.on(AndroidApplication.activityCreatedEvent, () => {});
```

## What is the new behavior?
<!-- Describe the changes. -->
These are now exposed statically on the AndroidApplication to restore/remove the breaking change.

They are marked as deprecated as the preferred way to write these would be:
```ts
Application.android.on(Application.android.activityCreatedEvent, () => {});
```
to simplify usage/code across the board.