### PR TITLE
fix(android): Do not try to rehydrate destroyed dialogs

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -173,7 +173,16 @@ function initializeDialogFragment() {
 
 			return global.__native(this);
 		}
-
+		public onCreate(savedInstanceState: android.os.Bundle) {
+			super.onCreate(savedInstanceState);
+			var ownerId = this.getArguments()?.getInt(DOMID);
+			var options = getModalOptions(ownerId);
+			// The teardown when the activity is destroyed happens after the state is saved, but is not recoverable,
+			// Cancel the native dialog in this case or the app will crash with subsequent errors.
+			if (savedInstanceState != null && options === undefined) {
+				this.dismissAllowingStateLoss();
+			}
+		}
 		public onCreateDialog(savedInstanceState: android.os.Bundle): android.app.Dialog {
 			const ownerId = this.getArguments().getInt(DOMID);
 			const options = getModalOptions(ownerId);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a Dialog is currently being shown, and the app is sent to the background where the Activity is then destroyed, when the app is brought to the foreground the app will crash.

This is because when the activity is destroyed, the dialog is torn down, but this happens after state is saved and it crashes when the dialog is being restored.

( Easy to test by turning on the `Don't keep activities` developer option. )

## What is the new behavior?
<!-- Describe the changes. -->
The change is to cancel the dialog creation if being restored in a state where the creation of the dialog will crash.



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

