### PR TITLE
feat(ios): addDelegateHandler to add App Delegate handlers

### DIFF
--- a/apps/automated/src/main.ts
+++ b/apps/automated/src/main.ts
@@ -12,6 +12,13 @@ if (Application.ios) {
 	Application.ios.addNotificationObserver(UIApplicationDidFinishLaunchingNotification, (notification: NSNotification) => {
 		console.log('UIApplicationDidFinishLaunchingNotification:', notification);
 	});
+
+	// Make sure we can add multiple handlers for the same event.
+	for (let i = 0; i < 10; i++) {
+		Application.ios.addDelegateHandler('applicationDidBecomeActive', (application: UIApplication) => {
+			console.log('applicationDidBecomeActive', i, application);
+		});
+	}
 }
 
 // Common events for both Android and iOS.

--- a/packages/core/application/application.d.ts
+++ b/packages/core/application/application.d.ts
@@ -168,6 +168,14 @@ export class iOSApplication extends ApplicationCommon {
 	set delegate(value: UIApplicationDelegate | unknown);
 
 	/**
+	 * Adds a delegate handler for the specified delegate method name. This method does not replace an existing handler,
+	 * but rather adds the new handler to the existing chain of handlers.
+	 * @param methodName The name of the delegate method to add a handler for.
+	 * @param handler A function that will be called when the specified delegate method is called.
+	 */
+	addDelegateHandler<T extends keyof UIApplicationDelegate>(methodName: T, handler: (typeof UIApplicationDelegate.prototype)[T]): void;
+
+	/**
 	 * Adds an observer to the default notification center for the specified notification.
 	 * For more information, please visit 'https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSNotificationCenter_Class/#//apple_ref/occ/instm/NSNotificationCenter/addObserver:selector:name:object:'
 	 * @param notificationName A string containing the name of the notification.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In order to add delegate handlers, users must replace the Application.ios.delegate with their own - accounting for existing delegates if any (ie. from plugins).

## What is the new behavior?

To simplify adding delegate handlers, users no longer need to replace the delegate, and can just add/register them via the new api:

```ts
Application.ios.addDelegateHandler('applicationDidBecomeActive', (application: UIApplication) => {
  console.log('applicationDidBecomeActive', application);
});
```

The types should automatically be inferred for the handler function.

Implementation loosely based off of https://github.com/nativescript-community/universal-links/blob/master/src/universal-links/index.ios.ts#L6-L31

