### PR TITLE
fix(ios): Added missing live-sync handling for plain js/ts apps

### DIFF
--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -366,6 +366,21 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 		}
 	}
 
+	public _onLivesync(context?: ModuleContext): void {
+		// Handle application root module
+		const isAppRootModuleChanged = context && context.path && context.path.includes(this.getMainEntry().moduleName) && context.type !== 'style';
+
+		// Set window content when:
+		// + Application root module is changed
+		// + View did not handle the change
+		// Note:
+		// The case when neither app root module is changed, nor livesync is handled on View,
+		// then changes will not apply until navigate forward to the module.
+		if (isAppRootModuleChanged || (this._rootView && !this._rootView._onLivesync(context))) {
+			this.setWindowContent();
+		}
+	}
+
 	private setWindowContent(view?: View): void {
 		if (this._rootView) {
 			// if we already have a root view, we reset it.
@@ -473,6 +488,14 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 		return this;
 	}
 }
+
+const iosApp = new iOSApplication();
+
+// Attach on global, so it can also be overwritten to implement different logic based on flavor
+global.__onLiveSyncCore = function (context?: ModuleContext) {
+	iosApp._onLivesync(context);
+};
+
 export * from './application-common';
-export const Application = new iOSApplication();
+export const Application = iosApp;
 export const AndroidApplication = undefined;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
It seems we accidentally removed live-sync handling for plain js/ts iOS apps in a past update.

## What is the new behavior?
Re-added live-sync handling for plain js/ts iOS apps.

Fixes #10447