### PR TITLE
fix(android): Background color is not applied to certain views

### DIFF
--- a/packages/core/ui/action-bar/index.android.ts
+++ b/packages/core/ui/action-bar/index.android.ts
@@ -189,6 +189,10 @@ export class ActionBar extends ActionBarBase {
 		this.update();
 	}
 
+	override get needsNativeDrawableFill(): boolean {
+		return true;
+	}
+
 	public update() {
 		if (!this.nativeViewProtected) {
 			return;

--- a/packages/core/ui/button/index.android.ts
+++ b/packages/core/ui/button/index.android.ts
@@ -106,6 +106,10 @@ export class Button extends ButtonBase {
 		}
 	}
 
+	override get needsNativeDrawableFill(): boolean {
+		return true;
+	}
+
 	[minWidthProperty.getDefault](): CoreTypes.LengthType {
 		const dips = org.nativescript.widgets.ViewHelper.getMinWidth(this.nativeViewProtected);
 

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -1134,7 +1134,8 @@ export class View extends ViewCommon {
 				nativeView.setBackground(backgroundDrawable);
 			}
 
-			if (backgroundDrawable) {
+			// Apply color to drawables when there is the need to maintain visual things like button ripple effect
+			if (this.needsNativeDrawableFill && backgroundDrawable) {
 				backgroundDrawable.mutate();
 
 				AndroidHelper.setDrawableColor(backgroundColor, backgroundDrawable);

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -784,6 +784,10 @@ export abstract class View extends ViewCommon {
 	/**
 	 * @private
 	 */
+	get needsNativeDrawableFill(): boolean;
+	/**
+	 * @private
+	 */
 	_gestureObservers: any;
 	/**
 	 * @private

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -984,6 +984,10 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		return true;
 	}
 
+	get needsNativeDrawableFill(): boolean {
+		return false;
+	}
+
 	public measure(widthMeasureSpec: number, heightMeasureSpec: number): void {
 		this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
This is a fix for a bug caused by #10451.
It seems some android views with background drawable will not render the drawable color filter (e.g. Material design bottom navigation bar).

## What is the new behavior?
From now on, we mark the views that need setting the drawable color and call `setBackgroundColor` as a default for the rest of them.
Getter `needsNativeDrawableFill` seems like a good way to distinguish those views and we might be able to use it on iOS if such a case arises.

See relevant discussion: https://discord.com/channels/603595811204366337/1019708793371770950/threads/1300825437882290177