### PR TITLE
feat(shared-transition): pageOut option for more dynamic page animations

### DIFF
--- a/packages/core/ui/transition/shared-transition-helper.ios.ts
+++ b/packages/core/ui/transition/shared-transition-helper.ios.ts
@@ -50,6 +50,7 @@ export class SharedTransitionHelper {
 						console.log(`2. Take snapshots of shared elements and position them based on presenting view:`);
 					}
 
+					const pageOut = state.pageOut;
 					const pageStart = state.pageStart;
 
 					const startFrame = getRectFromProps(pageStart, getPageStartDefaultsForType(type));
@@ -273,6 +274,14 @@ export class SharedTransitionHelper {
 						const endFrame = getRectFromProps(pageEnd);
 						transition.presented.view.frame = CGRectMake(endFrame.x, endFrame.y, endFrame.width, endFrame.height);
 
+						if (pageOut) {
+							if (isNumber(pageOut.opacity)) {
+								transition.presenting.view.alpha = pageOut?.opacity;
+							}
+
+							const outFrame = getRectFromProps(pageOut);
+							transition.presenting.view.frame = CGRectMake(outFrame.x, outFrame.y, outFrame.width, outFrame.height);
+						}
 						// animate page properties to the following:
 						// https://stackoverflow.com/a/27997678/1418981
 						// In order to have proper layout. Seems mostly needed when presenting.
@@ -368,6 +377,7 @@ export class SharedTransitionHelper {
 						console.log(`2. Add back previously stored sharedElements to dismiss:`);
 					}
 
+					const pageOut = state.pageOut;
 					const pageEnd = state.pageEnd;
 					const pageEndTags = pageEnd?.sharedTransitionTags || {};
 					const pageReturn = state.pageReturn;
@@ -456,6 +466,14 @@ export class SharedTransitionHelper {
 
 						const endFrame = getRectFromProps(pageReturn, getPageStartDefaultsForType(type));
 						transition.presented.view.frame = CGRectMake(endFrame.x, endFrame.y, endFrame.width, endFrame.height);
+
+						if (pageOut) {
+							// always return to defaults if pageOut had been used
+							transition.presenting.view.alpha = 1;
+
+							const outFrame = getRectFromProps(null);
+							transition.presenting.view.frame = CGRectMake(0, 0, outFrame.width, outFrame.height);
+						}
 
 						for (const presenting of transition.sharedElements.presenting) {
 							iOSUtils.copyLayerProperties(presenting.snapshot, presenting.view.ios, presenting.propertiesToMatch as any);

--- a/packages/core/ui/transition/shared-transition.ts
+++ b/packages/core/ui/transition/shared-transition.ts
@@ -104,13 +104,17 @@ export interface SharedTransitionConfig {
 		dismiss?: SharedTransitionInteractiveOptions;
 	};
 	/**
-	 * View settings to start your transition with.
+	 * View settings applied to the incoming page to start your transition with.
 	 */
 	pageStart?: SharedTransitionPageProperties;
 	/**
-	 * View settings to end your transition with.
+	 * View settings applied to the incoming page to end your transition with.
 	 */
 	pageEnd?: SharedTransitionPageWithDurationProperties;
+	/**
+	 * View settings applied to the outgoing page in your transition.
+	 */
+	pageOut?: SharedTransitionPageWithDurationProperties;
 	/**
 	 * View settings to return to the original page with.
 	 */


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

When setting up page navigation shared transitions, sometimes you want to use transparent backgrounds on the page to bring more dynamic possibilities into the animation. Currently there was no way to specify custom `pageOut` animatable properties to adjust how the transition animates between the *outgoing* page and incoming.

## What is the new behavior?

Adds a new `pageOut` property which will be applied *to the outgoing page* to provide versatility in animated options.
Given settings as follows:

```ts
SharedTransition.custom(new PageTransition(), {
    pageStart: {
      opacity: 0,
      x: 0,
      y: -50,
    },
    pageEnd: {
      opacity: 1,
      x: 0,
      y: 0,
    },
    pageReturn: {
      opacity: 0,
      x: 0,
      y: -50,
    },
    pageOut: {
      opacity: 0,
      y: -50
    }
  });
```

You can now achieve page transition effects like this (just one page navigating to another with a `sharedTransitionTag` on the logo and email whereby the content opacity/frame of the outgoing page can now be customized for the transition to appear with more seamless control between two page layouts:

https://github.com/NativeScript/NativeScript/assets/457187/aaebc27c-b593-490d-9b3e-a7548d6ea699




