### PR TITLE
fix: dont add to parent from `_setupAsRootView`

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -1011,8 +1011,17 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 		// }
 	}
 
+	/**
+	 * if _setupAsRootView is called it means it is not supposed to be
+	 * added to a parent. However parent can be set before for the purpose
+	 * of CSS variables/classes. That variable ensures that _addViewToNativeVisualTree
+	 * is not called in _setupAsRootView
+	 */
+	mIsRootView = false;
 	_setupAsRootView(context: any): void {
+		this.mIsRootView = true;
 		this._setupUI(context);
+		this.mIsRootView = false;
 	}
 
 	/**
@@ -1025,7 +1034,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 			// this check is unnecessary as this function should never be called when this._context === context as it means the view was somehow detached,
 			// which is only possible by setting reusable = true. Adding it either way for feature flag safety
 			if (this.reusable) {
-				if (this.parent && !this._isAddedToNativeVisualTree) {
+				if (!this.mIsRootView && this.parent && !this._isAddedToNativeVisualTree) {
 					const nativeIndex = this.parent._childIndexToNativeChildIndex(atIndex);
 					this._isAddedToNativeVisualTree = this.parent._addViewToNativeVisualTree(this, nativeIndex);
 				}
@@ -1100,7 +1109,7 @@ export abstract class ViewBase extends Observable implements ViewBaseDefinition 
 
 		this.setNativeView(nativeView);
 
-		if (this.parent) {
+		if (!this.mIsRootView && this.parent) {
 			const nativeIndex = this.parent._childIndexToNativeChildIndex(atIndex);
 			this._isAddedToNativeVisualTree = this.parent._addViewToNativeVisualTree(this, nativeIndex);
 		}


### PR DESCRIPTION
In some cases you might want to set a parent(mostly rootView) before `_setupAsRootView` so that the the view calling `_setupAsRootView` inherits CSS variables and classes from the parent.
This is especially done in plugins like bottomsheet or dialogs or popover.
The issue is that if you set parent before `_setupAsRootView` then `_addViewToNativeVisualTree` will be called which could break things like it does with RadSideDrawer https://github.com/nativescript-community/ui-material-components/issues/462.

This PR fixes that by just preventing `_addViewToNativeVisualTree` to be called from `_setupAsRootView` which makes sense to me.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

