### PR TITLE
fix(ios): Safe area memory leak on iOS 10 and older versions

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -200,20 +200,38 @@ export class IOSHelper {
 		}
 	}
 
+	/**
+	 * This method simulates the iOS 11+ safeAreaLayoutGuide property and its constraints for older versions.
+	 *
+	 * @param controller
+	 * @param owner
+	 */
 	static updateConstraints(controller: UIViewController, owner: View): void {
 		if (!__VISIONOS__ && SDK_VERSION <= 10) {
-			const layoutGuide = IOSHelper.initLayoutGuide(controller);
-			(<any>controller.view).safeAreaLayoutGuide = layoutGuide;
+			if (!controller.view.safeAreaLayoutGuide) {
+				IOSHelper.initLayoutGuide(controller);
+			}
 		}
 	}
 
-	static initLayoutGuide(controller: UIViewController) {
+	/**
+	 * This method simulates the iOS 11+ safeAreaLayoutGuide property for older versions.
+	 *
+	 * @param controller
+	 */
+	static initLayoutGuide(controller: UIViewController): UILayoutGuide {
 		const rootView = controller.view;
-		const layoutGuide = UILayoutGuide.new();
-		rootView.addLayoutGuide(layoutGuide);
-		NSLayoutConstraint.activateConstraints(<any>[layoutGuide.topAnchor.constraintEqualToAnchor(controller.topLayoutGuide.bottomAnchor), layoutGuide.bottomAnchor.constraintEqualToAnchor(controller.bottomLayoutGuide.topAnchor), layoutGuide.leadingAnchor.constraintEqualToAnchor(rootView.leadingAnchor), layoutGuide.trailingAnchor.constraintEqualToAnchor(rootView.trailingAnchor)]);
 
-		return layoutGuide;
+		if (!rootView.safeAreaLayoutGuide) {
+			const layoutGuide = UILayoutGuide.new();
+
+			rootView.addLayoutGuide(layoutGuide);
+			NSLayoutConstraint.activateConstraints([layoutGuide.topAnchor.constraintEqualToAnchor(controller.topLayoutGuide.bottomAnchor), layoutGuide.bottomAnchor.constraintEqualToAnchor(controller.bottomLayoutGuide.topAnchor), layoutGuide.leadingAnchor.constraintEqualToAnchor(rootView.leadingAnchor), layoutGuide.trailingAnchor.constraintEqualToAnchor(rootView.trailingAnchor)]);
+
+			(<any>rootView).safeAreaLayoutGuide = layoutGuide;
+		}
+
+		return rootView.safeAreaLayoutGuide;
 	}
 
 	static layoutView(controller: UIViewController, owner: View): void {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In iOS 10 and earlier versions, custom implementation of `safeAreaLayoutGuide` causes memory leaks.

## What is the new behavior?
Custom `safeAreaLayoutGuide` and its constraints will be created once.