### PR TITLE
chore: use `__ANDROID__` and `__IOS__` instead of the global variables

### DIFF
--- a/packages/core/accessibility/accessibility-properties.ts
+++ b/packages/core/accessibility/accessibility-properties.ts
@@ -55,7 +55,7 @@ export const iosAccessibilityMaxFontScaleProperty = new InheritedCssProperty<Sty
 });
 iosAccessibilityMaxFontScaleProperty.register(Style);
 
-export const accessibilityHiddenProperty = new (global.isIOS ? InheritedCssProperty : CssProperty)({
+export const accessibilityHiddenProperty = new (__IOS__ ? InheritedCssProperty : CssProperty)({
 	name: 'accessibilityHidden',
 	cssName: 'a11y-hidden',
 	valueConverter: booleanConverter,

--- a/packages/core/accessibility/font-scale-common.ts
+++ b/packages/core/accessibility/font-scale-common.ts
@@ -1,4 +1,4 @@
-export const VALID_FONT_SCALES = global.isIOS // iOS supports a wider number of font scales than Android does.
+export const VALID_FONT_SCALES = __IOS__ // iOS supports a wider number of font scales than Android does.
 	? [0.5, 0.7, 0.85, 1, 1.15, 1.3, 1.5, 2, 2.5, 3, 3.5, 4]
 	: [0.85, 1, 1.15, 1.3];
 

--- a/packages/core/file-system/index.ts
+++ b/packages/core/file-system/index.ts
@@ -11,7 +11,7 @@ let fileAccess: IFileSystemAccess;
  */
 export function getFileAccess(): IFileSystemAccess {
 	if (!fileAccess) {
-		if (global.isAndroid && SDK_VERSION >= 29) {
+		if (__ANDROID__ && SDK_VERSION >= 29) {
 			fileAccess = new FileSystemAccess29();
 		} else {
 			fileAccess = new FileSystemAccess();
@@ -275,7 +275,7 @@ function getAndroidDirectory(value: AndroidDirectory): { path: string; column: a
 
 class Android {
 	createFile(options: { relativePath?: string; name: string; mime: string; directory: AndroidDirectory }): File {
-		if (!global.isAndroid) {
+		if (!__ANDROID__) {
 			throw new Error(`createFile is available on Android only!`);
 		}
 
@@ -326,7 +326,7 @@ export class File extends FileSystemEntity {
 			throw error;
 		};
 
-		if (global.isAndroid && copy) {
+		if (__ANDROID__ && copy) {
 			if (path.startsWith('content:')) {
 				const fileInfo = getFileAccess().getFile(path, onError);
 				// falls back to creating a temp file without a known extension.
@@ -897,7 +897,7 @@ export namespace knownFolders {
 
 	export namespace ios {
 		function _checkPlatform(knownFolderName: string) {
-			if (!global.isIOS) {
+			if (!__IOS__) {
 				throw new Error(`The "${knownFolderName}" known folder is available on iOS only!`);
 			}
 		}

--- a/packages/core/ui/content-view/index.ts
+++ b/packages/core/ui/content-view/index.ts
@@ -27,7 +27,7 @@ export class ContentView extends CustomLayoutView implements AddChildFromBuilder
 		}
 
 		this._onContentChanged(oldView, value);
-		if (global.isIOS && oldView !== value) {
+		if (__IOS__ && oldView !== value) {
 			this.requestLayout();
 		}
 	}

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -987,7 +987,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 
 	private resetNativeViewInternal(): void {
 		// const nativeView = this.nativeViewProtected;
-		// if (nativeView && global.isAndroid) {
+		// if (nativeView && __ANDROID__) {
 		//     const recycle = this.recycleNativeView;
 		//     if (recycle === "always" || (recycle === "auto" && !this._disableNativeViewRecycling)) {
 		//         resetNativeView(this);
@@ -1034,7 +1034,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		// or for backward compatibility - set before _setupUI in iOS constructor.
 		let nativeView = this.nativeViewProtected;
 
-		// if (global.isAndroid) {
+		// if (__ANDROID__) {
 		//     const recycle = this.recycleNativeView;
 		//     if (recycle === "always" || (recycle === "auto" && !this._disableNativeViewRecycling)) {
 		//         nativeView = <android.view.View>getNativeView(context, this.typeName);
@@ -1044,7 +1044,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 			nativeView = this.createNativeView();
 		}
 
-		if (global.isAndroid) {
+		if (__ANDROID__) {
 			// this check is also unecessary as this code should never be reached with _androidView != null unless reusable = true
 			// also adding this check for feature flag safety
 			if (this._androidView !== nativeView || !this.reusable) {
@@ -1168,7 +1168,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		}
 
 		// const nativeView = this.nativeViewProtected;
-		// if (nativeView && global.isAndroid) {
+		// if (nativeView && __ANDROID__) {
 		//     const recycle = this.recycleNativeView;
 		//     let shouldRecycle = false;
 		//     if (recycle === "always") {
@@ -1178,7 +1178,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		//         shouldRecycle = propertiesSet <= this.recyclePropertyCounter;
 		//     }
 
-		//     // const nativeParent = global.isAndroid ? (<android.view.View>nativeView).getParent() : (<UIView>nativeView).superview;
+		//     // const nativeParent = __ANDROID__ ? (<android.view.View>nativeView).getParent() : (<UIView>nativeView).superview;
 		//     const nativeParent = (<android.view.View>nativeView).getParent();
 		//     const animation = (<android.view.View>nativeView).getAnimation();
 		//     if (shouldRecycle && !nativeParent && !animation) {
@@ -1429,7 +1429,7 @@ bindingContextProperty.register(ViewBase);
 export const hiddenProperty = new Property<ViewBase, boolean>({
 	name: 'hidden',
 	defaultValue: false,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: booleanConverter,
 	valueChanged: (target, oldValue, newValue) => {
 		if (target) {

--- a/packages/core/ui/dialogs/dialogs-common.ts
+++ b/packages/core/ui/dialogs/dialogs-common.ts
@@ -271,7 +271,7 @@ export function getButtonColors(): { color: Color; backgroundColor: Color } {
 	if (!button) {
 		const Button = require('../button').Button;
 		button = new Button();
-		if (global.isIOS) {
+		if (__IOS__) {
 			button._setupUI(<any>{});
 		}
 	}
@@ -290,7 +290,7 @@ export function getLabelColor(): Color {
 	if (!label) {
 		const Label = require('../label').Label;
 		label = new Label();
-		if (global.isIOS) {
+		if (__IOS__) {
 			label._setupUI(<any>{});
 		}
 	}
@@ -307,7 +307,7 @@ export function getTextFieldColor(): Color {
 	if (!textField) {
 		const TextField = require('../text-field').TextField;
 		textField = new TextField();
-		if (global.isIOS) {
+		if (__IOS__) {
 			textField._setupUI(<any>{});
 		}
 	}

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -556,11 +556,11 @@ export class FrameBase extends CustomLayoutView {
 
 	public _getNavigationTransition(entry: NavigationEntry): NavigationTransition {
 		if (entry) {
-			if (global.isIOS && entry.transitioniOS !== undefined) {
+			if (__IOS__ && entry.transitioniOS !== undefined) {
 				return entry.transitioniOS;
 			}
 
-			if (global.isAndroid && entry.transitionAndroid !== undefined) {
+			if (__ANDROID__ && entry.transitionAndroid !== undefined) {
 				return entry.transitionAndroid;
 			}
 
@@ -767,5 +767,5 @@ export const defaultPage = new Property<FrameBase, string>({
 });
 defaultPage.register(FrameBase);
 
-export const actionBarVisibilityProperty = new Property<FrameBase, 'auto' | 'never' | 'always'>({ name: 'actionBarVisibility', defaultValue: 'auto', affectsLayout: global.isIOS });
+export const actionBarVisibilityProperty = new Property<FrameBase, 'auto' | 'never' | 'always'>({ name: 'actionBarVisibility', defaultValue: 'auto', affectsLayout: __IOS__ });
 actionBarVisibilityProperty.register(FrameBase);

--- a/packages/core/ui/gestures/touch-manager.ts
+++ b/packages/core/ui/gestures/touch-manager.ts
@@ -65,7 +65,7 @@ export class TouchManager {
 		const handleDown = (view?.touchAnimation && (<TouchAnimationOptions>view?.touchAnimation).down) || (TouchManager.animations && TouchManager.animations.down);
 		const handleUp = (view?.touchAnimation && (<TouchAnimationOptions>view?.touchAnimation).up) || (TouchManager.animations && TouchManager.animations.up);
 
-		if (global.isIOS) {
+		if (__IOS__) {
 			if (view?.ios?.addTargetActionForControlEvents) {
 				// can use UIControlEvents
 				if (!TouchManager.touchHandlers) {
@@ -215,7 +215,7 @@ export let TouchControlHandler: {
 ensureTouchControlHandlers();
 
 function ensureTouchControlHandlers() {
-	if (global.isIOS) {
+	if (__IOS__) {
 		@NativeClass
 		class TouchHandlerImpl extends NSObject {
 			private _owner: WeakRef<View>;

--- a/packages/core/ui/image/image-common.ts
+++ b/packages/core/ui/image/image-common.ts
@@ -153,7 +153,7 @@ isLoadingProperty.register(ImageBase);
 export const stretchProperty = new Property<ImageBase, CoreTypes.ImageStretchType>({
 	name: 'stretch',
 	defaultValue: 'aspectFit',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 });
 stretchProperty.register(ImageBase);
 

--- a/packages/core/ui/layouts/dock-layout/dock-layout-common.ts
+++ b/packages/core/ui/layouts/dock-layout/dock-layout-common.ts
@@ -53,7 +53,7 @@ dockProperty.register(View);
 export const stretchLastChildProperty = new Property<DockLayoutBase, boolean>({
 	name: 'stretchLastChild',
 	defaultValue: true,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: booleanConverter,
 });
 stretchLastChildProperty.register(DockLayoutBase);

--- a/packages/core/ui/layouts/flexbox-layout/flexbox-layout-common.ts
+++ b/packages/core/ui/layouts/flexbox-layout/flexbox-layout-common.ts
@@ -222,7 +222,7 @@ export const flexDirectionProperty = new CssProperty<Style, FlexDirection>({
 	name: 'flexDirection',
 	cssName: 'flex-direction',
 	defaultValue: FlexDirection.ROW,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: FlexDirection.parse,
 });
 flexDirectionProperty.register(Style);
@@ -231,7 +231,7 @@ export const flexWrapProperty = new CssProperty<Style, FlexWrap>({
 	name: 'flexWrap',
 	cssName: 'flex-wrap',
 	defaultValue: 'nowrap',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: FlexWrap.parse,
 });
 flexWrapProperty.register(Style);
@@ -240,7 +240,7 @@ export const justifyContentProperty = new CssProperty<Style, JustifyContent>({
 	name: 'justifyContent',
 	cssName: 'justify-content',
 	defaultValue: JustifyContent.FLEX_START,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: JustifyContent.parse,
 });
 justifyContentProperty.register(Style);
@@ -249,7 +249,7 @@ export const alignItemsProperty = new CssProperty<Style, AlignItems>({
 	name: 'alignItems',
 	cssName: 'align-items',
 	defaultValue: AlignItems.STRETCH,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: AlignItems.parse,
 });
 alignItemsProperty.register(Style);
@@ -258,7 +258,7 @@ export const alignContentProperty = new CssProperty<Style, AlignContent>({
 	name: 'alignContent',
 	cssName: 'align-content',
 	defaultValue: AlignContent.STRETCH,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: AlignContent.parse,
 });
 alignContentProperty.register(Style);

--- a/packages/core/ui/layouts/stack-layout/stack-layout-common.ts
+++ b/packages/core/ui/layouts/stack-layout/stack-layout-common.ts
@@ -16,7 +16,7 @@ const converter = makeParser<CoreTypes.OrientationType>(makeValidator('horizonta
 export const orientationProperty = new Property<StackLayoutBase, CoreTypes.OrientationType>({
 	name: 'orientation',
 	defaultValue: 'vertical',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: converter,
 });
 orientationProperty.register(StackLayoutBase);

--- a/packages/core/ui/layouts/wrap-layout/wrap-layout-common.ts
+++ b/packages/core/ui/layouts/wrap-layout/wrap-layout-common.ts
@@ -21,7 +21,7 @@ WrapLayoutBase.prototype.recycleNativeView = 'auto';
 export const itemWidthProperty = new Property<WrapLayoutBase, CoreTypes.LengthType>({
 	name: 'itemWidth',
 	defaultValue: 'auto',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (v) => Length.parse(v),
 	valueChanged: (target, oldValue, newValue) => (target.effectiveItemWidth = Length.toDevicePixels(newValue, -1)),
 });
@@ -30,7 +30,7 @@ itemWidthProperty.register(WrapLayoutBase);
 export const itemHeightProperty = new Property<WrapLayoutBase, CoreTypes.LengthType>({
 	name: 'itemHeight',
 	defaultValue: 'auto',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (v) => Length.parse(v),
 	valueChanged: (target, oldValue, newValue) => (target.effectiveItemHeight = Length.toDevicePixels(newValue, -1)),
 });
@@ -40,7 +40,7 @@ const converter = makeParser<CoreTypes.OrientationType>(makeValidator<CoreTypes.
 export const orientationProperty = new Property<WrapLayoutBase, CoreTypes.OrientationType>({
 	name: 'orientation',
 	defaultValue: CoreTypes.Orientation.horizontal,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: converter,
 });
 orientationProperty.register(WrapLayoutBase);

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -185,7 +185,7 @@ export interface PageBase {
  */
 export const actionBarHiddenProperty = new Property<PageBase, boolean>({
 	name: 'actionBarHidden',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: booleanConverter,
 });
 actionBarHiddenProperty.register(PageBase);
@@ -196,7 +196,7 @@ actionBarHiddenProperty.register(PageBase);
 export const backgroundSpanUnderStatusBarProperty = new Property<PageBase, boolean>({
 	name: 'backgroundSpanUnderStatusBar',
 	defaultValue: false,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: booleanConverter,
 });
 backgroundSpanUnderStatusBarProperty.register(PageBase);

--- a/packages/core/ui/search-bar/search-bar-common.ts
+++ b/packages/core/ui/search-bar/search-bar-common.ts
@@ -20,7 +20,7 @@ SearchBarBase.prototype.recycleNativeView = 'auto';
 export const textProperty = new Property<SearchBarBase, string>({
 	name: 'text',
 	defaultValue: '',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 });
 textProperty.register(SearchBarBase);
 

--- a/packages/core/ui/slider/slider-common.ts
+++ b/packages/core/ui/slider/slider-common.ts
@@ -39,7 +39,7 @@ export const valueProperty = new CoercibleProperty<SliderBase, number>({
 
 		return value;
 	},
-	valueConverter: (v) => (global.isIOS ? parseFloat(v) : parseInt(v)),
+	valueConverter: (v) => (__IOS__ ? parseFloat(v) : parseInt(v)),
 });
 valueProperty.register(SliderBase);
 
@@ -53,7 +53,7 @@ export const minValueProperty = new Property<SliderBase, number>({
 		maxValueProperty.coerce(target);
 		valueProperty.coerce(target);
 	},
-	valueConverter: (v) => (global.isIOS ? parseFloat(v) : parseInt(v)),
+	valueConverter: (v) => (__IOS__ ? parseFloat(v) : parseInt(v)),
 });
 minValueProperty.register(SliderBase);
 
@@ -72,6 +72,6 @@ export const maxValueProperty = new CoercibleProperty<SliderBase, number>({
 		return value;
 	},
 	valueChanged: (target, oldValue, newValue) => valueProperty.coerce(target),
-	valueConverter: (v) => (global.isIOS ? parseFloat(v) : parseInt(v)),
+	valueConverter: (v) => (__IOS__ ? parseFloat(v) : parseInt(v)),
 });
 maxValueProperty.register(SliderBase);

--- a/packages/core/ui/tab-view/tab-view-common.ts
+++ b/packages/core/ui/tab-view/tab-view-common.ts
@@ -216,7 +216,7 @@ export function traceMissingIcon(icon: string) {
 export const selectedIndexProperty = new CoercibleProperty<TabViewBase, number>({
 	name: 'selectedIndex',
 	defaultValue: -1,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueChanged: (target, oldValue, newValue) => {
 		target.onSelectedIndexChanged(oldValue, newValue);
 	},
@@ -257,7 +257,7 @@ androidIconRenderingModeProperty.register(TabViewBase);
 export const androidOffscreenTabLimitProperty = new Property<TabViewBase, number>({
 	name: 'androidOffscreenTabLimit',
 	defaultValue: 1,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (v) => parseInt(v),
 });
 androidOffscreenTabLimitProperty.register(TabViewBase);

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -221,7 +221,7 @@ export function isBold(fontWeight: FontWeightType): boolean {
 export const textProperty = new Property<TextBaseCommon, string>({
 	name: 'text',
 	defaultValue: '',
-	affectsLayout: global.isAndroid,
+	affectsLayout: __ANDROID__,
 });
 textProperty.register(TextBaseCommon);
 
@@ -282,7 +282,7 @@ textTransformProperty.register(Style);
 export const textShadowProperty = new CssProperty<Style, string | ShadowCSSValues>({
 	name: 'textShadow',
 	cssName: 'text-shadow',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (value) => {
 		return parseCSSShadow(value);
 	},
@@ -292,7 +292,7 @@ textShadowProperty.register(Style);
 export const textStrokeProperty = new CssProperty<Style, string | StrokeCSSValues>({
 	name: 'textStroke',
 	cssName: 'text-stroke',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (value) => {
 		return parseCSSStroke(value);
 	},
@@ -304,7 +304,7 @@ export const whiteSpaceProperty = new CssProperty<Style, CoreTypes.WhiteSpaceTyp
 	name: 'whiteSpace',
 	cssName: 'white-space',
 	defaultValue: 'initial',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: whiteSpaceConverter,
 });
 whiteSpaceProperty.register(Style);
@@ -314,7 +314,7 @@ export const textOverflowProperty = new CssProperty<Style, CoreTypes.TextOverflo
 	name: 'textOverflow',
 	cssName: 'text-overflow',
 	defaultValue: 'initial',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: textOverflowConverter,
 });
 textOverflowProperty.register(Style);
@@ -332,7 +332,7 @@ export const letterSpacingProperty = new InheritedCssProperty<Style, number>({
 	name: 'letterSpacing',
 	cssName: 'letter-spacing',
 	defaultValue: 0,
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (v) => parseFloat(v),
 });
 letterSpacingProperty.register(Style);
@@ -340,7 +340,7 @@ letterSpacingProperty.register(Style);
 export const lineHeightProperty = new InheritedCssProperty<Style, number>({
 	name: 'lineHeight',
 	cssName: 'line-height',
-	affectsLayout: global.isIOS,
+	affectsLayout: __IOS__,
 	valueConverter: (v) => parseFloat(v),
 });
 lineHeightProperty.register(Style);

--- a/packages/core/ui/transition/shared-transition.ts
+++ b/packages/core/ui/transition/shared-transition.ts
@@ -177,7 +177,7 @@ export class SharedTransition {
 		if (isNumber(pageEnd?.duration)) {
 			// Android uses milliseconds/iOS uses seconds
 			// users pass in milliseconds
-			transition.setDuration(global.isIOS ? pageEnd?.duration / 1000 : pageEnd?.duration);
+			transition.setDuration(__IOS__ ? pageEnd?.duration / 1000 : pageEnd?.duration);
 		}
 		return { instance: transition };
 	}
@@ -365,9 +365,9 @@ export function getPageStartDefaultsForType(type: TransitionNavigationType) {
 }
 
 function getPlatformWidth() {
-	return global.isAndroid ? Screen.mainScreen.widthPixels : Screen.mainScreen.widthDIPs;
+	return __ANDROID__ ? Screen.mainScreen.widthPixels : Screen.mainScreen.widthDIPs;
 }
 
 function getPlatformHeight() {
-	return global.isAndroid ? Screen.mainScreen.heightPixels : Screen.mainScreen.heightDIPs;
+	return __ANDROID__ ? Screen.mainScreen.heightPixels : Screen.mainScreen.heightDIPs;
 }

--- a/packages/core/utils/debug.ts
+++ b/packages/core/utils/debug.ts
@@ -61,7 +61,7 @@ export class ScopeError extends Error {
 			formattedMessage = message || inner.message || undefined;
 		}
 		super(formattedMessage);
-		this.stack = global.isAndroid ? 'Error: ' + this.message + '\n' + inner.stack.substr(inner.stack.indexOf('\n') + 1) : inner.stack;
+		this.stack = __ANDROID__ ? 'Error: ' + this.message + '\n' + inner.stack.substr(inner.stack.indexOf('\n') + 1) : inner.stack;
 		this.message = formattedMessage;
 	}
 }

--- a/packages/core/utils/platform-check.ts
+++ b/packages/core/utils/platform-check.ts
@@ -8,7 +8,7 @@ export function platformCheck(parent?: string) {
 			{
 				get(_, prop) {
 					const propPretty = [parent, prop.toString()].join('.');
-					const hintPlatformCheck = global.isAndroid ? 'global.isIOS' : 'global.isAndroid';
+					const hintPlatformCheck = __ANDROID__ ? '__IOS__' : '__ANDROID__';
 
 					// prettier-ignore
 					const errorMsg = [


### PR DESCRIPTION
Simple refactor. We should only use those now and stop relying on global