### PR TITLE
fix: prevent duplicate system classes

### DIFF
--- a/packages/core/css/system-classes.ts
+++ b/packages/core/css/system-classes.ts
@@ -12,7 +12,10 @@ export namespace CSSUtils {
 	}
 
 	export function pushToSystemCssClasses(value: string): number {
-		cssClasses.push(value);
+		const index = cssClasses.indexOf(value);
+		if (index == -1) {
+			cssClasses.push(value);
+		}
 
 		return cssClasses.length;
 	}


### PR DESCRIPTION
If we call recreate on an activity the `setRootViewCSSClasses` is called again on the `rootView`. This would cause duplicate system css entries which could make theming fail. This fix ensure every system css entry is inserted only once

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

