### PR TITLE
fix: profile decorator fix

### DIFF
--- a/packages/core/profiling/index.ts
+++ b/packages/core/profiling/index.ts
@@ -177,10 +177,10 @@ export function disable() {
 }
 
 function profileFunction<F extends Function>(fn: F, customName?: string): F {
-	return profileFunctionFactory(fn, customName || fn.name);
+	return profileFunctionFactory<F>(fn, customName || fn.name);
 }
 
-const profileMethodUnnamed = (target, key, descriptor) => {
+const profileMethodUnnamed = (target: Object, key: symbol | string, descriptor) => {
 	// save a reference to the original method this way we keep the values currently in the
 	// descriptor and don't overwrite what another decorator might have done to the descriptor.
 	if (descriptor === undefined) {
@@ -193,7 +193,7 @@ const profileMethodUnnamed = (target, key, descriptor) => {
 		className = target.constructor.name + '.';
 	}
 
-	const name = className + key;
+	const name = className + key?.toString();
 
 	//editing the descriptor/value parameter
 	descriptor.value = profileFunctionFactory(originalMethod, name, MemberType.Instance);
@@ -202,7 +202,7 @@ const profileMethodUnnamed = (target, key, descriptor) => {
 	return descriptor;
 };
 
-const profileStaticMethodUnnamed = (ctor, key, descriptor) => {
+const profileStaticMethodUnnamed = <F extends Function>(ctor: F, key: symbol | string, descriptor) => {
 	// save a reference to the original method this way we keep the values currently in the
 	// descriptor and don't overwrite what another decorator might have done to the descriptor.
 	if (descriptor === undefined) {
@@ -214,7 +214,7 @@ const profileStaticMethodUnnamed = (ctor, key, descriptor) => {
 	if (ctor && ctor.name) {
 		className = ctor.name + '.';
 	}
-	const name = className + key;
+	const name = className + key?.toString();
 
 	//editing the descriptor/value parameter
 	descriptor.value = profileFunctionFactory(originalMethod, name, MemberType.Static);


### PR DESCRIPTION
Not sure why we started getting this, but i was getting a crash saying `Symbol` cant be converted to string (or concat with a string)