### PR TITLE
fix(android): handle width and height as strings in ImageAsset options

### DIFF
--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -5,7 +5,7 @@ import { Screen } from '../platform';
 export * from './image-asset-common';
 
 export class ImageAsset extends ImageAssetBase {
-	private _android: string; //file name of the image
+	private _android: string; // file name of the image
 
 	constructor(asset: string) {
 		super();
@@ -26,10 +26,34 @@ export class ImageAsset extends ImageAssetBase {
 	}
 
 	public getImageAsync(callback: (image, error) => void) {
+		// Clone and sanitize the options before sending to Android
+		const options = { ...(this.options || {}) };
+
+		// Sanitize width and height (convert string to number if needed)
+		if (typeof options.width === 'string') {
+			const parsedWidth = parseInt(options.width, 10);
+			if (!isNaN(parsedWidth)) {
+				options.width = parsedWidth;
+			} else {
+				console.warn('Invalid width value provided:', options.width);
+				delete options.width;
+			}
+		}
+
+		if (typeof options.height === 'string') {
+			const parsedHeight = parseInt(options.height, 10);
+			if (!isNaN(parsedHeight)) {
+				options.height = parsedHeight;
+			} else {
+				console.warn('Invalid height value provided:', options.height);
+				delete options.height;
+			}
+		}
+
 		org.nativescript.widgets.Utils.loadImageAsync(
 			ad.getApplicationContext(),
 			this.android,
-			JSON.stringify(this.options || {}),
+			JSON.stringify(options),
 			Screen.mainScreen.widthPixels,
 			Screen.mainScreen.heightPixels,
 			new org.nativescript.widgets.Utils.AsyncImageCallback({


### PR DESCRIPTION
## PR Checklist
- [x] There is an issue for the bug/feature this PR is for: #10668
- [x] I have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing.

---

## What is the current behavior?

When `ImageAsset.options.width` and `options.height` are provided as **strings** (e.g., `"300"`), the Android implementation crashes. The method `loadImageAsync` expects numeric values for dimensions, but receives a stringified version, causing an exception and breaking image loading.

---

## What is the new behavior?

- Explicitly parses `options.width` and `options.height` using `parseInt()`.
- Prevents crashes when developers provide string values.
- Defaults to `Screen.mainScreen.widthPixels` and `heightPixels` when parsing fails.
- Adds resilience to the image loading logic and improves developer experience.

---

Fixes #10668

---

## Additional Notes

- This update resolves a breaking bug that affected multiple NativeScript users.
- Validated across devices with both numeric and string values.
- PR tested manually; guidance requested to add or locate proper unit tests for `ImageAsset`.

---
