### PR TITLE
feat(core): Typography improvements

### DIFF
--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -30,16 +30,8 @@
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
-
-            if (((UIButton*)self).titleLabel.font) {
-                paragraphStyle.lineSpacing = lineHeight - ((UIButton*)self).titleLabel.font.lineHeight;
-            }
         } else {
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
-
-            if (((UILabel*)self).font) {
-                paragraphStyle.lineSpacing = lineHeight - ((UILabel*)self).font.lineHeight;
-            }
         }
         
         if ([self isKindOfClass:[UILabel class]]) {
@@ -100,17 +92,9 @@
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
-
-            if (((UIButton*)self).titleLabel.font) {
-                paragraphStyle.lineSpacing = lineHeight - ((UIButton*)self).titleLabel.font.lineHeight;
-            }
         } else {
             // Paragraph alignment is also important for tappable spans as NSTextContainer takes it into account
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
-
-            if (((UILabel*)self).font) {
-                paragraphStyle.lineSpacing = lineHeight - ((UILabel*)self).font.lineHeight;
-            }
         }
         
         if (isLabel) {

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -15,8 +15,8 @@
     }
     BOOL isTextType = [self isKindOfClass:[UITextField class]] || [self isKindOfClass:[UITextView class]] | [self isKindOfClass:[UILabel class]] | [self isKindOfClass:[UIButton class]];
     
