### PR TITLE
fix(ios): Prevent animator from animating colors on shadow layer

### DIFF
--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -477,9 +477,11 @@ export class Animation extends AnimationBase {
 				this.animateNestedLayerSizeUsingBasicAnimation(nativeView, args.toValue.CGRectValue, animation, args, nativeAnimation);
 			}
 
-			// Shadow layers do not inherit from animating view layer
-			if (nativeView.outerShadowContainerLayer) {
-				nativeView.outerShadowContainerLayer.addAnimationForKey(nativeAnimation, args.propertyNameToAnimate);
+			// Shadow container layer belongs to the parent view layer, so animate all its properties (except for colors) separately
+			if (args.propertyNameToAnimate && !args.propertyNameToAnimate.endsWith('Color')) {
+				if (nativeView.outerShadowContainerLayer) {
+					nativeView.outerShadowContainerLayer.addAnimationForKey(nativeAnimation, args.propertyNameToAnimate);
+				}
 			}
 		}
 		let callback = undefined;
@@ -594,7 +596,7 @@ export class Animation extends AnimationBase {
 						animation._originalValue = nativeView.layer.transform;
 						nativeView.layer.setValueForKey(args.toValue, args.propertyNameToAnimate);
 
-						// Shadow layers do not inherit from animating view layer
+						// Shadow container layer belongs to the parent view layer, so animate its transform separately
 						if (nativeView.outerShadowContainerLayer) {
 							nativeView.outerShadowContainerLayer.setValueForKey(args.toValue, args.propertyNameToAnimate);
 						}
@@ -859,7 +861,7 @@ export class Animation extends AnimationBase {
 			}
 		}
 
-		// Shadow layers do not inherit from animating view layer
+		// Shadow container layer belongs to the parent view layer, so animate its properties separately
 		if (nativeView.outerShadowContainerLayer) {
 			const shadowClipMask = nativeView.outerShadowContainerLayer.mask;
 

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -410,9 +410,7 @@ export class View extends ViewCommon implements ViewDefinition {
 		transform = iosUtils.applyRotateTransform(transform, this.rotateX, this.rotateY, this.rotate);
 		transform = CATransform3DScale(transform, scaleX, scaleY, 1);
 
-		const needsTransform: boolean = !CATransform3DEqualToTransform(this.nativeViewProtected.layer.transform, transform);
-
-		if (needsTransform) {
+		if (!CATransform3DEqualToTransform(this.nativeViewProtected.layer.transform, transform)) {
 			const updateSuspended = this._isPresentationLayerUpdateSuspended();
 			if (!updateSuspended) {
 				CATransaction.begin();

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -41,7 +41,7 @@ export class View extends ViewCommon implements ViewDefinition {
 	 */
 	private _modalAnimatedOptions: Array<boolean>;
 	private _isLaidOut = false;
-	private _hasTransform = false;
+	private _isTransformed = false;
 	private _privateFlags: number = PFLAG_LAYOUT_REQUIRED | PFLAG_FORCE_LAYOUT;
 	private _cachedFrame: CGRect;
 	private _suspendCATransaction = false;
@@ -66,7 +66,7 @@ export class View extends ViewCommon implements ViewDefinition {
 
 		this._cachedFrame = null;
 		this._isLaidOut = false;
-		this._hasTransform = false;
+		this._isTransformed = false;
 	}
 
 	public requestLayout(): void {
@@ -211,7 +211,7 @@ export class View extends ViewCommon implements ViewDefinition {
 			this._cachedFrame = frame;
 			let adjustedFrame = null;
 			let transform = null;
-			if (this._hasTransform) {
+			if (this._isTransformed) {
 				// Always set identity transform before setting frame;
 				transform = nativeView.layer.transform;
 				nativeView.layer.transform = CATransform3DIdentity;
@@ -225,7 +225,7 @@ export class View extends ViewCommon implements ViewDefinition {
 				nativeView.frame = adjustedFrame;
 			}
 
-			if (this._hasTransform) {
+			if (this._isTransformed) {
 				// re-apply the transform after the frame is adjusted
 				nativeView.layer.transform = transform;
 			}
@@ -410,7 +410,7 @@ export class View extends ViewCommon implements ViewDefinition {
 		transform = iosUtils.applyRotateTransform(transform, this.rotateX, this.rotateY, this.rotate);
 		transform = CATransform3DScale(transform, scaleX, scaleY, 1);
 
-		const needsTransform: boolean = !CATransform3DEqualToTransform(this.nativeViewProtected.layer.transform, transform) || (nativeView.outerShadowContainerLayer && !CATransform3DEqualToTransform(nativeView.outerShadowContainerLayer.transform, transform));
+		const needsTransform: boolean = !CATransform3DEqualToTransform(this.nativeViewProtected.layer.transform, transform);
 
 		if (needsTransform) {
 			const updateSuspended = this._isPresentationLayerUpdateSuspended();
@@ -424,7 +424,7 @@ export class View extends ViewCommon implements ViewDefinition {
 			if (nativeView.outerShadowContainerLayer) {
 				nativeView.outerShadowContainerLayer.transform = transform;
 			}
-			this._hasTransform = this.nativeViewProtected && !CATransform3DEqualToTransform(this.nativeViewProtected.transform3D, CATransform3DIdentity);
+			this._isTransformed = this.nativeViewProtected && !CATransform3DEqualToTransform(this.nativeViewProtected.transform3D, CATransform3DIdentity);
 
 			CATransaction.setDisableActions(false);
 			if (!updateSuspended) {

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -1114,6 +1114,7 @@ function drawBoxShadow(view: View): void {
 	}
 
 	outerShadowContainerLayer.bounds = bounds;
+	outerShadowContainerLayer.transform = layer.transform;
 	outerShadowContainerLayer.anchorPoint = layer.anchorPoint;
 	outerShadowContainerLayer.position = nativeView.center;
 	outerShadowContainerLayer.zPosition = layer.zPosition;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In iOS, background-color animation will also animate shadow container color resulting in unexpected visual results.

## What is the new behavior?
The iOS animator will also animate shadow container properties provided that they're not layer colors.
This PR also adds a missing shadow transform handling that's needed ever since #10675 took effect.