### PR TITLE
fix(ios): 18.4 simulator networking case

### DIFF
--- a/packages/core/http/http-request/index.ios.ts
+++ b/packages/core/http/http-request/index.ios.ts
@@ -3,6 +3,8 @@ import * as httpModule from '../../http';
 import * as imageSourceModule from '../../image-source';
 import * as fsModule from '../../file-system';
 
+import { SDK_VERSION } from '../../utils/constants';
+import { isRealDevice } from '../../utils/ios';
 import * as types from '../../utils/types';
 import * as domainDebugger from '../../debugger';
 import { getFilenameFromUrl } from './http-request-common';
@@ -19,7 +21,9 @@ const osVersion = currentDevice.systemVersion;
 const GET = 'GET';
 const USER_AGENT_HEADER = 'User-Agent';
 const USER_AGENT = `Mozilla/5.0 (i${device}; CPU OS ${osVersion.replace('.', '_')} like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/${osVersion} Mobile/10A5355d Safari/8536.25`;
-const sessionConfig = NSURLSessionConfiguration.ephemeralSessionConfiguration;
+// mitigate iOS 18.4 simulator regression
+// https://developer.apple.com/forums/thread/777999
+const sessionConfig = SDK_VERSION === 18.4 && !isRealDevice() ? NSURLSessionConfiguration.ephemeralSessionConfiguration : NSURLSessionConfiguration.defaultSessionConfiguration;
 const queue = NSOperationQueue.mainQueue;
 
 function parseJSON(source: string): any {


### PR DESCRIPTION
## What is the current behavior?

iOS 18.4 "simulators only" have networking bug. Physical devices are fine.

## What is the new behavior?

Just mitigate for end users for these 18.4 simulators.
https://developer.apple.com/forums/thread/777999

