### PR TITLE
fix(core): Added missing length property equality comparers

### DIFF
--- a/packages/core/ui/image/image-common.ts
+++ b/packages/core/ui/image/image-common.ts
@@ -182,6 +182,7 @@ tintColorProperty.register(Style);
 export const decodeHeightProperty = new Property<ImageBase, CoreTypes.LengthType>({
 	name: 'decodeHeight',
 	defaultValue: { value: 0, unit: 'dip' },
+	equalityComparer: Length.equals,
 	valueConverter: Length.parse,
 });
 decodeHeightProperty.register(ImageBase);
@@ -189,6 +190,7 @@ decodeHeightProperty.register(ImageBase);
 export const decodeWidthProperty = new Property<ImageBase, CoreTypes.LengthType>({
 	name: 'decodeWidth',
 	defaultValue: { value: 0, unit: 'dip' },
+	equalityComparer: Length.equals,
 	valueConverter: Length.parse,
 });
 decodeWidthProperty.register(ImageBase);

--- a/packages/core/ui/layouts/absolute-layout/absolute-layout-common.ts
+++ b/packages/core/ui/layouts/absolute-layout/absolute-layout-common.ts
@@ -61,7 +61,8 @@ export const leftProperty = new Property<View, CoreTypes.LengthType>({
 			layout.onLeftChanged(target, oldValue, newValue);
 		}
 	},
-	valueConverter: (v) => Length.parse(v),
+	equalityComparer: Length.equals,
+	valueConverter: Length.parse,
 });
 leftProperty.register(View);
 
@@ -75,6 +76,7 @@ export const topProperty = new Property<View, CoreTypes.LengthType>({
 			layout.onTopChanged(target, oldValue, newValue);
 		}
 	},
-	valueConverter: (v) => Length.parse(v),
+	equalityComparer: Length.equals,
+	valueConverter: Length.parse,
 });
 topProperty.register(View);

--- a/packages/core/ui/layouts/wrap-layout/wrap-layout-common.ts
+++ b/packages/core/ui/layouts/wrap-layout/wrap-layout-common.ts
@@ -22,7 +22,8 @@ export const itemWidthProperty = new Property<WrapLayoutBase, CoreTypes.LengthTy
 	name: 'itemWidth',
 	defaultValue: 'auto',
 	affectsLayout: __APPLE__,
-	valueConverter: (v) => Length.parse(v),
+	equalityComparer: Length.equals,
+	valueConverter: Length.parse,
 	valueChanged: (target, oldValue, newValue) => (target.effectiveItemWidth = Length.toDevicePixels(newValue, -1)),
 });
 itemWidthProperty.register(WrapLayoutBase);
@@ -31,7 +32,8 @@ export const itemHeightProperty = new Property<WrapLayoutBase, CoreTypes.LengthT
 	name: 'itemHeight',
 	defaultValue: 'auto',
 	affectsLayout: __APPLE__,
-	valueConverter: (v) => Length.parse(v),
+	equalityComparer: Length.equals,
+	valueConverter: Length.parse,
 	valueChanged: (target, oldValue, newValue) => (target.effectiveItemHeight = Length.toDevicePixels(newValue, -1)),
 });
 itemHeightProperty.register(WrapLayoutBase);

--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -527,7 +527,7 @@ export class ListView extends ListViewBase {
 	}
 	[iosEstimatedRowHeightProperty.setNative](value: CoreTypes.LengthType) {
 		const nativeView = this.nativeViewProtected;
-		const estimatedHeight = Length.toDevicePixels(value, 0);
+		const estimatedHeight = layout.toDeviceIndependentPixels(Length.toDevicePixels(value, 0));
 		nativeView.estimatedRowHeight = estimatedHeight < 0 ? DEFAULT_HEIGHT : estimatedHeight;
 	}
 }

--- a/packages/core/ui/list-view/list-view-common.ts
+++ b/packages/core/ui/list-view/list-view-common.ts
@@ -237,7 +237,8 @@ rowHeightProperty.register(ListViewBase);
 
 export const iosEstimatedRowHeightProperty = new Property<ListViewBase, CoreTypes.LengthType>({
 	name: 'iosEstimatedRowHeight',
-	valueConverter: (v) => Length.parse(v),
+	equalityComparer: Length.equals,
+	valueConverter: Length.parse,
 });
 iosEstimatedRowHeightProperty.register(ListViewBase);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Some length property definitions are missing equality comparers.

## What is the new behavior?
Added missing comparers for these properties.