### PR TITLE
feat(core): Added css class for styling dialog nested elements

### DIFF
--- a/packages/core/ui/dialogs/dialogs-common.ts
+++ b/packages/core/ui/dialogs/dialogs-common.ts
@@ -3,6 +3,7 @@ import { View } from '../core/view';
 import { Color } from '../../color';
 import { Page } from '../page';
 import { Frame } from '../frame';
+import { CSSUtils } from '../../css/system-classes';
 import { isObject, isString } from '../../utils/types';
 
 export namespace DialogStrings {
@@ -14,6 +15,8 @@ export namespace DialogStrings {
 	export const OK = 'OK';
 	export const CANCEL = 'Cancel';
 }
+
+const CSS_CLASS = `${CSSUtils.CLASS_PREFIX}dialog-item`;
 
 /**
  * Provides options for the dialog.
@@ -271,6 +274,7 @@ export function getButtonColors(): { color: Color; backgroundColor: Color } {
 	if (!button) {
 		const Button = require('../button').Button;
 		button = new Button();
+		button.className = CSS_CLASS;
 		if (__APPLE__) {
 			button._setupUI(<any>{});
 		}
@@ -290,6 +294,7 @@ export function getLabelColor(): Color {
 	if (!label) {
 		const Label = require('../label').Label;
 		label = new Label();
+		label.className = CSS_CLASS;
 		if (__APPLE__) {
 			label._setupUI(<any>{});
 		}
@@ -307,6 +312,7 @@ export function getTextFieldColor(): Color {
 	if (!textField) {
 		const TextField = require('../text-field').TextField;
 		textField = new TextField();
+		textField.className = CSS_CLASS;
 		if (__APPLE__) {
 			textField._setupUI(<any>{});
 		}

--- a/packages/core/ui/dialogs/dialogs-common.ts
+++ b/packages/core/ui/dialogs/dialogs-common.ts
@@ -6,6 +6,8 @@ import { Frame } from '../frame';
 import { CSSUtils } from '../../css/system-classes';
 import { isObject, isString } from '../../utils/types';
 
+const CSS_CLASS = `${CSSUtils.CLASS_PREFIX}dialog-item`;
+
 export namespace DialogStrings {
 	export const STRING = 'string';
 	export const PROMPT = 'Prompt';
@@ -15,8 +17,6 @@ export namespace DialogStrings {
 	export const OK = 'OK';
 	export const CANCEL = 'Cancel';
 }
-
-const CSS_CLASS = `${CSSUtils.CLASS_PREFIX}dialog-item`;
 
 /**
  * Provides options for the dialog.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Ever since #10201, Dialog buttons, labels, and inputs are affected by global scope CSS. That brings the drawback of not being able to style the dialog specifically. One good example example, some apps ended up with light-colored text not being distinct in light-mode Dialogs because of how these apps were styled in global scope.

## What is the new behavior?
Added `ns-dialog-item` css class to style nested dialog views.

Sample:
```css
Label {
  color: #fff;
}

Label.ns-dialog-item {
  color: #000;
}
```