### PR TITLE
fix(android): reject promise if cancel animation

### DIFF
--- a/packages/core/ui/animation/index.android.ts
+++ b/packages/core/ui/animation/index.android.ts
@@ -248,7 +248,7 @@ export class Animation extends AnimationBase {
 	private _onAndroidAnimationCancel() {
 		// tslint:disable-line
 		this._propertyResetCallbacks.forEach((v) => v());
-		this._resolveAnimationFinishedPromise();
+		this._rejectAnimationFinishedPromise();
 
 		if (this._target) {
 			this._target._removeAnimation(this);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When an animation is cancelled, the animation promise ends as if the animation had been played to completion. Thus, it is not possible to determine whether it was cancelled or completed.

## What is the new behavior?
When an animation is cancelled, the animation promise ends as rejected. It helps to separate cancelled animation with animation that had been played to completion.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

