### PR TITLE
chore(core): Corrected Frame navigation event types

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -12,6 +12,7 @@ import { sanitizeModuleName } from '../../utils/common';
 import { profile } from '../../profiling';
 import { FRAME_SYMBOL } from './frame-helpers';
 import { SharedTransition } from '../transition/shared-transition';
+import { NavigationData } from '.';
 
 export { NavigationType } from './frame-interfaces';
 export type { AndroidActivityCallbacks, AndroidFragmentCallbacks, AndroidFrame, BackstackEntry, NavigationContext, NavigationEntry, NavigationTransition, TransitionState, ViewEntry, iOSFrame } from './frame-interfaces';
@@ -256,6 +257,7 @@ export class FrameBase extends CustomLayoutView {
 	}
 
 	public setCurrent(entry: BackstackEntry, navigationType: NavigationType): void {
+		const fromEntry = this._currentEntry;
 		const newPage = entry.resolvedPage;
 
 		// In case we navigated forward to a page that was in the backstack
@@ -274,11 +276,12 @@ export class FrameBase extends CustomLayoutView {
 		}
 
 		newPage.onNavigatedTo(isBack);
-		this.notify({
+		this.notify<NavigationData>({
 			eventName: FrameBase.navigatedToEvent,
 			object: this,
 			isBack,
 			entry,
+			fromEntry,
 		});
 
 		// Reset executing context after NavigatedTo is raised;
@@ -478,7 +481,7 @@ export class FrameBase extends CustomLayoutView {
 		}
 
 		backstackEntry.resolvedPage.onNavigatingTo(backstackEntry.entry.context, isBack, backstackEntry.entry.bindingContext);
-		this.notify({
+		this.notify<NavigationData>({
 			eventName: FrameBase.navigatingToEvent,
 			object: this,
 			isBack,

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -7,8 +7,8 @@ import { Transition } from '../transition';
 export * from './frame-interfaces';
 
 export interface NavigationData extends EventData {
-	entry?: NavigationEntry;
-	fromEntry?: NavigationEntry;
+	entry?: BackstackEntry;
+	fromEntry?: BackstackEntry;
 	isBack?: boolean;
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Frame has incorrect types for navigation events. These types seem to be leftovers from a previous breaking change regarding those events.

## What is the new behavior?
Updated Frame navigation event types to describe the event payload accurately.
Also, added a missing property to `navigatedTo` event.