### PR TITLE
fix(core): Page frame reference not unset on native view disposal

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -594,6 +594,10 @@ export class FrameBase extends CustomLayoutView {
 	// We don't need to put Page as visual child. Don't call super.
 	public _removeViewFromNativeVisualTree(child: View): void {
 		child._isAddedToNativeVisualTree = false;
+		// There are cases that page gets disposed before removing its entry from frame so get rid of frame reference
+		if (child instanceof Page) {
+			child._frame = null;
+		}
 	}
 
 	public _printFrameBackStack() {

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -201,7 +201,6 @@ export class FrameBase extends CustomLayoutView {
 	public _removeEntry(removed: BackstackEntry): void {
 		const page = removed.resolvedPage;
 		const frame = page.frame;
-		page._frame = null;
 		if (frame) {
 			frame._removeView(page);
 		} else {
@@ -250,7 +249,6 @@ export class FrameBase extends CustomLayoutView {
 			this._resolvedPage = newPage;
 
 			this._addView(newPage);
-			newPage._frame = this;
 		}
 
 		this._currentEntry = entry;
@@ -594,10 +592,6 @@ export class FrameBase extends CustomLayoutView {
 	// We don't need to put Page as visual child. Don't call super.
 	public _removeViewFromNativeVisualTree(child: View): void {
 		child._isAddedToNativeVisualTree = false;
-		// There are cases that page gets disposed before removing its entry from frame so get rid of frame reference
-		if (child instanceof Page) {
-			child._frame = null;
-		}
 	}
 
 	public _printFrameBackStack() {

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -927,6 +927,8 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 				page.callLoaded();
 			}
 		} else {
+			page._frame = frame;
+
 			if (!frame._styleScope) {
 				// Make sure page will have styleScope even if parents don't.
 				page._updateStyleScope();

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -927,8 +927,6 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 				page.callLoaded();
 			}
 		} else {
-			page._frame = frame;
-
 			if (!frame._styleScope) {
 				// Make sure page will have styleScope even if parents don't.
 				page._updateStyleScope();

--- a/packages/core/ui/page/index.d.ts
+++ b/packages/core/ui/page/index.d.ts
@@ -143,10 +143,6 @@ export declare class Page extends PageBase {
 	 * @private
 	 */
 	hasActionBar: boolean;
-	/**
-	 * @private
-	 */
-	_frame: Frame;
 
 	/**
 	 * A method called before navigating to the page.

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -427,10 +427,6 @@ export class Page extends PageBase {
 		return this._ios;
 	}
 
-	get frame(): Frame {
-		return this._frame;
-	}
-
 	public layoutNativeView(left: number, top: number, right: number, bottom: number): void {
 		//
 	}

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -134,7 +134,6 @@ class UIViewControllerImpl extends UIViewController {
 			frame._resolvedPage = owner;
 
 			if (!owner.parent) {
-				owner._frame = frame;
 				if (!frame._styleScope) {
 					// Make sure page will have styleScope even if frame don't.
 					owner._updateStyleScope();
@@ -436,7 +435,7 @@ export class Page extends PageBase {
 	}
 
 	public _shouldDelayLayout(): boolean {
-		return this._frame && this._frame._animationInProgress;
+		return this.frame && this.frame._animationInProgress;
 	}
 
 	public onLoaded(): void {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -464,7 +464,7 @@ export class Page extends PageBase {
 
 	public _updateStatusBarStyle(value?: string) {
 		const frame = this.frame;
-		if (this.frame && value) {
+		if (frame && value) {
 			const navigationController: UINavigationController = frame.ios.controller;
 			const navigationBar = navigationController.navigationBar;
 

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -80,12 +80,6 @@ export class PageBase extends ContentView {
 		return this;
 	}
 
-	disposeNativeView() {
-		// There are cases that page gets disposed before removing its entry from frame so get rid of frame reference
-		this._frame = null;
-		super.disposeNativeView();
-	}
-
 	public _addChildFromBuilder(name: string, value: any) {
 		if (value instanceof ActionBar) {
 			this.actionBar = value;

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -7,6 +7,7 @@ import { Style } from '../styling/style';
 import { Color } from '../../color';
 import { EventData } from '../../data/observable';
 import type { Frame } from '../frame';
+import { isFrame } from '../frame/frame-helpers';
 import { ActionBar } from '../action-bar';
 import { KeyframeAnimationInfo } from '../animation/keyframe-animation';
 import { profile } from '../../profiling';
@@ -25,8 +26,6 @@ export class PageBase extends ContentView {
 
 	private _navigationContext: any;
 	private _actionBar: ActionBar;
-
-	public _frame: Frame;
 
 	public actionBarHidden: boolean;
 	public enableSwipeBackNavigation: boolean;
@@ -80,6 +79,15 @@ export class PageBase extends ContentView {
 		return this;
 	}
 
+	public _parentChanged(oldParent: View): void {
+		const newParent = this.parent;
+		if (newParent && !isFrame(newParent)) {
+			throw new Error(`Page can only be nested inside Frame. New parent: ${newParent}`);
+		}
+
+		super._parentChanged(oldParent);
+	}
+
 	public _addChildFromBuilder(name: string, value: any) {
 		if (value instanceof ActionBar) {
 			this.actionBar = value;
@@ -93,7 +101,7 @@ export class PageBase extends ContentView {
 	}
 
 	get frame(): Frame {
-		return this._frame;
+		return <Frame>this.parent;
 	}
 
 	private createNavigatedData(eventName: string, isBackNavigation: boolean): NavigatedData {

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -7,7 +7,6 @@ import { Style } from '../styling/style';
 import { Color } from '../../color';
 import { EventData } from '../../data/observable';
 import type { Frame } from '../frame';
-import { isFrame } from '../frame/frame-helpers';
 import { ActionBar } from '../action-bar';
 import { KeyframeAnimationInfo } from '../animation/keyframe-animation';
 import { profile } from '../../profiling';
@@ -81,6 +80,12 @@ export class PageBase extends ContentView {
 		return this;
 	}
 
+	disposeNativeView() {
+		// There are cases that page gets disposed before removing its entry from frame so get rid of frame reference
+		this._frame = null;
+		super.disposeNativeView();
+	}
+
 	public _addChildFromBuilder(name: string, value: any) {
 		if (value instanceof ActionBar) {
 			this.actionBar = value;
@@ -94,9 +99,7 @@ export class PageBase extends ContentView {
 	}
 
 	get frame(): Frame {
-		const parent = this.parent;
-
-		return isFrame(parent) ? (parent as Frame) : undefined;
+		return this._frame;
 	}
 
 	private createNavigatedData(eventName: string, isBackNavigation: boolean): NavigatedData {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
There is currently an issue on Svelte Native that's related to HMR removing page elements and throwing exception.
The reason is that even though `_removeView` unsets page parent, the page still keeps reference of parent using property `_frame` and parent Frame happens to check that property when trying to dispose entry views in Core.

## What is the new behavior?
This change will ensure page won't keep any reference to parent after disposal. Doing so helps avoid calling `_removeView` multiple times.
More specifically, it ends up meddling with the following check:
https://github.com/NativeScript/NativeScript/blob/main/packages/core/ui/frame/frame-common.ts#L201

Fixes #10361 https://github.com/halfnelson/svelte-native/issues/347