### PR TITLE
fix(ios/background): Fix background clear

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -349,7 +349,9 @@ function clearLayerMask(nativeView: NativeScriptUIView, background: BackgroundDe
 	if (nativeView.outerShadowContainerLayer) {
 		nativeView.outerShadowContainerLayer.mask = null;
 	}
-	nativeView.layer.mask = nativeView.originalMask;
+	if (nativeView.layer) {
+		nativeView.layer.mask = nativeView.originalMask;
+	}
 	nativeView.originalMask = null;
 	nativeView.maskType = null;
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now seems it can happen that the `layer` of the background ends up undefined in some situations. As an example I have a view with List that navigates to a page with a BottomNavigation. When navigating back to the list the `layer` ends up undefined and the app crashes. 

## What is the new behavior?
Adds a safety check before trying to reset the layer's mask thus resolving the crash. 

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

