### PR TITLE
fix(core): include everything but core.aar in android platforms

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,9 +14,8 @@
     "**/*.js",
     "**/*.map",
     "**/platforms/ios/**",
-    "platforms/android/native-api-usage.json",
-    "platforms/android/res/values/ids.xml",
-    "platforms/android/widgets-release.aar",
+    "platforms/android/**",
+    "!platforms/android/core.aar",
     "**/package.json"
   ],
   "keywords": [


### PR DESCRIPTION
The current configuration excludes winter_cg-release.aar since it's not included in the files. This change now force includes everything *but* the `core.aar` which isn't needed as it's auto-generated by the CLI every time (we should probably remove it and .gitignore it)