### PR TITLE
fix(core): fix Page event overload resolution

### DIFF
--- a/packages/core/ui/page/index.d.ts
+++ b/packages/core/ui/page/index.d.ts
@@ -31,22 +31,22 @@ export declare class Page extends PageBase {
 	/**
 	 * String value used when hooking to navigatingTo event.
 	 */
-	public static navigatingToEvent: string;
+	public static readonly navigatingToEvent = 'navigatingTo';
 
 	/**
 	 * String value used when hooking to navigatedTo event.
 	 */
-	public static navigatedToEvent: string;
+	public static readonly navigatedToEvent = 'navigatedTo';
 
 	/**
 	 * String value used when hooking to navigatingFrom event.
 	 */
-	public static navigatingFromEvent: string;
+	public static readonly navigatingFromEvent = 'navigatingFrom';
 
 	/**
 	 * String value used when hooking to navigatedFrom event.
 	 */
-	public static navigatedFromEvent: string;
+	public static readonly navigatedFromEvent = 'navigatedFrom';
 
 	/**
 	 * Gets or sets whether page background spans under status bar.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
Compiling a project with Typescript strict mode enabled will file the compile will throw an error for:
```ts
this.page.on(Page.navigatedToEvent, (data: NavigatedData) => {});
```

because it cannot resolve the overloads for Page.on

## What is the new behavior?
<!-- Describe the changes. -->
Making `Page.navigatedToEvent` etc. constants with the correct event name string resolves the error.



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

