### PR TITLE
fix(android): Setting String Value to Width And Height

### DIFF
--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -57,7 +57,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 	}
 
 	return {
-		width: reqWidth,
-		height: reqHeight,
+		width: Number(reqWidth),
+		height: Number(reqHeight),
 	};
 }

--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -1,17 +1,17 @@
-import { ImageAssetBase, getRequestedImageSize } from './image-asset-common';
-import { path as fsPath, knownFolders } from '../file-system';
-import { ad } from '../utils';
-import { Screen } from '../platform';
-export * from './image-asset-common';
+import { ImageAssetBase, getRequestedImageSize } from "./image-asset-common";
+import { path as fsPath, knownFolders } from "../file-system";
+import { ad } from "../utils";
+import { Screen } from "../platform";
+export * from "./image-asset-common";
 
 export class ImageAsset extends ImageAssetBase {
 	private _android: string; //file name of the image
 
 	constructor(asset: string) {
 		super();
-		let fileName = typeof asset === 'string' ? asset.trim() : '';
-		if (fileName.indexOf('~/') === 0) {
-			fileName = fsPath.join(knownFolders.currentApp().path, fileName.replace('~/', ''));
+		let fileName = typeof asset === "string" ? asset.trim() : "";
+		if (fileName.indexOf("~/") === 0) {
+			fileName = fsPath.join(knownFolders.currentApp().path, fileName.replace("~/", ""));
 		}
 		this.android = fileName;
 	}
@@ -25,7 +25,58 @@ export class ImageAsset extends ImageAssetBase {
 		this._android = value;
 	}
 
-	public getImageAsync(callback: (image, error) => void) {
+	/**
+	 * Validates and adjusts image dimensions to prevent bitmap size exceeding Android's 32-bit limit.
+	 * Android has a limitation where bitmap size (width * height) cannot exceed 2^31-1.
+	 * This method ensures the dimensions are within safe bounds while maintaining aspect ratio.
+	 *
+	 * @param {number|string} width - The desired width of the image
+	 * @param {number|string} height - The desired height of the image
+	 * @returns {{ width: number; height: number }} Object containing validated dimensions
+	 *
+	 * @example
+	 * // Returns safe dimensions that won't exceed Android's bitmap size limit
+	 * const safe = validateDimensions("4000", "3000");
+	 */
+	private _validateDimensions(width: number | string, height: number | string): { width: number; height: number } {
+		const parseSize = (size: number | string): number => {
+			return typeof size === "string" ? parseInt(size, 10) : size;
+		};
+
+		let w = parseSize(width);
+		let h = parseSize(height);
+
+		// Check for 32-bit limitation (2^31 - 1, leaving some headroom)
+		const MAX_DIMENSION = Math.floor(Math.sqrt(Math.pow(2, 31) - 1));
+
+		// Check if each dimension exceeds MAX_DIMENSION
+		w = Math.min(w, MAX_DIMENSION);
+		h = Math.min(h, MAX_DIMENSION);
+
+		// Check the total pixel count
+		if (w * h > Math.pow(2, 31) - 1) {
+			const scale = Math.sqrt((Math.pow(2, 31) - 1) / (w * h));
+			w = Math.floor(w * scale);
+			h = Math.floor(h * scale);
+		}
+
+		return { width: w, height: h };
+	}
+
+	/**
+	 * Asynchronously loads an image with the specified dimensions.
+	 * Handles string/number dimension types and applies size validation for Android bitmap limitations.
+	 *
+	 * @param {Function} callback - Callback function that receives (image, error)
+	 * @param {{ width?: number; height?: number }} [options] - Optional dimensions for the image
+	 */
+	public getImageAsync(callback: (image, error) => void, options?: { width?: number; height?: number }) {
+		if (options?.width || options?.height) {
+			const validDimensions = this._validateDimensions(options.width || this.options.width || 0, options.height || this.options.height || 0);
+			options.width = validDimensions.width;
+			options.height = validDimensions.height;
+		}
+
 		org.nativescript.widgets.Utils.loadImageAsync(
 			ad.getApplicationContext(),
 			this.android,
@@ -39,7 +90,7 @@ export class ImageAsset extends ImageAssetBase {
 				onError(ex) {
 					callback(null, ex);
 				},
-			})
+			}),
 		);
 	}
 }

