### PR TITLE
fix(core): Corrected background color between Label and nested spans

### DIFF
--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -624,8 +624,10 @@ function setSpanModifiers(ssb: android.text.SpannableStringBuilder, span: Span, 
 		ssb.setSpan(new android.text.style.ForegroundColorSpan(color.android), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 	}
 
-	if (spanStyle.backgroundColor) {
-		ssb.setSpan(new android.text.style.BackgroundColorSpan(spanStyle.backgroundColor.android), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+	// Use span or formatted string color
+	const backgroundColor = spanStyle.backgroundColor || span.parent.backgroundColor;
+	if (backgroundColor) {
+		ssb.setSpan(new android.text.style.BackgroundColorSpan(backgroundColor.android), start, end, android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 	}
 
 	const textDecoration: CoreTypes.TextDecorationType = getClosestPropertyValue(textDecorationProperty, span);

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -394,8 +394,8 @@ export class TextBase extends TextBaseCommon {
 		const fontScale = adjustMinMaxFontScale(span.style.fontScaleInternal, span);
 		const font = new Font(span.style.fontFamily, span.style.fontSize, span.style.fontStyle, span.style.fontWeight, fontScale, span.style.fontVariationSettings);
 		const iosFont = font.getUIFont(this.nativeTextViewProtected.font);
+		const backgroundColor = span.style.backgroundColor;
 
-		const backgroundColor = <Color>(span.style.backgroundColor || (<FormattedString>span.parent).backgroundColor || (<TextBase>span.parent.parent).backgroundColor);
 		return {
 			text,
 			iosFont,

--- a/packages/core/ui/text-base/index.ios.ts
+++ b/packages/core/ui/text-base/index.ios.ts
@@ -394,7 +394,8 @@ export class TextBase extends TextBaseCommon {
 		const fontScale = adjustMinMaxFontScale(span.style.fontScaleInternal, span);
 		const font = new Font(span.style.fontFamily, span.style.fontSize, span.style.fontStyle, span.style.fontWeight, fontScale, span.style.fontVariationSettings);
 		const iosFont = font.getUIFont(this.nativeTextViewProtected.font);
-		const backgroundColor = span.style.backgroundColor;
+		// Use span or formatted string color
+		const backgroundColor = span.style.backgroundColor || span.parent.backgroundColor;
 
 		return {
 			text,

--- a/packages/core/ui/text-base/span.d.ts
+++ b/packages/core/ui/text-base/span.d.ts
@@ -10,6 +10,13 @@ import { FormattedString } from './formatted-string';
  * @nsView Span
  */
 export class Span extends ViewBase {
+	/**
+	 * String value used when hooking to linkTap event.
+	 *
+	 * @nsEvent linkTap
+	 */
+	public static linkTapEvent: string;
+
 	declare parent: FormattedString;
 
 	/**
@@ -95,12 +102,6 @@ export class Span extends ViewBase {
 	 *  @nsProperty
 	 */
 	public text: string;
-	/**
-	 * String value used when hooking to linkTap event.
-	 *
-	 * @nsEvent linkTap
-	 */
-	public static linkTapEvent: string;
 
 	/**
 	 * Gets if the span is tappable or not.

--- a/packages/core/ui/text-base/span.d.ts
+++ b/packages/core/ui/text-base/span.d.ts
@@ -2,6 +2,7 @@
 import { ViewBase } from '../core/view-base';
 import { FontStyleType, FontVariationSettingsType, FontWeightType } from '../styling/font';
 import { CoreTypes } from '../../core-types';
+import { FormattedString } from './formatted-string';
 
 /**
  * A class used to create a single part of formatted string with a common text properties.
@@ -9,6 +10,8 @@ import { CoreTypes } from '../../core-types';
  * @nsView Span
  */
 export class Span extends ViewBase {
+	declare parent: FormattedString;
+
 	/**
 	 * Gets or sets the font family of the span.
 	 *

--- a/packages/core/ui/text-base/span.ts
+++ b/packages/core/ui/text-base/span.ts
@@ -5,11 +5,15 @@ import { FontStyleType, FontVariationSettingsType, FontWeightType } from '../sty
 import { CoreTypes } from '../../core-types';
 import { EventData } from '../../data/observable';
 import { isNullOrUndefined, isString } from '../../utils/types';
+import type { FormattedString } from './formatted-string';
 
 export class Span extends ViewBase implements SpanDefinition {
-	static linkTapEvent = 'linkTap';
+	public static linkTapEvent = 'linkTap';
+
 	private _text: string;
 	private _tappable = false;
+
+	declare parent: FormattedString;
 
 	get fontFamily(): string {
 		return this.style.fontFamily;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
There are cases when TextBase and Span background colors mismatch.
That is very apparent when tapping a button with spans and css `:pressed` pseudo-state.

## What is the new behavior?
Spans will be colorless (transparent) to display TextBase parent background color unless they or their `FormattedString` parents have a background color of their own.
This issue was partially fixed on android but also broke `FormattedString` color inheritance, so this PR fixes that too (see #10682).

Fixes/Closes #7379 .