### PR TITLE
feat(css): support for text-overflow

### DIFF
--- a/apps/toolbox/src/pages/labels.xml
+++ b/apps/toolbox/src/pages/labels.xml
@@ -14,6 +14,17 @@
 		<GridLayout marginTop="10" borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
 			<Label text="Test Label 3: should be aligned top" verticalAlignment="top" />
 		</GridLayout>
+		<GridLayout marginTop="10" borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
+			<Label text="Test Label text-overflow: ellipsis, this should be long sentence and clipped at very end." textOverflow="ellipsis" whiteSpace="nowrap" />
+		</GridLayout>
+
+		<GridLayout marginTop="10" borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
+			<Button text="Test Button text-overflow: ellipsis, this should be long sentence and clipped at very end." textOverflow="ellipsis" whiteSpace="nowrap" />
+		</GridLayout>
+
+		<GridLayout marginTop="10" borderWidth="1" borderColor="#efefef" height="60" paddingLeft="5">
+			<Button text="Test Button text-overflow: initial, this should be long sentence and truncated in the middle with ellipsis." textOverflow="initial" whiteSpace="nowrap" />
+		</GridLayout>
         <Label text="maxLines 2" fontWeight="bold" marginTop="10" />
         <Label
 				text="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -94,6 +94,14 @@ export namespace CoreTypes {
 		export const nowrap = 'nowrap';
 	}
 
+	export type TextOverflowType = 'clip' | 'ellipsis' | 'initial' | 'unset';
+	export namespace TextOverflow {
+		export const clip = 'clip';
+		export const ellipsis = 'ellipsis';
+		export const initial = 'initial';
+		export const unset = 'unset';
+	}
+
 	export type MaxLinesType = number;
 
 	export type OrientationType = 'horizontal' | 'vertical';

--- a/packages/core/ui/button/index.ios.ts
+++ b/packages/core/ui/button/index.ios.ts
@@ -2,7 +2,7 @@ import { ControlStateChangeListener } from '../core/control-state-change';
 import { ButtonBase } from './button-common';
 import { View, PseudoClassHandler } from '../core/view';
 import { backgroundColorProperty, borderTopWidthProperty, borderRightWidthProperty, borderBottomWidthProperty, borderLeftWidthProperty, paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty } from '../styling/style-properties';
-import { textAlignmentProperty, whiteSpaceProperty } from '../text-base';
+import { textAlignmentProperty, whiteSpaceProperty, textOverflowProperty } from '../text-base';
 import { layout } from '../../utils';
 import { CoreTypes } from '../../core-types';
 import { Color } from '../../color';
@@ -219,16 +219,41 @@ export class Button extends ButtonBase {
 	}
 
 	[whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {
+		this.adjustLineBreak();
+	}
+
+	[textOverflowProperty.setNative](value: CoreTypes.TextOverflowType) {
+		this.adjustLineBreak();
+	}
+
+	private adjustLineBreak() {
+		const whiteSpace = this.whiteSpace;
+		const textOverflow = this.textOverflow;
 		const nativeView = this.nativeViewProtected.titleLabel;
-		switch (value) {
+		switch (whiteSpace) {
 			case 'normal':
 				nativeView.lineBreakMode = NSLineBreakMode.ByWordWrapping;
 				nativeView.numberOfLines = this.maxLines;
 				break;
-			case 'nowrap':
 			case 'initial':
 				nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingMiddle;
 				nativeView.numberOfLines = 1;
+				break;
+			case 'nowrap':
+				switch (textOverflow) {
+					case 'clip':
+						nativeView.lineBreakMode = NSLineBreakMode.ByClipping;
+						nativeView.numberOfLines = this.maxLines;
+						break;
+					case 'ellipsis':
+						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
+						nativeView.numberOfLines = 1;
+						break;
+					default:
+						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingMiddle;
+						nativeView.numberOfLines = 1;
+						break;
+				}
 				break;
 		}
 	}

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -68,7 +68,7 @@ export { CSSHelper } from './styling/css-selector';
 
 export { Switch } from './switch';
 export { TabView, TabViewItem } from './tab-view';
-export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, whiteSpaceProperty, lineHeightProperty } from './text-base';
+export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, whiteSpaceProperty, textOverflowProperty, lineHeightProperty } from './text-base';
 export { FormattedString } from './text-base/formatted-string';
 export { Span } from './text-base/span';
 export { TextField } from './text-field';

