### PR TITLE
fix(android): Layout change listeners are ignored when using addEventListener

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -336,8 +336,8 @@ export class View extends ViewCommon {
 		}
 	}
 
-	on(eventNames: string, callback: (data: EventData) => void, thisArg?: any) {
-		super.on(eventNames, callback, thisArg);
+	addEventListener(eventNames: string, callback: (data: EventData) => void, thisArg?: any) {
+		super.addEventListener(eventNames, callback, thisArg);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 
 		if (this.isLoaded && !this.layoutChangeListenerIsSet && isLayoutEvent) {
@@ -345,8 +345,8 @@ export class View extends ViewCommon {
 		}
 	}
 
-	off(eventNames: string, callback?: (data: EventData) => void, thisArg?: any) {
-		super.off(eventNames, callback, thisArg);
+	removeEventListener(eventNames: string, callback?: (data: EventData) => void, thisArg?: any) {
+		super.removeEventListener(eventNames, callback, thisArg);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 
 		// Remove native listener only if there are no more user listeners for LayoutChanged event
@@ -687,13 +687,13 @@ export class View extends ViewCommon {
 		// if the app is in background while triggering _showNativeModalView
 		// then DialogFragment.show will trigger IllegalStateException: Can not perform this action after onSaveInstanceState
 		// so if in background we create an event to call _showNativeModalView when loaded (going back in foreground)
-		if (Application.inBackground &&  !parent.isLoaded) {
-				const onLoaded = ()=> {
-						parent.off('loaded', onLoaded)
-						this._showNativeModalView(parent, options);
-				};
-				parent.on('loaded', onLoaded);
-				return;
+		if (Application.inBackground && !parent.isLoaded) {
+			const onLoaded = () => {
+				parent.off('loaded', onLoaded);
+				this._showNativeModalView(parent, options);
+			};
+			parent.on('loaded', onLoaded);
+			return;
 		}
 		super._showNativeModalView(parent, options);
 		initializeDialogFragment();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In the case of android, layout change event listeners cannot be manipulated using addEventListener/removeEventListener.

## What is the new behavior?
Layout change event listeners can be manipulated using addEventListener/removeEventListener.
Methods `on` and `off` call those internally.