### PR TITLE
fix: provide correct page for action bar update on title change

### DIFF
--- a/packages/core/ui/action-bar/index.ios.ts
+++ b/packages/core/ui/action-bar/index.ios.ts
@@ -397,7 +397,7 @@ export class ActionBar extends ActionBarBase {
 		}
 
 		if (page.frame) {
-			page.frame._updateActionBar();
+			page.frame._updateActionBar(page);
 		}
 
 		const navigationItem: UINavigationItem = (<UIViewController>page.ios).navigationItem;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When you change the title of a specific page during navigation, the ActionBar will toggle off then on shortly due to the fact that the page is only set on the frame after the navigation is completely finished

## What is the new behavior?
This issue is now fixed by passing the current page to the `_updateActionBar` function. This also fixes cases where you might have multiple navigations and the current page could impact the action bar display mode of future pages.
