### PR TITLE
fix(embed): use factory only when it's available

### DIFF
--- a/packages/core/utils/ios/index.ts
+++ b/packages/core/utils/ios/index.ts
@@ -65,7 +65,7 @@ export function getRootViewController(): UIViewController {
 
 export function getWindow(): UIWindow {
 	let window: UIWindow;
-	if (SDK_VERSION >= 15) {
+	if (SDK_VERSION >= 15 && typeof NativeScriptViewFactory !== 'undefined') {
 		// UIWindowScene.keyWindow is only available 15+
 		window = NativeScriptViewFactory.getKeyWindow();
 	}


### PR DESCRIPTION
When embedding via 'ns embed ios', the .swift symbols may not be available and are not needed. This can be revisited in the future with project settings for embedded projects.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?

When embedding apps into platform host projects, the factory would always attempt to be used.

## What is the new behavior?

When embedding apps into platform host projects, the factory is not needed.

