### PR TITLE
fix(ios): consistent box-shadow radius blur

### DIFF
--- a/apps/ui/src/text-view/scrolling-and-sizing-page.css
+++ b/apps/ui/src/text-view/scrolling-and-sizing-page.css
@@ -2,6 +2,10 @@
     padding: 10 20 10 20;
 }
 
+.p-20 {
+    padding: 20;
+}
+
 .m-b-10 {
     margin-bottom: 10;
 }
@@ -47,7 +51,7 @@ TextView {
 }
 
 .shadow {
-    box-shadow: inset 0 0 5 5 #000000;
+    box-shadow: 2 2 6 6 #ff0000;
 }
 
 .body {

--- a/apps/ui/src/text-view/scrolling-and-sizing-page.xml
+++ b/apps/ui/src/text-view/scrolling-and-sizing-page.xml
@@ -36,7 +36,7 @@
             <TextView hint="fixed-height gradient" class="fixed-height gradient" />
         </StackLayout>
 
-        <StackLayout class="p-10">
+        <StackLayout class="p-20">
             <TextView hint="fixed-height shadow" class="fixed-height shadow" />
         </StackLayout>
 

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -1140,7 +1140,7 @@ function drawBoxShadow(view: View): void {
 
 			// Shadow opacity is handled on the shadow's color instance
 			shadowLayer.shadowOpacity = boxShadow.color?.a ? boxShadow.color.a / 255 : 1;
-			shadowLayer.shadowRadius = shadowRadius;
+			shadowLayer.shadowRadius = shadowRadius * 0.65;
 			shadowLayer.shadowColor = boxShadow.color?.ios?.CGColor;
 			shadowLayer.shadowOffset = CGSizeMake(offsetX, offsetY);
 


### PR DESCRIPTION
The radius blurring has been adjusted in iOS to match that in Android

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
The box-shadow radius amount differs in iOS compared to Android

## What is the new behavior?
The box-shadow radius amount in iOS matches Android

BREAKING CHANGES: none


