### PR TITLE
Revert "fix(core): Proper line-height calculation"

### DIFF
--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -26,8 +26,7 @@
     BOOL isTextView = [self isKindOfClass:[UITextView class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        // Note: Avoid using lineSpacing as it will append the height as extra space
-        paragraphStyle.minimumLineHeight = lineHeight;
+        paragraphStyle.lineSpacing = lineHeight;
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
@@ -89,8 +88,7 @@
     BOOL isLabel = [self isKindOfClass:[UILabel class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        // Note: Avoid using lineSpacing as it will append the height as extra space
-        paragraphStyle.minimumLineHeight = lineHeight;
+        paragraphStyle.lineSpacing = lineHeight;
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;

--- a/packages/core/ui/styling/style-properties.d.ts
+++ b/packages/core/ui/styling/style-properties.d.ts
@@ -77,6 +77,7 @@ export const minWidthProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.Leng
 export const minHeightProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.LengthDipUnit | CoreTypes.LengthPxUnit>;
 export const widthProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
 export const heightProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
+export const lineHeightProperty: CssProperty<Style, number>;
 export const marginProperty: ShorthandProperty<Style, string | CoreTypes.PercentLengthType>;
 export const marginLeftProperty: CssProperty<Style, CoreTypes.PercentLengthType>;
 export const marginRightProperty: CssProperty<Style, CoreTypes.PercentLengthType>;

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -374,20 +374,10 @@ export class TextBase extends TextBaseCommon {
 	}
 
 	[lineHeightProperty.getDefault](): number {
-		return this.nativeTextViewProtected.getLineHeight() / layout.getDisplayDensity();
+		return this.nativeTextViewProtected.getLineSpacingExtra() / layout.getDisplayDensity();
 	}
 	[lineHeightProperty.setNative](value: number) {
-		const dpValue = value * layout.getDisplayDensity();
-
-		if (SDK_VERSION >= 28) {
-			this.nativeTextViewProtected.setLineHeight(dpValue);
-		} else {
-			const fontHeight = this.nativeTextViewProtected.getPaint().getFontMetricsInt(null);
-			// Actual line spacing is the diff of line height and font height
-			const lineSpacing = Math.max(dpValue - fontHeight, 0);
-
-			this.nativeTextViewProtected.setLineSpacing(lineSpacing, 1);
-		}
+		this.nativeTextViewProtected.setLineSpacing(value * layout.getDisplayDensity(), 1);
 	}
 
 	[fontInternalProperty.getDefault](): android.graphics.Typeface {


### PR DESCRIPTION
Reverts NativeScript/NativeScript#10642

@NathanWalker I revert these changes because due to a weird line height behavior on iOS.
I'm preparing a new PR with typography improvements that will include a better version of these changes.

Note: Additionally, css `line-height` accepts multipliers so the original {N} approach might be the most recommended approach.