### PR TITLE
fix: targetSdk 34 registerBroadcastReceiver needs additional flags

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -2,6 +2,7 @@ import { profile } from '../profiling';
 import { View } from '../ui/core/view';
 import { isEmbedded } from '../ui/embedding';
 import { AndroidActivityCallbacks, NavigationEntry } from '../ui/frame/frame-common';
+import { SDK_VERSION } from '../utils/constants';
 import type { AndroidApplication as IAndroidApplication } from './application';
 import { ApplicationCommon } from './application-common';
 import type { AndroidActivityBundleEventData, AndroidActivityEventData, ApplicationEventData } from './application-interfaces';
@@ -442,10 +443,18 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 		return this._packageName;
 	}
 
-	public registerBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void): void {
+	// Possible flags are:
+	// RECEIVER_EXPORTED (2)
+	// RECEIVER_NOT_EXPORTED (4)
+	// RECEIVER_VISIBLE_TO_INSTANT_APPS (1)
+	public registerBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void, flags = 2): void {
 		const registerFunc = (context: android.content.Context) => {
 			const receiver: android.content.BroadcastReceiver = new (initBroadcastReceiver())(onReceiveCallback);
-			context.registerReceiver(receiver, new android.content.IntentFilter(intentFilter));
+			if (SDK_VERSION >= 26) {
+				context.registerReceiver(receiver, new android.content.IntentFilter(intentFilter), flags);
+			} else {
+				context.registerReceiver(receiver, new android.content.IntentFilter(intentFilter));
+			}
 			this._registeredReceivers[intentFilter] = receiver;
 		};
 


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When targetting API 34, calling registerBroadcastReceiver throws an error due to https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported

## What is the new behavior?
Error no longer thrown and we mark the broadcast as exported by default. The user can opt to make it not exported by passing the correct flag.
