### PR TITLE
fix(core): Proper line-height calculation

### DIFF
--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -26,7 +26,8 @@
     BOOL isTextView = [self isKindOfClass:[UITextView class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.lineSpacing = lineHeight;
+        // Note: Avoid using lineSpacing as it will append the height as extra space
+        paragraphStyle.minimumLineHeight = lineHeight;
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
@@ -88,7 +89,8 @@
     BOOL isLabel = [self isKindOfClass:[UILabel class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.lineSpacing = lineHeight;
+        // Note: Avoid using lineSpacing as it will append the height as extra space
+        paragraphStyle.minimumLineHeight = lineHeight;
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;

--- a/packages/core/ui/styling/style-properties.d.ts
+++ b/packages/core/ui/styling/style-properties.d.ts
@@ -77,7 +77,6 @@ export const minWidthProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.Leng
 export const minHeightProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.LengthDipUnit | CoreTypes.LengthPxUnit>;
 export const widthProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
 export const heightProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
-export const lineHeightProperty: CssProperty<Style, number>;
 export const marginProperty: ShorthandProperty<Style, string | CoreTypes.PercentLengthType>;
 export const marginLeftProperty: CssProperty<Style, CoreTypes.PercentLengthType>;
 export const marginRightProperty: CssProperty<Style, CoreTypes.PercentLengthType>;

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -374,10 +374,20 @@ export class TextBase extends TextBaseCommon {
 	}
 
 	[lineHeightProperty.getDefault](): number {
-		return this.nativeTextViewProtected.getLineSpacingExtra() / layout.getDisplayDensity();
+		return this.nativeTextViewProtected.getLineHeight() / layout.getDisplayDensity();
 	}
 	[lineHeightProperty.setNative](value: number) {
-		this.nativeTextViewProtected.setLineSpacing(value * layout.getDisplayDensity(), 1);
+		const dpValue = value * layout.getDisplayDensity();
+
+		if (SDK_VERSION >= 28) {
+			this.nativeTextViewProtected.setLineHeight(dpValue);
+		} else {
+			const fontHeight = this.nativeTextViewProtected.getPaint().getFontMetricsInt(null);
+			// Actual line spacing is the diff of line height and font height
+			const lineSpacing = Math.max(dpValue - fontHeight, 0);
+
+			this.nativeTextViewProtected.setLineSpacing(lineSpacing, 1);
+		}
 	}
 
 	[fontInternalProperty.getDefault](): android.graphics.Typeface {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Line height value seems to be applied on texts as spacing.

## What is the new behavior?
Line height value will be applied on texts as height of the line box.

This feature seems to be prone to breaking frequently so I made sure to include comments.
The correct behavior was implemented in #8257, although the value was being miscalculated on the android side resulting in #8751.

Fixes #9830 #10641.

