### PR TITLE
fix: detect core version before including inspector_modules on android

### DIFF
--- a/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/angular.spec.ts.snap
@@ -435,9 +435,6 @@ exports[`angular configuration for android 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/base.spec.ts.snap
@@ -323,9 +323,6 @@ exports[`base configuration for android 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/javascript.spec.ts.snap
@@ -322,9 +322,6 @@ exports[`javascript configuration for android 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/react.spec.ts.snap
@@ -352,9 +352,6 @@ exports[`react configuration > android > adds ReactRefreshWebpackPlugin when HMR
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"
@@ -683,9 +680,6 @@ exports[`react configuration > android > base config 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/svelte.spec.ts.snap
@@ -344,9 +344,6 @@ exports[`svelte configuration for android 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/typescript.spec.ts.snap
@@ -322,9 +322,6 @@ exports[`typescript configuration for android 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
+++ b/packages/webpack5/__tests__/configuration/__snapshots__/vue.spec.ts.snap
@@ -357,9 +357,6 @@ exports[`vue configuration for android 1`] = `
       '__jest__/src/app.js',
       '@nativescript/core/ui/frame',
       '@nativescript/core/ui/frame/activity'
-    ],
-    'tns_modules/inspector_modules': [
-      '@nativescript/core/inspector_modules'
     ]
   }
 }"

--- a/packages/webpack5/__tests__/configuration/base.spec.ts
+++ b/packages/webpack5/__tests__/configuration/base.spec.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import base from '../../src/configuration/base';
 import { init } from '../../src';
 import { applyFileReplacements } from '../../src/helpers/fileReplacements';
+import * as dependenciesHelpers from '../../src/helpers/dependencies';
 import { additionalCopyRules } from '../../src/helpers/copyRules';
 
 describe('base configuration', () => {
@@ -220,5 +221,31 @@ describe('base configuration', () => {
 
 		expect(config.output.get('sourceMapFilename')).toMatchSnapshot();
 		expect(config.get('devtool')).toBe('hidden-source-map');
+	});
+
+	it('includes inspector_modules on android when @nativescript/core version is >= 8.7.0', () => {
+		const getDependencyVersionSpy = jest.spyOn(
+			dependenciesHelpers,
+			'getDependencyVersion'
+		);
+		getDependencyVersionSpy.withImplementation(
+			(name) => {
+				if (name === '@nativescript/core') {
+					return '8.7.0';
+				}
+				return null;
+			},
+			() => {
+				init({
+					android: true,
+				});
+
+				const config = base(new Config());
+				const entry = config.entryPoints.get('tns_modules/inspector_modules');
+
+				expect(entry).toBeDefined();
+				expect(entry.values().length).toBe(1);
+			}
+		);
 	});
 });

--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -41,7 +41,7 @@
 		"sass": "^1.0.0",
 		"sass-loader": "^13.0.0",
 		"sax": "^1.0.0",
-		"semver": "^7.6.0",
+		"semver": "^7.0.0 || ^6.0.0",
 		"source-map": "^0.7.0",
 		"terser-webpack-plugin": "^5.0.0",
 		"ts-dedent": "^2.0.0",

--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -41,6 +41,7 @@
 		"sass": "^1.0.0",
 		"sass-loader": "^13.0.0",
 		"sax": "^1.0.0",
+		"semver": "^7.6.0",
 		"source-map": "^0.7.0",
 		"terser-webpack-plugin": "^5.0.0",
 		"ts-dedent": "^2.0.0",

--- a/packages/webpack5/src/configuration/angular.ts
+++ b/packages/webpack5/src/configuration/angular.ts
@@ -1,5 +1,6 @@
 import { extname, resolve } from 'path';
 import Config from 'webpack-chain';
+import { satisfies } from 'semver';
 import { existsSync } from 'fs';
 
 import { getTypescript, readTsConfig } from '../helpers/typescript';
@@ -13,7 +14,6 @@ import {
 	getPlatformName,
 } from '../helpers/platform';
 import base from './base';
-import { satisfies } from 'semver';
 
 // until we can switch to async/await on the webpack config, copy this from '@angular/compiler-cli'
 const GLOBAL_DEFS_FOR_TERSER = {

--- a/packages/webpack5/src/helpers/dependencies.ts
+++ b/packages/webpack5/src/helpers/dependencies.ts
@@ -47,3 +47,23 @@ export function getDependencyPath(dependencyName: string): string | null {
 		return null;
 	}
 }
+
+/**
+ * Utility to get the version of a dependency.
+ *
+ * @param dependencyName
+ * @returns string | null - version of the dependency or null if not found
+ */
+export function getDependencyVersion(dependencyName: string): string | null {
+	const dependencyPath = getDependencyPath(dependencyName);
+	if (!dependencyPath) {
+		return null;
+	}
+
+	try {
+		return require(`${dependencyPath}/package.json`).version;
+	} catch (err) {
+		// ignore
+	}
+	return null;
+}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Using `@nativescript/webpack@5.0.19` on a pre 8.7.0 version of core prints an error about missing inspector_modules.

## What is the new behavior?

We detect core version and only include android inspector_modules if core version is >=8.7.0.

Fixes #10511
