### PR TITLE
fix(ios): Shadow does not consider z-index

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -864,7 +864,13 @@ export class View extends ViewCommon implements ViewDefinition {
 		return 0;
 	}
 	[zIndexProperty.setNative](value: number) {
-		this.nativeViewProtected.layer.zPosition = value;
+		const nativeView: NativeScriptUIView = <NativeScriptUIView>this.nativeViewProtected;
+
+		nativeView.layer.zPosition = value;
+		// Apply z-index to shadows as well
+		if (nativeView.outerShadowContainerLayer) {
+			nativeView.outerShadowContainerLayer.zPosition = value;
+		}
 	}
 
 	[backgroundInternalProperty.getDefault](): UIColor {

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -143,7 +143,7 @@ export namespace ios {
 		}
 
 		if (!needsMask) {
-			clearLayerMask(nativeView, background);
+			clearLayerMask(nativeView);
 		}
 
 		// Clear box shadow if it's no longer needed
@@ -345,7 +345,7 @@ function maskLayerIfNeeded(nativeView: NativeScriptUIView, background: Backgroun
 	}
 }
 
-function clearLayerMask(nativeView: NativeScriptUIView, background: BackgroundDefinition) {
+function clearLayerMask(nativeView: NativeScriptUIView) {
 	if (nativeView.outerShadowContainerLayer) {
 		nativeView.outerShadowContainerLayer.mask = null;
 	}
@@ -1127,6 +1127,7 @@ function drawBoxShadow(view: View): void {
 	outerShadowContainerLayer.bounds = bounds;
 	outerShadowContainerLayer.anchorPoint = layer.anchorPoint;
 	outerShadowContainerLayer.position = nativeView.center;
+	outerShadowContainerLayer.zPosition = layer.zPosition;
 
 	// Inherit view visibility values
 	outerShadowContainerLayer.opacity = layer.opacity;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Box shadow does not consider z-index.

## What is the new behavior?
Box shadow will consider z-index.