### PR TITLE
Move Android build to Ubuntu. Use FlyCI for iOS.

### DIFF
--- a/.github/workflows/apps_automated_android.yml
+++ b/.github/workflows/apps_automated_android.yml
@@ -1,0 +1,60 @@
+name: 'apps/automated/android'
+
+on:
+  push:
+    branches:
+      - main
+      - 'ci/**'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.10.0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3'
+
+      - name: Install NativeScript
+        run: |
+          python3 -m pip install --upgrade pip six
+          npm i -g nativescript --ignore-scripts --legacy-peer-deps
+          ns usage-reporting disable
+          ns error-reporting disable
+
+      - name: Setup
+        run: npm run setup
+
+      - name: Unit Tests
+        run: npx nx run-many --target=test --configuration=ci --projects=core
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run tests on Android Emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          script: node tools/scripts/run-automated.js android

--- a/.github/workflows/apps_automated_ios.yml
+++ b/.github/workflows/apps_automated_ios.yml
@@ -1,4 +1,4 @@
-name: 'apps/automated'
+name: 'apps/automated/ios'
 
 on:
   push:
@@ -13,25 +13,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: macos-12
+  test-ios:
+    runs-on: flyci-macos-14-m2
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.10.0
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
 
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3' 
+          python-version: '3'
 
       - name: Install NativeScript
         run: |
@@ -47,21 +42,8 @@ jobs:
       - name: Unit Tests
         run: npx nx run-many --target=test --configuration=ci --projects=core
 
-      - name: Create Emulator
-        uses: rigor789/action-create-emulator@main
-        with:
-          package: system-images;android-34;default;x86_64
-
-      - name: Test (Android)
-        run: node tools/scripts/run-automated.js android
-
       - name: Start iOS Simulator
-        if: ${{ always() && !cancelled() }} # run iOS tests even if Android tests failed
-        uses: futureware-tech/simulator-action@v2
-        with:
-          model: 'iPhone 13 Pro Max'
-          os_version: '>=15.0'
+        uses: futureware-tech/simulator-action@v3
 
-      - name: Test (iOS)
-        if: ${{ always() && !cancelled() }} # run iOS tests even if Android tests failed
+      - name: Run tests on iOS Simulator
         run: node tools/scripts/run-automated.js ios


### PR DESCRIPTION
This change improve both Android and iOS CI builds. Now there are separate builds for Android and iOS which cuts the CI time dramatically.

### Android
Android CI build is moved to `ubuntu-latest` in order to take advantage of the newer faster GitHub runners that have nested hardware virtualization. This enables the Android Emulator to start faster.

### iOS
iOS CI build is moved to the faster M2 runners of [FlyCI](https://www.flyci.net/). It now uses the default iOS Simulators that [are installed](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#installed-sdks) in the runner.
