### PR TITLE
perf: cache default view paddings on android

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -309,6 +309,8 @@ namespace SuspendType {
 	}
 }
 
+const DEFAULT_VIEW_PADDINGS: Map<string, any> = new Map();
+
 export abstract class ViewBase extends Observable implements ViewBaseDefinition {
 	/**
 	 * String value used when hooking to loaded event.
@@ -1048,14 +1050,21 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 			if (this._androidView !== nativeView || !this.reusable) {
 				this._androidView = nativeView;
 				if (nativeView) {
+					const className = this.constructor.name;
+
 					if (this._isPaddingRelative === undefined) {
 						this._isPaddingRelative = nativeView.isPaddingRelative();
 					}
 
-					let result: any /* android.graphics.Rect */ = (<any>nativeView).defaultPaddings;
+					let result: any /* android.graphics.Rect */ = DEFAULT_VIEW_PADDINGS.get(className) || (<any>nativeView).defaultPaddings;
 					if (result === undefined) {
-						result = org.nativescript.widgets.ViewHelper.getPadding(nativeView);
-						(<any>nativeView).defaultPaddings = result;
+						DEFAULT_VIEW_PADDINGS.set(className, org.nativescript.widgets.ViewHelper.getPadding(nativeView));
+						(<any>nativeView).defaultPaddings = DEFAULT_VIEW_PADDINGS.get(className);
+						result = DEFAULT_VIEW_PADDINGS.get(className);
+					}
+
+					if (!nativeView.defaultPaddings) {
+						nativeView.defaultPaddings = DEFAULT_VIEW_PADDINGS.get(className);
 					}
 
 					this._defaultPaddingTop = result.top;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
```
09-27 21:44:42.911  6331  6331 V 1000_StackLayouts: 389 <--- Cold Start
09-27 21:44:43.243  6331  6331 V 1000_StackLayouts: 332
09-27 21:44:43.521  6331  6331 V 1000_StackLayouts: 278
09-27 21:44:43.787  6331  6331 V 1000_StackLayouts: 265
09-27 21:44:44.018  6331  6331 V 1000_StackLayouts: 231
09-27 21:44:44.256  6331  6331 V 1000_StackLayouts: 237
09-27 21:44:44.502  6331  6331 V 1000_StackLayouts: 246
09-27 21:44:44.774  6331  6331 V 1000_StackLayouts: 271
09-27 21:44:45.027  6331  6331 V 1000_StackLayouts: 253
09-27 21:44:45.268  6331  6331 V 1000_StackLayouts: 241
```

## What is the new behavior?
Roughly 25-30% faster view rendering on android after this change:
```
09-27 21:43:28.150  6330  6330 V 1000_StackLayouts: 290 <--- Cold Start
09-27 21:43:28.412  6330  6330 V 1000_StackLayouts: 262
09-27 21:43:28.634  6330  6330 V 1000_StackLayouts: 221
09-27 21:43:28.847  6330  6330 V 1000_StackLayouts: 213
09-27 21:43:29.027  6330  6330 V 1000_StackLayouts: 179
09-27 21:43:29.230  6330  6330 V 1000_StackLayouts: 203
09-27 21:43:29.420  6330  6330 V 1000_StackLayouts: 189
09-27 21:43:29.654  6330  6330 V 1000_StackLayouts: 234
09-27 21:43:29.854  6330  6330 V 1000_StackLayouts: 200
09-27 21:43:30.043  6330  6330 V 1000_StackLayouts: 189
```
Benchmarks were done on Android 12, LG G7, 4 GB, SD845 from 2018.
