### PR TITLE
feat(observable): enhance event callback type specificity

### DIFF
--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -1,4 +1,4 @@
-import { Optional } from '../../utils/typescript-utils';
+import { Optional, EndsWith } from '../../utils/typescript-utils';
 
 /**
  * Base event data.
@@ -160,7 +160,7 @@ export class Observable {
 	 * `this` context when the callback is called. Falsy values will be not be
 	 * bound.
 	 */
-	public on(eventName: string, callback: (data: EventData) => void, thisArg?: any): void {
+	public on<S extends string>(eventName: S, callback: (data: EndsWith<S, 'Change', PropertyChangeData, EventData>) => void, thisArg?: any): void {
 		this.addEventListener(eventName, callback, thisArg);
 	}
 
@@ -175,7 +175,7 @@ export class Observable {
 	 * `this` context when the callback is called. Falsy values will be not be
 	 * bound.
 	 */
-	public once(eventName: string, callback: (data: EventData) => void, thisArg?: any): void {
+	public once<S extends string>(eventName: S, callback: (data: EndsWith<S, 'Change', PropertyChangeData, EventData>) => void, thisArg?: any): void {
 		this.addEventListener(eventName, callback, thisArg, true);
 	}
 
@@ -188,7 +188,7 @@ export class Observable {
 	 * @param thisArg An optional parameter which, when set, will be used to
 	 * refine search of the correct event listener to be removed.
 	 */
-	public off(eventName: string, callback?: (data: EventData) => void, thisArg?: any): void {
+	public off<S extends string>(eventName: S, callback?: (data: EndsWith<S, 'Change', PropertyChangeData, EventData>) => void, thisArg?: any): void {
 		this.removeEventListener(eventName, callback, thisArg);
 	}
 

--- a/packages/core/utils/typescript-utils.d.ts
+++ b/packages/core/utils/typescript-utils.d.ts
@@ -4,3 +4,12 @@
  * // returns: { eventName: string; object?: Observable }
  */
 export type Optional<T, K extends keyof T> = Omit<T, K> & { [P in K]?: T[P] };
+
+/**
+ * Determines if a string type ends with a specified suffix.
+ * @example type IsChangeEvent = EndsWith<"propertyNameChange", "Change", true, false>
+ * // returns: true
+ * @example type IsChangeEvent = EndsWith<"someEvent", "Change", true, false>
+ * // returns: false
+ */
+export type EndsWith<T extends string, S extends string, PassType = true, FailType = false> = T extends `${infer _}${S}` ? PassType : FailType;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Currently, the `on`, `off`, and `once` methods in `@nativescript/core/data/observable/index.ts` use a generic `EventData` type for all event callbacks, regardless of the event name. This lacks type specificity, especially for "Change" events, which should use `PropertyChangeData`.

## What is the new behavior?
This PR introduces the `EndsWith` utility type to dynamically determine the callback data type based on the event name. If the `eventName` ends with "Change", the callback will use `PropertyChangeData`; otherwise, it will use `EventData`. This provides improved type safety and developer experience.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

