### PR TITLE
fix(core): Font variation settings parser invalid axis

### DIFF
--- a/packages/core/ui/styling/font-common.ts
+++ b/packages/core/ui/styling/font-common.ts
@@ -1,6 +1,7 @@
 import { Font as FontDefinition } from './font';
 import { ParsedFont, FontStyleType, FontWeightType, FontVariationSettingsType } from './font-interfaces';
 import { makeValidator, makeParser } from '../core/properties';
+import { Trace } from '../../trace';
 
 export abstract class Font implements FontDefinition {
 	public static default = undefined;
@@ -69,13 +70,18 @@ export namespace FontWeight {
 
 export namespace FontVariationSettings {
 	export function parse(fontVariationSettings: string): Array<FontVariationSettingsType> | null {
-		const allowedValues = ['normal', 'inherit', 'initial', 'revert', 'revert-layer', 'unset'];
-		const lower = fontVariationSettings?.toLowerCase().trim();
-		if (allowedValues.indexOf(lower) !== -1) {
+		if (!fontVariationSettings) {
 			return null;
 		}
 
-		const chunks = lower.split(',');
+		const allowedValues = ['normal', 'inherit', 'initial', 'revert', 'revert-layer', 'unset'];
+		const variationSettingsValue: string = fontVariationSettings.trim();
+
+		if (allowedValues.indexOf(variationSettingsValue.toLowerCase()) !== -1) {
+			return null;
+		}
+
+		const chunks = variationSettingsValue.split(',');
 		if (chunks.length) {
 			const parsed: Array<FontVariationSettingsType> = [];
 			for (const chunk of chunks) {
@@ -89,22 +95,22 @@ export namespace FontVariationSettings {
 					if (!isNaN(axisValue) && axisName.length === 6 && ((axisName.startsWith("'") && axisName.endsWith("'")) || (axisName.startsWith('"') && axisName.endsWith('"')))) {
 						parsed.push({ axis: axisName, value: axisValue });
 					} else {
-						console.error('Invalid value (font-variation-settings): ' + fontVariationSettings);
+						Trace.write('Invalid value (font-variation-settings): ' + variationSettingsValue, Trace.categories.Error, Trace.messageType.error);
 					}
 				} else {
-					console.error('Invalid value (font-variation-settings): ' + fontVariationSettings);
+					Trace.write('Invalid value (font-variation-settings): ' + variationSettingsValue, Trace.categories.Error, Trace.messageType.error);
 				}
 			}
 
 			return parsed;
 		}
 
-		console.error('Invalid value (font-variation-settings): ' + fontVariationSettings);
+		Trace.write('Invalid value (font-variation-settings): ' + variationSettingsValue, Trace.categories.Error, Trace.messageType.error);
 	}
 
 	export function toString(fontVariationSettings: FontVariationSettingsType[] | null): string | null {
 		if (fontVariationSettings?.length) {
-			return fontVariationSettings.map(({ axis, value }) => `'${axis}' ${value}`).join(', ');
+			return fontVariationSettings.map(({ axis, value }) => `${axis} ${value}`).join(', ');
 		}
 
 		return null;

--- a/packages/core/ui/styling/font-common.ts
+++ b/packages/core/ui/styling/font-common.ts
@@ -79,10 +79,11 @@ export namespace FontVariationSettings {
 		if (chunks.length) {
 			const parsed: Array<FontVariationSettingsType> = [];
 			for (const chunk of chunks) {
-				const axisChunks = chunk.trim();
+				const trimmedChunk = chunk.trim();
+				const axisChunks = trimmedChunk.split(' ');
 				if (axisChunks.length === 2) {
-					const axisName = chunk[0].trim();
-					const axisValue = parseFloat(chunk[0]);
+					const axisName = axisChunks[0].trim();
+					const axisValue = parseFloat(axisChunks[1]);
 					// See https://drafts.csswg.org/css-fonts/#font-variation-settings-def.
 					// Axis name strings longer or shorter than four characters are invalid.
 					if (!isNaN(axisValue) && axisName.length === 6 && ((axisName.startsWith("'") && axisName.endsWith("'")) || (axisName.startsWith('"') && axisName.endsWith('"')))) {

--- a/packages/core/ui/styling/font.android.ts
+++ b/packages/core/ui/styling/font.android.ts
@@ -63,8 +63,7 @@ function computeFontCacheKey(fontFamily: string, font: Font) {
 }
 
 function loadFontFromFile(fontFamily: string, font: Font): android.graphics.Typeface {
-	const apiLevel = android.os.Build.VERSION.SDK_INT;
-	const cacheKey = apiLevel >= 26 ? computeFontCacheKey(fontFamily, font) : fontFamily;
+	const cacheKey = SDK_VERSION >= 26 ? computeFontCacheKey(fontFamily, font) : fontFamily;
 
 	appAssets = appAssets || (ad.getApplicationContext() as android.content.Context).getAssets();
 	if (!appAssets) {
@@ -89,7 +88,7 @@ function loadFontFromFile(fontFamily: string, font: Font): android.graphics.Type
 		if (fontAssetPath) {
 			try {
 				fontAssetPath = fs.path.join(fs.knownFolders.currentApp().path, fontAssetPath);
-				if (apiLevel >= 26) {
+				if (SDK_VERSION >= 26) {
 					const builder = new android.graphics.Typeface.Builder(fontAssetPath);
 					if (builder) {
 						if (font.fontVariationSettings !== undefined) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Font variation settings property complains about defined axes being invalid.

## What is the new behavior?
Font variation settings property will parse axes as expected.