--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -1,17 +1,17 @@
-import { ImageAssetBase, getRequestedImageSize } from "./image-asset-common";
-import { path as fsPath, knownFolders } from "../file-system";
-import { ad } from "../utils";
-import { Screen } from "../platform";
-export * from "./image-asset-common";
+import { ImageAssetBase, getRequestedImageSize } from './image-asset-common';
+import { path as fsPath, knownFolders } from '../file-system';
+import { ad } from '../utils';
+import { Screen } from '../platform';
+export * from './image-asset-common';
 
 export class ImageAsset extends ImageAssetBase {
 	private _android: string; //file name of the image
 
 	constructor(asset: string) {
 		super();
-		let fileName = typeof asset === "string" ? asset.trim() : "";
-		if (fileName.indexOf("~/") === 0) {
-			fileName = fsPath.join(knownFolders.currentApp().path, fileName.replace("~/", ""));
+		let fileName = typeof asset === 'string' ? asset.trim() : '';
+		if (fileName.indexOf('~/') === 0) {
+			fileName = fsPath.join(knownFolders.currentApp().path, fileName.replace('~/', ''));
 		}
 		this.android = fileName;
 	}
@@ -40,7 +40,7 @@ export class ImageAsset extends ImageAssetBase {
 	 */
 	private _validateDimensions(width: number | string, height: number | string): { width: number; height: number } {
 		const parseSize = (size: number | string): number => {
-			return typeof size === "string" ? parseInt(size, 10) : size;
+			return typeof size === 'string' ? parseInt(size, 10) : size;
 		};
 
 		let w = parseSize(width);

--- a/packages/core/image-asset/index.d.ts
+++ b/packages/core/image-asset/index.d.ts
@@ -1,4 +1,4 @@
-import { Observable } from "../data/observable";
+import { Observable } from '../data/observable';
 
 export class ImageAsset extends Observable {
 	constructor(asset: any);

--- a/packages/core/image-asset/index.d.ts
+++ b/packages/core/image-asset/index.d.ts
@@ -1,4 +1,4 @@
-import { Observable } from '../data/observable';
+import { Observable } from "../data/observable";
 
 export class ImageAsset extends Observable {
 	constructor(asset: any);
@@ -10,8 +10,8 @@ export class ImageAsset extends Observable {
 }
 
 export interface ImageAssetOptions {
-	width?: number;
-	height?: number;
+	width?: number | string;
+	height?: number | string;
 	keepAspectRatio?: boolean;
 	autoScaleFactor?: boolean;
 }

--- a/packages/core/image-asset/index.ios.ts
+++ b/packages/core/image-asset/index.ios.ts
@@ -1,17 +1,17 @@
-import { ImageAssetBase, getRequestedImageSize } from "./image-asset-common";
-import { path as fsPath, knownFolders } from "../file-system";
-import { queueGC } from "../utils";
+import { ImageAssetBase, getRequestedImageSize } from './image-asset-common';
+import { path as fsPath, knownFolders } from '../file-system';
+import { queueGC } from '../utils';
 
-export * from "./image-asset-common";
+export * from './image-asset-common';
 
 export class ImageAsset extends ImageAssetBase {
 	private _ios: PHAsset;
 
 	constructor(asset: string | PHAsset | UIImage) {
 		super();
-		if (typeof asset === "string") {
-			if (asset.indexOf("~/") === 0) {
-				asset = fsPath.join(knownFolders.currentApp().path, asset.replace("~/", ""));
+		if (typeof asset === 'string') {
+			if (asset.indexOf('~/') === 0) {
+				asset = fsPath.join(knownFolders.currentApp().path, asset.replace('~/', ''));
 			}
 
 			this.nativeImage = UIImage.imageWithContentsOfFile(asset);
@@ -40,16 +40,16 @@ export class ImageAsset extends ImageAssetBase {
 	 */
 	public getImageAsync(callback: (image, error) => void, options?: { width?: number | string; height?: number | string }) {
 		if (options) {
-			if (typeof options.width === "string") {
+			if (typeof options.width === 'string') {
 				options.width = parseInt(options.width, 10);
 			}
-			if (typeof options.height === "string") {
+			if (typeof options.height === 'string') {
 				options.height = parseInt(options.height, 10);
 			}
 		}
 
 		if (!this.ios && !this.nativeImage) {
-			callback(null, "Asset cannot be found.");
+			callback(null, 'Asset cannot be found.');
 		}
 
 		const srcWidth = this.nativeImage ? this.nativeImage.size.width : this.ios.pixelWidth;

--- a/packages/core/image-asset/index.ios.ts
+++ b/packages/core/image-asset/index.ios.ts
@@ -1,17 +1,17 @@
-import { ImageAssetBase, getRequestedImageSize } from './image-asset-common';
-import { path as fsPath, knownFolders } from '../file-system';
-import { queueGC } from '../utils';
+import { ImageAssetBase, getRequestedImageSize } from "./image-asset-common";
+import { path as fsPath, knownFolders } from "../file-system";
+import { queueGC } from "../utils";
 
-export * from './image-asset-common';
+export * from "./image-asset-common";
 
 export class ImageAsset extends ImageAssetBase {
 	private _ios: PHAsset;
 
 	constructor(asset: string | PHAsset | UIImage) {
 		super();
-		if (typeof asset === 'string') {
-			if (asset.indexOf('~/') === 0) {
-				asset = fsPath.join(knownFolders.currentApp().path, asset.replace('~/', ''));
+		if (typeof asset === "string") {
+			if (asset.indexOf("~/") === 0) {
+				asset = fsPath.join(knownFolders.currentApp().path, asset.replace("~/", ""));
 			}
 
 			this.nativeImage = UIImage.imageWithContentsOfFile(asset);
@@ -31,9 +31,25 @@ export class ImageAsset extends ImageAssetBase {
 		this._ios = value;
 	}
 
-	public getImageAsync(callback: (image, error) => void) {
+	/**
+	 * Asynchronously loads an image and optionally resizes it.
+	 * Handles both string and number type dimensions by converting strings to numbers.
+	 *
+	 * @param {Function} callback - Callback function that receives (image, error)
+	 * @param {{ width?: number|string; height?: number|string }} [options] - Optional dimensions for the image
+	 */
+	public getImageAsync(callback: (image, error) => void, options?: { width?: number | string; height?: number | string }) {
+		if (options) {
+			if (typeof options.width === "string") {
+				options.width = parseInt(options.width, 10);
+			}
+			if (typeof options.height === "string") {
+				options.height = parseInt(options.height, 10);
+			}
+		}
+
 		if (!this.ios && !this.nativeImage) {
-			callback(null, 'Asset cannot be found.');
+			callback(null, "Asset cannot be found.");
 		}
 
 		const srcWidth = this.nativeImage ? this.nativeImage.size.width : this.ios.pixelWidth;
@@ -60,6 +76,14 @@ export class ImageAsset extends ImageAssetBase {
 		});
 	}
 
+	/**
+	 * Scales the image to the requested size while respecting device scale factor settings.
+	 *
+	 * @param {UIImage} image - The source UIImage to scale
+	 * @param {{ width: number; height: number }} requestedSize - Target dimensions
+	 * @returns {UIImage} Scaled image
+	 * @private
+	 */
 	private scaleImage(image: UIImage, requestedSize: { width: number; height: number }): UIImage {
 		return NativeScriptUtils.scaleImageWidthHeightScaleFactor(image, requestedSize.width, requestedSize.height, this.options?.autoScaleFactor === false ? 1.0 : 0.0);
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Currently, when a string value is assigned to the width or height property of ImageAssetOptions, an error occurs on Android. This issue prevents users from specifying these properties as strings, which can be problematic in scenarios where string-based dimensions are used.

## What is the new behavior?
With this update, assigning a string value to the width or height property of ImageAssetOptions no longer results in an error on Android. The system now properly handles string-based dimensions, providing a more flexible and consistent experience for users.

Fixes/Implements/Closes #6289 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

