### PR TITLE
fix(core): Frame ignored event listeners in xml markup

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -35,7 +35,8 @@ function buildEntryFromArgs(arg: any): NavigationEntry {
 
 @CSSType('Frame')
 export class FrameBase extends CustomLayoutView {
-	public static androidOptionSelectedEvent = 'optionSelected';
+	public static navigatingToEvent = 'navigatingTo';
+	public static navigatedToEvent = 'navigatedTo';
 
 	private _animated: boolean;
 	private _transition: NavigationTransition;
@@ -267,7 +268,7 @@ export class FrameBase extends CustomLayoutView {
 
 		newPage.onNavigatedTo(isBack);
 		this.notify({
-			eventName: Page.navigatedToEvent,
+			eventName: FrameBase.navigatedToEvent,
 			object: this,
 			isBack,
 			entry,
@@ -452,7 +453,7 @@ export class FrameBase extends CustomLayoutView {
 
 		backstackEntry.resolvedPage.onNavigatingTo(backstackEntry.entry.context, isBack, backstackEntry.entry.bindingContext);
 		this.notify({
-			eventName: Page.navigatingToEvent,
+			eventName: FrameBase.navigatingToEvent,
 			object: this,
 			isBack,
 			entry: backstackEntry,

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -18,6 +18,16 @@ export interface NavigationData extends EventData {
  */
 export class Frame extends FrameBase {
 	/**
+	 * String value used when hooking to navigatingTo event.
+	 */
+	public static readonly navigatingToEvent = 'navigatingTo';
+
+	/**
+	 * String value used when hooking to navigatedTo event.
+	 */
+	public static readonly navigatedToEvent = 'navigatedTo';
+
+	/**
 	 * @private
 	 */
 	_originalBackground?: any;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Frame ignores listeners defined in xml markup

## What is the new behavior?
Frame will now register listeners defined in xml markup.
This PR also removes an `androidOptionSelectedEvent` property which was garbage from an old PR.