### PR TITLE
fix(ios): Unset cached frame before updating  origin point

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -444,8 +444,13 @@ export class View extends ViewCommon implements ViewDefinition {
 		CATransaction.setDisableActions(true);
 
 		nativeView.layer.anchorPoint = newPoint;
+
+		// Bounds have to be recalculated after anchor point update
 		if (this._cachedFrame) {
-			this._setNativeViewFrame(nativeView, this._cachedFrame);
+			const frame = this._cachedFrame;
+
+			this._cachedFrame = null;
+			this._setNativeViewFrame(nativeView, frame);
 		}
 
 		// Make sure new origin also applies to outer shadow layers


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, there are cases that iOS view frame size is not updated properly when updating `originX` or `originY` programmatically.

## What is the new behavior?
The iOS view frame size will be updated properly when updating `originX` or `originY` programmatically.