### PR TITLE
feat(TextField): support css white-space and text-overflow

### DIFF
--- a/apps/toolbox/src/app.css
+++ b/apps/toolbox/src/app.css
@@ -261,3 +261,9 @@ Button {
 .no-shadow {
     box-shadow: none;
 }
+
+.truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/apps/toolbox/src/pages/forms.xml
+++ b/apps/toolbox/src/pages/forms.xml
@@ -24,6 +24,10 @@
       <TextView hint="Type text..." style.placeholderColor="silver" textChange="{{textChangeArea}}" color="black" width="80%" borderColor="silver" borderWidth="1" height="200" borderRadius="4" fontSize="14">
       </TextView>
 
+      <Label text="TextField white-space + text-overflow" fontWeight="bold" marginTop="12" />
+      <TextField text="https://a.very.long.url.that.needs.to.be.truncated.com/" class="truncate" marginTop="6" backgroundColor="#efefef" padding="8" fontSize="18" height="60">
+      </TextField>
+
     </StackLayout>
   </ScrollView>
 </Page>

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -91,7 +91,7 @@ export namespace CoreTypes {
 		export const lowercase = 'lowercase';
 	}
 
-	export type WhiteSpaceType = 'normal' | 'nowrap' | CSSWideKeywords;
+	export type WhiteSpaceType = 'normal' | 'nowrap' | 'wrap' | CSSWideKeywords;
 	export namespace WhiteSpace {
 		export const normal = 'normal';
 		export const nowrap = 'nowrap';

--- a/packages/core/ui/text-base/text-base-common.ts
+++ b/packages/core/ui/text-base/text-base-common.ts
@@ -318,7 +318,7 @@ export const textStrokeProperty = new InheritedCssProperty<Style, string | Strok
 });
 textStrokeProperty.register(Style);
 
-const whiteSpaceConverter = makeParser<CoreTypes.WhiteSpaceType>(makeValidator<CoreTypes.WhiteSpaceType>('normal', 'nowrap'));
+const whiteSpaceConverter = makeParser<CoreTypes.WhiteSpaceType>(makeValidator<CoreTypes.WhiteSpaceType>('normal', 'nowrap', 'wrap'));
 export const whiteSpaceProperty = new InheritedCssProperty<Style, CoreTypes.WhiteSpaceType>({
 	name: 'whiteSpace',
 	cssName: 'white-space',

--- a/packages/core/ui/text-field/index.android.ts
+++ b/packages/core/ui/text-field/index.android.ts
@@ -1,7 +1,5 @@
 import { TextFieldBase, secureProperty } from './text-field-common';
-import { whiteSpaceProperty } from '../text-base';
 import { keyboardTypeProperty } from '../editable-text-base';
-import { CoreTypes } from '../../core-types';
 
 export * from './text-field-common';
 
@@ -95,13 +93,6 @@ export class TextField extends TextFieldBase {
 		}
 
 		this._setInputType(inputType);
-	}
-
-	[whiteSpaceProperty.getDefault](): CoreTypes.WhiteSpaceType {
-		return 'nowrap';
-	}
-	[whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {
-		// Don't change it otherwise TextField will go to multiline mode.
 	}
 }
 

--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -350,7 +350,7 @@ export class TextField extends TextFieldBase {
 		}
 
 		if (paragraphStyle) {
-			let attributedString = NSMutableAttributedString.alloc().initWithString(this.nativeViewProtected.text);
+			let attributedString = NSMutableAttributedString.alloc().initWithString(this.nativeViewProtected.text || '');
 			attributedString.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, NSRangeFromString(`{0,${attributedString.length}}`));
 
 			this.nativeViewProtected.attributedText = attributedString;

--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -343,6 +343,10 @@ export class TextField extends TextFieldBase {
 						break;
 				}
 				break;
+			case 'wrap':
+				paragraphStyle = NSMutableParagraphStyle.new();
+				paragraphStyle.lineBreakMode = NSLineBreakMode.ByWordWrapping;
+				break;
 		}
 
 		if (paragraphStyle) {

--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -1,5 +1,5 @@
 import { TextFieldBase, secureProperty } from './text-field-common';
-import { textProperty } from '../text-base';
+import { textOverflowProperty, textProperty, whiteSpaceProperty } from '../text-base';
 import { hintProperty, placeholderColorProperty, _updateCharactersInRangeReplacementString } from '../editable-text-base';
 import { CoreTypes } from '../../core-types';
 import { Color } from '../../color';
@@ -316,5 +316,40 @@ export class TextField extends TextFieldBase {
 	}
 	[paddingLeftProperty.setNative](value: CoreTypes.LengthType) {
 		// Padding is realized via UITextFieldImpl.textRectForBounds method
+	}
+
+	[whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {
+		this.adjustLineBreak();
+	}
+
+	[textOverflowProperty.setNative](value: CoreTypes.TextOverflowType) {
+		this.adjustLineBreak();
+	}
+
+	private adjustLineBreak() {
+		let paragraphStyle: NSMutableParagraphStyle;
+
+		switch (this.whiteSpace) {
+			case 'nowrap':
+				switch (this.textOverflow) {
+					case 'clip':
+						paragraphStyle = NSMutableParagraphStyle.new();
+						paragraphStyle.lineBreakMode = NSLineBreakMode.ByClipping;
+						break;
+					default:
+						// ellipsis
+						paragraphStyle = NSMutableParagraphStyle.new();
+						paragraphStyle.lineBreakMode = NSLineBreakMode.ByTruncatingTail;
+						break;
+				}
+				break;
+		}
+
+		if (paragraphStyle) {
+			let attributedString = NSMutableAttributedString.alloc().initWithString(this.nativeViewProtected.text);
+			attributedString.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, NSRangeFromString(`{0,${attributedString.length}}`));
+
+			this.nativeViewProtected.attributedText = attributedString;
+		}
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Using `text-overflow` or `white-space` with `TextField` had no effect on the appearance of the text input.

## What is the new behavior?

Users can now use:

```css
.truncate {
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
}
```
Or the tailwind equivalent `truncate` utility to properly add ending ellipsis to a long input field. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for text truncation in text fields, allowing long text to be displayed with an ellipsis and preventing wrapping.
  - Introduced a new section in the form page demonstrating text truncation with a long URL example.
  - Expanded white-space handling in text fields to include wrapping behavior.

- **Bug Fixes**
  - Corrected a CSS syntax issue with the `.no-shadow` class.

- **Style**
  - Added a `.truncate` CSS class for handling text overflow and truncation.

- **Improvements**
  - Enhanced text field handling of white-space and text-overflow properties, especially on iOS, for better control over line breaking and truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->