### PR TITLE
fix(datepicker): max, min and date value binding handling

### DIFF
--- a/apps/toolbox/src/pages/datepicker.ts
+++ b/apps/toolbox/src/pages/datepicker.ts
@@ -8,6 +8,8 @@ export function navigatingTo(args: EventData) {
 }
 
 export class SampleData extends Observable {
+	minDate = new Date();
+	maxDate = new Date(2030, 7, 1);
 	displayDate = {
 		day: new Date().getDate(),
 		month: new Date().getMonth(),
@@ -17,6 +19,15 @@ export class SampleData extends Observable {
 		second: new Date().getSeconds(),
 	};
 	showTime = true;
+
+	constructor() {
+		super();
+		// setTimeout(() => {
+		// 	// test dynamic min and max date changes
+		// 	this.notifyPropertyChange('minDate', null);
+		// 	this.notifyPropertyChange('maxDate', null);
+		// }, 2000);
+	}
 
 	dateChange(args) {
 		console.log('dateChange:', (<DatePicker>args.object).date);

--- a/apps/toolbox/src/pages/datepicker.xml
+++ b/apps/toolbox/src/pages/datepicker.xml
@@ -11,7 +11,7 @@ year="{{displayDate?.year}}"
         minute="{{displayDate?.minute}}"
         second="{{{{displayDate?.second}}"-->
     <StackLayout padding="20">
-      <DatePicker class="v-center text-center" width="{{ showTime ? 220 : 300}}" height="{{ showTime ? 100 : 250}}" showTime="{{ showTime }}" iosPreferredDatePickerStyle="{{showTime ? 2 : 1}}" dateChange="{{ dateChange }}" />
+      <DatePicker class="v-center text-center" width="{{ showTime ? 220 : 300}}" height="{{ showTime ? 100 : 250}}" minDate="{{minDate}}" maxDate="{{maxDate}}" showTime="{{ showTime }}" iosPreferredDatePickerStyle="{{showTime ? 2 : 1}}" dateChange="{{ dateChange }}" />
       <GridLayout rows="auto" columns="auto,*">
         <Switch checked="true" col="0" checkedChange="{{checkedChange}}" />
         <Label text="Show Time" col="1" class="m-l-10" />

--- a/packages/core/ui/date-picker/index.android.ts
+++ b/packages/core/ui/date-picker/index.android.ts
@@ -130,7 +130,7 @@ export class DatePicker extends DatePickerBase {
 
 	[dateProperty.setNative](value: Date) {
 		const nativeView = this.nativeViewProtected;
-		if ((value && nativeView.getDayOfMonth() !== value.getDate()) || nativeView.getMonth() !== value.getMonth() || nativeView.getYear() !== value.getFullYear()) {
+		if (value && (nativeView.getDayOfMonth() !== value.getDate() || nativeView.getMonth() !== value.getMonth() || nativeView.getYear() !== value.getFullYear())) {
 			nativeView.updateDate(value.getFullYear(), value.getMonth(), value.getDate());
 		}
 	}

--- a/packages/core/ui/date-picker/index.android.ts
+++ b/packages/core/ui/date-picker/index.android.ts
@@ -130,7 +130,7 @@ export class DatePicker extends DatePickerBase {
 
 	[dateProperty.setNative](value: Date) {
 		const nativeView = this.nativeViewProtected;
-		if (nativeView.getDayOfMonth() !== value.getDate() || nativeView.getMonth() !== value.getMonth() || nativeView.getYear() !== value.getFullYear()) {
+		if ((value && nativeView.getDayOfMonth() !== value.getDate()) || nativeView.getMonth() !== value.getMonth() || nativeView.getYear() !== value.getFullYear()) {
 			nativeView.updateDate(value.getFullYear(), value.getMonth(), value.getDate());
 		}
 	}

--- a/packages/core/ui/date-picker/index.ios.ts
+++ b/packages/core/ui/date-picker/index.ios.ts
@@ -79,39 +79,45 @@ export class DatePicker extends DatePickerBase {
 	}
 
 	[dateProperty.setNative](value: Date) {
-		const picker = this.nativeViewProtected;
-		const comps = NSCalendar.currentCalendar.componentsFromDate(NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay | NSCalendarUnit.HourCalendarUnit | NSCalendarUnit.MinuteCalendarUnit | NSCalendarUnit.SecondCalendarUnit, picker.date);
-		comps.year = value.getFullYear();
-		comps.month = value.getMonth() + 1;
-		comps.day = value.getDate();
-		comps.hour = value.getHours();
-		comps.minute = value.getMinutes();
-		comps.second = value.getSeconds();
-		this.year = comps.year;
-		this.month = comps.month;
-		this.day = comps.day;
-		this.hour = comps.hour;
-		this.minute = comps.minute;
-		this.second = comps.second;
-		picker.setDateAnimated(NSCalendar.currentCalendar.dateFromComponents(comps), false);
+		if (value) {
+			const comps = NSCalendar.currentCalendar.componentsFromDate(NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay | NSCalendarUnit.HourCalendarUnit | NSCalendarUnit.MinuteCalendarUnit | NSCalendarUnit.SecondCalendarUnit, this.nativeViewProtected.date);
+			comps.year = value.getFullYear();
+			comps.month = value.getMonth() + 1;
+			comps.day = value.getDate();
+			comps.hour = value.getHours();
+			comps.minute = value.getMinutes();
+			comps.second = value.getSeconds();
+			this.year = comps.year;
+			this.month = comps.month;
+			this.day = comps.day;
+			this.hour = comps.hour;
+			this.minute = comps.minute;
+			this.second = comps.second;
+			this.nativeViewProtected.setDateAnimated(NSCalendar.currentCalendar.dateFromComponents(comps), false);
+		}
 	}
 
 	[maxDateProperty.getDefault](): Date {
 		return this.nativeViewProtected.maximumDate;
 	}
 	[maxDateProperty.setNative](value: Date) {
-		const picker = this.nativeViewProtected;
-		const nsDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000);
-		picker.maximumDate = <any>nsDate;
+		if (value) {
+			const nsDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000);
+			this.nativeViewProtected.maximumDate = <any>nsDate;
+		} else {
+			this.nativeViewProtected.maximumDate = null;
+		}
 	}
 
 	[minDateProperty.getDefault](): Date {
 		return this.nativeViewProtected.minimumDate;
 	}
 	[minDateProperty.setNative](value: Date) {
-		const picker = this.nativeViewProtected;
-		const nsDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000);
-		picker.minimumDate = <any>nsDate;
+		if (value) {
+			this.nativeViewProtected.minimumDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000) as any;
+		} else {
+			this.nativeViewProtected.minimumDate = null;
+		}
 	}
 
 	[colorProperty.getDefault](): UIColor {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

When using data bindings with `date`, `minDate` and `maxDate` crashes could occur with null/undefined values.

## What is the new behavior?

These properties are now resilient to dynamic data binding conditions.

closes https://github.com/NativeScript/NativeScript/issues/8885

