### PR TITLE
fix(android) handle width height as strings in image-asset

### DIFF
--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -1,7 +1,6 @@
 import { ImageAsset as ImageAssetDefinition, ImageAssetOptions } from '.';
 import { Observable } from '../data/observable';
 import { Screen } from '../platform';
-import { Trace } from '../trace/index';
 
 export class ImageAssetBase extends Observable implements ImageAssetDefinition {
 	private _options: ImageAssetOptions;
@@ -55,7 +54,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 		if (!isNaN(parsedWidth)) {
 			optionsCopy.width = parsedWidth;
 		} else {
-			Trace.write('Invalid width value provided: ' + optionsCopy.width, Trace.categories.Debug, Trace.messageType.warn);
+			console.warn('Invalid width value provided: ', optionsCopy.width);
 			delete optionsCopy.width;
 		}
 	}
@@ -65,7 +64,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 		if (!isNaN(parsedHeight)) {
 			optionsCopy.height = parsedHeight;
 		} else {
-			Trace.write('Invalid height value provided: ' + optionsCopy.height, Trace.categories.Debug, Trace.messageType.warn);
+			console.warn('Invalid height value provided: ', optionsCopy.height);
 			delete optionsCopy.height;
 		}
 	}

--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -47,8 +47,30 @@ export function getAspectSafeDimensions(sourceWidth, sourceHeight, reqWidth, req
 }
 
 export function getRequestedImageSize(src: { width: number; height: number }, options: ImageAssetOptions): { width: number; height: number } {
-	let reqWidth = options.width || Math.min(src.width, Screen.mainScreen.widthPixels);
-	let reqHeight = options.height || Math.min(src.height, Screen.mainScreen.heightPixels);
+	const optionsCopy = { ...(this.options || {}) };
+
+	if (typeof optionsCopy.width === 'string') {
+		const parsedWidth = parseInt(optionsCopy.width, 10);
+		if (!isNaN(parsedWidth)) {
+			optionsCopy.width = parsedWidth;
+		} else {
+			console.warn('Invalid width value provided: ', optionsCopy.width);
+			delete optionsCopy.width;
+		}
+	}
+
+	if (typeof optionsCopy.height === 'string') {
+		const parsedHeight = parseInt(optionsCopy.height, 10);
+		if (!isNaN(parsedHeight)) {
+			optionsCopy.height = parsedHeight;
+		} else {
+			console.warn('Invalid height value provided: ', options.height);
+			delete optionsCopy.height;
+		}
+	}
+
+	let reqWidth = optionsCopy.width || Math.min(src.width, Screen.mainScreen.widthPixels);
+	let reqHeight = optionsCopy.height || Math.min(src.height, Screen.mainScreen.heightPixels);
 
 	if (options && options.keepAspectRatio) {
 		const safeAspectSize = getAspectSafeDimensions(src.width, src.height, reqWidth, reqHeight);

--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -47,7 +47,7 @@ export function getAspectSafeDimensions(sourceWidth, sourceHeight, reqWidth, req
 }
 
 export function getRequestedImageSize(src: { width: number; height: number }, options: ImageAssetOptions): { width: number; height: number } {
-	const optionsCopy = { ...(this.options || {}) };
+	const optionsCopy = { ...(options || {}) };
 
 	if (typeof optionsCopy.width === 'string') {
 		const parsedWidth = parseInt(optionsCopy.width, 10);
@@ -69,8 +69,8 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 		}
 	}
 
-	let reqWidth = optionsCopy.width || Math.min(src.width, Screen.mainScreen.widthPixels);
-	let reqHeight = optionsCopy.height || Math.min(src.height, Screen.mainScreen.heightPixels);
+	let reqWidth = (optionsCopy.width as number) || Math.min(src.width, Screen.mainScreen.widthPixels);
+	let reqHeight = (optionsCopy.height as number) || Math.min(src.height, Screen.mainScreen.heightPixels);
 
 	if (options && options.keepAspectRatio) {
 		const safeAspectSize = getAspectSafeDimensions(src.width, src.height, reqWidth, reqHeight);

--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -1,6 +1,7 @@
 import { ImageAsset as ImageAssetDefinition, ImageAssetOptions } from '.';
 import { Observable } from '../data/observable';
 import { Screen } from '../platform';
+import { Trace } from '../trace/index';
 
 export class ImageAssetBase extends Observable implements ImageAssetDefinition {
 	private _options: ImageAssetOptions;
@@ -54,7 +55,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 		if (!isNaN(parsedWidth)) {
 			optionsCopy.width = parsedWidth;
 		} else {
-			console.warn('Invalid width value provided: ', optionsCopy.width);
+			Trace.write('Invalid width value provided: ' + optionsCopy.width, Trace.categories.Debug, Trace.messageType.warn);
 			delete optionsCopy.width;
 		}
 	}
@@ -64,7 +65,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 		if (!isNaN(parsedHeight)) {
 			optionsCopy.height = parsedHeight;
 		} else {
-			console.warn('Invalid height value provided: ', options.height);
+			Trace.write('Invalid height value provided: ' + optionsCopy.height, Trace.categories.Debug, Trace.messageType.warn);
 			delete optionsCopy.height;
 		}
 	}

--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -55,7 +55,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 			optionsCopy.width = parsedWidth;
 		} else {
 			console.warn('Invalid width value provided: ', optionsCopy.width);
-			delete optionsCopy.width;
+			optionsCopy.width = undefined;
 		}
 	}
 
