### PR TITLE
fix(webpack): force experimentalDecorators on NativeClass

### DIFF
--- a/packages/webpack5/src/transformers/NativeClass/index.ts
+++ b/packages/webpack5/src/transformers/NativeClass/index.ts
@@ -38,6 +38,8 @@ export default function (ctx: ts.TransformationContext) {
 							noEmitHelpers: true,
 							module: ts.ModuleKind.ESNext,
 							target: ts.ScriptTarget.ES5,
+							experimentalDecorators: true,
+							emitDecoratorMetadata: true,
 						},
 					}
 				)


### PR DESCRIPTION
Fixes TS 5+ where it now uses __esDecorate by default where we need __decorate (set by experimentalDecorators)