### PR TITLE
perf(core): Avoid setting the same value to view properties

### DIFF
--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -721,25 +721,40 @@ export class CssState {
 				cssExpsProperties[property] = value;
 				continue;
 			}
-			delete oldProperties[property];
-			if (property in oldProperties && oldProperties[property] === value) {
-				// Skip unchanged values
-				continue;
+
+			if (property in oldProperties) {
+				const oldValue = oldProperties[property];
+
+				delete oldProperties[property];
+
+				if (oldValue === value) {
+					// Skip unchanged values
+					continue;
+				}
 			}
+
 			if (isCssVariable(property)) {
 				view.style.setScopedCssVariable(property, value);
 				delete newPropertyValues[property];
 				continue;
 			}
+
 			valuesToApply[property] = value;
 		}
-		//we need to parse CSS vars first before evaluating css expressions
+
+		// we need to parse CSS vars first before evaluating css expressions
 		for (const property in cssExpsProperties) {
-			delete oldProperties[property];
 			const value = evaluateCssExpressions(view, property, cssExpsProperties[property]);
-			if (property in oldProperties && oldProperties[property] === value) {
-				// Skip unchanged values
-				continue;
+
+			if (property in oldProperties) {
+				const oldValue = oldProperties[property];
+
+				delete oldProperties[property];
+
+				if (oldValue === value) {
+					// Skip unchanged values
+					continue;
+				}
 			}
 			if (value === unsetValue) {
 				delete newPropertyValues[property];
@@ -761,9 +776,11 @@ export class CssState {
 				view[camelCasedProperty] = unsetValue;
 			}
 		}
+
 		// Set new values to the style
 		for (const property in valuesToApply) {
 			const value = valuesToApply[property];
+
 			try {
 				if (property in view.style) {
 					view.style[`css:${property}`] = value;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
It seems we have 2 portions of dead code when setting view property values.

Sample:
```js
delete oldProperties[property];
if (property in oldProperties && oldProperties[property] === value) {
	// Skip unchanged values
	continue;
}
```

This ends up with a dead if block and core will attempt to re-apply the same values to view properties.
Even though this is getting caught in Observable, we do one more additional check even though it's always going to be `false`.

## What is the new behavior?
This PR corrects property set behaviour and deletes property from list once its existence has been confirmed, enabling core to proceed to value check.
This is trivial, yet it keeps code cleaner and functional.