### PR TITLE
fix(application): rootView undefined on resume

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -364,8 +364,8 @@ export class ApplicationCommon {
 		// rest of implementation is platform specific
 	}
 
-	initRootView() {
-		this.setRootViewCSSClasses(this.getRootView());
+	initRootView(rootView: View) {
+		this.setRootViewCSSClasses(rootView);
 		initAccessibilityCssHelper();
 		initAccessibilityFontScale();
 	}

--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -157,7 +157,7 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 			visibleVC.presentViewControllerAnimatedCompletion(controller, true, null);
 		}
 
-		this.initRootView();
+		this.initRootView(rootView);
 		this.notifyAppStarted();
 	}
 
@@ -349,7 +349,7 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 			this._window.makeKeyAndVisible();
 		}
 
-		this.initRootView();
+		this.initRootView(rootView);
 
 		rootView.on(IOSHelper.traitCollectionColorAppearanceChangedEvent, () => {
 			const userInterfaceStyle = controller.traitCollection.userInterfaceStyle;

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -1378,7 +1378,7 @@ class ActivityCallbacksImplementation implements AndroidActivityCallbacks {
 		this._rootView = rootView;
 
 		// sets root classes once rootView is ready...
-		Application.initRootView();
+		Application.initRootView(rootView);
 	}
 }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The commit https://github.com/NativeScript/NativeScript/commit/ab5fa941bc93d4ac5e917b5e4b8de29ba7f435fc seems to have broken the resume of the app in some situations, e.g. when switching back from [nativescript-inappbrowser](https://github.com/proyecto26/nativescript-inappbrowser). As illustrated by this [repo](https://github.com/jcassidyav/testcrashresume).

On closing the browser you get a crash on android with the stack:

```
  TNS.Native: setRootViewCSSClasses(file: app/webpack:/testpopcrash/node_modules/@nativescript/core/application/application-common.js:151:0)
  TNS.Native:   at initRootView(file: app/webpack:/testpopcrash/node_modules/@nativescript/core/application/application-common.js:221:0)
  TNS.Native:   at setActivityContent(file: app/webpack:/testpopcrash/node_modules/@nativescript/core/ui/frame/index.android.js:1190:19)
  TNS.Native:   at onCreate(file: app/webpack:/testpopcrash/node_modules/@nativescript/core/ui/frame/index.android.js:1003:0)
  TNS.Native:   at onCreate(file: app/webpack:/testpopcrash/node_modules/@nativescript/core/ui/frame/activity.android.js:21:0)
```

The reason is that the application.foregroundActivity is undefined, and the startActivity is a chromeManagerActivity, and the code then fails to resolve the rootView.


## What is the new behavior?
<!-- Describe the changes. -->

This change modifies `initRootView` to accept a root view, since all calling code seems to already have the rootView and can pass it in.



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

