### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/apps_automated_ios.yml
+++ b/.github/workflows/apps_automated_ios.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test-ios:
-    runs-on: flyci-macos-14-m2
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).