### PR TITLE
chore: generic EventData type for `object` property

### DIFF
--- a/packages/core/application/application-interfaces.ts
+++ b/packages/core/application/application-interfaces.ts
@@ -48,7 +48,7 @@ export interface ApplicationEventData {
 /**
  * Event data containing information for launch event.
  */
-export interface LaunchEventData extends EventData {
+export interface LaunchEventData extends EventData<ApplicationCommon> {
 	/**
 	 * The root view for this Window on iOS or Activity for Android.
 	 * If not set a new Frame will be created as a root view in order to maintain backwards compatibility.

--- a/packages/core/data/observable-array/index.ts
+++ b/packages/core/data/observable-array/index.ts
@@ -13,7 +13,7 @@ export class ChangeType {
 /**
  * Event args for "changed" event.
  */
-export interface ChangedData<T> extends EventData {
+export interface ChangedData<T, U = Observable> extends EventData<U> {
 	/**
 	 * Change type.
 	 */

--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -3,7 +3,7 @@ import { Optional } from '../../utils/typescript-utils';
 /**
  * Base event data.
  */
-export interface EventData {
+export interface EventData<T = Observable> {
 	/**
 	 * The name of the event.
 	 */
@@ -11,17 +11,17 @@ export interface EventData {
 	/**
 	 * The Observable instance that has raised the event.
 	 */
-	object: Observable;
+	object: T;
 }
 
-export interface EventDataValue extends EventData {
+export interface EventDataValue<T = Observable> extends EventData<T> {
 	value?: boolean;
 }
 
 /**
  * Data for the "propertyChange" event.
  */
-export interface PropertyChangeData extends EventData {
+export interface PropertyChangeData<T = Observable> extends EventData<T> {
 	/**
 	 * The name of the property that has changed.
 	 */
@@ -36,8 +36,8 @@ export interface PropertyChangeData extends EventData {
 	oldValue?: any;
 }
 
-interface ListenerEntry {
-	callback: (data: EventData) => void;
+interface ListenerEntry<T = Observable> {
+	callback: (data: EventData<T>) => void;
 	thisArg: any;
 	once?: true;
 }
@@ -106,7 +106,7 @@ export class Observable {
 	 */
 	public _isViewBase: boolean;
 
-	private readonly _observers: { [eventName: string]: ListenerEntry[] } = {};
+	private readonly _observers: { [eventName: string]: ListenerEntry<any>[] } = {};
 
 	/**
 	 * Gets the value of the specified property.
@@ -465,7 +465,7 @@ export class Observable {
 		return list;
 	}
 
-	private static _indexOfListener(list: Array<ListenerEntry>, callback: (data: EventData) => void, thisArg?: any): number {
+	private static _indexOfListener<T = Observable>(list: Array<ListenerEntry<T>>, callback: (data: EventData<T>) => void, thisArg?: any): number {
 		for (let i = 0; i < list.length; i++) {
 			const entry = list[i];
 			if (thisArg) {

--- a/packages/core/data/virtual-array/index.ts
+++ b/packages/core/data/virtual-array/index.ts
@@ -4,7 +4,7 @@ import { ChangedData, ChangeType } from '../observable-array';
 /**
  * Event args for "itemsLoading" event.
  */
-export interface ItemsLoading extends EventData {
+export interface ItemsLoading<T = Observable> extends EventData<T> {
 	/**
 	 * Start index.
 	 */

--- a/packages/core/ui/gestures/gestures-common.ts
+++ b/packages/core/ui/gestures/gestures-common.ts
@@ -1,6 +1,6 @@
 ﻿import type { GesturesObserver as GesturesObserverDefinition } from '.';
 import type { View } from '../core/view';
-import type { EventData } from '../../data/observable';
+import type { EventData, Observable } from '../../data/observable';
 
 export * from './touch-manager';
 
@@ -133,7 +133,7 @@ export enum TouchAction {
 /**
  * Provides gesture event data.
  */
-export interface GestureEventData extends EventData {
+export interface GestureEventData<T = Observable> extends EventData<T> {
 	/**
 	 * Gets the type of the gesture.
 	 */

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -12,7 +12,7 @@ import { ActionBar } from '../action-bar';
 import { KeyframeAnimationInfo } from '../animation/keyframe-animation';
 import { profile } from '../../profiling';
 
-interface NavigatedData extends EventData {
+interface NavigatedData extends EventData<PageDefinition> {
 	context: any;
 	isBackNavigation: boolean;
 }

--- a/packages/core/ui/placeholder/placeholder-common.ts
+++ b/packages/core/ui/placeholder/placeholder-common.ts
@@ -1,6 +1,7 @@
+import type { Placeholder } from '.';
 import { EventData } from '../../data/observable';
 
-export interface CreateViewEventData extends EventData {
+export interface CreateViewEventData extends EventData<Placeholder> {
 	/**
 	 * The native view that should be added to the visual tree.
 	 */

--- a/packages/core/ui/web-view/web-view-interfaces.ts
+++ b/packages/core/ui/web-view/web-view-interfaces.ts
@@ -1,9 +1,10 @@
 ﻿import { WebView } from '.';
-import { EventData } from '../../data/observable';
+import { EventData, Observable } from '../../data/observable';
+import type { WebViewBase } from './web-view-common';
 
 export type WebViewNavigationType = 'linkClicked' | 'formSubmitted' | 'backForward' | 'reload' | 'formResubmitted' | 'other' | undefined;
 
-export interface LoadEventData extends EventData {
+export interface LoadEventData<T = WebViewBase> extends EventData<T> {
 	url: string;
 	navigationType: WebViewNavigationType;
 	error: string;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

`EventData` is now a generic type. This allows us to use `EventData<StackLayout>` which will say that `object` is of type `StackLayout`.
It also comes from some event pre defined generic type. Like `LaunchEventData`

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

