### PR TITLE
fix(android): RootLayout shade cover null color handling

### DIFF
--- a/packages/core/ui/layouts/root-layout/index.android.ts
+++ b/packages/core/ui/layouts/root-layout/index.android.ts
@@ -22,7 +22,7 @@ export class RootLayout extends RootLayoutBase {
 						onTouch: function (view, event) {
 							return true;
 						},
-					})
+					}),
 				);
 			}
 		}
@@ -63,9 +63,9 @@ export class RootLayout extends RootLayoutBase {
 					rotate: 0,
 					opacity: options.opacity,
 				},
-				options.color
+				options.color,
 			),
-			duration
+			duration,
 		);
 	}
 
@@ -78,9 +78,9 @@ export class RootLayout extends RootLayoutBase {
 	}
 
 	private _getAnimationSet(view: View, shadeCoverAnimation: TransitionAnimation, backgroundColor: string = defaultShadeCoverOptions.color): Array<android.animation.Animator> {
-		const backgroundIsGradient = backgroundColor.startsWith('linear-gradient');
+		const isBackgroundGradient = backgroundColor && backgroundColor.startsWith('linear-gradient');
 
-		const animationSet = Array.create(android.animation.Animator, backgroundIsGradient ? 6 : 7);
+		const animationSet = Array.create(android.animation.Animator, isBackgroundGradient ? 6 : 7);
 		animationSet[0] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'translationX', [shadeCoverAnimation.translateX]);
 		animationSet[1] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'translationY', [shadeCoverAnimation.translateY]);
 		animationSet[2] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'scaleX', [shadeCoverAnimation.scaleX]);
@@ -88,7 +88,7 @@ export class RootLayout extends RootLayoutBase {
 		animationSet[4] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'rotation', [shadeCoverAnimation.rotate]);
 		animationSet[5] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'alpha', [shadeCoverAnimation.opacity]);
 
-		if (backgroundIsGradient) {
+		if (isBackgroundGradient) {
 			if (view.backgroundColor) {
 				view.backgroundColor = undefined;
 			}
@@ -105,8 +105,9 @@ export class RootLayout extends RootLayoutBase {
 
 	private _getBackgroundColorAnimator(view: View, backgroundColor: string): android.animation.ValueAnimator {
 		const nativeArray = Array.create(java.lang.Object, 2);
-		nativeArray[0] = view.backgroundColor ? java.lang.Integer.valueOf((<Color>view.backgroundColor).argb) : java.lang.Integer.valueOf(-1);
-		nativeArray[1] = java.lang.Integer.valueOf(new Color(backgroundColor).argb);
+
+		nativeArray[0] = java.lang.Integer.valueOf(view.backgroundColor ? (<Color>view.backgroundColor).argb : -1);
+		nativeArray[1] = java.lang.Integer.valueOf(backgroundColor ? new Color(backgroundColor).argb : -1);
 		const backgroundColorAnimator = android.animation.ValueAnimator.ofObject(new android.animation.ArgbEvaluator(), nativeArray);
 		backgroundColorAnimator.addUpdateListener(
 			new android.animation.ValueAnimator.AnimatorUpdateListener({
@@ -114,7 +115,7 @@ export class RootLayout extends RootLayoutBase {
 					const argb = (<java.lang.Integer>animator.getAnimatedValue()).intValue();
 					view.backgroundColor = new Color(argb);
 				},
-			})
+			}),
 		);
 		return backgroundColorAnimator;
 	}
@@ -132,7 +133,7 @@ export class RootLayout extends RootLayoutBase {
 					},
 					onAnimationRepeat: function (animator: android.animation.Animator): void {},
 					onAnimationCancel: function (animator: android.animation.Animator): void {},
-				})
+				}),
 			);
 			animatorSet.start();
 		});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When Android RootLayout shade cover color is null, it results in unhandled exception.

## What is the new behavior?
Added null checks for android shade cover color.