### PR TITLE
fix(android): prevent errors on filesystem operations while using `content://...`

### DIFF
--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/Async.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/Async.java
@@ -602,12 +602,17 @@ public class Async {
 	public static class File {
 
 		static void updateValue(Context context, Uri uri) {
-			ContentValues values = new ContentValues();
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-				context.getContentResolver().update(uri, values, null);
-			} else {
-				context.getContentResolver().update(uri, values, null, null);
+			try {
+				ContentValues values = new ContentValues();
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+					context.getContentResolver().update(uri, values, null);
+				} else {
+					context.getContentResolver().update(uri, values, null, null);
+				}
+			} catch (Exception exception){
+				Log.e(TAG, "Failed to updateValue: " + exception.getMessage());
 			}
+			
 		}
 
 		public static void append(final String path, final byte[] content, final CompleteCallback callback, final Object context) {

--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/FileHelper.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/FileHelper.java
@@ -11,6 +11,7 @@ import android.os.Looper;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.webkit.MimeTypeMap;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.documentfile.provider.DocumentFile;
@@ -34,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class FileHelper {
+	static final String TAG = "FileHelper";
 	private Uri uri;
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 	private final Handler handler;
@@ -566,7 +568,11 @@ public class FileHelper {
 		os.write(content, 0, content.length);
 		os.flush();
 		os.close();
-		updateInternal(context);
+		try {
+			updateInternal(context);
+		} catch (Exception exception){
+			Log.e(TAG, "Failed to updateValue: " + exception.getMessage());
+		}
 	}
 
 	private void writeBufferSyncInternal(Context context, ByteBuffer content) throws Exception {
@@ -579,7 +585,11 @@ public class FileHelper {
 		channel.write(content);
 		os.flush();
 		os.close();
-		updateInternal(context);
+		try {
+			updateInternal(context);
+		} catch (Exception exception){
+			Log.e(TAG, "Failed to updateValue: " + exception.getMessage());
+		}
 	}
 
 	public void writeSync(Context context, byte[] content, @Nullable Callback callback) {
@@ -638,7 +648,11 @@ public class FileHelper {
 		osw.write(content);
 		osw.flush();
 		osw.close();
-		updateInternal(context);
+		try {
+			updateInternal(context);
+		} catch (Exception exception){
+			Log.e(TAG, "Failed to updateValue: " + exception.getMessage());
+		}
 	}
 
 	public void writeTextSync(Context context, String content, @Nullable String encoding, @Nullable Callback callback) {
@@ -764,14 +778,17 @@ public class FileHelper {
 			}
 
 		}
-
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-			context.getContentResolver().update(uri, values, null);
-		} else {
-			context.getContentResolver().update(uri, values, null, null);
+		try {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+				context.getContentResolver().update(uri, values, null);
+			} else {
+				context.getContentResolver().update(uri, values, null, null);
+			}
+			updateInternal(context, false);
+		} catch (Exception exception){
+			Log.e(TAG, "Failed to updateValue: " + exception.getMessage());
 		}
-
-		updateInternal(context, false);
+		
 	}
 
 	public void renameSync(Context context, String newName, @Nullable Callback callback) {


### PR DESCRIPTION
I discussed this with @triniwiz . I am not sure why we are doing those update operations. Any way in my apps (may be better to say on my testing android versions) those `update` operations throws with something like `update not supported`.
A simple try catch prevent that error while preserving the code for what it be there for.
@triniwiz  could be nice if you remembered and added a comment on why that code even exists