### PR TITLE
fix(core): Inheritable property changes backstack propagation

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -845,11 +845,9 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		//
 	}
 
-	public _inheritStyles(view: ViewBase, inheritScope: boolean): void {
+	public _inheritStyles(view: ViewBase): void {
 		propagateInheritableProperties(this, view);
-		if (inheritScope) {
-			view._inheritStyleScope(this._styleScope);
-		}
+		view._inheritStyleScope(this._styleScope);
 		propagateInheritableCssProperties(this.style, view.style);
 	}
 
@@ -882,7 +880,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 	 * Method is intended to be overridden by inheritors and used as "protected"
 	 */
 	public _addViewCore(view: ViewBase, atIndex?: number) {
-		this._inheritStyles(view, true);
+		this._inheritStyles(view);
 
 		if (this._context) {
 			view._setupUI(this._context, atIndex);

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -845,6 +845,12 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		//
 	}
 
+	public _inheritStyles(view: ViewBase): void {
+		propagateInheritableProperties(this, view);
+		view._inheritStyleScope(this._styleScope);
+		propagateInheritableCssProperties(this.style, view.style);
+	}
+
 	@profile
 	public _addView(view: ViewBase, atIndex?: number) {
 		if (Trace.isEnabled()) {
@@ -874,9 +880,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 	 * Method is intended to be overridden by inheritors and used as "protected"
 	 */
 	public _addViewCore(view: ViewBase, atIndex?: number) {
-		propagateInheritableProperties(this, view);
-		view._inheritStyleScope(this._styleScope);
-		propagateInheritableCssProperties(this.style, view.style);
+		this._inheritStyles(view);
 
 		if (this._context) {
 			view._setupUI(this._context, atIndex);

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -845,9 +845,11 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		//
 	}
 
-	public _inheritStyles(view: ViewBase): void {
+	public _inheritStyles(view: ViewBase, inheritScope: boolean): void {
 		propagateInheritableProperties(this, view);
-		view._inheritStyleScope(this._styleScope);
+		if (inheritScope) {
+			view._inheritStyleScope(this._styleScope);
+		}
 		propagateInheritableCssProperties(this.style, view.style);
 	}
 
@@ -880,7 +882,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 	 * Method is intended to be overridden by inheritors and used as "protected"
 	 */
 	public _addViewCore(view: ViewBase, atIndex?: number) {
-		this._inheritStyles(view);
+		this._inheritStyles(view, true);
 
 		if (this._context) {
 			view._setupUI(this._context, atIndex);

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -2,7 +2,7 @@ import type { BackstackEntry, NavigationContext, NavigationEntry, NavigationTran
 import { NavigationType } from './frame-interfaces';
 import { Page } from '../page';
 import { View, CustomLayoutView, CSSType } from '../core/view';
-import { Property } from '../core/properties';
+import { Property, propagateInheritableCssProperties, propagateInheritableProperties } from '../core/properties';
 import { Trace } from '../../trace';
 import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack } from './frame-stack';
 import { viewMatchesModuleContext } from '../core/view/view-common';
@@ -243,12 +243,17 @@ export class FrameBase extends CustomLayoutView {
 
 	public setCurrent(entry: BackstackEntry, navigationType: NavigationType): void {
 		const newPage = entry.resolvedPage;
+		const frame = newPage.frame;
+
+		this._resolvedPage = newPage;
+
 		// In case we navigated forward to a page that was in the backstack
 		// with clearHistory: true
-		if (!newPage.frame) {
-			this._resolvedPage = newPage;
-
+		if (!frame) {
 			this._addView(newPage);
+		} else {
+			propagateInheritableProperties(frame, newPage);
+			propagateInheritableCssProperties(frame.style, newPage.style);
 		}
 
 		this._currentEntry = entry;

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -252,7 +252,7 @@ export class FrameBase extends CustomLayoutView {
 		if (!frame) {
 			this._addView(newPage);
 		} else {
-			frame._inheritStyles(newPage);
+			frame._inheritStyles(newPage, false);
 		}
 
 		this._currentEntry = entry;

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -243,16 +243,13 @@ export class FrameBase extends CustomLayoutView {
 
 	public setCurrent(entry: BackstackEntry, navigationType: NavigationType): void {
 		const newPage = entry.resolvedPage;
-		const frame = newPage.frame;
-
-		this._resolvedPage = newPage;
 
 		// In case we navigated forward to a page that was in the backstack
 		// with clearHistory: true
-		if (!frame) {
+		if (!newPage.frame) {
+			this._resolvedPage = newPage;
+
 			this._addView(newPage);
-		} else {
-			frame._inheritStyles(newPage, false);
 		}
 
 		this._currentEntry = entry;

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -2,7 +2,7 @@ import type { BackstackEntry, NavigationContext, NavigationEntry, NavigationTran
 import { NavigationType } from './frame-interfaces';
 import { Page } from '../page';
 import { View, CustomLayoutView, CSSType } from '../core/view';
-import { Property, propagateInheritableCssProperties, propagateInheritableProperties } from '../core/properties';
+import { Property } from '../core/properties';
 import { Trace } from '../../trace';
 import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack } from './frame-stack';
 import { viewMatchesModuleContext } from '../core/view/view-common';
@@ -252,8 +252,7 @@ export class FrameBase extends CustomLayoutView {
 		if (!frame) {
 			this._addView(newPage);
 		} else {
-			propagateInheritableProperties(frame, newPage);
-			propagateInheritableCssProperties(frame.style, newPage.style);
+			frame._inheritStyles(newPage);
 		}
 
 		this._currentEntry = entry;

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -916,7 +916,7 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 		frame._resolvedPage = page;
 
 		if (page.parent === frame) {
-			frame._inheritStyles(page, false);
+			frame._inheritStyles(page);
 
 			// If we are navigating to a page that was destroyed
 			// reinitialize its UI.

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -916,7 +916,7 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 		frame._resolvedPage = page;
 
 		if (page.parent === frame) {
-			frame._inheritStyles(page);
+			frame._inheritStyles(page, false);
 
 			// If we are navigating to a page that was destroyed
 			// reinitialize its UI.

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -9,7 +9,7 @@ import { AndroidActivityBackPressedEventData, AndroidActivityNewIntentEventData,
 import { Color } from '../../color';
 import { Observable } from '../../data/observable';
 import { Trace } from '../../trace';
-import { propagateInheritableCssProperties, propagateInheritableProperties, View } from '../core/view';
+import { View } from '../core/view';
 import { _stack, FrameBase, NavigationType } from './frame-common';
 
 import { _clearEntry, _clearFragment, _getAnimatedEntries, _reverseTransitions, _setAndroidFragmentTransitions, _updateTransitions, addNativeTransitionListener } from './fragment.transitions';
@@ -916,8 +916,7 @@ class FragmentCallbacksImplementation implements AndroidFragmentCallbacks {
 		frame._resolvedPage = page;
 
 		if (page.parent === frame) {
-			propagateInheritableProperties(frame, page);
-			propagateInheritableCssProperties(frame.style, page.style);
+			frame._inheritStyles(page);
 
 			// If we are navigating to a page that was destroyed
 			// reinitialize its UI.

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -2,7 +2,7 @@
 import { Frame, BackstackEntry, NavigationType } from '../frame';
 
 // Types.
-import { View, IOSHelper, propagateInheritableProperties, propagateInheritableCssProperties } from '../core/view';
+import { View, IOSHelper } from '../core/view';
 import { PageBase, actionBarHiddenProperty, statusBarStyleProperty } from './page-common';
 
 import { profile } from '../../profiling';
@@ -134,8 +134,7 @@ class UIViewControllerImpl extends UIViewController {
 			frame._resolvedPage = owner;
 
 			if (owner.parent === frame) {
-				propagateInheritableProperties(frame, owner);
-				propagateInheritableCssProperties(frame.style, owner.style);
+				frame._inheritStyles(owner);
 			} else {
 				if (!owner.parent) {
 					if (!frame._styleScope) {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -134,7 +134,7 @@ class UIViewControllerImpl extends UIViewController {
 			frame._resolvedPage = owner;
 
 			if (owner.parent === frame) {
-				frame._inheritStyles(owner);
+				frame._inheritStyles(owner, false);
 			} else {
 				if (!owner.parent) {
 					if (!frame._styleScope) {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -2,7 +2,7 @@
 import { Frame, BackstackEntry, NavigationType } from '../frame';
 
 // Types.
-import { View, IOSHelper } from '../core/view';
+import { View, IOSHelper, propagateInheritableProperties, propagateInheritableCssProperties } from '../core/view';
 import { PageBase, actionBarHiddenProperty, statusBarStyleProperty } from './page-common';
 
 import { profile } from '../../profiling';
@@ -133,15 +133,20 @@ class UIViewControllerImpl extends UIViewController {
 		if (frame) {
 			frame._resolvedPage = owner;
 
-			if (!owner.parent) {
-				if (!frame._styleScope) {
-					// Make sure page will have styleScope even if frame don't.
-					owner._updateStyleScope();
-				}
+			if (owner.parent === frame) {
+				propagateInheritableProperties(frame, owner);
+				propagateInheritableCssProperties(frame.style, owner.style);
+			} else {
+				if (!owner.parent) {
+					if (!frame._styleScope) {
+						// Make sure page will have styleScope even if frame don't.
+						owner._updateStyleScope();
+					}
 
-				frame._addView(owner);
-			} else if (owner.parent !== frame) {
-				throw new Error('Page is already shown on another frame.');
+					frame._addView(owner);
+				} else {
+					throw new Error('Page is already shown on another frame.');
+				}
 			}
 
 			frame._updateActionBar(owner);

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -134,7 +134,7 @@ class UIViewControllerImpl extends UIViewController {
 			frame._resolvedPage = owner;
 
 			if (owner.parent === frame) {
-				frame._inheritStyles(owner, false);
+				frame._inheritStyles(owner);
 			} else {
 				if (!owner.parent) {
 					if (!frame._styleScope) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
If an inheritable view or style property is changed programmatically, the new value does not propagate to pages in frame backstack.

UPDATED: The style scope needs update as well, as it might change parent and eventually need to update children.

## What is the new behavior?
Updating an inheritable property programmatically will propagate changes to pages in frame backstack when navigating to them.


Fixes #10435.