### PR TITLE
fix(android): ListView tap not working after setting children as focusable

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -986,13 +986,6 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 	}
 
 	/**
-	 * This is called after the initialization of properties/listeners of the native view.
-	 */
-	public afterInitNativeView(): void {
-		//
-	}
-
-	/**
 	 * Resets properties/listeners set to the native view.
 	 */
 	public resetNativeView(): void {
@@ -1140,7 +1133,6 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		if (this.__nativeView) {
 			this._suspendedUpdates = undefined;
 			this.initNativeView();
-			this.afterInitNativeView();
 			this._resumeNativeUpdates(SuspendType.NativeView);
 		}
 	}

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -986,6 +986,13 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 	}
 
 	/**
+	 * This is called after the initialization of properties/listeners of the native view.
+	 */
+	public afterInitNativeView(): void {
+		//
+	}
+
+	/**
 	 * Resets properties/listeners set to the native view.
 	 */
 	public resetNativeView(): void {
@@ -1133,6 +1140,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		if (this.__nativeView) {
 			this._suspendedUpdates = undefined;
 			this.initNativeView();
+			this.afterInitNativeView();
 			this._resumeNativeUpdates(SuspendType.NativeView);
 		}
 	}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -179,8 +179,8 @@ function initializeDialogFragment() {
 		}
 		public onCreate(savedInstanceState: android.os.Bundle) {
 			super.onCreate(savedInstanceState);
-			var ownerId = this.getArguments()?.getInt(DOMID);
-			var options = getModalOptions(ownerId);
+			const ownerId = this.getArguments()?.getInt(DOMID);
+			const options = getModalOptions(ownerId);
 			// The teardown when the activity is destroyed happens after the state is saved, but is not recoverable,
 			// Cancel the native dialog in this case or the app will crash with subsequent errors.
 			if (savedInstanceState != null && options === undefined) {
@@ -325,8 +325,7 @@ export class View extends ViewCommon {
 
 	public _dialogFragment: androidx.fragment.app.DialogFragment;
 	public _manager: androidx.fragment.app.FragmentManager;
-	private _isClickable: boolean;
-	private _isFocusable: boolean;
+	private _isFocusable: boolean = false;
 	private touchListenerIsSet: boolean;
 	private touchListener: android.view.View.OnTouchListener;
 	private layoutChangeListenerIsSet: boolean;
@@ -466,7 +465,6 @@ export class View extends ViewCommon {
 
 	public initNativeView(): void {
 		super.initNativeView();
-		this._isClickable = this.nativeViewProtected.isClickable();
 		this._isFocusable = this.nativeViewProtected.isFocusable();
 		if (this.needsOnLayoutChangeListener()) {
 			this.setOnLayoutChangeListener();

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -1269,17 +1269,6 @@ export class ContainerView extends View {
 export class CustomLayoutView extends ContainerView implements CustomLayoutViewDefinition {
 	nativeViewProtected: android.view.ViewGroup;
 
-	constructor() {
-		super();
-
-		/**
-		 * mark accessible as false without triggering property change
-		 * equivalent to changing the default
-		 * TODO: Remove this when we have a more flexible API for declaring default property values per type of view
-		 */
-		this.style[accessibilityEnabledProperty.key] = false;
-	}
-
 	public createNativeView() {
 		return new org.nativescript.widgets.ContentLayout(this._context);
 	}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -325,7 +325,7 @@ export class View extends ViewCommon {
 
 	public _dialogFragment: androidx.fragment.app.DialogFragment;
 	public _manager: androidx.fragment.app.FragmentManager;
-	private _isFocusable: boolean = false;
+	private _isFocusableByDefault: boolean = false;
 	private touchListenerIsSet: boolean;
 	private touchListener: android.view.View.OnTouchListener;
 	private layoutChangeListenerIsSet: boolean;
@@ -465,7 +465,9 @@ export class View extends ViewCommon {
 
 	public initNativeView(): void {
 		super.initNativeView();
-		this._isFocusable = this.nativeViewProtected.isFocusable();
+
+		this._isFocusableByDefault = this.nativeViewProtected.isFocusable();
+
 		if (this.needsOnLayoutChangeListener()) {
 			this.setOnLayoutChangeListener();
 		}
@@ -825,10 +827,14 @@ export class View extends ViewCommon {
 	}
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {
-		// ensure `accessibilityEnabled=false` does not disable focus for focusable views or enable it for non-focusable ones
-		this.nativeViewProtected.setFocusable(!!value || this._isFocusable);
 		if (value) {
+			this.nativeViewProtected.setFocusable(true);
 			updateAccessibilityProperties(this);
+		} else {
+			// Mark as non-focusable only if view is supposed to be so by default
+			if (!this._isFocusableByDefault) {
+				this.nativeViewProtected.setFocusable(false);
+			}
 		}
 	}
 
@@ -1269,7 +1275,7 @@ export class ContainerView extends View {
 	constructor() {
 		super();
 		/**
-		 * mark accessible as false without triggering proerty change
+		 * mark accessible as false without triggering property change
 		 * equivalent to changing the default
 		 */
 		this.style[accessibilityEnabledProperty.key] = false;

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -326,6 +326,7 @@ export class View extends ViewCommon {
 	public _dialogFragment: androidx.fragment.app.DialogFragment;
 	public _manager: androidx.fragment.app.FragmentManager;
 	private _isClickable: boolean;
+	private _isFocusable: boolean;
 	private touchListenerIsSet: boolean;
 	private touchListener: android.view.View.OnTouchListener;
 	private layoutChangeListenerIsSet: boolean;
@@ -466,6 +467,7 @@ export class View extends ViewCommon {
 	public initNativeView(): void {
 		super.initNativeView();
 		this._isClickable = this.nativeViewProtected.isClickable();
+		this._isFocusable = this.nativeViewProtected.isFocusable();
 		if (this.needsOnLayoutChangeListener()) {
 			this.setOnLayoutChangeListener();
 		}
@@ -825,8 +827,8 @@ export class View extends ViewCommon {
 	}
 
 	[accessibilityEnabledProperty.setNative](value: boolean): void {
-		// ensure `accessibilityEnabled=false` does not disable focus for view with `isUserInteractionEnabled=true`
-		this.nativeViewProtected.setFocusable(!!value || this.isUserInteractionEnabled);
+		// ensure `accessibilityEnabled=false` does not disable focus for focusable views or enable it for non-focusable ones
+		this.nativeViewProtected.setFocusable(!!value || this._isFocusable);
 		if (value) {
 			updateAccessibilityProperties(this);
 		}

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -466,11 +466,17 @@ export class View extends ViewCommon {
 	public initNativeView(): void {
 		super.initNativeView();
 
-		this._isFocusableByDefault = this.nativeViewProtected.isFocusable();
-
 		if (this.needsOnLayoutChangeListener()) {
 			this.setOnLayoutChangeListener();
 		}
+	}
+
+	public afterInitNativeView(): void {
+		super.afterInitNativeView();
+
+		// Setting this during initNativeView would result in skipping the right focusable state on views
+		// like ListView which becomes focusable in initNativeView scope
+		this._isFocusableByDefault = this.nativeViewProtected.isFocusable();
 	}
 
 	public needsOnLayoutChangeListener() {

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -1275,7 +1275,7 @@ export class CustomLayoutView extends ContainerView implements CustomLayoutViewD
 		/**
 		 * mark accessible as false without triggering property change
 		 * equivalent to changing the default
-		 * TODO: Remove this when we have a more flexible API for having default property values per type of view
+		 * TODO: Remove this when we have a more flexible API for declaring default property values per type of view
 		 */
 		this.style[accessibilityEnabledProperty.key] = false;
 	}

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -1069,11 +1069,6 @@ export class ContainerView extends View {
 	constructor() {
 		super();
 		this.iosOverflowSafeArea = true;
-		/**
-		 * mark accessible as false without triggering proerty change
-		 * equivalent to changing the default
-		 */
-		this.style[accessibilityEnabledProperty.key] = false;
 	}
 }
 

--- a/packages/core/ui/layouts/layout-base-common.ts
+++ b/packages/core/ui/layouts/layout-base-common.ts
@@ -3,9 +3,21 @@ import { CoreTypes } from '../../core-types';
 import { View, CustomLayoutView, AddChildFromBuilder } from '../core/view';
 import { booleanConverter, getViewById } from '../core/view-base';
 import { Property } from '../core/properties';
+import { accessibilityEnabledProperty } from '../../accessibility/accessibility-properties';
 
 export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefinition, AddChildFromBuilder {
 	private _subViews = new Array<View>();
+
+	constructor() {
+		super();
+
+		/**
+		 * mark accessible as false without triggering property change
+		 * equivalent to changing the default
+		 * TODO: Remove this when we have a more flexible API for declaring default property values per type of view
+		 */
+		this.style[accessibilityEnabledProperty.key] = false;
+	}
 
 	public _addChildFromBuilder(name: string, value: any) {
 		if (value instanceof View) {

--- a/packages/core/ui/layouts/layout-base-common.ts
+++ b/packages/core/ui/layouts/layout-base-common.ts
@@ -3,7 +3,6 @@ import { CoreTypes } from '../../core-types';
 import { View, CustomLayoutView, AddChildFromBuilder } from '../core/view';
 import { booleanConverter, getViewById } from '../core/view-base';
 import { Property } from '../core/properties';
-import { accessibilityEnabledProperty } from '../../accessibility/accessibility-properties';
 
 export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefinition, AddChildFromBuilder {
 	private _subViews = new Array<View>();

--- a/packages/core/ui/layouts/layout-base-common.ts
+++ b/packages/core/ui/layouts/layout-base-common.ts
@@ -3,6 +3,7 @@ import { CoreTypes } from '../../core-types';
 import { View, CustomLayoutView, AddChildFromBuilder } from '../core/view';
 import { booleanConverter, getViewById } from '../core/view-base';
 import { Property } from '../core/properties';
+import { accessibilityEnabledProperty } from '../../accessibility/accessibility-properties';
 
 export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefinition, AddChildFromBuilder {
 	private _subViews = new Array<View>();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
We had reports that android ListView `itemTap` event stopped working at core 8.7 and later.
The problem seemed to be that ListView proxy views became focusable due to some a11y calls, thus breaking native item click listener. A thread in StackOverflow explains why ListView does not operate well if list items become focusable: https://stackoverflow.com/questions/11610023/click-is-not-working-on-the-listitem-listview-android

## What is the new behavior?
Views will become focusable or non-focusable only when needed.

This is a continuation of the previous fix related to WebView accessibility focus: https://github.com/NativeScript/NativeScript/commit/92b2ff83a038ece4ab4411cf983ee9e252bba141

@farfromrefug Let me know if there's room for any improvements.