### PR TITLE
fix(http): xcode 16.3, ios 18.4 urlsession change

### DIFF
--- a/packages/core/http/http-request/index.ios.ts
+++ b/packages/core/http/http-request/index.ios.ts
@@ -19,7 +19,7 @@ const osVersion = currentDevice.systemVersion;
 const GET = 'GET';
 const USER_AGENT_HEADER = 'User-Agent';
 const USER_AGENT = `Mozilla/5.0 (i${device}; CPU OS ${osVersion.replace('.', '_')} like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/${osVersion} Mobile/10A5355d Safari/8536.25`;
-const sessionConfig = NSURLSessionConfiguration.defaultSessionConfiguration;
+const sessionConfig = NSURLSessionConfiguration.ephemeralSessionConfiguration;
 const queue = NSOperationQueue.mainQueue;
 
 function parseJSON(source: string): any {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

With Xcode 16.3 (iOS 18.4) simulators, network failures could occur.

## What is the new behavior?

Use `ephemeralSessionConfiguration` instead of `defaultSessionConfiguration`.

