### PR TITLE
fix(android): crash with material components

### DIFF
--- a/packages/core/ui/text-field/index.android.ts
+++ b/packages/core/ui/text-field/index.android.ts
@@ -40,7 +40,7 @@ export class TextField extends TextFieldBase {
 	setSecureAndKeyboardType(): void {
 		let inputType: number;
 
-		const nativeView = this.nativeViewProtected;
+		const nativeView = this.nativeTextViewProtected;
 		const numericKeyboardType = +this.keyboardType;
 
 		// Check for a passed in numeric value


### PR DESCRIPTION
`setSecureAndKeyboardType` needs to use `nativeTextViewProtected`  As a reminder in text base components there is `nativeViewProtected` and `nativeTextViewProtected`. The reason is that material components (and maybe other) differentiate the layout and the textfield itself inside one view. A while back i made a PR for the whole N to support those two getters. But we need to remain careful on which one we use everytime

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

