### PR TITLE
feat(config): multi target support for swift packages

### DIFF
--- a/packages/core/config/config.interface.ts
+++ b/packages/core/config/config.interface.ts
@@ -12,16 +12,22 @@ interface IConfigPlatform {
 	discardUncaughtJsExceptions?: boolean;
 }
 
-export interface IOSRemoteSPMPackage {
+interface IOSSPMPackageBase {
 	name: string;
 	libs: string[];
+	/**
+	 * Optional: If you have more targets (like widgets for example)
+	 * you can list their names here to include the Swift Package with them
+	 */
+	targets?: string[];
+}
+
+export interface IOSRemoteSPMPackage extends IOSSPMPackageBase {
 	repositoryURL: string;
 	version: string;
 }
 
-export interface IOSLocalSPMPackage {
-	name: string;
-	libs: string[];
+export interface IOSLocalSPMPackage extends IOSSPMPackageBase {
 	path: string;
 }
 


### PR DESCRIPTION


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Swift packages attach by default to the main app target with no way to specify multiple target use.

## What is the new behavior?

When using iOS Widget/Extensions, you may want to use swift packages from those. This `targets` array can list any targets by name to add swift packages to.



