### PR TITLE
fix(core): Added missing parameter for once event listeners

### DIFF
--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -197,7 +197,7 @@ export class Observable {
 	 * @param eventName Name of the event to attach to.
 	 * @param callback A function to be called when some of the specified event(s) is raised.
 	 * @param thisArg An optional parameter which when set will be used as "this" in callback method call.
-	 * @param once An optional parameter which when set will cause the event to fire once.
+	 * @param once An optional parameter which when set will cause the event listener to fire once.
 	 */
 	public addEventListener(eventName: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean): void {
 		once = once || undefined;

--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -197,6 +197,7 @@ export class Observable {
 	 * @param eventName Name of the event to attach to.
 	 * @param callback A function to be called when some of the specified event(s) is raised.
 	 * @param thisArg An optional parameter which when set will be used as "this" in callback method call.
+	 * @param once An optional parameter which when set will cause the event to fire once.
 	 */
 	public addEventListener(eventName: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean): void {
 		once = once || undefined;

--- a/packages/core/media-query-list/index.ts
+++ b/packages/core/media-query-list/index.ts
@@ -118,13 +118,13 @@ class MediaQueryListImpl extends Observable implements MediaQueryList {
 	}
 
 	// @ts-ignore
-	public addEventListener(eventName: string, callback: (data: EventData) => void, thisArg?: any): void {
+	public addEventListener(eventName: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean): void {
 		this._throwInvocationError?.();
 
 		const hasChangeListeners = this.hasListeners(MediaQueryListImpl.changeEvent);
 
 		// Call super method first since it throws in the case of bad parameters
-		super.addEventListener(eventName, callback, thisArg);
+		super.addEventListener(eventName, callback, thisArg, once);
 
 		if (eventName === MediaQueryListImpl.changeEvent && !hasChangeListeners) {
 			mediaQueryLists.push(this);

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -335,8 +335,8 @@ export class View extends ViewCommon {
 		}
 	}
 
-	addEventListener(eventNames: string, callback: (data: EventData) => void, thisArg?: any) {
-		super.addEventListener(eventNames, callback, thisArg);
+	addEventListener(eventNames: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean) {
+		super.addEventListener(eventNames, callback, thisArg, once);
 		const isLayoutEvent = typeof eventNames === 'string' ? eventNames.indexOf(ViewCommon.layoutChangedEvent) !== -1 : false;
 
 		if (this.isLoaded && !this.layoutChangeListenerIsSet && isLayoutEvent) {

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -303,7 +303,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		return this._gestureObservers[type];
 	}
 
-	public addEventListener(eventNames: string, callback: (data: EventData) => void, thisArg?: any) {
+	public addEventListener(eventNames: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean) {
 		thisArg = thisArg || undefined;
 
 		// TODO: Remove this once we fully switch to the new event system
@@ -330,7 +330,7 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 			return;
 		}
 
-		super.addEventListener(normalizedName, callback, thisArg);
+		super.addEventListener(normalizedName, callback, thisArg, once);
 	}
 
 	public removeEventListener(eventNames: string, callback?: (data: EventData) => void, thisArg?: any) {

--- a/packages/core/ui/scroll-view/scroll-view-common.ts
+++ b/packages/core/ui/scroll-view/scroll-view-common.ts
@@ -17,10 +17,10 @@ export abstract class ScrollViewBase extends ContentView implements ScrollViewDe
 
 	private _addedScrollEvent = false;
 
-	public addEventListener(arg: string, callback: (data: EventData) => void, thisArg?: any): void {
+	public addEventListener(arg: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean): void {
 		const hasExistingScrollListeners: boolean = this.hasListeners(ScrollViewBase.scrollEvent);
 
-		super.addEventListener(arg, callback, thisArg);
+		super.addEventListener(arg, callback, thisArg, once);
 
 		// This indicates that a scroll listener was added for first time
 		if (!hasExistingScrollListeners && this.hasListeners(ScrollViewBase.scrollEvent)) {

--- a/packages/core/ui/text-base/span.ts
+++ b/packages/core/ui/text-base/span.ts
@@ -113,8 +113,8 @@ export class Span extends ViewBase implements SpanDefinition {
 		return this._tappable;
 	}
 
-	addEventListener(arg: string, callback: (data: EventData) => void, thisArg?: any): void {
-		super.addEventListener(arg, callback, thisArg);
+	addEventListener(arg: string, callback: (data: EventData) => void, thisArg?: any, once?: boolean): void {
+		super.addEventListener(arg, callback, thisArg, once);
 		this._setTappable(this.hasListeners(Span.linkTapEvent));
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, `View` event listeners registered using `once` don't get removed upon being called.

## What is the new behavior?
`View` event listeners registered using `once` will behave as expected.