@@ -65,7 +65,7 @@ export function getRequestedImageSize(src: { width: number; height: number }, op
 			optionsCopy.height = parsedHeight;
 		} else {
 			console.warn('Invalid height value provided: ', optionsCopy.height);
-			delete optionsCopy.height;
+			optionsCopy.height = undefined;
 		}
 	}
 

--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -31,8 +31,14 @@ export class ImageAsset extends ImageAssetBase {
 			return;
 		}
 
-		const srcWidth = this.nativeImage ? this.nativeImage.size.width : Screen.mainScreen.widthPixels;
-		const srcHeight = this.nativeImage ? this.nativeImage.size.height : Screen.mainScreen.heightPixels;
+		const srcWidth = this.nativeImage ? (
+			typeof this.nativeImage.getWidth === 'function' ? this.nativeImage.getWidth() : this.nativeImage.size?.width
+		) : Screen.mainScreen.widthPixels;
+
+		const srcHeight = this.nativeImage ? (
+			typeof this.nativeImage.getHeight === 'function' ? this.nativeImage.getHeight() : this.nativeImage.size?.height
+		) : Screen.mainScreen.widthPixels;
+
 		const requestedSize = getRequestedImageSize({ width: srcWidth, height: srcHeight }, this.options);
 
 		const optionsCopy = {

--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -26,10 +26,25 @@ export class ImageAsset extends ImageAssetBase {
 	}
 
 	public getImageAsync(callback: (image, error) => void) {
+		if (!this._android && !this.nativeImage) {
+			callback(null, 'Asset cannot be found.');
+			return;
+		}
+
+		const srcWidth = this.nativeImage ? this.nativeImage.size.width : Screen.mainScreen.widthPixels;
+		const srcHeight = this.nativeImage ? this.nativeImage.size.height : Screen.mainScreen.heightPixels;
+		const requestedSize = getRequestedImageSize({ width: srcWidth, height: srcHeight }, this.options);
+
+		const optionsCopy = {
+			...this.options,
+			width: requestedSize.width,
+			height: requestedSize.height,
+		};
+
 		org.nativescript.widgets.Utils.loadImageAsync(
 			ad.getApplicationContext(),
 			this.android,
-			JSON.stringify(this.options || {}),
+			JSON.stringify(optionsCopy),
 			Screen.mainScreen.widthPixels,
 			Screen.mainScreen.heightPixels,
 			new org.nativescript.widgets.Utils.AsyncImageCallback({
@@ -39,7 +54,7 @@ export class ImageAsset extends ImageAssetBase {
 				onError(ex) {
 					callback(null, ex);
 				},
-			})
+			}),
 		);
 	}
 }

--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -26,7 +26,7 @@ export class ImageAsset extends ImageAssetBase {
 	}
 
 	public getImageAsync(callback: (image, error) => void) {
-		if (!this._android && !this.nativeImage) {
+		if (!this.android && !this.nativeImage) {
 			callback(null, 'Asset cannot be found.');
 			return;
 		}

--- a/packages/core/image-asset/index.d.ts
+++ b/packages/core/image-asset/index.d.ts
@@ -10,8 +10,8 @@ export class ImageAsset extends Observable {
 }
 
 export interface ImageAssetOptions {
-	width?: number;
-	height?: number;
+	width?: number | string;
+	height?: number | string;
 	keepAspectRatio?: boolean;
 	autoScaleFactor?: boolean;
 }

--- a/packages/core/image-asset/index.ios.ts
+++ b/packages/core/image-asset/index.ios.ts
@@ -1,6 +1,7 @@
 import { ImageAssetBase, getRequestedImageSize } from './image-asset-common';
 import { path as fsPath, knownFolders } from '../file-system';
 import { queueGC } from '../utils';
+import {Screen} from "../platform";
 
 export * from './image-asset-common';
 
@@ -36,8 +37,14 @@ export class ImageAsset extends ImageAssetBase {
 			callback(null, 'Asset cannot be found.');
 		}
 
-		const srcWidth = this.nativeImage ? this.nativeImage.size.width : this.ios.pixelWidth;
-		const srcHeight = this.nativeImage ? this.nativeImage.size.height : this.ios.pixelHeight;
+		const srcWidth = this.nativeImage ? (
+			typeof this.nativeImage.getWidth === 'function' ? this.nativeImage.getWidth() : this.nativeImage.size?.width
+		) : this.ios.pixelWidth;
+
+		const srcHeight = this.nativeImage ? (
+			typeof this.nativeImage.getHeight === 'function' ? this.nativeImage.getHeight() : this.nativeImage.size?.height
+		) : this.ios.pixelHeight;
+
 		const requestedSize = getRequestedImageSize({ width: srcWidth, height: srcHeight }, this.options);
 
 		if (this.nativeImage) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Passing a string (e.g. "300") to width or height in ImageAssetOptions on Android results in a crash on older API levels (e.g. API 22), with the error:

`IllegalArgumentException: bitmap size exceeds 32 bits`

This happens because the dimensions are not parsed properly, and Android attempts to decode the image with invalid bounds.

## What is the new behavior?
<!-- Describe the changes. -->
Ensures that width and height are explicitly parsed using parseInt() if they are strings.
Falls back to screen dimensions (Screen.mainScreen.widthPixels/heightPixels) if parsing fails.
Prevents runtime crashes.

Fixes/Implements/Closes #[6289].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image asset configuration now supports specifying width and height as either numbers or strings for greater flexibility.

- **Bug Fixes**
  - Improved handling of invalid width and height values by normalizing or removing them as needed, with warnings logged for invalid entries.

- **Chores**
  - Enhanced internal logic for image size calculation and loading, providing more robust and predictable image asset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->