### PR TITLE
fix(core): Improved css clip-path parsing

### DIFF
--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -201,10 +201,11 @@ function isNonNegativeFiniteNumber(value: number): boolean {
 }
 
 function parseClipPath(value: string): string | ClipPathFunction {
-	const functionStartIndex = value.indexOf('(');
+	const funcStartIndex = value.indexOf('(');
+	const funcEndIndex = value.lastIndexOf(')');
 
-	if (functionStartIndex > -1) {
-		const functionName = value.substring(0, functionStartIndex).trim();
+	if (funcStartIndex > -1 && funcEndIndex > -1) {
+		const functionName = value.substring(0, funcStartIndex).trim();
 
 		switch (functionName) {
 			case 'rect':
@@ -212,8 +213,7 @@ function parseClipPath(value: string): string | ClipPathFunction {
 			case 'ellipse':
 			case 'polygon':
 			case 'inset': {
-				const rule: string = value.replace(`${functionName}(`, '').replace(')', '');
-				return new ClipPathFunction(functionName, rule);
+				return new ClipPathFunction(functionName, value.substring(funcStartIndex + 1, funcEndIndex));
 			}
 			default:
 				throw new Error(`Clip-path function ${functionName} is not valid.`);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, there are times that users update css `clip-path` property and do things like accidentally append semi-colon.
For example:
```
view.style.clipPath = "circle(50 at 0 100);"; // wrong
view.style.clipPath = "circle(50 at 0 100)"; // right
```

## What is the new behavior?
This PR makes sure parser will ignore everything after the closing parenthesis.

Fixes/Closes #10717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of clip-path CSS function strings to ensure more accurate parsing and error checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->