### PR TITLE
fix(webpack): set keep_quoted_props: true in TerserOptions

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -325,7 +325,10 @@ exports[`angular configuration for android 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -751,7 +754,10 @@ exports[`angular configuration for ios 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -218,7 +218,10 @@ exports[`base configuration for android 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -539,7 +542,10 @@ exports[`base configuration for ios 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -218,7 +218,10 @@ exports[`javascript configuration for android 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -538,7 +541,10 @@ exports[`javascript configuration for ios 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
@@ -240,7 +240,10 @@ exports[`react configuration > android > adds ReactRefreshWebpackPlugin when HMR
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -572,7 +575,10 @@ exports[`react configuration > android > base config 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -911,7 +917,10 @@ exports[`react configuration > ios > adds ReactRefreshWebpackPlugin when HMR ena
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -1244,7 +1253,10 @@ exports[`react configuration > ios > base config 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -245,7 +245,10 @@ exports[`svelte configuration for android 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -587,7 +590,10 @@ exports[`svelte configuration for ios 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -218,7 +218,10 @@ exports[`typescript configuration for android 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -538,7 +541,10 @@ exports[`typescript configuration for ios 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
@@ -250,7 +250,10 @@ exports[`vue configuration for android 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )
@@ -605,7 +608,10 @@ exports[`vue configuration for ios 1`] = `
               }
             },
             keep_fnames: true,
-            keep_classnames: true
+            keep_classnames: true,
+            format: {
+              keep_quoted_props: true
+            }
           }
         }
       )

--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -157,6 +157,9 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 				},
 				keep_fnames: true,
 				keep_classnames: true,
+				format: {
+					keep_quoted_props: true,
+				},
 			},
 		},
 	]);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In release builds, Terser strips quotes from props, and in some cases causes boot crashes while parsing the bundle/vendor chunks. For example, if the app uses a `html-entities` package, the mapping from entities -> their html equivalent causes the app to crash on boot in minified/production builds.

Example:
```js
characters: {
    Æ: '&AElig;',
    '&': '&amp;',
    Á: '&Aacute;',
    Ă: '&Abreve;',
    Â: '&Acirc;',
    А: '&Acy;',
    𝔄: '&Afr;', // <-- this fails
```

```
***** Fatal JavaScript exception - application has been terminated. *****
2023-09-13 22:14:29.640530-0700 app[1:1] NativeScript encountered a fatal error: Uncaught SyntaxError: Invalid or unexpected token
 at 
	require(:1:232)
	at __webpack_require__.f.require(file:///app/runtime.js:1:1468)
	at (file:///app/runtime.js:1:692)
	at __webpack_require__.e(file:///app/runtime.js:1:652)
	at __webpack_require__.X(file:///app/runtime.js:1:1143)
	at (file:///app/bundle.js:2:691934)
	at (file:///app/bundle.js:2:692118)
	at require(:1:232)
```

## What is the new behavior?

The minified code will keep the original quotes from the library, example:
```js
characters: {
    'Æ': '&AElig;',
    '&': '&amp;',
    'Á': '&Aacute;',
    'Ă': '&Abreve;',
    'Â': '&Acirc;',
    'А': '&Acy;',
    '𝔄': '&Afr;', // <-- this no longer fails
```

This can now properly be parsed and the app runs.



Fixes #9703, and likely also #8550.



