### PR TITLE
fix(css): box-shadow none handling

### DIFF
--- a/apps/toolbox/src/app.css
+++ b/apps/toolbox/src/app.css
@@ -222,3 +222,7 @@ Button {
     color: #ddd;
     background-color: #777;
 }
+
+.no-shadow {
+    box-shadow: none;
+}

--- a/apps/toolbox/src/pages/box-shadow.xml
+++ b/apps/toolbox/src/pages/box-shadow.xml
@@ -9,7 +9,7 @@
             <!-- layouts -->
             <ScrollView height="100%" visibility="{{ selectedComponentType === 'layouts' ? 'visible' : 'collapsed' }}">
                 <StackLayout padding="20">
-									<StackLayout width="300" height="100" class="demo-component" boxShadow="{{ appliedBoxShadow }}" borderColor="{{ borderColor }}" borderWidth="{{ borderWidth }}" borderRadius="{{ borderRadius }}" background="{{ background }}" tap="{{ toggleAnimation }}">
+					<StackLayout width="300" height="100" class="demo-component" boxShadow="{{ appliedBoxShadow }}" borderColor="{{ borderColor }}" borderWidth="{{ borderWidth }}" borderRadius="{{ borderRadius }}" background="{{ background }}" tap="{{ toggleAnimation }}">
                         <Label text="StackLayout" />
                     </StackLayout>
 
@@ -40,9 +40,11 @@
             </GridLayout>
 
             <!-- buttons -->
-            <GridLayout rows="*" height="100%" visibility="{{ selectedComponentType === 'buttons' ? 'visible' : 'collapsed' }}">
+            <GridLayout rows="*,*" height="100%" visibility="{{ selectedComponentType === 'buttons' ? 'visible' : 'collapsed' }}">
 
                 <Button horizontalAlignment="center" verticalAlignment="center" class="demo-component" boxShadow="{{ appliedBoxShadow }}" borderColor="{{ borderColor }}" borderWidth="{{ borderWidth }}" borderRadius="{{ borderRadius }}" background="{{ background }}" tap="{{ toggleAnimation }}" text="button" />
+
+                <Button row="1" horizontalAlignment="center" verticalAlignment="center" class="demo-component no-shadow" text="button no shadow" />
 
             </GridLayout>
 

--- a/packages/core/ui/styling/css-shadow.spec.ts
+++ b/packages/core/ui/styling/css-shadow.spec.ts
@@ -6,12 +6,7 @@ import { Color } from '../../color';
 describe('css-shadow', () => {
 	it('empty', () => {
 		const shadow = parseCSSShadow('');
-		expect(shadow.inset).toBe(false);
-		expect(shadow.offsetX).toBeUndefined();
-		expect(shadow.offsetY).toBeUndefined();
-		expect(shadow.blurRadius).toBeUndefined();
-		expect(shadow.spreadRadius).toBeUndefined();
-		expect(shadow.color).toBeUndefined();
+		expect(shadow).toBeNull();
 	});
 
 	it('1px 1px 2px black', () => {
@@ -137,33 +132,18 @@ describe('css-shadow', () => {
 
 	it('none', () => {
 		const shadow = parseCSSShadow('none');
-		expect(shadow.inset).toBe(false);
-		expect(shadow.offsetX).toBeUndefined();
-		expect(shadow.offsetY).toBeUndefined();
-		expect(shadow.blurRadius).toBeUndefined();
-		expect(shadow.spreadRadius).toBeUndefined();
-		expect(shadow.color).toBeUndefined();
+		expect(shadow).toBeNull();
 	});
 
 	it('unset', () => {
 		const shadow = parseCSSShadow('unset');
-		expect(shadow.inset).toBe(false);
-		expect(shadow.offsetX).toBeUndefined();
-		expect(shadow.offsetY).toBeUndefined();
-		expect(shadow.blurRadius).toBeUndefined();
-		expect(shadow.spreadRadius).toBeUndefined();
-		expect(shadow.color).toBeUndefined();
+		expect(shadow).toBeNull();
 	});
 
 	it('unset 5em 1em gold', () => {
 		// invalid shorthand should result in nothing being applied
 		const shadow = parseCSSShadow('unset 5em 1em gold');
-		expect(shadow.inset).toBe(false);
-		expect(shadow.offsetX).toBeUndefined();
-		expect(shadow.offsetY).toBeUndefined();
-		expect(shadow.blurRadius).toBeUndefined();
-		expect(shadow.spreadRadius).toBeUndefined();
-		expect(shadow.color).toBeUndefined();
+		expect(shadow).toBeNull();
 	});
 
 	it('5em 1em gold unset', () => {

--- a/packages/core/ui/styling/css-shadow.ts
+++ b/packages/core/ui/styling/css-shadow.ts
@@ -21,6 +21,9 @@ export interface ShadowCSSValues {
  */
 export function parseCSSShadow(value: string): ShadowCSSValues {
 	const data = parseCSSShorthand(value);
+	if (!data) {
+		return null;
+	}
 	const [offsetX, offsetY, blurRadius, spreadRadius] = data.values;
 
 	return {

--- a/packages/core/ui/styling/css-stroke.spec.ts
+++ b/packages/core/ui/styling/css-stroke.spec.ts
@@ -6,8 +6,7 @@ import { Color } from '../../color';
 describe('css-text-stroke', () => {
 	it('empty', () => {
 		const stroke = parseCSSStroke('');
-		expect(stroke.width).toBeUndefined();
-		expect(stroke.color).toBeUndefined();
+		expect(stroke).toBeNull();
 	});
 
 	it('1px navy', () => {

--- a/packages/core/ui/styling/css-stroke.ts
+++ b/packages/core/ui/styling/css-stroke.ts
@@ -14,6 +14,9 @@ export interface StrokeCSSValues {
  */
 export function parseCSSStroke(value: string): StrokeCSSValues {
 	const data = parseCSSShorthand(value);
+	if (!data) {
+		return null;
+	}
 	const [width] = data.values;
 
 	return {

--- a/packages/core/ui/styling/css-utils.ts
+++ b/packages/core/ui/styling/css-utils.ts
@@ -37,11 +37,7 @@ export function parseCSSShorthand(value: string): {
 	const first = parts[0];
 
 	if (['', 'none', 'unset'].includes(first)) {
-		return {
-			inset: false,
-			color: undefined,
-			values: [],
-		};
+		return null;
 	} else {
 		const invalidColors = ['inset', 'unset'];
 		const inset = parts.includes('inset');


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

box-shadow: none had slightly different behavior between platforms (ios would create CALayers unnecessarily and Android would throw error).

## What is the new behavior?

This `none` condition is now handled the same across both and avoids any unnecessary work.

closes https://github.com/NativeScript/NativeScript/issues/10403