### PR TITLE
fix(ios): listview incorrect measurement

### DIFF
--- a/packages/core/ui/list-view/index.ios.ts
+++ b/packages/core/ui/list-view/index.ios.ts
@@ -392,9 +392,12 @@ export class ListView extends ListViewBase {
 	}
 
 	public measure(widthMeasureSpec: number, heightMeasureSpec: number): void {
+		const changed: boolean = this._currentWidthMeasureSpec !== widthMeasureSpec || this._currentHeightMeasureSpec !== heightMeasureSpec;
+
 		this.widthMeasureSpec = widthMeasureSpec;
-		const changed = this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
 		super.measure(widthMeasureSpec, heightMeasureSpec);
+
+		// Reload native view cells only in the case of size change
 		if (changed) {
 			this.nativeViewProtected.reloadData();
 		}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
On iOS, there are times `ListView` skips needed measure updates. That is because method `measure` is overridden and performs a check that causes defects.
See: https://github.com/NativeScript/NativeScript/blob/main/packages/core/ui/list-view/index.ios.ts#L396

Calling `_setCurrentMeasureSpecs` may indicate whether size changed but also updates previous measure spec values, resulting in skipping measure update in the `super.measure()` call.

## What is the new behavior?
iOS ListView will undergo measurements as expected.