### PR TITLE
fix(android): outline path is only supported on api >=33. But we can …

### DIFF
--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/BorderDrawable.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/BorderDrawable.java
@@ -896,24 +896,29 @@ public class BorderDrawable extends ColorDrawable implements BitmapOwner {
 	@Override
 	public void getOutline(@NonNull Outline outline) {
 		if (android.os.Build.VERSION.SDK_INT >= 21) {
-			outlineBackgroundPath.reset();
-			float[] backgroundRadii = {
-				Math.max(0, borderTopLeftRadius), Math.max(0, borderTopLeftRadius),
-				Math.max(0, borderTopRightRadius), Math.max(0, borderTopRightRadius),
-				Math.max(0, borderBottomRightRadius), Math.max(0, borderBottomRightRadius),
-				Math.max(0, borderBottomLeftRadius), Math.max(0, borderBottomLeftRadius)
-			};
 			outlineRectF.setEmpty();
 			outlineRectF.set(getBounds());
-			outlineBackgroundPath.addRoundRect(outlineRectF, backgroundRadii, Path.Direction.CW);
-
-			if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-				// see setConvexPath notes
-				outline.setPath(outlineBackgroundPath);
+			if (hasUniformBorderRadius()) {
+				outline.setRoundRect(getBounds(), borderTopLeftRadius);
 			} else {
-				outline.setConvexPath(outlineBackgroundPath);
-			}
+				// cliping with path is only support on API >= 33
+				// before it only works for rectangle, circle, or round rect
+				outlineBackgroundPath.reset();
+				float[] backgroundRadii = {
+					Math.max(0, borderTopLeftRadius), Math.max(0, borderTopLeftRadius),
+					Math.max(0, borderTopRightRadius), Math.max(0, borderTopRightRadius),
+					Math.max(0, borderBottomRightRadius), Math.max(0, borderBottomRightRadius),
+					Math.max(0, borderBottomLeftRadius), Math.max(0, borderBottomLeftRadius)
+				};
+				outlineBackgroundPath.addRoundRect(outlineRectF, backgroundRadii, Path.Direction.CW);
 
+				if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+					// see setConvexPath notes
+					outline.setPath(outlineBackgroundPath);
+				} else {
+					outline.setConvexPath(outlineBackgroundPath);
+				}
+			}
 		} else {
 			throw new IllegalStateException("Method supported on API 21 or higher");
 		}


### PR DESCRIPTION
Outline "path" wont clip on android < 33. Only  rectangle, circle, or round rect will work.
This makes it work for uniform border radius on android >= 21 and < 33