### PR TITLE
feat(css): allow infinity values within css calc expressions

### DIFF
--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -150,11 +150,13 @@ export function _evaluateCssCalcExpression(value: string) {
 	}
 
 	if (isCssCalcExpression(value)) {
-		// WORKAROUND: reduce-css-calc can't handle the dip-unit.
+		// Note: reduce-css-calc can't handle certain values
 		let cssValue = value.replace(/([0-9]+(\.[0-9]+)?)dip\b/g, '$1');
 		if (cssValue.includes('unset')) {
-			// ensure unset is properly handled before processing calc
 			cssValue = cssValue.replace(/unset/g, '0');
+		}
+		if (cssValue.includes('infinity')) {
+			cssValue = cssValue.replace(/infinity/g, '999999');
 		}
 		return require('reduce-css-calc')(cssValue);
 	} else {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Tailwind 4, for example, uses css calc expressions, some of which contain `infinity` values. These would not be processed properly.

## What is the new behavior?

The `infinity` value will now properly evaluate to get expected styling results.

