### PR TITLE
fix(core): clean up event-handling in ViewCommon

### DIFF
--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -33,8 +33,6 @@ import { SharedTransition, SharedTransitionInteractiveOptions } from '../../tran
 // helpers (these are okay re-exported here)
 export * from './view-helper';
 
-const eventNamesRegex = /\s*,\s*/;
-
 let animationModule: typeof am;
 function ensureAnimationModule() {
 	if (!animationModule) {
@@ -311,9 +309,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 			return;
 		}
 
-		for (const eventName of normalizedName.trim().split(eventNamesRegex)) {
-			super.addEventListener(eventName, callback, thisArg);
-		}
+		super.addEventListener(normalizedName, callback, thisArg);
 	}
 
 	public removeEventListener(arg: string | GestureTypes, callback?: (data: EventData) => void, thisArg?: any) {
@@ -335,9 +331,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 			return;
 		}
 
-		for (const eventName of normalizedName.trim().split(eventNamesRegex)) {
-			super.removeEventListener(eventName, callback, thisArg);
-		}
+		super.removeEventListener(normalizedName, callback, thisArg);
 	}
 
 	public onBackPressed(): boolean {

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -125,7 +125,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	_setMinWidthNative: (value: CoreTypes.LengthType) => void;
 	_setMinHeightNative: (value: CoreTypes.LengthType) => void;
 
-	public _gestureObservers = {};
+	public readonly _gestureObservers = {} as Record<GestureTypes, Array<GesturesObserver>>;
 
 	_androidContentDescriptionUpdated?: boolean;
 
@@ -179,7 +179,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 
 	onLoaded() {
 		if (!this.isLoaded) {
-			const hasTap = this.hasListeners('tap') || this.hasListeners('tapChange') || this.getGestureObservers(GestureTypes.tap);
+			const hasTap = this.hasListeners('tap') || this.hasListeners('tapChange') || !!this.getGestureObservers(GestureTypes.tap);
 			const enableTapAnimations = TouchManager.enableGlobalTapAnimations && hasTap;
 			if (!this.ignoreTouchAnimation && (this.touchAnimation || enableTapAnimations)) {
 				TouchManager.addAnimations(this);
@@ -288,7 +288,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		this._gestureObservers[type].push(gestureObserve(this, type, callback, thisArg));
 	}
 
-	public getGestureObservers(type: GestureTypes): Array<GesturesObserver> {
+	public getGestureObservers(type: GestureTypes): Array<GesturesObserver> | undefined {
 		return this._gestureObservers[type];
 	}
 
@@ -497,10 +497,12 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 
 	private _disconnectGestureObservers(type: GestureTypes): void {
 		const observers = this.getGestureObservers(type);
-		if (observers) {
-			for (let i = 0; i < observers.length; i++) {
-				observers[i].disconnect();
-			}
+		if (!observers) {
+			return;
+		}
+
+		for (const observer of observers) {
+			observer.disconnect();
 		}
 	}
 


### PR DESCRIPTION
Relates to #10531. These two PRs are independent and can be merged in either order.

Cleans up the code related to event-handling in ViewCommon.

It makes it a lot clearer that we're actually splitting event names both here *and again* in Observable! So in a follow-up PR after this and the related PR, we can investigate removing event name splitting altogether.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

There's some unclear, redundant code.

## What is the new behavior?

I've made the code clear and readable.
