### PR TITLE
fix(ios): Corrected rotate animation execution

### DIFF
--- a/apps/automated/src/ui/animation/animation-tests.ts
+++ b/apps/automated/src/ui/animation/animation-tests.ts
@@ -79,7 +79,7 @@ export function test_PlayRejectsWhenAlreadyPlayingAnimation(done) {
 			if (e === 'Animation is already playing.') {
 				done();
 			}
-		}
+		},
 	);
 }
 
@@ -164,8 +164,8 @@ export function test_ChainingAnimations(done) {
 		.then(() => label.animate({ translate: { x: 0, y: 0 }, duration: duration }))
 		.then(() => label.animate({ scale: { x: 5, y: 5 }, duration: duration }))
 		.then(() => label.animate({ scale: { x: 1, y: 1 }, duration: duration }))
-		.then(() => label.animate({ rotate: 180, duration: duration }))
-		.then(() => label.animate({ rotate: 0, duration: duration }))
+		.then(() => label.animate({ rotate: { x: 90, y: 0, z: 180 }, duration: duration }))
+		.then(() => label.animate({ rotate: { x: 0, y: 0, z: 0 }, duration: duration }))
 		.then(() => {
 			//console.log("Animation finished");
 			// >> (hide)
@@ -610,7 +610,7 @@ export function test_PlayPromiseIsResolvedWhenAnimationFinishes(done) {
 		function onRejected(e) {
 			TKUnit.assert(false, 'Animation play promise should be resolved, not rejected.');
 			done(e);
-		}
+		},
 	);
 }
 
@@ -627,7 +627,7 @@ export function test_PlayPromiseIsRejectedWhenAnimationIsCancelled(done) {
 		function onRejected(e) {
 			TKUnit.assert(animation.isPlaying === false, 'Animation.isPlaying should be false when animation play promise is rejected.');
 			done();
-		}
+		},
 	);
 
 	animation.cancel();

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -79,8 +79,8 @@ class AnimationDelegateImpl extends NSObject implements CAAnimationDelegate {
 				targetStyle[setLocal ? widthProperty.name : widthProperty.keyframe] = value;
 				break;
 			case Properties.scale:
-				targetStyle[setLocal ? scaleXProperty.name : scaleXProperty.keyframe] = value.x === 0 ? 0.001 : value.x;
-				targetStyle[setLocal ? scaleYProperty.name : scaleYProperty.keyframe] = value.y === 0 ? 0.001 : value.y;
+				targetStyle[setLocal ? scaleXProperty.name : scaleXProperty.keyframe] = value.x === 0 ? 1e-6 : value.x;
+				targetStyle[setLocal ? scaleYProperty.name : scaleYProperty.keyframe] = value.y === 0 ? 1e-6 : value.y;
 				break;
 			case _transform:
 				if (value[Properties.translate] !== undefined) {
@@ -95,8 +95,8 @@ class AnimationDelegateImpl extends NSObject implements CAAnimationDelegate {
 				if (value[Properties.scale] !== undefined) {
 					const x = value[Properties.scale].x;
 					const y = value[Properties.scale].y;
-					targetStyle[setLocal ? scaleXProperty.name : scaleXProperty.keyframe] = x === 0 ? 0.001 : x;
-					targetStyle[setLocal ? scaleYProperty.name : scaleYProperty.keyframe] = y === 0 ? 0.001 : y;
+					targetStyle[setLocal ? scaleXProperty.name : scaleXProperty.keyframe] = x === 0 ? 1e-6 : x;
+					targetStyle[setLocal ? scaleYProperty.name : scaleYProperty.keyframe] = y === 0 ? 1e-6 : y;
 				}
 				break;
 		}
@@ -365,10 +365,10 @@ export class Animation extends AnimationBase {
 					break;
 				case Properties.scale:
 					if (toValue.x === 0) {
-						toValue.x = 0.001;
+						toValue.x = 1e-6;
 					}
 					if (toValue.y === 0) {
-						toValue.y = 0.001;
+						toValue.y = 1e-6;
 					}
 					animation._originalValue = { x: view.scaleX, y: view.scaleY };
 					animation._propertyResetCallback = (value, valueSource) => {

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -639,9 +639,9 @@ export class Animation extends AnimationBase {
 		}
 
 		if (value[Properties.scale] !== undefined) {
-			const x = value[Properties.scale].x;
-			const y = value[Properties.scale].y;
-			result = CATransform3DScale(result, x === 0 ? 0.001 : x, y === 0 ? 0.001 : y, 1);
+			const x = value[Properties.scale].x || 1e-6;
+			const y = value[Properties.scale].y || 1e-6;
+			result = CATransform3DScale(result, x, y, 1);
 		}
 
 		if (value[Properties.rotate] !== undefined) {

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -517,21 +517,12 @@ export class Animation extends AnimationBase {
 	}
 
 	private static _createGroupAnimation(args: AnimationInfo, animation: PropertyAnimation) {
+		const animations = NSMutableArray.alloc<CAAnimation>().initWithCapacity(3);
 		const groupAnimation = CAAnimationGroup.new();
 		groupAnimation.duration = args.duration;
-		if (args.repeatCount !== undefined) {
-			groupAnimation.repeatCount = args.repeatCount;
-		}
-		if (args.delay !== undefined) {
-			groupAnimation.beginTime = CACurrentMediaTime() + args.delay;
-		}
-		if (animation.curve !== undefined) {
-			groupAnimation.timingFunction = animation.curve;
-		}
-		const animations = NSMutableArray.alloc<CAAnimation>().initWithCapacity(3);
 
 		args.subPropertiesToAnimate.forEach((property) => {
-			const basicAnimationArgs = { ...args, duration: undefined, repeatCount: undefined, delay: undefined, curve: undefined };
+			const basicAnimationArgs = { ...args };
 			basicAnimationArgs.propertyNameToAnimate = `${args.propertyNameToAnimate}.${property}`;
 			basicAnimationArgs.fromValue = args.fromValue[property];
 			basicAnimationArgs.toValue = args.toValue[property];
@@ -676,11 +667,18 @@ export class Animation extends AnimationBase {
 			result = CATransform3DScale(result, x === 0 ? 0.001 : x, y === 0 ? 0.001 : y, 1);
 		}
 
+		if (value[Properties.rotate] !== undefined) {
+			const x = value[Properties.rotate].x;
+			const y = value[Properties.rotate].y;
+			const z = value[Properties.rotate].z;
+			result = iosHelper.applyRotateTransform(result, x, y, z);
+		}
+
 		return result;
 	}
 
 	private static _isAffineTransform(property: string): boolean {
-		return property === _transform || property === Properties.translate || property === Properties.scale;
+		return property === _transform || property === Properties.translate || property === Properties.scale || property === Properties.rotate;
 	}
 
 	private static _canBeMerged(animation1: PropertyAnimation, animation2: PropertyAnimation) {

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -498,8 +498,18 @@ export class Animation extends AnimationBase {
 		const groupAnimation = CAAnimationGroup.new();
 		groupAnimation.duration = args.duration;
 
+		if (args.repeatCount !== undefined) {
+			groupAnimation.repeatCount = args.repeatCount;
+		}
+		if (args.delay !== undefined) {
+			groupAnimation.beginTime = CACurrentMediaTime() + args.delay;
+		}
+		if (animation.curve !== undefined) {
+			groupAnimation.timingFunction = animation.curve;
+		}
+
 		args.subPropertiesToAnimate.forEach((property) => {
-			const basicAnimationArgs = { ...args };
+			const basicAnimationArgs = { ...args, duration: undefined, repeatCount: undefined, delay: undefined, curve: undefined };
 			basicAnimationArgs.propertyNameToAnimate = `${args.propertyNameToAnimate}.${property}`;
 			basicAnimationArgs.fromValue = args.fromValue[property];
 			basicAnimationArgs.toValue = args.toValue[property];

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -658,6 +658,13 @@ export class Animation extends AnimationBase {
 			const x = value[Properties.rotate].x;
 			const y = value[Properties.rotate].y;
 			const z = value[Properties.rotate].z;
+			const perspective = animation.target.perspective || 300;
+
+			// Set perspective in case of rotation since we use z
+			if (x || y) {
+				result.m34 = -1 / perspective;
+			}
+
 			result = iosHelper.applyRotateTransform(result, x, y, z);
 		}
 
@@ -932,11 +939,11 @@ function calculateTransform(view: View): CATransform3D {
 	// Order is important: translate, rotate, scale
 	let expectedTransform = new CATransform3D(CATransform3DIdentity);
 
-	// Only set perspective if there is 3D rotation
 	// TODO: Add perspective property to transform animations (not just rotation)
-	// if (view.rotateX || view.rotateY) {
-	// 	expectedTransform.m34 = -1 / perspective;
-	// }
+	// Set perspective in case of rotation since we use z
+	if (view.rotateX || view.rotateY) {
+		expectedTransform.m34 = -1 / perspective;
+	}
 
 	expectedTransform = CATransform3DTranslate(expectedTransform, view.translateX, view.translateY, 0);
 	expectedTransform = iosHelper.applyRotateTransform(expectedTransform, view.rotateX, view.rotateY, view.rotate);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, core iOS animations do not consider rotate as an affine transform causing some features like spring animation to break.
This became apparent once I took a small look in @farfromrefug's #9892 (thanks 🙏 ) and noticed that some rotation logic was missing.

## What is the new behavior?
iOS will animate rotations the right way. Also, it fixes the broken spring case.