### PR TITLE
fix(core): Scroll listener register failure after unregister

### DIFF
--- a/packages/core/ui/scroll-view/index.android.ts
+++ b/packages/core/ui/scroll-view/index.android.ts
@@ -130,10 +130,10 @@ export class ScrollView extends ScrollViewBase {
 
 	protected attachNative() {
 		if (!this.handler) {
-			const that = new WeakRef(this);
+			const viewRef = new WeakRef(this);
 			this.handler = new android.view.ViewTreeObserver.OnScrollChangedListener({
 				onScrollChanged: function () {
-					const owner: ScrollView = that.get();
+					const owner: ScrollView = viewRef.get();
 					if (owner) {
 						owner._onScrollChanged();
 					}
@@ -166,9 +166,13 @@ export class ScrollView extends ScrollViewBase {
 		}
 	}
 
-	protected dettachNative() {
-		this.nativeViewProtected.getViewTreeObserver().removeOnScrollChangedListener(this.handler);
-		this.handler = null;
+	protected detachNative() {
+		if (this.handler) {
+			if (this.nativeViewProtected) {
+				this.nativeViewProtected.getViewTreeObserver().removeOnScrollChangedListener(this.handler);
+			}
+			this.handler = null;
+		}
 	}
 }
 

--- a/packages/core/ui/scroll-view/index.ios.ts
+++ b/packages/core/ui/scroll-view/index.ios.ts
@@ -49,12 +49,6 @@ export class ScrollView extends ScrollViewBase {
 		this._setNativeClipToBounds();
 	}
 
-	disposeNativeView() {
-		this.dettachNative();
-		this._delegate = null;
-		super.disposeNativeView();
-	}
-
 	_setNativeClipToBounds() {
 		if (!this.nativeViewProtected) {
 			return;
@@ -70,9 +64,12 @@ export class ScrollView extends ScrollViewBase {
 		}
 	}
 
-	protected dettachNative() {
-		if (this.nativeViewProtected) {
-			this.nativeViewProtected.delegate = null;
+	protected detachNative() {
+		if (this._delegate) {
+			if (this.nativeViewProtected) {
+				this.nativeViewProtected.delegate = null;
+			}
+			this._delegate = null;
 		}
 	}
 

--- a/packages/core/ui/scroll-view/scroll-view-common.ts
+++ b/packages/core/ui/scroll-view/scroll-view-common.ts
@@ -31,15 +31,12 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 		super.removeEventListener(arg, callback, thisArg);
 
 		if (arg === ScrollViewBase.scrollEvent) {
-			let shouldDetach = false;
-
 			if (this._scrollChangeCount > 0) {
 				this._scrollChangeCount--;
-				shouldDetach = this._scrollChangeCount === 0;
-			}
 
-			if (this.nativeViewProtected && shouldDetach) {
-				this.detachNative();
+				if (this.nativeViewProtected && this._scrollChangeCount === 0) {
+					this.detachNative();
+				}
 			}
 		}
 	}

--- a/packages/core/ui/scroll-view/scroll-view-common.ts
+++ b/packages/core/ui/scroll-view/scroll-view-common.ts
@@ -21,7 +21,9 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 
 		if (arg === ScrollViewBase.scrollEvent) {
 			this._scrollChangeCount++;
-			this.attach();
+			if (this.nativeViewProtected) {
+				this.attachNative();
+			}
 		}
 	}
 
@@ -29,40 +31,38 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 		super.removeEventListener(arg, callback, thisArg);
 
 		if (arg === ScrollViewBase.scrollEvent) {
-			this._scrollChangeCount--;
-			this.dettach();
+			let shouldDetach = false;
+
+			if (this._scrollChangeCount > 0) {
+				this._scrollChangeCount--;
+				shouldDetach = this._scrollChangeCount === 0;
+			}
+
+			if (this.nativeViewProtected && shouldDetach) {
+				this.detachNative();
+			}
 		}
 	}
 
-	@profile
-	public onLoaded() {
-		super.onLoaded();
-
-		this.attach();
-	}
-
-	public disposeNativeView() {
-		this.dettach();
-		super.disposeNativeView();
-	}
-
-	private attach() {
-		if (this._scrollChangeCount > 0 && this.isLoaded) {
+	initNativeView() {
+		super.initNativeView();
+		if (this._scrollChangeCount > 0) {
 			this.attachNative();
 		}
 	}
 
-	private dettach() {
-		if (this._scrollChangeCount === 0 && this.isLoaded) {
-			this.dettachNative();
+	public disposeNativeView() {
+		if (this._scrollChangeCount > 0) {
+			this.detachNative();
 		}
+		super.disposeNativeView();
 	}
 
 	protected attachNative() {
 		//
 	}
 
-	protected dettachNative() {
+	protected detachNative() {
 		//
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
There is a case that `ScrollView` scroll event listeners fail to register if a `removeEventListener` call occurs prior.
e.g.
```js
view.off('scroll', onScroll);
view.on('scroll', onScroll); // This won't work because of line above
```
This occurs mostly on iOS because we don't unset property `_delegate` when detaching delegate.
PR will take care of this and improve few other things for both platforms.

## What is the new behavior?
Scroll listeners will register without problems.