### PR TITLE
fix(android): RootLayout shade cover unexpected delay

### DIFF
--- a/packages/core/ui/layouts/root-layout/index.android.ts
+++ b/packages/core/ui/layouts/root-layout/index.android.ts
@@ -4,6 +4,7 @@ import { RootLayoutBase, defaultShadeCoverOptions } from './root-layout-common';
 import { TransitionAnimation, ShadeCoverOptions } from '.';
 import { parseLinearGradient } from '../../../css/parser';
 import { LinearGradient } from '../../styling/linear-gradient';
+import { layout } from '../../../utils';
 
 export * from './root-layout-common';
 
@@ -38,11 +39,20 @@ export class RootLayout extends RootLayoutBase {
 	}
 
 	protected _initShadeCover(view: View, shadeOptions: ShadeCoverOptions): void {
-		const initialState = <TransitionAnimation>{
+		const options = <TransitionAnimation>{
 			...defaultShadeCoverOptions.animation.enterFrom,
 			...shadeOptions?.animation?.enterFrom,
 		};
-		this._playAnimation(this._getAnimationSet(view, initialState));
+		const nativeView: android.view.View = view?.nativeViewProtected;
+
+		if (nativeView) {
+			nativeView.setAlpha(options.opacity);
+			org.nativescript.widgets.ViewHelper.setScaleX(nativeView, float(options.scaleX));
+			org.nativescript.widgets.ViewHelper.setScaleY(nativeView, float(options.scaleY));
+			org.nativescript.widgets.ViewHelper.setTranslateX(nativeView, layout.toDevicePixels(options.translateX));
+			org.nativescript.widgets.ViewHelper.setTranslateY(nativeView, layout.toDevicePixels(options.translateY));
+			org.nativescript.widgets.ViewHelper.setRotate(nativeView, float(options.rotate));
+		}
 	}
 
 	protected _updateShadeCover(view: View, shadeOptions: ShadeCoverOptions): Promise<void> {
@@ -51,6 +61,7 @@ export class RootLayout extends RootLayoutBase {
 			...shadeOptions,
 		};
 		const duration = options.animation?.enterFrom?.duration || defaultShadeCoverOptions.animation.enterFrom.duration;
+
 		return this._playAnimation(
 			this._getAnimationSet(
 				view,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
During initialization, android RootLayout shade cover animates properties instead of directly setting values.
Also, the exit animation breaks if shade cover color is a gradient as current implementation unsets it.

## What is the new behavior?
- Android RootLayout will set shade cover defaults directly during init step
- The exit animation will no longer unset color
- Translate animation values will now be converted to pixels as that's what android expects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for linear gradient backgrounds in shade cover animations on Android.

* **Bug Fixes**
  * Enhanced animation smoothness and consistency for shade covers with gradient backgrounds.

* **Style**
  * Animations now apply more accurately to device pixel values, resulting in better visual fidelity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->