### PR TITLE
fix(core): Added missing inheritance support for text css properties

### DIFF
--- a/packages/core/ui/text-base/index.d.ts
+++ b/packages/core/ui/text-base/index.d.ts
@@ -194,15 +194,15 @@ export const formattedTextProperty: Property<TextBase, FormattedString>;
 export const maxLinesProperty: InheritedCssProperty<Style, number>;
 export const textAlignmentProperty: InheritedCssProperty<Style, CoreTypes.TextAlignmentType>;
 export const textDecorationProperty: CssProperty<Style, CoreTypes.TextDecorationType>;
-export const textTransformProperty: CssProperty<Style, CoreTypes.TextTransformType>;
-export const textShadowProperty: CssProperty<Style, ShadowCSSValues>;
-export const textStrokeProperty: CssProperty<Style, StrokeCSSValues>;
-export const whiteSpaceProperty: CssProperty<Style, CoreTypes.WhiteSpaceType>;
+export const textTransformProperty: InheritedCssProperty<Style, CoreTypes.TextTransformType>;
+export const textShadowProperty: InheritedCssProperty<Style, ShadowCSSValues>;
+export const textStrokeProperty: InheritedCssProperty<Style, StrokeCSSValues>;
+export const whiteSpaceProperty: InheritedCssProperty<Style, CoreTypes.WhiteSpaceType>;
 export const textOverflowProperty: CssProperty<Style, CoreTypes.TextOverflowType>;
-export const letterSpacingProperty: CssProperty<Style, number>;
-export const lineHeightProperty: CssProperty<Style, number>;
+export const letterSpacingProperty: InheritedCssProperty<Style, number>;
+export const lineHeightProperty: InheritedCssProperty<Style, number>;
 
-//Used by tab view
+// Used by tab view
 export function getTransformedText(text: string, textTransform: CoreTypes.TextTransformType): string;
 
 export const resetSymbol: symbol;

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -290,7 +290,7 @@ export const textAlignmentProperty = new InheritedCssProperty<Style, CoreTypes.T
 textAlignmentProperty.register(Style);
 
 const textTransformConverter = makeParser<CoreTypes.TextTransformType>(makeValidator<CoreTypes.TextTransformType>('initial', 'none', 'capitalize', 'uppercase', 'lowercase'));
-export const textTransformProperty = new CssProperty<Style, CoreTypes.TextTransformType>({
+export const textTransformProperty = new InheritedCssProperty<Style, CoreTypes.TextTransformType>({
 	name: 'textTransform',
 	cssName: 'text-transform',
 	defaultValue: 'initial',
@@ -298,7 +298,7 @@ export const textTransformProperty = new CssProperty<Style, CoreTypes.TextTransf
 });
 textTransformProperty.register(Style);
 
-export const textShadowProperty = new CssProperty<Style, string | ShadowCSSValues>({
+export const textShadowProperty = new InheritedCssProperty<Style, string | ShadowCSSValues>({
 	name: 'textShadow',
 	cssName: 'text-shadow',
 	affectsLayout: __APPLE__,
@@ -308,7 +308,7 @@ export const textShadowProperty = new CssProperty<Style, string | ShadowCSSValue
 });
 textShadowProperty.register(Style);
 
-export const textStrokeProperty = new CssProperty<Style, string | StrokeCSSValues>({
+export const textStrokeProperty = new InheritedCssProperty<Style, string | StrokeCSSValues>({
 	name: 'textStroke',
 	cssName: 'text-stroke',
 	affectsLayout: __APPLE__,
@@ -319,7 +319,7 @@ export const textStrokeProperty = new CssProperty<Style, string | StrokeCSSValue
 textStrokeProperty.register(Style);
 
 const whiteSpaceConverter = makeParser<CoreTypes.WhiteSpaceType>(makeValidator<CoreTypes.WhiteSpaceType>('initial', 'normal', 'nowrap'));
-export const whiteSpaceProperty = new CssProperty<Style, CoreTypes.WhiteSpaceType>({
+export const whiteSpaceProperty = new InheritedCssProperty<Style, CoreTypes.WhiteSpaceType>({
 	name: 'whiteSpace',
 	cssName: 'white-space',
 	defaultValue: 'initial',


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the new behavior?
This PR adds missing inheritance support for some text-base properties according to MDN docs:
https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#formal_definition
https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow#formal_definition
https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-stroke#formal_definition
https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#formal_definition
