### PR TITLE
fix(ios): replace depreciated UIApplication.shared.openUrl method call

### DIFF
--- a/packages/core/utils/index.ios.ts
+++ b/packages/core/utils/index.ios.ts
@@ -1,5 +1,5 @@
 import { Trace } from '../trace';
-import { ios as iOSUtils } from './native-helper';
+import { dataSerialize, ios as iOSUtils } from './native-helper';
 
 export { clearInterval, clearTimeout, setInterval, setTimeout } from '../timer';
 export * from './common';
@@ -39,7 +39,8 @@ export function openUrl(location: string): boolean {
 	try {
 		const url = NSURL.URLWithString(location.trim());
 		if (UIApplication.sharedApplication.canOpenURL(url)) {
-			return UIApplication.sharedApplication.openURL(url);
+			UIApplication.sharedApplication.openURLOptionsCompletionHandler(url, dataSerialize({}), null);
+			return true;
 		}
 	} catch (e) {
 		// We Don't do anything with an error.  We just output it


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Calls to `Utils.openUrl` do not do anything if the app is compiled with XCode 16.

## What is the new behavior?
<!-- Describe the changes. -->

`UIApplication.shared.openUrl` is [depreciated](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl?language=objc), replaced with call to `openURL:options:completionHandler`



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

