### PR TITLE
chore: improve task flow for native core deps

### DIFF
--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -24,6 +24,17 @@
 				"verbose": true
 			}
 		},
+		"copy-native-deps": {
+			"dependsOn": ["winter-cg:build", "ui-mobile-base:build"],
+			"inputs": ["{workspaceRoot}/dist/packages/winter-cg/platforms/**/*", "{workspaceRoot}/dist/packages/ui-mobile-base/platforms/**/*"],
+			"outputs": ["{projectRoot}/platforms/android/winter_cg-release.aar", "{projectRoot}/platforms/android/widgets-release.aar"],
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["cp -R dist/packages/winter-cg/platforms/* packages/core/platforms", "cp -R dist/packages/ui-mobile-base/platforms/* packages/core/platforms"],
+				"cwd": ".",
+				"parallel": false
+			}
+		},
 		"build": {
 			"executor": "nx:run-commands",
 			"inputs": ["default", "^production"],

--- a/packages/ui-mobile-base/build.android.sh
+++ b/packages/ui-mobile-base/build.android.sh
@@ -5,20 +5,23 @@ set -e
 
 echo "Use dumb gradle terminal"
 export TERM=dumb
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-rm -rf dist/package/platforms/android || true
-mkdir -p dist/package/platforms/android
+OUTDIR=$SCRIPT_DIR/../../dist/packages/ui-mobile-base
+
+rm -rf $OUTDIR/platforms/android || true
+mkdir -p $OUTDIR/platforms/android
 
 echo "Build android"
 cd android
 ./gradlew --quiet assembleRelease
 cd ..
-cp android/widgets/build/outputs/aar/widgets-release.aar dist/package/platforms/android/widgets-release.aar
+cp android/widgets/build/outputs/aar/widgets-release.aar $OUTDIR/platforms/android/widgets-release.aar
 
 if [ "$1" ]
 then
   echo "Suffix package.json's version with tag: $1"
-  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./dist/package/package.json
+  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./$OUTDIR/package.json
 fi
 
 if [ "$SKIP_PACK" ]
@@ -26,11 +29,10 @@ then
   echo "SKIP pack" 
 else
   echo "Copy NPM artefacts"
-  cp .npmignore LICENSE README.md package.json dist/package
+  cp .npmignore LICENSE README.md package.json $OUTDIR
   echo "NPM pack"
-  cd dist/package
-  PACKAGE="$(npm pack)"
-  cd ../..
-  mv dist/package/$PACKAGE dist/$PACKAGE
+  cd $OUTDIR
+  cd ..
+  PACKAGE="$(npm pack $OUTDIR)"
   echo "Output: dist/$PACKAGE"
 fi

--- a/packages/ui-mobile-base/build.ios.sh
+++ b/packages/ui-mobile-base/build.ios.sh
@@ -5,25 +5,28 @@ set -e
 
 echo "Use dumb terminal"
 export TERM=dumb
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-rm -rf dist/package/platforms/ios || true
-mkdir -p dist/package/platforms/ios
+OUTDIR=$SCRIPT_DIR/../../dist/packages/ui-mobile-base
+
+rm -rf $OUTDIR/platforms/ios || true
+mkdir -p $OUTDIR/platforms/ios
 
 echo "Build iOS"
 
 cd ios
 ./build.sh
 cd ..
-echo "Copy ios/TNSWidgets/build/*.xcframework dist/package/platforms/ios"
+echo "Copy ios/TNSWidgets/build/*.xcframework $OUTDIR/platforms/ios"
 
-cp -R ios/TNSWidgets/build/TNSWidgets.xcframework dist/package/platforms/ios
+cp -R ios/TNSWidgets/build/TNSWidgets.xcframework $OUTDIR/platforms/ios
 
-# cp ios/TNSWidgets/build/*.framework.dSYM.zip dist/package/platforms/ios
+# cp ios/TNSWidgets/build/*.framework.dSYM.zip $OUTDIR/platforms/ios
 
 if [ "$1" ]
 then
   echo "Suffix package.json's version with tag: $1"
-  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./dist/package/package.json
+  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' $OUTDIR/package.json
 fi
 
 if [ "$SKIP_PACK" ]
@@ -31,11 +34,10 @@ then
   echo "SKIP pack" 
 else
   echo "Copy NPM artifacts"
-  cp .npmignore LICENSE README.md package.json dist/package
+  cp .npmignore LICENSE README.md package.json $OUTDIR
   echo "NPM pack"
-  cd dist/package
-  PACKAGE="$(npm pack)"
-  cd ../..
-  mv dist/package/$PACKAGE dist/$PACKAGE
+  cd $OUTDIR
+  cd ..
+  PACKAGE="$(npm pack $OUTDIR)"
   echo "Output: dist/$PACKAGE"
 fi

--- a/packages/ui-mobile-base/build.sh
+++ b/packages/ui-mobile-base/build.sh
@@ -6,17 +6,20 @@ set -e
 
 echo "Use dumb gradle terminal"
 export TERM=dumb
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+OUTDIR=$SCRIPT_DIR/../../dist/packages/ui-mobile-base
 
 echo "Clean dist"
-rm -rf dist
+rm -rf $OUTDIR
 
 export SKIP_PACK=true
 ./build.android.sh
 ./build.ios.sh
 
 echo "Copy NPM artifacts"
-cp .npmignore README.md package.json dist/package
-cp ../../LICENSE dist/package
+cp .npmignore README.md package.json $OUTDIR
+cp ../../LICENSE $OUTDIR
 
 
 if [ "$1" ]
@@ -26,9 +29,7 @@ then
 fi
 
 echo "NPM pack"
-cd dist/package
-PACKAGE="$(npm pack)"
-cd ../..
-mv dist/package/$PACKAGE dist/$PACKAGE
+cd $OUTDIR/..
+PACKAGE="$(npm pack $OUTDIR)"
 echo "Output: dist/$PACKAGE"
 

--- a/packages/ui-mobile-base/project.json
+++ b/packages/ui-mobile-base/project.json
@@ -7,8 +7,10 @@
 	"targets": {
 		"build": {
 			"executor": "nx:run-commands",
+			"inputs": ["default", "!{projectRoot}/android/.gradle/**/*", "!{projectRoot}/android/*/build/**/*", "!{projectRoot}/ios/*/build/**/*"],
+			"outputs": ["{workspaceRoot}/dist/packages/ui-mobile-base"],
 			"options": {
-				"commands": ["./build.sh", "cp -R dist/package/platforms/* ../../packages/core/platforms"],
+				"commands": ["./build.sh"],
 				"cwd": "packages/ui-mobile-base",
 				"parallel": false
 			}

--- a/packages/winter-cg/build.android.sh
+++ b/packages/winter-cg/build.android.sh
@@ -5,20 +5,23 @@ set -e
 
 echo "Use dumb gradle terminal"
 export TERM=dumb
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-rm -rf dist/package/platforms/android || true
-mkdir -p dist/package/platforms/android
+OUTDIR=$SCRIPT_DIR/../../dist/packages/winter-cg
+
+rm -rf $OUTDIR/platforms/android || true
+mkdir -p $OUTDIR/platforms/android
 
 echo "Build android"
 cd android
 ./gradlew --quiet assembleRelease
 cd ..
-cp android/winter_cg/build/outputs/aar/winter_cg-release.aar dist/package/platforms/android/winter_cg-release.aar
+cp android/winter_cg/build/outputs/aar/winter_cg-release.aar $OUTDIR/platforms/android/winter_cg-release.aar
 
 if [ "$1" ]
 then
   echo "Suffix package.json's version with tag: $1"
-  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./dist/package/package.json
+  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./$OUTDIR/package.json
 fi
 
 if [ "$SKIP_PACK" ]
@@ -26,11 +29,10 @@ then
   echo "SKIP pack" 
 else
   echo "Copy NPM artefacts"
-  cp .npmignore LICENSE README.md package.json dist/package
+  cp .npmignore LICENSE README.md package.json $OUTDIR
   echo "NPM pack"
-  cd dist/package
-  PACKAGE="$(npm pack)"
-  cd ../..
-  mv dist/package/$PACKAGE dist/$PACKAGE
+  cd $OUTDIR
+  cd ..
+  PACKAGE="$(npm pack $OUTDIR)"
   echo "Output: dist/$PACKAGE"
 fi

--- a/packages/winter-cg/build.ios.sh
+++ b/packages/winter-cg/build.ios.sh
@@ -5,25 +5,28 @@ set -e
 
 echo "Use dumb terminal"
 export TERM=dumb
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-rm -rf dist/package/platforms/ios || true
-mkdir -p dist/package/platforms/ios
+OUTDIR=$SCRIPT_DIR/../../dist/packages/winter-cg
+
+rm -rf $OUTDIR/platforms/ios || true
+mkdir -p $OUTDIR/platforms/ios
 
 echo "Build iOS"
 
 cd ios
 ./build.sh
 cd ..
-echo "Copy ios/NSCWinterCG/build/*.xcframework dist/package/platforms/ios"
+echo "Copy ios/NSCWinterCG/build/*.xcframework $OUTDIR/platforms/ios"
 
-cp -R ios/NSCWinterCG/build/NSCWinterCG.xcframework dist/package/platforms/ios
+cp -R ios/NSCWinterCG/build/NSCWinterCG.xcframework $OUTDIR/platforms/ios
 
-# cp ios/NSCWinterCG/build/*.framework.dSYM.zip dist/package/platforms/ios
+# cp ios/NSCWinterCG/build/*.framework.dSYM.zip $OUTDIR/platforms/ios
 
 if [ "$1" ]
 then
   echo "Suffix package.json's version with tag: $1"
-  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' ./dist/package/package.json
+  sed -i.bak 's/\(\"version\"\:[[:space:]]*\"[^\"]*\)\"/\1-'$1'"/g' $OUTDIR/package.json
 fi
 
 if [ "$SKIP_PACK" ]
@@ -31,11 +34,10 @@ then
   echo "SKIP pack" 
 else
   echo "Copy NPM artifacts"
-  cp .npmignore LICENSE README.md package.json dist/package
+  cp .npmignore LICENSE README.md package.json $OUTDIR
   echo "NPM pack"
-  cd dist/package
-  PACKAGE="$(npm pack)"
-  cd ../..
-  mv dist/package/$PACKAGE dist/$PACKAGE
+  cd $OUTDIR
+  cd ..
+  PACKAGE="$(npm pack $OUTDIR)"
   echo "Output: dist/$PACKAGE"
 fi

--- a/packages/winter-cg/build.sh
+++ b/packages/winter-cg/build.sh
@@ -6,17 +6,20 @@ set -e
 
 echo "Use dumb gradle terminal"
 export TERM=dumb
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+OUTDIR=$SCRIPT_DIR/../../dist/packages/winter-cg
 
 echo "Clean dist"
-rm -rf dist
+rm -rf $OUTDIR
 
 export SKIP_PACK=true
 ./build.android.sh
 ./build.ios.sh
 
 echo "Copy NPM artifacts"
-cp .npmignore README.md package.json dist/package
-cp ../../LICENSE dist/package
+cp .npmignore README.md package.json $OUTDIR
+cp ../../LICENSE $OUTDIR
 
 
 if [ "$1" ]
@@ -26,9 +29,7 @@ then
 fi
 
 echo "NPM pack"
-cd dist/package
-PACKAGE="$(npm pack)"
-cd ../..
-mv dist/package/$PACKAGE dist/$PACKAGE
+cd $OUTDIR/..
+PACKAGE="$(npm pack $OUTDIR)"
 echo "Output: dist/$PACKAGE"
 

--- a/packages/winter-cg/project.json
+++ b/packages/winter-cg/project.json
@@ -7,8 +7,10 @@
 	"targets": {
 		"build": {
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/packages/winter-cg"],
+			"inputs": ["default", "!{projectRoot}/android/.gradle/**/*", "!{projectRoot}/android/*/build/**/*", "!{projectRoot}/ios/*/build/**/*"],
 			"options": {
-				"commands": ["./build.sh", "cp -R dist/package/platforms/* ../../packages/core/platforms"],
+				"commands": ["./build.sh"],
 				"cwd": "packages/winter-cg",
 				"parallel": false
 			}


### PR DESCRIPTION
Creating this as a draft.

Currently we need to manually build ui-mobile-base and winter-cg internal packages before building core since core itself need the artifacts from these packages.

This PR changes it so we just need to run `copy-native-deps` and we can leverage nx caching. We could make `copy-native-deps` a dependency of `build` but it'd require `build` to be ran only from a mac machine, even if not changing any iOS source (currently this works by storing the artifcats themselves in git).

Thoughts on this?