--- a/packages/core/ui/label/index.ios.ts
+++ b/packages/core/ui/label/index.ios.ts
@@ -4,7 +4,7 @@ import { Length, borderTopWidthProperty, borderRightWidthProperty, borderBottomW
 import { booleanConverter } from '../core/view-base';
 import { View, CSSType } from '../core/view';
 import { CoreTypes } from '../../core-types';
-import { TextBase, whiteSpaceProperty } from '../text-base';
+import { TextBase, whiteSpaceProperty, textOverflowProperty } from '../text-base';
 import { layout } from '../../utils';
 
 import { ios } from '../styling/background';
@@ -113,16 +113,41 @@ export class Label extends TextBase implements LabelDefinition {
 	}
 
 	[whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {
-		const nativeView = this.nativeTextViewProtected;
-		switch (value) {
+		this.adjustLineBreak();
+	}
+
+	[textOverflowProperty.setNative](value: CoreTypes.TextOverflowType) {
+		this.adjustLineBreak();
+	}
+
+	private adjustLineBreak() {
+		const whiteSpace = this.whiteSpace;
+		const textOverflow = this.textOverflow;
+		const nativeView = this.nativeViewProtected;
+		switch (whiteSpace) {
 			case 'normal':
 				nativeView.lineBreakMode = NSLineBreakMode.ByWordWrapping;
 				nativeView.numberOfLines = this.maxLines;
 				break;
-			case 'nowrap':
 			case 'initial':
 				nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
 				nativeView.numberOfLines = 1;
+				break;
+			case 'nowrap':
+				switch (textOverflow) {
+					case 'clip':
+						nativeView.lineBreakMode = NSLineBreakMode.ByClipping;
+						nativeView.numberOfLines = this.maxLines;
+						break;
+					case 'ellipsis':
+						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
+						nativeView.numberOfLines = 1;
+						break;
+					default:
+						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingMiddle;
+						nativeView.numberOfLines = 1;
+						break;
+				}
 				break;
 		}
 	}

--- a/packages/core/ui/label/index.ios.ts
+++ b/packages/core/ui/label/index.ios.ts
@@ -139,12 +139,8 @@ export class Label extends TextBase implements LabelDefinition {
 						nativeView.lineBreakMode = NSLineBreakMode.ByClipping;
 						nativeView.numberOfLines = this.maxLines;
 						break;
-					case 'ellipsis':
-						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
-						nativeView.numberOfLines = 1;
-						break;
 					default:
-						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingMiddle;
+						nativeView.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
 						nativeView.numberOfLines = 1;
 						break;
 				}

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -172,6 +172,7 @@ export class Style extends Observable implements StyleDefinition {
 	public textTransform: CoreTypes.TextTransformType;
 	public textShadow: CSSShadow;
 	public whiteSpace: CoreTypes.WhiteSpaceType;
+	public textOverflow: CoreTypes.TextOverflowType;
 
 	public minWidth: CoreTypes.LengthType;
 	public minHeight: CoreTypes.LengthType;

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -330,14 +330,13 @@ export class TextBase extends TextBaseCommon {
 				break;
 			case 'nowrap':
 				switch (textOverflow) {
-					case 'unset':
-					case 'clip':
-						nativeView.setSingleLine(false);
-						nativeView.setEllipsize(null);
-						break;
 					case 'initial':
 					case 'ellipsis':
 						nativeView.setSingleLine(true);
+						nativeView.setEllipsize(android.text.TextUtils.TruncateAt.END);
+						break;
+					default:
+						nativeView.setSingleLine(false);
 						nativeView.setEllipsize(android.text.TextUtils.TruncateAt.END);
 						break;
 				}

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -1,5 +1,5 @@
 // Types
-import { getClosestPropertyValue, maxLinesProperty } from './text-base-common';
+import { getClosestPropertyValue, maxLinesProperty, textOverflowProperty } from './text-base-common';
 import { CSSShadow } from '../styling/css-shadow';
 
 // Requires
@@ -311,16 +311,36 @@ export class TextBase extends TextBaseCommon {
 	// Overridden in TextField because setSingleLine(false) will remove methodTransformation.
 	// and we don't want to allow TextField to be multiline
 	[whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {
+		this.adjustLineBreak();
+	}
+
+	[textOverflowProperty.setNative](value: CoreTypes.TextOverflowType) {
+		this.adjustLineBreak();
+	}
+
+	private adjustLineBreak() {
+		const whiteSpace = this.whiteSpace;
+		const textOverflow = this.textOverflow;
 		const nativeView = this.nativeTextViewProtected;
-		switch (value) {
+		switch (whiteSpace) {
 			case 'initial':
 			case 'normal':
 				nativeView.setSingleLine(false);
 				nativeView.setEllipsize(null);
 				break;
 			case 'nowrap':
-				nativeView.setSingleLine(true);
-				nativeView.setEllipsize(android.text.TextUtils.TruncateAt.END);
+				switch (textOverflow) {
+					case 'unset':
+					case 'clip':
+						nativeView.setSingleLine(false);
+						nativeView.setEllipsize(null);
+						break;
+					case 'initial':
+					case 'ellipsis':
+						nativeView.setSingleLine(true);
+						nativeView.setEllipsize(android.text.TextUtils.TruncateAt.END);
+						break;
+				}
 				break;
 		}
 	}

--- a/packages/core/ui/text-base/index.d.ts
+++ b/packages/core/ui/text-base/index.d.ts
@@ -64,6 +64,11 @@ export class TextBase extends View implements AddChildFromBuilder {
 	whiteSpace: CoreTypes.WhiteSpaceType;
 
 	/**
+	 * Gets or sets text-overflow style property.
+	 */
+	textOverflow: CoreTypes.TextOverflowType;
+
+	/**
 	 * Gets or sets white space style property.
 	 */
 	maxLines: CoreTypes.MaxLinesType;
@@ -134,6 +139,7 @@ export const textDecorationProperty: CssProperty<Style, CoreTypes.TextDecoration
 export const textTransformProperty: CssProperty<Style, CoreTypes.TextTransformType>;
 export const textShadowProperty: CssProperty<Style, CSSShadow>;
 export const whiteSpaceProperty: CssProperty<Style, CoreTypes.WhiteSpaceType>;
+export const textOverflowProperty: CssProperty<Style, CoreTypes.TextOverflowType>;
 export const letterSpacingProperty: CssProperty<Style, number>;
 export const lineHeightProperty: CssProperty<Style, number>;
 

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -132,6 +132,13 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
 		this.style.whiteSpace = value;
 	}
 
+	get textOverflow(): CoreTypes.TextOverflowType {
+		return this.style.textOverflow;
+	}
+	set textOverflow(value: CoreTypes.TextOverflowType) {
+		this.style.textOverflow = value;
+	}
+
 	get padding(): string | CoreTypes.LengthType {
 		return this.style.padding;
 	}
@@ -290,6 +297,16 @@ export const whiteSpaceProperty = new CssProperty<Style, CoreTypes.WhiteSpaceTyp
 	valueConverter: whiteSpaceConverter,
 });
 whiteSpaceProperty.register(Style);
+
+const textOverflowConverter = makeParser<CoreTypes.TextOverflowType>(makeValidator<CoreTypes.TextOverflowType>('clip', 'ellipsis', 'initial', 'unset'));
+export const textOverflowProperty = new CssProperty<Style, CoreTypes.TextOverflowType>({
+	name: 'textOverflow',
+	cssName: 'text-overflow',
+	defaultValue: 'initial',
+	affectsLayout: global.isIOS,
+	valueConverter: textOverflowConverter,
+});
+textOverflowProperty.register(Style);
 
 const textDecorationConverter = makeParser<CoreTypes.TextDecorationType>(makeValidator<CoreTypes.TextDecorationType>('none', 'underline', 'line-through', 'underline line-through'));
 export const textDecorationProperty = new CssProperty<Style, CoreTypes.TextDecorationType>({


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

`text-overflow` was not supported. This means most buttons would truncate awkwardly like this by default:
<img width="328" alt="Screenshot 2023-08-25 at 1 54 40 PM" src="https://github.com/NativeScript/NativeScript/assets/457187/9c39141c-432f-4d8f-a5d1-4961097e9438">


## What is the new behavior?

Adds support for standard CSS `text-overflow` to combine with `white-space` to achieve different truncation on text with labels and buttons. This allows you to set `text-overflow: ellipsis` to allow desired truncation:
<img width="327" alt="Screenshot 2023-08-25 at 1 54 46 PM" src="https://github.com/NativeScript/NativeScript/assets/457187/45d51944-a5d9-44c7-a1fb-883d281aa8c2">

ref: https://github.com/NativeScript/tailwind/pull/189
closes https://github.com/NativeScript/NativeScript/issues/5487