### PR TITLE
fix(android): allow CSS styling of neutral button in dialogs

### DIFF
--- a/packages/core/ui/dialogs/index.android.ts
+++ b/packages/core/ui/dialogs/index.android.ts
@@ -48,7 +48,7 @@ function showDialog(builder: android.app.AlertDialog.Builder) {
 
 	if (color) {
 		const buttons: android.widget.Button[] = [];
-		for (let i = 0; i < 3; i++) {
+		for (let i = 0; i < 4; i++) {
 			const id = dlg
 				.getContext()
 				.getResources()
@@ -82,7 +82,7 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
 					dialog.cancel();
 					callback(true);
 				},
-			})
+			}),
 		);
 	}
 
@@ -94,7 +94,7 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
 					dialog.cancel();
 					callback(false);
 				},
-			})
+			}),
 		);
 	}
 
@@ -106,7 +106,7 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
 					dialog.cancel();
 					callback(undefined);
 				},
-			})
+			}),
 		);
 	}
 	alert.setOnDismissListener(
@@ -114,7 +114,7 @@ function addButtonsToAlertDialog(alert: android.app.AlertDialog.Builder, options
 			onDismiss: function () {
 				callback(false);
 			},
-		})
+		}),
 	);
 }
 
@@ -132,14 +132,14 @@ export function alert(arg: any): Promise<void> {
 						dialog.cancel();
 						resolve();
 					},
-				})
+				}),
 			);
 			alert.setOnDismissListener(
 				new android.content.DialogInterface.OnDismissListener({
 					onDismiss: function () {
 						resolve();
 					},
-				})
+				}),
 			);
 
 			showDialog(alert);
@@ -158,7 +158,7 @@ export function confirm(arg: any): Promise<boolean> {
 						okButtonText: DialogStrings.OK,
 						cancelButtonText: DialogStrings.CANCEL,
 						message: arg + '',
-				  }
+					}
 				: arg;
 			const alert = createAlertDialog(options);
 
@@ -345,7 +345,7 @@ export function action(...args): Promise<string> {
 						onClick: function (dialog: android.content.DialogInterface, which: number) {
 							resolve(options.actions[which]);
 						},
-					})
+					}),
 				);
 			}
 
@@ -357,7 +357,7 @@ export function action(...args): Promise<string> {
 							dialog.cancel();
 							resolve(options.cancelButtonText);
 						},
-					})
+					}),
 				);
 			}
 
@@ -370,7 +370,7 @@ export function action(...args): Promise<string> {
 							resolve('');
 						}
 					},
-				})
+				}),
 			);
 
 			showDialog(alert);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When styling the android dialog buttons through CSS, the neutral button will be unstyled. This is because the buttons are actually `android:id/button1` to `android:id/button3` not 0 to 2.

## What is the new behavior?
The neutral button is properly styled. As a failsafe, I decided to keep looking for buttons 0-3 instead of 1-3, just in case there's an edge case I might have missed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved button color styling in dialogs to support an additional button on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->