### PR TITLE
fix(ios): Proper shadow position after translate transform

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -155,21 +155,13 @@ export class View extends ViewCommon implements ViewDefinition {
 
 	private layoutOuterShadows(): void {
 		const nativeView: NativeScriptUIView = <NativeScriptUIView>this.nativeViewProtected;
-		if (nativeView) {
-			const frame = nativeView.frame;
-			const needsUpdate: boolean = nativeView.outerShadowContainerLayer != null;
-
-			if (needsUpdate) {
-				CATransaction.setDisableActions(true);
-
-				if (nativeView.outerShadowContainerLayer) {
-					const { x: originX, y: originY }: CGPoint = nativeView.outerShadowContainerLayer.anchorPoint;
-					nativeView.outerShadowContainerLayer.bounds = nativeView.bounds;
-					nativeView.outerShadowContainerLayer.position = CGPointMake(frame.origin.x + frame.size.width * originX, frame.origin.y + frame.size.height * originY);
-				}
-
-				CATransaction.setDisableActions(false);
+		if (nativeView?.outerShadowContainerLayer) {
+			CATransaction.setDisableActions(true);
+			if (nativeView.outerShadowContainerLayer) {
+				nativeView.outerShadowContainerLayer.bounds = nativeView.bounds;
+				nativeView.outerShadowContainerLayer.position = nativeView.center;
 			}
+			CATransaction.setDisableActions(false);
 		}
 	}
 

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -157,10 +157,10 @@ export class View extends ViewCommon implements ViewDefinition {
 		const nativeView: NativeScriptUIView = <NativeScriptUIView>this.nativeViewProtected;
 		if (nativeView?.outerShadowContainerLayer) {
 			CATransaction.setDisableActions(true);
-			if (nativeView.outerShadowContainerLayer) {
-				nativeView.outerShadowContainerLayer.bounds = nativeView.bounds;
-				nativeView.outerShadowContainerLayer.position = nativeView.center;
-			}
+
+			nativeView.outerShadowContainerLayer.bounds = nativeView.bounds;
+			nativeView.outerShadowContainerLayer.position = nativeView.center;
+
 			CATransaction.setDisableActions(false);
 		}
 	}

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -1091,7 +1091,6 @@ function drawBoxShadow(view: View): void {
 	}
 
 	const bounds = nativeView.bounds;
-	const viewFrame = nativeView.frame;
 	const boxShadow: BoxShadow = background.getBoxShadow();
 
 	// Initialize outer shadows
@@ -1127,10 +1126,7 @@ function drawBoxShadow(view: View): void {
 
 	outerShadowContainerLayer.bounds = bounds;
 	outerShadowContainerLayer.anchorPoint = layer.anchorPoint;
-
-	// Since shadow uses superlayer's coordinate system, we have to be more specific about shadow layer position
-	const { x: originX, y: originY }: CGPoint = outerShadowContainerLayer.anchorPoint;
-	outerShadowContainerLayer.position = CGPointMake(viewFrame.origin.x + viewFrame.size.width * originX, viewFrame.origin.y + viewFrame.size.height * originY);
+	outerShadowContainerLayer.position = nativeView.center;
 
 	// Inherit view visibility values
 	outerShadowContainerLayer.opacity = layer.opacity;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
On iOS, shadow layer position gets messed up if translate transformation is applied to view.

## What is the new behavior?
On iOS, shadow layer position aligns with view position when translate transformation is applied to view.
To achieve this, we set shadow layer position to match view's `center` coordinates.