### PR TITLE
revert: "perf: disable accessibility for layout views (#10482)"

### DIFF
--- a/packages/core/accessibility/accessibility-properties.ts
+++ b/packages/core/accessibility/accessibility-properties.ts
@@ -26,7 +26,6 @@ function makePropertyEnumConverter<T>(enumValues) {
 
 export const accessibilityEnabledProperty = new CssProperty<Style, boolean>({
 	name: 'accessible',
-	defaultValue: true,
 	cssName: 'a11y-enabled',
 	valueConverter: booleanConverter,
 });

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -2,6 +2,7 @@ import { AlignSelf, FlexGrow, FlexShrink, FlexWrapBefore, Order } from '../../la
 import { Page } from '../../page';
 import { CoreTypes } from '../../../core-types';
 import { Property, CssProperty, CssAnimationProperty, InheritedProperty, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView } from '../properties';
+import { setupAccessibleView } from '../../../accessibility';
 import { CSSUtils } from '../../../css/system-classes';
 import { Source } from '../../../utils/debug';
 import { Binding, BindingOptions } from '../bindable';
@@ -598,6 +599,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 
 			return true;
 		});
+		setupAccessibleView(<any>this);
 
 		this._emit('loaded');
 	}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -826,9 +826,8 @@ export class View extends ViewCommon {
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {
 		this.nativeViewProtected.setFocusable(!!value);
-		if (value) {
-			updateAccessibilityProperties(this);
-		}
+
+		updateAccessibilityProperties(this);
 	}
 
 	[accessibilityIdentifierProperty.setNative](value: string): void {
@@ -1264,15 +1263,6 @@ export class View extends ViewCommon {
 
 export class ContainerView extends View {
 	public iosOverflowSafeArea: boolean;
-
-	constructor() {
-		super();
-		/**
-		 * mark accessible as false without triggering proerty change
-		 * equivalent to changing the default
-		 */
-		this.style[accessibilityEnabledProperty.key] = false;
-	}
 }
 
 export class CustomLayoutView extends ContainerView implements CustomLayoutViewDefinition {

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -229,6 +229,11 @@ export abstract class View extends ViewCommon {
 	color: Color;
 
 	/**
+	 * If `true` the element is an accessibility element and all the children will be treated as a single selectable component.
+	 */
+	accessible: boolean;
+
+	/**
 	 * Hide the view and its children from the a11y service
 	 */
 	accessibilityHidden: boolean;

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -683,9 +683,8 @@ export class View extends ViewCommon implements ViewDefinition {
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {
 		this.nativeViewProtected.isAccessibilityElement = !!value;
-		if (value) {
-			updateAccessibilityProperties(this);
-		}
+
+		updateAccessibilityProperties(this);
 	}
 
 	[accessibilityIdentifierProperty.getDefault](): string {
@@ -1069,11 +1068,6 @@ export class ContainerView extends View {
 	constructor() {
 		super();
 		this.iosOverflowSafeArea = true;
-		/**
-		 * mark accessible as false without triggering proerty change
-		 * equivalent to changing the default
-		 */
-		this.style[accessibilityEnabledProperty.key] = false;
 	}
 }
 

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -12,7 +12,6 @@ import { EventData } from '../../../data/observable';
 import { Trace } from '../../../trace';
 import { CoreTypes } from '../../../core-types';
 import { ViewHelper } from './view-helper';
-import { setupAccessibleView } from '../../../accessibility';
 
 import { PercentLength } from '../../styling/style-properties';
 
@@ -191,9 +190,6 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 			}
 		}
 		super.onLoaded();
-		if (this.accessible) {
-			setupAccessibleView(this);
-		}
 	}
 
 	public _closeAllModalViewsInternal(): boolean {
@@ -827,9 +823,11 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 
 	get accessible(): boolean {
 		return this.style.accessible;
+		// return this._accessible;
 	}
 	set accessible(value: boolean) {
 		this.style.accessible = value;
+		// this._accessible = value;
 	}
 
 	get accessibilityHidden(): boolean {


### PR DESCRIPTION
cc @farfromrefug

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

ContainerView is the base class for a lot of other elements (list view, plugins, etc) and this change was making it non-accessible and not properly focused. This resulted in the keyboard on a WebView not working, for example.

This was an undocumented breaking change.

## What is the new behavior?
All views are properly accessible.
