### PR TITLE
fix(css): prevent shorthand parse error on 'unset' and 'inset'

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jest-environment-jsdom": "~29.6.0",
     "lint-staged": "^14.0.0",
     "module-alias": "^2.2.2",
-    "nativescript": "~8.5.0",
+    "nativescript": "~8.6.0",
     "nativescript-typedoc-theme": "1.1.0",
     "nx": "16.9.1",
     "parse-css": "git+https://github.com/tabatkins/parse-css.git",

--- a/packages/core/ui/styling/css-shadow.spec.ts
+++ b/packages/core/ui/styling/css-shadow.spec.ts
@@ -144,4 +144,36 @@ describe('css-shadow', () => {
 		expect(shadow.spreadRadius).toBeUndefined();
 		expect(shadow.color).toBeUndefined();
 	});
+
+	it('unset', () => {
+		const shadow = parseCSSShadow('unset');
+		expect(shadow.inset).toBe(false);
+		expect(shadow.offsetX).toBeUndefined();
+		expect(shadow.offsetY).toBeUndefined();
+		expect(shadow.blurRadius).toBeUndefined();
+		expect(shadow.spreadRadius).toBeUndefined();
+		expect(shadow.color).toBeUndefined();
+	});
+
+	it('unset 5em 1em gold', () => {
+		// invalid shorthand should result in nothing being applied
+		const shadow = parseCSSShadow('unset 5em 1em gold');
+		expect(shadow.inset).toBe(false);
+		expect(shadow.offsetX).toBeUndefined();
+		expect(shadow.offsetY).toBeUndefined();
+		expect(shadow.blurRadius).toBeUndefined();
+		expect(shadow.spreadRadius).toBeUndefined();
+		expect(shadow.color).toBeUndefined();
+	});
+
+	it('5em 1em gold unset', () => {
+		// partially invalid shorthand should result in standard default fallback
+		const shadow = parseCSSShadow('5em 1em gold unset');
+		expect(shadow.inset).toBe(false);
+		expect(shadow.offsetX).toBe(5);
+		expect(shadow.offsetY).toBe(1);
+		expect(shadow.blurRadius).toEqual(CoreTypes.zeroLength);
+		expect(shadow.spreadRadius).toBeUndefined();
+		expect(shadow.color).toEqual(new Color('black'));
+	});
 });

--- a/packages/core/ui/styling/css-utils.ts
+++ b/packages/core/ui/styling/css-utils.ts
@@ -43,17 +43,18 @@ export function parseCSSShorthand(value: string): {
 			values: [],
 		};
 	} else {
+		const invalidColors = ['inset', 'unset'];
 		const inset = parts.includes('inset');
 		const last = parts[parts.length - 1];
 		let color = 'black';
-		if (first && !isLength(first) && first !== 'inset') {
+		if (first && !isLength(first) && !invalidColors.includes(first)) {
 			color = first;
-		} else if (last && !isLength(last)) {
+		} else if (last && !isLength(last) && !invalidColors.includes(last)) {
 			color = last;
 		}
 
 		const values = parts
-			.filter((n) => n !== 'inset')
+			.filter((n) => !invalidColors.includes(n))
 			.filter((n) => n !== color)
 			.map((val) => {
 				try {

--- a/packages/core/ui/styling/css-utils.ts
+++ b/packages/core/ui/styling/css-utils.ts
@@ -36,7 +36,7 @@ export function parseCSSShorthand(value: string): {
 	const parts = value.trim().split(PARTS_RE);
 	const first = parts[0];
 
-	if (['', 'none'].includes(first)) {
+	if (['', 'none', 'unset'].includes(first)) {
 		return {
 			inset: false,
 			color: undefined,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Usage of shadow css with `unset` in shorthand would result in css parse error.

## What is the new behavior?

`unset` is no longer inadvertently parsed as a color.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

