### PR TITLE
fix(ios): Broken transform if set before any layout

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -42,7 +42,6 @@ export class View extends ViewCommon implements ViewDefinition {
 	private _modalAnimatedOptions: Array<boolean>;
 	private _isLaidOut = false;
 	private _hasTransform = false;
-	private _hasPendingTransform = false;
 	private _privateFlags: number = PFLAG_LAYOUT_REQUIRED | PFLAG_FORCE_LAYOUT;
 	private _cachedFrame: CGRect;
 	private _suspendCATransaction = false;
@@ -68,7 +67,6 @@ export class View extends ViewCommon implements ViewDefinition {
 		this._cachedFrame = null;
 		this._isLaidOut = false;
 		this._hasTransform = false;
-		this._hasPendingTransform = false;
 	}
 
 	public requestLayout(): void {
@@ -140,10 +138,6 @@ export class View extends ViewCommon implements ViewDefinition {
 		}
 
 		this.updateBackground(sizeChanged, needsLayout);
-		if (this._hasPendingTransform) {
-			this.updateNativeTransform();
-			this._hasPendingTransform = false;
-		}
 		this._privateFlags &= ~PFLAG_FORCE_LAYOUT;
 	}
 
@@ -400,11 +394,6 @@ export class View extends ViewCommon implements ViewDefinition {
 	}
 
 	public updateNativeTransform() {
-		if (!this.isLayoutValid) {
-			this._hasPendingTransform = true;
-			return;
-		}
-
 		const scaleX = this.scaleX || 1e-6;
 		const scaleY = this.scaleY || 1e-6;
 		const perspective = this.perspective || 300;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
There is a case when iOS view transform gets broken if set before layout.
This was originally an 8.2 fix that is no longer needed since we have done improvements on iOS layout and it also fixes one thing but breaks another.

## What is the new behavior?
iOS view transform will properly apply even if set before layout.
Thanks goes to @farfromrefug for informing me about this some time ago.