### PR TITLE
feat(android): allow shared element transition to work with ListView/CollectionView/Pager

### DIFF
--- a/packages/core/ui/transition/page-transition.android.ts
+++ b/packages/core/ui/transition/page-transition.android.ts
@@ -77,7 +77,7 @@ function setTransitionName(view: ViewBase) {
 }
 
 export class PageTransition extends Transition {
-	constructor(duration?: number, curve?: any) {
+	constructor(duration?: number, curve?: any, private pageLoadedTimeout: number = 0) {
 		// disable custom curves until we can fix the issue with the animation not completing
 		if (curve) {
 			console.warn('PageTransition does not support custom curves at the moment. The passed in curve will be ignored.');
@@ -220,7 +220,7 @@ export class PageTransition extends Transition {
 				// const sharedElementTags = sharedElements.map((v) => v.sharedTransitionTag);
 				presented.forEach(setTransitionName);
 				newFragment.startPostponedEnterTransition();
-			}, 0);
+			}, this.pageLoadedTimeout);
 		};
 
 		fragmentTransaction.setReorderingAllowed(true);

--- a/packages/core/ui/transition/page-transition.d.ts
+++ b/packages/core/ui/transition/page-transition.d.ts
@@ -1,2 +1,4 @@
 ﻿import { Transition } from '.';
-export declare class PageTransition extends Transition {}
+export declare class PageTransition extends Transition {
+	constructor(duration?: number, nativeCurve?: any /* UIViewAnimationCurve | string | CubicBezierAnimationCurve | android.view.animation.Interpolator | android.view.animation.LinearInterpolator */, pageLoadedTimeout?: number);
+}


### PR DESCRIPTION
In the current implementation it would not work because the collectionview would not have time to realize the cells which you would want to use as shared element.

The idea is to defer a bit for :
* the page to be loaded
* a timeout giving time to the collectionview to realize its "cells". In most my case the 0 timeout was enough, though for some reason i did not find yet it requires just a bit more with the pager. So what i did is make the timeout a parameter of the `PageTransition` so that each use case can be handled.

A few notes :
* i left the old commented code for now to be able to compare
* presenting and presented can not be "compared" anymore. We cant filter on intersection. Though it is not a big deal. Android handles that on its own.
* i am starting to think it would be best for `PageTransition` constructor parameters to be an object. Would be less messy, though it would be a breaking change. But as it is quite a new feature, would that be acceptable?
* in my fork the `PageTransition` has a `onTransitionEnd` which revert `setTransitionName` to null for all presenting views. The reason is that my fork uses `add` for fragments instead of `replace`. Thus back navigation fragments are still existing. And if you use the same  `setTransitionName` for multiple pages in deep navigation it would fail/crash. I did not add it here as it is unecessary. Just a note for the future!