### PR TITLE
fix(android): Proper change of input interaction mode programmatically

### DIFF
--- a/packages/core/ui/scroll-view/index.android.ts
+++ b/packages/core/ui/scroll-view/index.android.ts
@@ -1,7 +1,7 @@
 import { ScrollEventData } from '.';
 import { ScrollViewBase, scrollBarIndicatorVisibleProperty, isScrollEnabledProperty } from './scroll-view-common';
-import { layout } from '../../utils';
 import { isUserInteractionEnabledProperty } from '../core/view';
+import { layout } from '../../utils';
 
 export * from './scroll-view-common';
 

--- a/packages/core/ui/search-bar/index.android.ts
+++ b/packages/core/ui/search-bar/index.android.ts
@@ -1,9 +1,9 @@
 import { Font } from '../styling/font';
 import { SearchBarBase, textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty } from './search-bar-common';
 import { isUserInteractionEnabledProperty, isEnabledProperty } from '../core/view';
+import { colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty, fontSizeProperty } from '../styling/style-properties';
 import { ad } from '../../utils';
 import { Color } from '../../color';
-import { colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty, fontSizeProperty } from '../styling/style-properties';
 
 export * from './search-bar-common';
 
@@ -97,6 +97,19 @@ function enableSearchView(nativeView: any, value: boolean) {
 }
 
 function enableUserInteractionSearchView(nativeView: any, value: boolean) {
+	if (nativeView instanceof android.widget.TextView) {
+		// Dismiss input before view loses focus
+		if (!value) {
+			ad.dismissSoftInput(nativeView);
+		}
+
+		nativeView.setClickable(value);
+		nativeView.setFocusable(value);
+		nativeView.setFocusableInTouchMode(value);
+		nativeView.setLongClickable(value);
+		return;
+	}
+
 	nativeView.setClickable(value);
 	nativeView.setFocusable(value);
 

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -223,6 +223,18 @@ export class TextBase extends TextBaseCommon {
 		this._maxHeight = this._maxLines = undefined;
 	}
 
+	createFormattedTextNative(value: FormattedString) {
+		return createSpannableStringBuilder(value, this.style.fontSize);
+	}
+
+	_getNativeTextTransform(value: CoreTypes.TextTransformType): android.text.method.TransformationMethod {
+		if (value === 'initial') {
+			return this._defaultTransformationMethod;
+		}
+
+		return new TextTransformation(this);
+	}
+
 	[textProperty.getDefault](): symbol | number {
 		return resetSymbol;
 	}
@@ -237,12 +249,11 @@ export class TextBase extends TextBaseCommon {
 
 		this._setNativeText(reset);
 	}
+
 	[textStrokeProperty.setNative](value: StrokeCSSValues) {
 		this._setNativeText();
 	}
-	createFormattedTextNative(value: FormattedString) {
-		return createSpannableStringBuilder(value, this.style.fontSize);
-	}
+
 	[formattedTextProperty.setNative](value: FormattedString) {
 		const nativeView = this.nativeTextViewProtected;
 		if (!value) {
@@ -271,18 +282,10 @@ export class TextBase extends TextBaseCommon {
 	}
 
 	[textTransformProperty.setNative](value: CoreTypes.TextTransformType) {
-		if (value === 'initial') {
-			this.nativeTextViewProtected.setTransformationMethod(this._defaultTransformationMethod);
-
-			return;
+		const transformationMethod = this._getNativeTextTransform(value);
+		if (transformationMethod != null) {
+			this.nativeTextViewProtected.setTransformationMethod(transformationMethod);
 		}
-
-		// Don't change the transformation method if this is secure TextField or we'll lose the hiding characters.
-		if ((<any>this).secure) {
-			return;
-		}
-
-		this.nativeTextViewProtected.setTransformationMethod(new TextTransformation(this));
 	}
 
 	[textAlignmentProperty.getDefault](): CoreTypes.TextAlignmentType {

--- a/packages/core/ui/text-base/index.d.ts
+++ b/packages/core/ui/text-base/index.d.ts
@@ -123,6 +123,11 @@ export class TextBase extends View implements AddChildFromBuilder {
 	/**
 	 * @private
 	 */
+	_getNativeTextTransform(value: CoreTypes.TextTransformType): android.text.method.TransformationMethod;
+
+	/**
+	 * @private
+	 */
 	_isSingleLine: boolean;
 	//@endprivate
 }

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -210,6 +210,10 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
 	_setNativeText(reset = false): void {
 		//
 	}
+
+	_getNativeTextTransform(value: CoreTypes.TextTransformType): any {
+		//
+	}
 }
 
 TextBaseCommon.prototype._isSingleLine = false;

--- a/packages/core/ui/text-field/index.android.ts
+++ b/packages/core/ui/text-field/index.android.ts
@@ -6,6 +6,10 @@ import { CoreTypes } from '../../core-types';
 export * from './text-field-common';
 
 export class TextField extends TextFieldBase {
+	nativeViewProtected: android.widget.EditText;
+
+	private _pendingTransformationMethod: android.text.method.TransformationMethod;
+
 	public _configureEditText(editText: android.widget.EditText) {
 		editText.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_NORMAL | android.text.InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
 		editText.setLines(1);
@@ -17,43 +21,52 @@ export class TextField extends TextFieldBase {
 		this.notify({ eventName: TextField.returnPressEvent, object: this });
 	}
 
-	[secureProperty.setNative]() {
-		this.setSecureAndKeyboardType();
+	public disposeNativeView(): void {
+		this._pendingTransformationMethod = null;
+		super.disposeNativeView();
 	}
 
-	[keyboardTypeProperty.setNative]() {
-		this.setSecureAndKeyboardType();
+	_getNativeTextTransform(value: CoreTypes.TextTransformType): android.text.method.TransformationMethod {
+		const transformationMethod = super._getNativeTextTransform(value);
+
+		if (this.secure) {
+			this._pendingTransformationMethod = transformationMethod;
+			return null;
+		}
+
+		return transformationMethod;
 	}
 
 	setSecureAndKeyboardType(): void {
 		let inputType: number;
 
-		// Check for a passed in Number value
-		const value = +this.keyboardType;
-		if (typeof this.keyboardType !== 'boolean' && !isNaN(value)) {
-			this._setInputType(value);
-			return;
-		}
+		const nativeView = this.nativeViewProtected;
+		const numericKeyboardType = +this.keyboardType;
 
-		// Password variations are supported only for Text and Number classes.
-		if (this.secure) {
+		// Check for a passed in numeric value
+		if (typeof this.keyboardType !== 'boolean' && !isNaN(numericKeyboardType)) {
+			inputType = numericKeyboardType;
+		} else if (this.secure) {
+			// Password variations are supported only for Text and Number classes
 			if (this.keyboardType === 'number') {
 				inputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD;
 			} else {
 				inputType = android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD;
 			}
+
+			this._pendingTransformationMethod = nativeView.getTransformationMethod();
 		} else {
-			// default
+			// Default
 			inputType = android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_NORMAL;
 
-			// add autocorrect flags
+			// Add autocorrect flags
 			if (this.autocorrect) {
 				inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE;
 				inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
 				inputType = inputType & ~android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
 			}
 
-			// add autocapitalization type
+			// Add autocapitalization type
 			switch (this.autocapitalizationType) {
 				case 'words':
 					inputType = inputType | android.text.InputType.TYPE_TEXT_FLAG_CAP_WORDS; //8192 (0x00020000) 14th bit
@@ -68,8 +81,7 @@ export class TextField extends TextFieldBase {
 					break;
 			}
 
-			// add keyboardType flags.
-			// They override previous if set.
+			// Add keyboardType flags (they override previous if set)
 			switch (this.keyboardType) {
 				case 'datetime':
 					inputType = android.text.InputType.TYPE_CLASS_DATETIME | android.text.InputType.TYPE_DATETIME_VARIATION_NORMAL;
@@ -95,6 +107,23 @@ export class TextField extends TextFieldBase {
 		}
 
 		this._setInputType(inputType);
+
+		// Restore text transformation when secure is set back to false
+		// This also takes care of transformation issues when toggling secure while view is not editable
+		if (!this.secure && this._pendingTransformationMethod) {
+			if (this._pendingTransformationMethod != nativeView.getTransformationMethod()) {
+				nativeView.setTransformationMethod(this._pendingTransformationMethod);
+			}
+			this._pendingTransformationMethod = null;
+		}
+	}
+
+	[secureProperty.setNative]() {
+		this.setSecureAndKeyboardType();
+	}
+
+	[keyboardTypeProperty.setNative]() {
+		this.setSecureAndKeyboardType();
 	}
 
 	[whiteSpaceProperty.getDefault](): CoreTypes.WhiteSpaceType {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
There are times when we want to change the interaction of android input elements programmatically. Right now, re-enabling interaction programmatically has no effect.

## What is the new behavior?
Android input interaction becomes programmatically toggleable without problems.
That goes for both `editable` and `isUserInteractionEnabled` properties.

Fixes #8498.
Fixes #8523 in an alternate way by letting programmatic change of `editable` to apply at the same time.