### PR TITLE
fix: Remove reference in NPS config to old Webpack package, and add reference to Webpack 5 unit tests.

### DIFF
--- a/tools/workspace-scripts.js
+++ b/tools/workspace-scripts.js
@@ -119,23 +119,16 @@ module.exports = {
           description: '@nativescript/ui-mobile-base: Build for npm'
         },
 			},
-			// @nativescript/webpack
-			webpack: {
-				build: {
-          script: 'nx run webpack:build',
-          description: '@nativescript/webpack: Build for npm'
-        },
-				test: {
-          script: 'nx run webpack:test',
-          description: '@nativescript/webpack: Unit tests'
-        },
-      },
       // @nativescript/webpack (5)
 			webpack5: {
 				build: {
           script: 'nx run webpack5:build',
           description: '@nativescript/webpack(5): Build for npm'
         },
+				test: {
+					script: 'nx run webpack5:test',
+					description: '@nativescript/webpack(5): Unit tests'
+				},
 			},
     },
     "⚡": {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Using 'npm start' (as in the documentation) shows a menu where you can pick from the various project build scripts and unit tests.  This menu still contains reference to the old Webpack package, and launching either of the options associated with it gives an error.  There is also no menu option to invoke the Webpack5 unit tests.

## What is the new behavior?
Removes the references to the old Webpack package from the NPS config file, and adds a reference to invoke the unit testing for the Webpack5 package.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

