### PR TITLE
fix(ios): Setting of property mask on 'undefined' during view disposal

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -74,11 +74,14 @@ export class View extends ViewCommon implements ViewDefinition {
 		this._hasTransform = false;
 		this._hasPendingTransform = false;
 
-		// Make sure shadows get removed
-		this.style.backgroundInternal.clearFlags |= BackgroundClearFlags.CLEAR_BOX_SHADOW;
+		// If native view extends UIView, perform a background cleanup to get rid of shadow layers
+		if (this.nativeViewProtected instanceof UIView) {
+			// Make sure shadows get removed
+			this.style.backgroundInternal.clearFlags |= BackgroundClearFlags.CLEAR_BOX_SHADOW;
 
-		// Perform background cleanup
-		iosBackground.clearBackgroundVisualEffects(this);
+			// Perform background cleanup
+			iosBackground.clearBackgroundVisualEffects(this);
+		}
 	}
 
 	public requestLayout(): void {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
iOS apps crash when trying to dispose native views that do not extend UIView (e.g. UITabBarItem) due to CALayers cleanup.

This trace was provided in discord:
```
[11:04:49.026] Debug: uncaughtErrorEvent - NativeScriptError: TypeError: Cannot set properties of undefined (setting 'mask')
  ***** Fatal JavaScript exception - application has been terminated. *****
  NativeScript encountered a fatal error:
  Uncaught TypeError: Cannot set properties of undefined (setting 'mask')
   at
      clearLayerMask(file: src/webpack:/app/node_modules/@nativescript/core/ui/styling/background.ios.js:279:0)
      at clearBackgroundVisualEffects(file: src/webpack:/app/node_modules/@nativescript/core/ui/styling/background.ios.js:100:0)
      at disposeNativeView(file: src/webpack:/app/node_modules/@nativescript/core/ui/core/view/index.ios.js:47:21)
      at _tearDownUI(file: src/webpack:/app/node_modules/@nativescript/core/ui/core/view-base/index.js:809:0)
      at (file: src/webpack:/app/node_modules/@nativescript/core/ui/core/view-base/index.js:784:0)
      at (file: src/webpack:/app/node_modules/@nativescript-community/ui-material-core-tabs/tab-strip/index.js:36:0)
      at eachChild(file: src/webpack:/app/node_modules/@nativescript-community/ui-material-core-tabs/tab-strip/index.js:35:0)
```

## What is the new behavior?
Apps will execute the steps after checking whether native view extends UIView.