### PR TITLE
feat(webpack): place hidden sourceMaps in platforms folder

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -648,3 +648,5 @@ exports[`base configuration support env.watchNodeModules 1`] = `
   "managedPaths": [],
 }
 `;
+
+exports[`base configuration supports env.sourceMap=hidden-source-map 1`] = `"../../../ios-sourceMaps/[file].map[query]"`;

--- a/packages/webpack5/__tests__/configuration/base.spec.ts
+++ b/packages/webpack5/__tests__/configuration/base.spec.ts
@@ -210,4 +210,15 @@ describe('base configuration', () => {
 
 		expect(config.get('profile')).toBe(true);
 	});
+
+	it('supports env.sourceMap=hidden-source-map', () => {
+		init({
+			ios: true,
+			sourceMap: 'hidden-source-map',
+		});
+		const config = base(new Config());
+
+		expect(config.output.get('sourceMapFilename')).toMatchSnapshot();
+		expect(config.get('devtool')).toBe('hidden-source-map');
+	});
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Passing `--env.sourceMap=hidden-source-map` generates the source maps deep in the platforms folder right next to the bundle/vendor chunks. This isn't quite right because the purpose of hidden source-maps is to not ship them with the app. Right now, the user would have to run a build with hidden-source-maps, take the source-maps, and then re-build without source-maps to not ship them with the app.

## What is the new behavior?
<!-- Describe the changes. -->
When using `--env.sourceMap=hidden-source-map` we automatically set the output path for the sourceMaps to `platforms/{platformName}-sourceMaps/`:
```bash
platforms/ios-sourceMaps/...
platforms/android-sourceMaps/...
```



