### PR TITLE
fix(android): prevent error while opening modal from background

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -684,6 +684,17 @@ export class View extends ViewCommon {
 		return result | (childMeasuredState & layout.MEASURED_STATE_MASK);
 	}
 	protected _showNativeModalView(parent: View, options: ShowModalOptions) {
+		// if the app is in background while triggering _showNativeModalView
+		// then DialogFragment.show will trigger IllegalStateException: Can not perform this action after onSaveInstanceState
+		// so if in background we create an event to call _showNativeModalView when loaded (going back in foreground)
+		if (Application.inBackground &&  !parent.isLoaded) {
+				const onLoaded = ()=> {
+						parent.off('loaded', onLoaded)
+						this._showNativeModalView(parent, options);
+				};
+				parent.on('loaded', onLoaded);
+				return;
+		}
 		super._showNativeModalView(parent, options);
 		initializeDialogFragment();
 


### PR DESCRIPTION
It is a known android "issue" that you cant commit/show a fragment while in background. The reason is, as explained [here](https://medium.com/@113408/avoid-fragment-illegalstateexception-can-not-perform-this-action-after-onsaveinstancestate-ba76ae4f00fe) or [here](https://stackoverflow.com/questions/15729138/on-showing-dialog-i-get-can-not-perform-this-action-after-onsaveinstancestate), that `onSaveInstanceState` is already called so any operation before activity start would be with state loss. There are 2 solutions in this case:
* use `commitAllowingStateLoss`, `dismissAllowingStateLoss` ... but then you loose state ... This is what we are doing in N in many cases. We can do this with `show` too but we would need to override the `DialogFragment.show` method.
* delay the action until the activity is resumed.

This PR uses the second solution. We could add an option to `showModal` to use the first solution. The user experience is different. Solution 1:  when the app is resumed the modal is already shown and layed out. Solution 2: you see the modal opening on app resume

EDIT: i actually implemented the 2 cases in my fork. Even though i can force `commitAllowingStateLoss` successfully from background it does not make the dialog fragment actually show while in background. I still see the open animation while putting the app back to foreground
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

