### PR TITLE
fix(ios): Proper cleanup of reused listview cell content

### DIFF
--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -460,8 +460,9 @@ export class ListView extends ListViewBase {
 			if (!cell.view) {
 				cell.owner = new WeakRef(view);
 			} else if (cell.view !== view) {
+				// Remove view from super view now as nativeViewProtected will be null afterwards
+				(<UIView>cell.view.nativeViewProtected)?.removeFromSuperview();
 				this._removeContainer(cell);
-				(<UIView>cell.view?.nativeViewProtected)?.removeFromSuperview();
 				cell.owner = new WeakRef(view);
 			}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When using iOS ListView with `itemLoading` event and always pass a new cell view, there's a chance that cell will keep both old (reusable) and new view resulting in duplicate content.

## What is the new behavior?
By removing old native view at the right time, we avoid content duplication.

Fixes the problem we tried to solve in #10001