### PR TITLE
fix(android): crash on writeText on Android > 29

### DIFF
--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/FileHelper.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/FileHelper.java
@@ -375,12 +375,12 @@ public class FileHelper {
 
 	private OutputStream getOutputStream(Context context, Uri uri, boolean append) throws Exception {
 		if (Build.VERSION.SDK_INT >= 19) {
+			if (DocumentsContract.isDocumentUri(context, uri)) {
+				return context.getContentResolver().openOutputStream(DocumentFile.fromSingleUri(context, uri).getUri(), append ? "wa" : "w");
+			}
 			if (isExternalStorageDocument(uri)) {
 				File file = getFile(context, uri);
 				return new FileOutputStream(file, append);
-			}
-			if (DocumentsContract.isDocumentUri(context, uri)) {
-				return context.getContentResolver().openOutputStream(DocumentFile.fromSingleUri(context, uri).getUri(), append ? "wa" : "w");
 			}
 		}
 		return context.getContentResolver().openOutputStream(uri, append ? "wa" : "w");


### PR DESCRIPTION
it was failing if you were to pass `content://com.android.externalstorage.documents/document/primary%3ADownload%2Fcom.akylas.documentscanner_settings_2024-01-02.json`.
It was trying to write `com.akylas.documentscanner_settings_2024-01-02.json/com.akylas.documentscanner_settings_2024-01-02.json` instead of `com.akylas.documentscanner_settings_2024-01-02.json`. It seems the `getFile` method is wrong.

This is not the perfect fix but in the meaning it should always work
 