### PR TITLE
fix(ios): Added missing Frame backstack disposal handling

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -217,6 +217,13 @@ export class FrameBase extends CustomLayoutView {
 		removed.resolvedPage = null;
 	}
 
+	protected _disposeBackstackEntry(entry: BackstackEntry): void {
+		const page = entry.resolvedPage;
+		if (page && page._context) {
+			entry.resolvedPage._tearDownUI(true);
+		}
+	}
+
 	public navigate(param: any) {
 		if (Trace.isEnabled()) {
 			Trace.write(`NAVIGATE`, Trace.categories.Navigation);

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -219,8 +219,8 @@ export class FrameBase extends CustomLayoutView {
 
 	protected _disposeBackstackEntry(entry: BackstackEntry): void {
 		const page = entry.resolvedPage;
-		if (page && page._context) {
-			entry.resolvedPage._tearDownUI(true);
+		if (page) {
+			page._tearDownUI(true);
 		}
 	}
 

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -318,11 +318,11 @@ export class Frame extends FrameBase {
 			if (this._tearDownPending) {
 				this._tearDownPending = false;
 				if (!entry.recreated) {
-					clearEntry(entry);
+					this._disposeBackstackEntry(entry);
 				}
 
 				if (current && !current.recreated) {
-					clearEntry(current);
+					this._disposeBackstackEntry(current);
 				}
 
 				// If we have context activity was recreated. Create new fragment
@@ -493,6 +493,17 @@ export class Frame extends FrameBase {
 		removed.viewSavedState = null;
 	}
 
+	protected _disposeBackstackEntry(entry: BackstackEntry): void {
+		if (entry.fragment) {
+			_clearFragment(entry);
+		}
+
+		entry.recreated = false;
+		entry.fragment = null;
+
+		super._disposeBackstackEntry(entry);
+	}
+
 	public createNativeView() {
 		// Create native view with available _currentEntry occur in Don't Keep Activities
 		// scenario when Activity is recreated on app suspend/resume. Push frame back in frame stack
@@ -527,12 +538,12 @@ export class Frame extends FrameBase {
 			// Don't destroy current and executing entries or UI will look blank.
 			// We will do it in setCurrent.
 			if (entry !== executingEntry) {
-				clearEntry(entry);
+				this._disposeBackstackEntry(entry);
 			}
 		});
 
 		if (current && !executingEntry) {
-			clearEntry(current);
+			this._disposeBackstackEntry(current);
 		}
 
 		this._android.rootViewGroup = null;
@@ -639,19 +650,6 @@ function restoreTransitionState(entry: BackstackEntry, snapshot: TransitionState
 	}
 
 	expandedEntry.transitionName = snapshot.transitionName;
-}
-
-function clearEntry(entry: BackstackEntry): void {
-	if (entry.fragment) {
-		_clearFragment(entry);
-	}
-
-	entry.recreated = false;
-	entry.fragment = null;
-	const page = entry.resolvedPage;
-	if (page && page._context) {
-		entry.resolvedPage._tearDownUI(true);
-	}
 }
 
 let framesCounter = 0;

--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -42,6 +42,23 @@ export class Frame extends FrameBase {
 	}
 
 	public disposeNativeView() {
+		const current = this._currentEntry;
+		const executingEntry = this._executingContext ? this._executingContext.entry : null;
+
+		if (executingEntry) {
+			this._disposeBackstackEntry(executingEntry);
+		}
+
+		this.backStack.forEach((entry) => {
+			if (entry !== executingEntry) {
+				this._disposeBackstackEntry(entry);
+			}
+		});
+
+		if (current) {
+			this._disposeBackstackEntry(current);
+		}
+
 		this._removeFromFrameStack();
 		this.viewController = null;
 		this._animatedDelegate = null;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Upon disposal, iOS frame does not dispose its page views resulting in memory leaks or accessible native view references that have already been affected by GC.
That goes for current, executing, and backstack pages.

## What is the new behavior?
Frame will dispose all owning page views upon its disposal.