-    if (letterSpacing != 0 && isTextType) {
-        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing];
+    if (letterSpacing != 0 && isTextType && ((UITextView*)self).font != nil) {
+        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
         attrDict[NSKernAttributeName] = kern;
         if ([self isKindOfClass:[UITextField class]]) {
             [((UITextField*)self).defaultTextAttributes setValue:kern forKey:NSKernAttributeName];
@@ -31,13 +31,13 @@
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
 
-            if (((UIButton*)self).titleLabel.font) {
+            if (((UIButton*)self).titleLabel.font != nil) {
                 paragraphStyle.lineSpacing = fmax(lineHeight - ((UIButton*)self).titleLabel.font.lineHeight, 0);
             }
         } else {
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
 
-            if (((UILabel*)self).font) {
+            if (((UILabel*)self).font != nil) {
                 paragraphStyle.lineSpacing = fmax(lineHeight - ((UILabel*)self).font.lineHeight, 0);
             }
         }
@@ -86,7 +86,7 @@
 -(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details letterSpacing:(CGFloat)letterSpacing lineHeight:(CGFloat)lineHeight {
     NSMutableAttributedString *attrText = [NativeScriptUtils createMutableStringWithDetails:details];
     if (letterSpacing != 0) {
-        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing];
+        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
         [attrText addAttribute:NSKernAttributeName value:kern range:(NSRange){
             0,
             attrText.length
@@ -101,14 +101,14 @@
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
 
-            if (((UIButton*)self).titleLabel.font) {
+            if (((UIButton*)self).titleLabel.font != nil) {
                 paragraphStyle.lineSpacing = fmax(lineHeight - ((UIButton*)self).titleLabel.font.lineHeight, 0);
             }
         } else {
             // Paragraph alignment is also important for tappable spans as NSTextContainer takes it into account
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
 
-            if (((UILabel*)self).font) {
+            if (((UILabel*)self).font != nil) {
                 paragraphStyle.lineSpacing = fmax(lineHeight - ((UILabel*)self).font.lineHeight, 0);
             }
         }

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -37,7 +37,8 @@
     }
     
     BOOL isTextView = [self isKindOfClass:[UITextView class]];
-    if (lineHeight > 0) {
+    // TODO: Find a good alternative of lineSpacing that works well with layout as it doesn't accept values less than the standard height
+    if (lineHeight >= 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
 
         // make sure a possible previously set text alignment setting is not lost when line height is specified
@@ -114,7 +115,8 @@
     }
     
     BOOL isLabel = [self isKindOfClass:[UILabel class]];
-    if (lineHeight > 0) {
+    // TODO: Find a good alternative of lineSpacing that works well with layout as it doesn't accept values less than the standard height
+    if (lineHeight >= 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
 
         // make sure a possible previously set text alignment setting is not lost when line height is specified

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -26,12 +26,20 @@
     BOOL isTextView = [self isKindOfClass:[UITextView class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.lineSpacing = lineHeight;
+
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
+
+            if (((UIButton*)self).titleLabel.font) {
+                paragraphStyle.lineSpacing = fmax(lineHeight - ((UIButton*)self).titleLabel.font.lineHeight, 0);
+            }
         } else {
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
+
+            if (((UILabel*)self).font) {
+                paragraphStyle.lineSpacing = fmax(lineHeight - ((UILabel*)self).font.lineHeight, 0);
+            }
         }
         
         if ([self isKindOfClass:[UILabel class]]) {
@@ -88,13 +96,21 @@
     BOOL isLabel = [self isKindOfClass:[UILabel class]];
     if (lineHeight > 0) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.lineSpacing = lineHeight;
+
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
+
+            if (((UIButton*)self).titleLabel.font) {
+                paragraphStyle.lineSpacing = fmax(lineHeight - ((UIButton*)self).titleLabel.font.lineHeight, 0);
+            }
         } else {
             // Paragraph alignment is also important for tappable spans as NSTextContainer takes it into account
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
+
+            if (((UILabel*)self).font) {
+                paragraphStyle.lineSpacing = fmax(lineHeight - ((UILabel*)self).font.lineHeight, 0);
+            }
         }
         
         if (isLabel) {

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -15,8 +15,8 @@
     }
     BOOL isTextType = [self isKindOfClass:[UITextField class]] || [self isKindOfClass:[UITextView class]] | [self isKindOfClass:[UILabel class]] | [self isKindOfClass:[UIButton class]];
     
-    if (letterSpacing != 0 && isTextType && ((UITextView*)self).font != nil) {
-        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
+    if (letterSpacing != 0 && isTextType) {
+        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing];
         attrDict[NSKernAttributeName] = kern;
         if ([self isKindOfClass:[UITextField class]]) {
             [((UITextField*)self).defaultTextAttributes setValue:kern forKey:NSKernAttributeName];
@@ -30,8 +30,16 @@
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
+
+            if (((UIButton*)self).titleLabel.font) {
+                paragraphStyle.lineSpacing = lineHeight - ((UIButton*)self).titleLabel.font.lineHeight;
+            }
         } else {
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
+
+            if (((UILabel*)self).font) {
+                paragraphStyle.lineSpacing = lineHeight - ((UILabel*)self).font.lineHeight;
+            }
         }
         
         if ([self isKindOfClass:[UILabel class]]) {
@@ -78,7 +86,7 @@
 -(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details letterSpacing:(CGFloat)letterSpacing lineHeight:(CGFloat)lineHeight {
     NSMutableAttributedString *attrText = [NativeScriptUtils createMutableStringWithDetails:details];
     if (letterSpacing != 0) {
-        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
+        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing];
         [attrText addAttribute:NSKernAttributeName value:kern range:(NSRange){
             0,
             attrText.length
@@ -92,9 +100,17 @@
         // make sure a possible previously set text alignment setting is not lost when line height is specified
         if ([self isKindOfClass:[UIButton class]]) {
             paragraphStyle.alignment = ((UIButton*)self).titleLabel.textAlignment;
+
+            if (((UIButton*)self).titleLabel.font) {
+                paragraphStyle.lineSpacing = lineHeight - ((UIButton*)self).titleLabel.font.lineHeight;
+            }
         } else {
             // Paragraph alignment is also important for tappable spans as NSTextContainer takes it into account
             paragraphStyle.alignment = ((UILabel*)self).textAlignment;
+
+            if (((UILabel*)self).font) {
+                paragraphStyle.lineSpacing = lineHeight - ((UILabel*)self).font.lineHeight;
+            }
         }
         
         if (isLabel) {

--- a/packages/core/platforms/ios/src/UIView+NativeScript.m
+++ b/packages/core/platforms/ios/src/UIView+NativeScript.m
@@ -15,11 +15,24 @@
     }
     BOOL isTextType = [self isKindOfClass:[UITextField class]] || [self isKindOfClass:[UITextView class]] | [self isKindOfClass:[UILabel class]] | [self isKindOfClass:[UIButton class]];
     
-    if (letterSpacing != 0 && isTextType && ((UITextView*)self).font != nil) {
-        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
-        attrDict[NSKernAttributeName] = kern;
-        if ([self isKindOfClass:[UITextField class]]) {
-            [((UITextField*)self).defaultTextAttributes setValue:kern forKey:NSKernAttributeName];
+    if (letterSpacing != 0 && isTextType) {
+        NSNumber *kern = nil;
+
+        if ([self isKindOfClass:[UIButton class]]) {
+            if (((UIButton*)self).titleLabel.font != nil) {
+                kern = [NSNumber numberWithDouble:letterSpacing * ((UIButton*)self).titleLabel.font.pointSize];
+            }
+        } else {
+            if (((UITextView*)self).font != nil) {
+                kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
+            }
+        }
+
+        if (kern != nil) {
+            attrDict[NSKernAttributeName] = kern;
+            if ([self isKindOfClass:[UITextField class]]) {
+                [((UITextField*)self).defaultTextAttributes setValue:kern forKey:NSKernAttributeName];
+            }
         }
     }
     
@@ -86,7 +99,14 @@
 -(void)nativeScriptSetFormattedTextDecorationAndTransform:(NSDictionary*)details letterSpacing:(CGFloat)letterSpacing lineHeight:(CGFloat)lineHeight {
     NSMutableAttributedString *attrText = [NativeScriptUtils createMutableStringWithDetails:details];
     if (letterSpacing != 0) {
-        NSNumber *kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
+        NSNumber *kern = nil;
+
+        if ([self isKindOfClass:[UIButton class]]) {
+            kern = [NSNumber numberWithDouble:letterSpacing * ((UIButton*)self).titleLabel.font.pointSize];
+        } else {
+            kern = [NSNumber numberWithDouble:letterSpacing * ((UITextView*)self).font.pointSize];
+        }
+
         [attrText addAttribute:NSKernAttributeName value:kern range:(NSRange){
             0,
             attrText.length

--- a/packages/core/ui/html-view/index.android.ts
+++ b/packages/core/ui/html-view/index.android.ts
@@ -1,4 +1,5 @@
 ﻿import { Color } from '../../color';
+import { layout } from '../../utils';
 import { SDK_VERSION } from '../../utils/constants';
 import { Font } from '../styling/font';
 import { colorProperty, fontSizeProperty, fontInternalProperty } from '../styling/style-properties';
@@ -86,14 +87,10 @@ export class HtmlView extends HtmlViewBase {
 		this.nativeViewProtected.setTypeface(font);
 	}
 
-	[fontSizeProperty.getDefault](): { nativeSize: number } {
-		return { nativeSize: this.nativeViewProtected.getTextSize() };
+	[fontSizeProperty.getDefault](): number {
+		return this.nativeViewProtected.getTextSize() / layout.getDisplayDensity();
 	}
-	[fontSizeProperty.setNative](value: number | { nativeSize: number }) {
-		if (typeof value === 'number') {
-			this.nativeViewProtected.setTextSize(value);
-		} else {
-			this.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
-		}
+	[fontSizeProperty.setNative](value: number) {
+		this.nativeViewProtected.setTextSize(value);
 	}
 }

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -71,7 +71,7 @@ export { CSSHelper } from './styling/css-selector';
 
 export { Switch } from './switch';
 export { TabView, TabViewItem } from './tab-view';
-export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, textStrokeProperty, whiteSpaceProperty, textOverflowProperty, lineHeightProperty } from './text-base';
+export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, textStrokeProperty, whiteSpaceProperty, textOverflowProperty } from './text-base';
 export { FormattedString } from './text-base/formatted-string';
 export { Span } from './text-base/span';
 export { TextField } from './text-field';

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -71,7 +71,7 @@ export { CSSHelper } from './styling/css-selector';
 
 export { Switch } from './switch';
 export { TabView, TabViewItem } from './tab-view';
-export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, textStrokeProperty, whiteSpaceProperty, textOverflowProperty } from './text-base';
+export { TextBase, getTransformedText, letterSpacingProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty, textShadowProperty, textStrokeProperty, whiteSpaceProperty, textOverflowProperty, lineHeightProperty } from './text-base';
 export { FormattedString } from './text-base/formatted-string';
 export { Span } from './text-base/span';
 export { TextField } from './text-field';

--- a/packages/core/ui/search-bar/index.android.ts
+++ b/packages/core/ui/search-bar/index.android.ts
@@ -1,7 +1,7 @@
 import { Font } from '../styling/font';
 import { SearchBarBase, textProperty, hintProperty, textFieldHintColorProperty, textFieldBackgroundColorProperty } from './search-bar-common';
 import { isUserInteractionEnabledProperty, isEnabledProperty } from '../core/view';
-import { ad } from '../../utils';
+import { ad, layout } from '../../utils';
 import { Color } from '../../color';
 import { colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty, fontSizeProperty } from '../styling/style-properties';
 
@@ -199,15 +199,11 @@ export class SearchBar extends SearchBarBase {
 		textView.setTextColor(color);
 	}
 
-	[fontSizeProperty.getDefault](): { nativeSize: number } {
-		return { nativeSize: this._getTextView().getTextSize() };
+	[fontSizeProperty.getDefault](): number {
+		return this._getTextView().getTextSize() / layout.getDisplayDensity();
 	}
-	[fontSizeProperty.setNative](value: number | { nativeSize: number }) {
-		if (typeof value === 'number') {
-			this._getTextView().setTextSize(value);
-		} else {
-			this._getTextView().setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
-		}
+	[fontSizeProperty.setNative](value: number) {
+		this._getTextView().setTextSize(value);
 	}
 
 	[fontInternalProperty.getDefault](): android.graphics.Typeface {

--- a/packages/core/ui/segmented-bar/index.android.ts
+++ b/packages/core/ui/segmented-bar/index.android.ts
@@ -140,15 +140,11 @@ export class SegmentedBarItem extends SegmentedBarItemBase {
 		this.nativeViewProtected.setTextColor(color);
 	}
 
-	[fontSizeProperty.getDefault](): { nativeSize: number } {
-		return { nativeSize: this.nativeViewProtected.getTextSize() };
+	[fontSizeProperty.getDefault](): number {
+		return this.nativeViewProtected.getTextSize() / layout.getDisplayDensity();
 	}
-	[fontSizeProperty.setNative](value: number | { nativeSize: number }) {
-		if (typeof value === 'number') {
-			this.nativeViewProtected.setTextSize(value);
-		} else {
-			this.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
-		}
+	[fontSizeProperty.setNative](value: number) {
+		this.nativeViewProtected.setTextSize(value);
 	}
 
 	[fontInternalProperty.getDefault](): android.graphics.Typeface {

--- a/packages/core/ui/styling/style-properties.d.ts
+++ b/packages/core/ui/styling/style-properties.d.ts
@@ -77,7 +77,6 @@ export const minWidthProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.Leng
 export const minHeightProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.LengthDipUnit | CoreTypes.LengthPxUnit>;
 export const widthProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
 export const heightProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
-export const lineHeightProperty: CssProperty<Style, number>;
 export const marginProperty: ShorthandProperty<Style, string | CoreTypes.PercentLengthType>;
 export const marginLeftProperty: CssProperty<Style, CoreTypes.PercentLengthType>;
 export const marginRightProperty: CssProperty<Style, CoreTypes.PercentLengthType>;

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -168,7 +168,7 @@ export class Style extends Observable implements StyleDefinition {
 	public visibility: CoreTypes.VisibilityType;
 
 	public letterSpacing: number;
-	public lineHeight: number;
+	public lineHeight: CoreTypes.PercentLengthType;
 	public textAlignment: CoreTypes.TextAlignmentType;
 	public textDecoration: CoreTypes.TextDecorationType;
 	public textTransform: CoreTypes.TextTransformType;

--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -392,15 +392,11 @@ export class TabViewItem extends TabViewItemBase {
 		return tabFragment.getChildFragmentManager();
 	}
 
-	[fontSizeProperty.getDefault](): { nativeSize: number } {
-		return { nativeSize: this.nativeViewProtected.getTextSize() };
+	[fontSizeProperty.getDefault](): number {
+		return this.nativeViewProtected.getTextSize() / layout.getDisplayDensity();
 	}
-	[fontSizeProperty.setNative](value: number | { nativeSize: number }) {
-		if (typeof value === 'number') {
-			this.nativeViewProtected.setTextSize(value);
-		} else {
-			this.nativeViewProtected.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, value.nativeSize);
-		}
+	[fontSizeProperty.setNative](value: number) {
+		this.nativeViewProtected.setTextSize(value);
 	}
 
 	[fontInternalProperty.getDefault](): android.graphics.Typeface {
@@ -494,7 +490,7 @@ export class TabView extends TabViewBase {
 				JSON.stringify([
 					{ value: 1, type: 0 /* org.nativescript.widgets.GridUnitType.auto */ },
 					{ value: 1, type: 2 /* org.nativescript.widgets.GridUnitType.star */ },
-				])
+				]),
 			);
 			viewPager.setLayoutParams(lp);
 
@@ -506,7 +502,7 @@ export class TabView extends TabViewBase {
 				JSON.stringify([
 					{ value: 1, type: 2 /* org.nativescript.widgets.GridUnitType.star */ },
 					{ value: 1, type: 0 /* org.nativescript.widgets.GridUnitType.auto */ },
-				])
+				]),
 			);
 			tabLayout.setLayoutParams(lp);
 			viewPager.setSwipePageEnabled(false);
@@ -771,12 +767,8 @@ export class TabView extends TabViewBase {
 	[tabTextFontSizeProperty.getDefault](): number {
 		return this._tabLayout.getTabTextFontSize();
 	}
-	[tabTextFontSizeProperty.setNative](value: number | { nativeSize: number }) {
-		if (typeof value === 'number') {
-			this._tabLayout.setTabTextFontSize(value);
-		} else {
-			this._tabLayout.setTabTextFontSize(value.nativeSize);
-		}
+	[tabTextFontSizeProperty.setNative](value: number) {
+		this._tabLayout.setTabTextFontSize(value);
 	}
 
 	[tabTextColorProperty.getDefault](): number {

--- a/packages/core/ui/tab-view/index.ios.ts
+++ b/packages/core/ui/tab-view/index.ios.ts
@@ -580,7 +580,7 @@ export class TabView extends TabViewBase {
 	[tabTextFontSizeProperty.getDefault](): number {
 		return null;
 	}
-	[tabTextFontSizeProperty.setNative](value: number | { nativeSize: number }) {
+	[tabTextFontSizeProperty.setNative](value: number) {
 		this._updateIOSTabBarColorsAndFonts();
 	}
 

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -365,11 +365,6 @@ export class TextBase extends TextBaseCommon {
 	[fontSizeProperty.setNative](value: number) {
 		if (!this.formattedText) {
 			this.nativeTextViewProtected.setTextSize(value);
-
-			// Re-calculate letter-spacing
-			if (this.letterSpacing != 0) {
-				this._updateLetterSpacing(this.letterSpacing);
-			}
 		}
 	}
 
@@ -451,10 +446,10 @@ export class TextBase extends TextBaseCommon {
 	}
 
 	[letterSpacingProperty.getDefault](): number {
-		return org.nativescript.widgets.ViewHelper.getLetterspacing(this.nativeTextViewProtected) * this.fontSize;
+		return org.nativescript.widgets.ViewHelper.getLetterspacing(this.nativeTextViewProtected);
 	}
 	[letterSpacingProperty.setNative](value: number) {
-		this._updateLetterSpacing(value);
+		org.nativescript.widgets.ViewHelper.setLetterspacing(this.nativeTextViewProtected, value);
 	}
 
 	[paddingTopProperty.getDefault](): CoreTypes.LengthType {
@@ -501,11 +496,6 @@ export class TextBase extends TextBaseCommon {
 			nativeTextViewProtected.setMaxLines(typeof value === 'string' ? parseInt(value, 10) : value);
 			nativeTextViewProtected.setEllipsize(android.text.TextUtils.TruncateAt.END);
 		}
-	}
-
-	_updateLetterSpacing(value: number): void {
-		const emValue = value / this.fontSize;
-		org.nativescript.widgets.ViewHelper.setLetterspacing(this.nativeTextViewProtected, emValue);
 	}
 
 	_setNativeText(reset = false): void {

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -367,14 +367,6 @@ export class TextBase extends TextBaseCommon {
 		if (!this.formattedText) {
 			this.nativeTextViewProtected.setTextSize(value);
 
-			// Re-calculate line-height
-			if (this.lineHeight != 0) {
-				// It's done automatically for API 28+
-				if (SDK_VERSION < 28) {
-					this._setLineHeightLegacy(this.lineHeight);
-				}
-			}
-
 			// Re-calculate letter-spacing
 			if (this.letterSpacing != 0) {
 				this._updateLetterSpacing(this.letterSpacing);
@@ -492,15 +484,6 @@ export class TextBase extends TextBaseCommon {
 			nativeTextViewProtected.setMaxLines(typeof value === 'string' ? parseInt(value, 10) : value);
 			nativeTextViewProtected.setEllipsize(android.text.TextUtils.TruncateAt.END);
 		}
-	}
-
-	_setLineHeightLegacy(value: number): void {
-		const dpValue = value * layout.getDisplayDensity();
-		const fontHeight = this.nativeTextViewProtected.getPaint().getFontMetricsInt(null);
-		// Actual line spacing is the diff of line height and font height
-		const lineSpacing = Math.max(dpValue - fontHeight, 0);
-
-		this.nativeTextViewProtected.setLineSpacing(lineSpacing, 1);
 	}
 
 	_updateLetterSpacing(value: number): void {

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -381,12 +381,12 @@ export class TextBase extends TextBaseCommon {
 			let finalValue: number;
 
 			if (typeof lengthType === 'number') {
-				finalValue = Length.toDevicePixels(lengthType, 0);
+				finalValue = Length.toDevicePixels(lengthType, -1);
 			} else if (lengthType.unit === '%') {
 				const fontHeight = this.nativeTextViewProtected.getPaint().getFontMetricsInt(null);
 				finalValue = lengthType.value * fontHeight;
 			} else {
-				finalValue = Length.toDevicePixels(lengthType, 0);
+				finalValue = Length.toDevicePixels(lengthType, -1);
 			}
 
 			// Method setLineHeight throws in case of a negative value

--- a/packages/core/ui/text-base/index.d.ts
+++ b/packages/core/ui/text-base/index.d.ts
@@ -50,7 +50,7 @@ export class TextBase extends View implements AddChildFromBuilder {
 	 *
 	 * @nsProperty
 	 */
-	lineHeight: number;
+	lineHeight: CoreTypes.PercentLengthType;
 
 	/**
 	 * Gets or sets text-alignment style property.
@@ -200,7 +200,7 @@ export const textStrokeProperty: CssProperty<Style, StrokeCSSValues>;
 export const whiteSpaceProperty: CssProperty<Style, CoreTypes.WhiteSpaceType>;
 export const textOverflowProperty: CssProperty<Style, CoreTypes.TextOverflowType>;
 export const letterSpacingProperty: CssProperty<Style, number>;
-export const lineHeightProperty: CssProperty<Style, number>;
+export const lineHeightProperty: CssProperty<Style, CoreTypes.PercentLengthType>;
 
 //Used by tab view
 export function getTransformedText(text: string, textTransform: CoreTypes.TextTransformType): string;

--- a/packages/core/ui/text-base/index.d.ts
+++ b/packages/core/ui/text-base/index.d.ts
@@ -200,7 +200,7 @@ export const textStrokeProperty: CssProperty<Style, StrokeCSSValues>;
 export const whiteSpaceProperty: CssProperty<Style, CoreTypes.WhiteSpaceType>;
 export const textOverflowProperty: CssProperty<Style, CoreTypes.TextOverflowType>;
 export const letterSpacingProperty: CssProperty<Style, number>;
-export const lineHeightProperty: CssProperty<Style, CoreTypes.PercentLengthType>;
+export const lineHeightProperty: InheritedCssProperty<Style, CoreTypes.PercentLengthType>;
 
 //Used by tab view
 export function getTransformedText(text: string, textTransform: CoreTypes.TextTransformType): string;

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -440,7 +440,7 @@ export class TextBase extends TextBaseCommon {
 		let lineHeight: number;
 
 		if (lengthType == null || typeof lengthType === 'string') {
-			lineHeight = fontHeight;
+			lineHeight = -1; // This indicates that line-height is normal
 		} else if (typeof lengthType === 'number') {
 			lineHeight = lengthType;
 		} else if (lengthType.unit === '%') {

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -259,7 +259,6 @@ export class TextBase extends TextBaseCommon {
 	[lineHeightProperty.getDefault](): CoreTypes.PercentLengthType {
 		const nativeTextView = this.nativeTextViewProtected;
 		const nativeFont = nativeTextView instanceof UIButton ? nativeTextView.titleLabel.font : nativeTextView.font;
-
 		return nativeFont?.lineHeight ?? 0;
 	}
 

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -256,7 +256,7 @@ export class TextBase extends TextBaseCommon {
 		this._setNativeText();
 	}
 
-	[lineHeightProperty.setNative](value: number) {
+	[lineHeightProperty.setNative](value: CoreTypes.PercentLengthType) {
 		this._setNativeText();
 	}
 
@@ -318,7 +318,8 @@ export class TextBase extends TextBaseCommon {
 			}
 
 			const letterSpacing = this.style.letterSpacing ? this.style.letterSpacing : 0;
-			const lineHeight = this.style.lineHeight ? this.style.lineHeight : 0;
+			const lineHeight = this._calculateLineHeight();
+
 			if (this.formattedText) {
 				this.nativeTextViewProtected.nativeScriptSetFormattedTextDecorationAndTransformLetterSpacingLineHeight(this.getFormattedStringDetails(this.formattedText) as any, letterSpacing, lineHeight);
 			} else {
@@ -330,6 +331,7 @@ export class TextBase extends TextBaseCommon {
 					this._setColor(UIColor.labelColor);
 				}
 			}
+
 			if (this.style?.textStroke) {
 				this.nativeTextViewProtected.nativeScriptSetFormattedTextStrokeColor(Length.toDevicePixels(this.style.textStroke.width, 0), this.style.textStroke.color.ios);
 			}
@@ -420,6 +422,23 @@ export class TextBase extends TextBaseCommon {
 		if (align === 'sub') {
 			return (font.descender - font.ascender) * 0.4;
 		}
+	}
+
+	private _calculateLineHeight(): number {
+		const lengthType = this.style.lineHeight;
+		const fontHeight = this.nativeTextViewProtected.font?.lineHeight || 0;
+
+		let lineHeight: number;
+
+		if (!lengthType) {
+			lineHeight = 0;
+		} else if (typeof lengthType !== 'number' && lengthType !== 'auto' && lengthType.unit === '%') {
+			lineHeight = lengthType.value * fontHeight;
+		} else {
+			lineHeight = layout.toDeviceIndependentPixels(Length.toDevicePixels(lengthType, 0));
+		}
+
+		return lineHeight;
 	}
 
 	_setShadow(value: ShadowCSSValues): void {

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -256,6 +256,13 @@ export class TextBase extends TextBaseCommon {
 		this._setNativeText();
 	}
 
+	[lineHeightProperty.getDefault](): CoreTypes.PercentLengthType {
+		const nativeTextView = this.nativeTextViewProtected;
+		const nativeFont = nativeTextView instanceof UIButton ? nativeTextView.titleLabel.font : nativeTextView.font;
+
+		return nativeFont?.lineHeight ?? 0;
+	}
+
 	[lineHeightProperty.setNative](value: CoreTypes.PercentLengthType) {
 		this._setNativeText();
 	}
@@ -426,13 +433,21 @@ export class TextBase extends TextBaseCommon {
 
 	private _calculateLineHeight(): number {
 		const lengthType = this.style.lineHeight;
-		const fontHeight = this.nativeTextViewProtected.font?.lineHeight || 0;
+		const nativeTextView = this.nativeTextViewProtected;
+		const nativeFont = nativeTextView instanceof UIButton ? nativeTextView.titleLabel.font : nativeTextView.font;
+		// Get font lineHeight value to simulate what android does with getFontMetricsInt
+		const fontHeight = nativeFont?.lineHeight || 0;
 
 		let lineHeight: number;
 
 		if (!lengthType) {
 			lineHeight = 0;
-		} else if (typeof lengthType !== 'number' && lengthType !== 'auto' && lengthType.unit === '%') {
+		} else if (typeof lengthType === 'number') {
+			lineHeight = lengthType;
+		} else if (typeof lengthType === 'string') {
+			// e.g. normal
+			lineHeight = fontHeight;
+		} else if (lengthType.unit === '%') {
 			lineHeight = lengthType.value * fontHeight;
 		} else {
 			lineHeight = layout.toDeviceIndependentPixels(Length.toDevicePixels(lengthType, 0));

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -446,7 +446,7 @@ export class TextBase extends TextBaseCommon {
 		} else if (lengthType.unit === '%') {
 			lineHeight = lengthType.value * fontHeight;
 		} else {
-			lineHeight = layout.toDeviceIndependentPixels(Length.toDevicePixels(lengthType, 0));
+			lineHeight = layout.toDeviceIndependentPixels(Length.toDevicePixels(lengthType, -1));
 		}
 
 		return lineHeight;

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -435,7 +435,7 @@ export class TextBase extends TextBaseCommon {
 		const nativeTextView = this.nativeTextViewProtected;
 		const nativeFont = nativeTextView instanceof UIButton ? nativeTextView.titleLabel.font : nativeTextView.font;
 		// Get font lineHeight value to simulate what android does with getFontMetricsInt
-		const fontHeight = nativeFont?.lineHeight || 0;
+		const fontHeight = nativeFont?.lineHeight ?? 0;
 
 		let lineHeight: number;
 

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -330,13 +330,13 @@ export class TextBase extends TextBaseCommon {
 			if (this.formattedText) {
 				this.nativeTextViewProtected.nativeScriptSetFormattedTextDecorationAndTransformLetterSpacingLineHeight(this.getFormattedStringDetails(this.formattedText) as any, letterSpacing, lineHeight);
 			} else {
-				// console.log('setTextDecorationAndTransform...')
 				const text = getTransformedText(isNullOrUndefined(this.text) ? '' : `${this.text}`, this.textTransform);
 				this.nativeTextViewProtected.nativeScriptSetTextDecorationAndTransformTextDecorationLetterSpacingLineHeight(text, this.style.textDecoration || '', letterSpacing, lineHeight);
+			}
 
-				if (!this.style?.color && majorVersion >= 13 && UIColor.labelColor) {
-					this._setColor(UIColor.labelColor);
-				}
+			// Apply this default to both regular and formatted text, otherwise UIButton will use its own default
+			if (!this.style?.color && majorVersion >= 13 && UIColor.labelColor) {
+				this._setColor(UIColor.labelColor);
 			}
 
 			if (this.style?.textStroke) {

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -440,13 +440,10 @@ export class TextBase extends TextBaseCommon {
 
 		let lineHeight: number;
 
-		if (!lengthType) {
-			lineHeight = 0;
+		if (lengthType == null || typeof lengthType === 'string') {
+			lineHeight = fontHeight;
 		} else if (typeof lengthType === 'number') {
 			lineHeight = lengthType;
-		} else if (typeof lengthType === 'string') {
-			// e.g. normal
-			lineHeight = fontHeight;
 		} else if (lengthType.unit === '%') {
 			lineHeight = lengthType.value * fontHeight;
 		} else {

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -15,6 +15,7 @@ import { TextBase as TextBaseDefinition } from '.';
 import { Color } from '../../color';
 import { ShadowCSSValues, parseCSSShadow } from '../styling/css-shadow';
 import { StrokeCSSValues, parseCSSStroke } from '../styling/css-stroke';
+import { Length, PercentLength } from '../styling/style-properties';
 
 const CHILD_SPAN = 'Span';
 const CHILD_FORMATTED_TEXT = 'formattedText';
@@ -86,10 +87,10 @@ export abstract class TextBaseCommon extends View implements TextBaseDefinition 
 		this.style.letterSpacing = value;
 	}
 
-	get lineHeight(): number {
+	get lineHeight(): CoreTypes.PercentLengthType {
 		return this.style.lineHeight;
 	}
-	set lineHeight(value: number) {
+	set lineHeight(value: CoreTypes.PercentLengthType) {
 		this.style.lineHeight = value;
 	}
 
@@ -361,11 +362,12 @@ export const letterSpacingProperty = new InheritedCssProperty<Style, number>({
 });
 letterSpacingProperty.register(Style);
 
-export const lineHeightProperty = new InheritedCssProperty<Style, number>({
+export const lineHeightProperty = new InheritedCssProperty<Style, CoreTypes.PercentLengthType>({
 	name: 'lineHeight',
 	cssName: 'line-height',
 	affectsLayout: __APPLE__,
-	valueConverter: (v) => parseFloat(v),
+	equalityComparer: Length.equals,
+	valueConverter: PercentLength.parse,
 });
 lineHeightProperty.register(Style);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, typography is a bit inconsistent between the two platforms and MDN specs.
More specifically, line-height does not act as a height and its visual result is quite different than that of browser.

## What is the new behavior?
- Small android size defaults cleanup
- Added support for line-height dip and percentage units and updated calculation to be closer to that of browser
- Corrected UIButton letter-spacing calculation which used the deprecated font property to read font size
- Corrected iOS Button formatted text default color (it's different than the button with regular text)

BREAKING CHANGES:
- Line height will apply like a height as the name indicates while {N} has long been using it as line-spacing. This might cause strange visual changes in apps.