### PR TITLE
fix(android): RootLayout shade cover blinking animation

### DIFF
--- a/packages/core/ui/layouts/root-layout/index.android.ts
+++ b/packages/core/ui/layouts/root-layout/index.android.ts
@@ -76,10 +76,10 @@ export class RootLayout extends RootLayoutBase {
 		return this._playAnimation(this._getAnimationSet(view, exitState), exitState?.duration);
 	}
 
-	private _getAnimationSet(view: View, shadeCoverAnimation: TransitionAnimation, backgroundColor: string = defaultShadeCoverOptions.color): Array<android.animation.Animator> {
+	private _getAnimationSet(view: View, shadeCoverAnimation: TransitionAnimation, backgroundColor?: string): Array<android.animation.Animator> {
 		const isBackgroundGradient = backgroundColor && backgroundColor.startsWith('linear-gradient');
 
-		const animationSet = Array.create(android.animation.Animator, isBackgroundGradient ? 6 : 7);
+		const animationSet = Array.create(android.animation.Animator, !backgroundColor || isBackgroundGradient ? 6 : 7);
 		animationSet[0] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'translationX', [shadeCoverAnimation.translateX]);
 		animationSet[1] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'translationY', [shadeCoverAnimation.translateY]);
 		animationSet[2] = android.animation.ObjectAnimator.ofFloat(view.nativeViewProtected, 'scaleX', [shadeCoverAnimation.scaleX]);
@@ -97,7 +97,10 @@ export class RootLayout extends RootLayoutBase {
 			if (view.backgroundImage) {
 				view.backgroundImage = undefined;
 			}
-			animationSet[6] = this._getBackgroundColorAnimator(view, backgroundColor);
+
+			if (backgroundColor) {
+				animationSet[6] = this._getBackgroundColorAnimator(view, backgroundColor);
+			}
 		}
 		return animationSet;
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
On android, `RootLayout` shade cover has a strange dark blinking on shade animation start.
That is because we enforce a default color in cases when color shouldn't be animated (init and close).

## What is the new behavior?
This PR makes sure that `RootLayout` will animate shade cover color only when needed.
As for default shade color, it's already set on a previous step so it doesn't break.