### PR TITLE
feat: allow the passing of a bundle suffix

### DIFF
--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -132,6 +132,10 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		.globalObject('global')
 		.set('clean', true);
 
+	if (env?.uniqueBundle) {
+		config.output.filename(`[name].${env.uniqueBundle}.js`);
+	}
+
 	config.watchOptions({
 		ignored: [
 			`${getProjectFilePath(env.buildPath ?? 'platforms')}/**`,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

This adds a new flag `env.uniqueBundle` which will be appended as a suffix to generated bundle names.

The cli then uses this id to set the main entry in the package.json in the resulting app.

There is a corresponding `nativescript-cli` PR [5814](https://github.com/NativeScript/nativescript-cli/pull/5814)


## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

