### PR TITLE
fix: view factory types

### DIFF
--- a/packages/types-ios/src/lib/ios/objc-x86_64/objc!NativeScriptEmbedder.d.ts
+++ b/packages/types-ios/src/lib/ios/objc-x86_64/objc!NativeScriptEmbedder.d.ts
@@ -31,6 +31,7 @@ declare var NativeScriptEmbedderDelegate: {
 
 declare class NativeScriptViewFactory extends NSObject {
 	static getKeyWindow(): UIWindow;
+	static initShared(): void;
 	static shared: NativeScriptViewFactory;
 	views: NSMutableDictionary<string, any>;
 	viewCreator: (id: string, ctrl: UIViewController) => void;


### PR DESCRIPTION
## What is the current behavior?

`initShared` was missing from view factory types.

## What is the new behavior?

Ensures `initShared` is strongly typed.

