### PR TITLE
ref(ios): Update deprecated UIGraphics API

### DIFF
--- a/packages/core/platforms/ios/src/NativeScriptUtils.m
+++ b/packages/core/platforms/ios/src/NativeScriptUtils.m
@@ -114,10 +114,15 @@
 +(UIImage*)scaleImage:(UIImage*)image width:(CGFloat)width height:(CGFloat)height scaleFactor:(CGFloat)scaleFactor {
     UIImage *resultImage;
     @autoreleasepool {
-        UIGraphicsBeginImageContextWithOptions(CGSizeMake(width, height), NO, scaleFactor);
-        [image drawInRect:CGRectMake(0, 0, width, height)];
-        resultImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
+        UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+        format.scale = scaleFactor;
+        format.opaque = NO;
+
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(width, height) format:format];
+
+        resultImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
+            [image drawInRect:CGRectMake(0, 0, width, height)];
+        }];
     }
     return resultImage;
 }

--- a/packages/core/utils/ios/index.ts
+++ b/packages/core/utils/ios/index.ts
@@ -215,10 +215,17 @@ export function snapshotView(view: UIView, scale: number): UIImage {
 	// console.log('snapshotView view.frame:', printRect(view.frame));
 	const originalOpacity = view.layer.opacity;
 	view.layer.opacity = originalOpacity > 0 ? originalOpacity : 1;
-	UIGraphicsBeginImageContextWithOptions(CGSizeMake(view.frame.size.width, view.frame.size.height), false, scale);
-	view.layer.renderInContext(UIGraphicsGetCurrentContext());
-	const image = UIGraphicsGetImageFromCurrentImageContext();
-	UIGraphicsEndImageContext();
+
+	const size = CGSizeMake(view.frame.size.width, view.frame.size.height);
+	const rendererFormat = UIGraphicsImageRendererFormat.defaultFormat();
+	rendererFormat.scale = scale;
+
+	const renderer = UIGraphicsImageRenderer.alloc().initWithSizeFormat(size, rendererFormat);
+	const image = renderer.imageWithActions((context: UIGraphicsRendererContext) => {
+		const ctx = context.CGContext;
+		view.layer.renderInContext(ctx);
+	});
+
 	setTimeout(() => {
 		// ensure set back properly on next tick
 		view.layer.opacity = originalOpacity;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Core uses some UIGraphics functions that got deprecated in iOS 17.

More specifically:
- [UIGraphicsBeginImageContextWithOptions](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho?language=objc)
- [UIGraphicsGetImageFromCurrentImageContext](https://developer.apple.com/documentation/uikit/1623924-uigraphicsgetimagefromcurrentima?language=objc)
- [UIGraphicsEndImageContext](https://developer.apple.com/documentation/uikit/1623933-uigraphicsendimagecontext?language=objc)

## What is the new behavior?
Replaced all deprecated image graphics functions with [UIGraphicsImageRenderer](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer?language=objc) API.
This API is supported by iOS 10 and later devices.