### PR TITLE
#10573 (webpack) fix union type

### DIFF
--- a/packages/webpack5/src/index.ts
+++ b/packages/webpack5/src/index.ts
@@ -158,10 +158,10 @@ export function chainWebpack(
  * @param mergeFn An object or a function that optionally returns an object (can mutate the object directly and return nothing)
  */
 export function mergeWebpack(
-	mergeFn: (
+	mergeFn: ((
 		config: Partial<webpack.Configuration>,
 		env: IWebpackEnv,
-	) => any | Partial<webpack.Configuration>,
+	) => any) | Partial<webpack.Configuration>,
 ) {
 	webpackMerges.push(mergeFn);
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
TypeScript only recognises the function type of the single argument of `mergeWebpack`. The object type is ignored.
## What is the new behavior?
<!-- Describe the changes. -->
Fixes the union type by parenthesising the function type. 

Fixes #10573

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

