### PR TITLE
chore: ignore android build errors

### DIFF
--- a/packages/ui-mobile-base/build.sh
+++ b/packages/ui-mobile-base/build.sh
@@ -29,7 +29,7 @@ ignoreErrors
 throwErrors
 
 # only build ios widgets framework on macOS
-if [ "$OSTYPE" = "darwin" ]
+if [[ "$OSTYPE" =~ "darwin" ]];
 then
   ./build.ios.sh
 fi

--- a/packages/ui-mobile-base/build.sh
+++ b/packages/ui-mobile-base/build.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
-echo "Set exit on simple errors"
-set -e
+function throwErrors()
+{
+  echo "Set exit on simple errors"
+    set -e
+}
 
+function ignoreErrors()
+{
+  echo "ignore errors"
+    set +e
+}
+
+throwErrors
 
 echo "Use dumb gradle terminal"
 export TERM=dumb
@@ -11,8 +21,18 @@ echo "Clean dist"
 rm -rf dist
 
 export SKIP_PACK=true
+
+# we ignore android widgets lib build errors for scenarios like:
+# macOS dev without android dev env
+ignoreErrors
 ./build.android.sh
-./build.ios.sh
+throwErrors
+
+# only build ios widgets framework on macOS
+if [ "$OSTYPE" = "darwin" ]
+then
+  ./build.ios.sh
+fi
 
 echo "Copy NPM artifacts"
 cp .npmignore README.md package.json dist/package

--- a/packages/ui-mobile-base/build.sh
+++ b/packages/ui-mobile-base/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function throwErrors()
 {


### PR DESCRIPTION
as we discussed this ignores android build errors but still shows ios ones