### PR TITLE
fix(ios): Shadow layer origin point update

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -1125,9 +1125,12 @@ function drawBoxShadow(view: View): void {
 		}
 	}
 
-	// Since shadow layer is added to view layer's superlayer, we have to be more specific about shadow layer position
 	outerShadowContainerLayer.bounds = bounds;
-	outerShadowContainerLayer.position = CGPointMake(viewFrame.origin.x + viewFrame.size.width / 2, viewFrame.origin.y + viewFrame.size.height / 2);
+	outerShadowContainerLayer.anchorPoint = layer.anchorPoint;
+
+	// Since shadow uses superlayer's coordinate system, we have to be more specific about shadow layer position
+	const { x: originX, y: originY }: CGPoint = outerShadowContainerLayer.anchorPoint;
+	outerShadowContainerLayer.position = CGPointMake(viewFrame.origin.x + viewFrame.size.width * originX, viewFrame.origin.y + viewFrame.size.height * originY);
 
 	// Inherit view visibility values
 	outerShadowContainerLayer.opacity = layer.opacity;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
iOS shadow layers do not respect origin point.

## What is the new behavior?
iOS shadow layers will respect origin point. This is a fix for https://github.com/NativeScript/NativeScript/pull/10374#issuecomment-1709232617
