### PR TITLE
fix: popover delegate should ignore non-native views

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -1002,7 +1002,11 @@ export class View extends ViewCommon implements ViewDefinition {
 		const popoverPresentationController = controller.popoverPresentationController;
 		this._popoverPresentationDelegate = IOSHelper.UIPopoverPresentationControllerDelegateImp.initWithOwnerAndCallback(new WeakRef(this), this._closeModalCallback);
 		popoverPresentationController.delegate = <UIPopoverPresentationControllerDelegate>this._popoverPresentationDelegate;
-		const view = parent.nativeViewProtected;
+		let view: UIView;
+		do {
+			view = parent.nativeViewProtected;
+			parent = parent.parent as View;
+		} while (parent && !view);
 		// Note: sourceView and sourceRect are needed to specify the anchor location for the popover.
 		// Note: sourceView should be the button triggering the modal. If it the Page the popover might appear "behind" the page content
 		popoverPresentationController.sourceView = view;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When opening a popover modal inside a "Proxy" view (like angular's ProxyViewContainer), the popover will fail to open with an error since the parent view has no native view.

## What is the new behavior?
We now loop over parents until we find a valid view.
