### PR TITLE
feat(config): embed options for existing platform host projects

### DIFF
--- a/packages/core/config/config.interface.ts
+++ b/packages/core/config/config.interface.ts
@@ -173,6 +173,28 @@ interface IConfigHook {
 	script: string;
 }
 
+interface IConfigEmbedProps {
+	/**
+	 * Relative path to the platform host project directory.
+	 */
+	hostProjectPath?: string;
+	/**
+	 * (Android only) Optional custom module name.
+	 */
+	hostProjectModuleName?: string;
+}
+
+interface IConfigEmbed extends IConfigEmbedProps {
+	/**
+	 * iOS specific embed configurations
+	 */
+	ios?: IConfigEmbedProps;
+	/**
+	 * Android specific embed configurations
+	 */
+	android?: IConfigEmbedProps;
+}
+
 export interface NativeScriptConfig {
 	/**
 	 * App's bundle id
@@ -202,6 +224,10 @@ export interface NativeScriptConfig {
 	 * You can override that to use a name of your choice by setting this.
 	 */
 	projectName?: string;
+	/**
+	 * For embedding into existing platform host projects.
+	 */
+	embed?: IConfigEmbed;
 	/**
 	 * Custom webpack config path
 	 * The default is `webpack.config.js` in the root however you can use a custom name and place elsewhere.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

Can only pass arguments to CLI to configure embedding options.

## What is the new behavior?

Enables ability to persist configuration easily for embedding use cases.

ref: https://github.com/NativeScript/nativescript-cli/pull/5803