### PR TITLE
feat(ios): Better handling for emitting navigation events

### DIFF
--- a/apps/automated/src/ui/tab-view/tab-view-root-tests.ts
+++ b/apps/automated/src/ui/tab-view/tab-view-root-tests.ts
@@ -140,22 +140,14 @@ export function test_offset_zero_should_raise_same_events() {
 		resetActualEventsRaised();
 		waitUntilNavigatedToMaxTimeout([items[2].page], () => (tabView.selectedIndex = 2));
 
-		const expectedEventsRaisedAfterSelectThirdTab = [['Tab0 Frame0 Page0 unloaded', 'Tab0 Frame0 unloaded', 'Tab0 Frame0 Page0 navigatingFrom'], [], ['Tab2 Frame2 loaded', 'Tab2 Frame2 Page2 navigatingTo', 'Tab2 Frame2 Page2 loaded', 'Tab2 Frame2 Page2 navigatedTo']];
-		let isNavigatingFromPage2 = false;
-		const page2NavigatingFrom = (args: EventData) => {
-			args.object.off('navigatingFrom', page2NavigatingFrom);
-			isNavigatingFromPage2 = true;
-		};
+		const expectedEventsRaisedAfterSelectThirdTab = [['Tab0 Frame0 Page0 unloaded', 'Tab0 Frame0 unloaded'], [], ['Tab2 Frame2 loaded', 'Tab2 Frame2 Page2 navigatingTo', 'Tab2 Frame2 Page2 loaded', 'Tab2 Frame2 Page2 navigatedTo']];
 
 		TKUnit.assertDeepEqual(actualEventsRaised, expectedEventsRaisedAfterSelectThirdTab);
 
 		resetActualEventsRaised();
-
-		items[2].page.on('navigatingFrom', page2NavigatingFrom);
 		waitUntilTabViewReady(items[0].page, () => (tabView.selectedIndex = 0));
-		TKUnit.waitUntilReady(() => isNavigatingFromPage2);
 
-		const expectedEventsRaisedAfterReturnToFirstTab = [['Tab0 Frame0 Page0 loaded', 'Tab0 Frame0 loaded'], [], ['Tab2 Frame2 Page2 unloaded', 'Tab2 Frame2 unloaded', 'Tab2 Frame2 Page2 navigatingFrom']];
+		const expectedEventsRaisedAfterReturnToFirstTab = [['Tab0 Frame0 Page0 loaded', 'Tab0 Frame0 loaded'], [], ['Tab2 Frame2 Page2 unloaded', 'Tab2 Frame2 unloaded']];
 
 		TKUnit.assertDeepEqual(actualEventsRaised, expectedEventsRaisedAfterReturnToFirstTab);
 	}

--- a/apps/automated/src/ui/tab-view/tab-view-root-tests.ts
+++ b/apps/automated/src/ui/tab-view/tab-view-root-tests.ts
@@ -1,5 +1,5 @@
 import * as TKUnit from '../../tk-unit';
-import { Application, EventData, Frame, NavigationEntry, Page, TabView, TabViewItem, isAndroid } from '@nativescript/core';
+import { Application, Frame, NavigationEntry, Page, TabView, TabViewItem, isAndroid } from '@nativescript/core';
 
 function waitUntilNavigatedToMaxTimeout(pages: Page[], action: Function) {
 	const maxTimeout = 8;

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -4,7 +4,7 @@ import { Page } from '../page';
 import { View, CustomLayoutView, CSSType } from '../core/view';
 import { Property } from '../core/properties';
 import { Trace } from '../../trace';
-import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack } from './frame-stack';
+import { frameStack, topmost as frameStackTopmost, _pushInFrameStack, _popFromFrameStack, _removeFromFrameStack, _isFrameStackEmpty } from './frame-stack';
 import { viewMatchesModuleContext } from '../core/view/view-common';
 import { getAncestor } from '../core/view-base';
 import { Builder } from '../builder';
@@ -193,7 +193,6 @@ export class FrameBase extends CustomLayoutView {
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
 			isBackNavigation: true,
-			isUserInitiated: false,
 			navigationType: NavigationType.back,
 		};
 
@@ -246,7 +245,6 @@ export class FrameBase extends CustomLayoutView {
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
 			isBackNavigation: false,
-			isUserInitiated: false,
 			navigationType: NavigationType.forward,
 		};
 
@@ -483,10 +481,6 @@ export class FrameBase extends CustomLayoutView {
 		}
 
 		backstackEntry.resolvedPage.onNavigatingTo(backstackEntry.entry.context, isBack, backstackEntry.entry.bindingContext);
-		this._notifyFrameNavigatingTo(backstackEntry, isBack);
-	}
-
-	public _notifyFrameNavigatingTo(backstackEntry: BackstackEntry, isBack: boolean): void {
 		this.notify<NavigationData>({
 			eventName: FrameBase.navigatingToEvent,
 			object: this,
@@ -546,6 +540,10 @@ export class FrameBase extends CustomLayoutView {
 		for (const frame of framesToPush) {
 			frame._pushInFrameStack();
 		}
+	}
+
+	public _isFrameStackEmpty() {
+		return _isFrameStackEmpty();
 	}
 
 	public _pushInFrameStack() {
@@ -767,7 +765,6 @@ export class FrameBase extends CustomLayoutView {
 		const navigationContext: NavigationContext = {
 			entry: newBackstackEntry,
 			isBackNavigation: false,
-			isUserInitiated: false,
 			navigationType: NavigationType.replace,
 		};
 

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -192,6 +192,7 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
+			isBackNavigation: true,
 			navigationType: NavigationType.back,
 		};
 
@@ -243,6 +244,7 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
+			isBackNavigation: true,
 			navigationType: NavigationType.forward,
 		};
 
@@ -762,6 +764,7 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: newBackstackEntry,
+			isBackNavigation: false,
 			navigationType: NavigationType.replace,
 		};
 

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -193,6 +193,7 @@ export class FrameBase extends CustomLayoutView {
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
 			isBackNavigation: true,
+			isUserInitiated: false,
 			navigationType: NavigationType.back,
 		};
 
@@ -245,6 +246,7 @@ export class FrameBase extends CustomLayoutView {
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
 			isBackNavigation: false,
+			isUserInitiated: false,
 			navigationType: NavigationType.forward,
 		};
 
@@ -765,6 +767,7 @@ export class FrameBase extends CustomLayoutView {
 		const navigationContext: NavigationContext = {
 			entry: newBackstackEntry,
 			isBackNavigation: false,
+			isUserInitiated: false,
 			navigationType: NavigationType.replace,
 		};
 

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -192,7 +192,6 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
-			isBackNavigation: true,
 			navigationType: NavigationType.back,
 		};
 
@@ -244,7 +243,6 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
-			isBackNavigation: false,
 			navigationType: NavigationType.forward,
 		};
 
@@ -481,6 +479,10 @@ export class FrameBase extends CustomLayoutView {
 		}
 
 		backstackEntry.resolvedPage.onNavigatingTo(backstackEntry.entry.context, isBack, backstackEntry.entry.bindingContext);
+		this._notifyFrameNavigatingTo(backstackEntry, isBack);
+	}
+
+	public _notifyFrameNavigatingTo(backstackEntry: BackstackEntry, isBack: boolean): void {
 		this.notify<NavigationData>({
 			eventName: FrameBase.navigatingToEvent,
 			object: this,
@@ -760,7 +762,6 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: newBackstackEntry,
-			isBackNavigation: false,
 			navigationType: NavigationType.replace,
 		};
 

--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -244,7 +244,7 @@ export class FrameBase extends CustomLayoutView {
 
 		const navigationContext: NavigationContext = {
 			entry: backstackEntry,
-			isBackNavigation: true,
+			isBackNavigation: false,
 			navigationType: NavigationType.forward,
 		};
 

--- a/packages/core/ui/frame/frame-interfaces.ts
+++ b/packages/core/ui/frame/frame-interfaces.ts
@@ -38,6 +38,10 @@ export interface NavigationEntry extends ViewEntry {
 
 export interface NavigationContext {
 	entry?: BackstackEntry;
+	/**
+	 * @deprecated Use navigationType instead.
+	 */
+	isBackNavigation: boolean;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/frame-interfaces.ts
+++ b/packages/core/ui/frame/frame-interfaces.ts
@@ -8,7 +8,6 @@ export enum NavigationType {
 	back,
 	forward,
 	replace,
-	user,
 }
 
 export interface TransitionState {
@@ -42,7 +41,6 @@ export interface NavigationContext {
 	 * @deprecated Use navigationType instead.
 	 */
 	isBackNavigation: boolean;
-	isUserInitiated: boolean;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/frame-interfaces.ts
+++ b/packages/core/ui/frame/frame-interfaces.ts
@@ -42,6 +42,7 @@ export interface NavigationContext {
 	 * @deprecated Use navigationType instead.
 	 */
 	isBackNavigation: boolean;
+	isUserInitiated: boolean;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/frame-interfaces.ts
+++ b/packages/core/ui/frame/frame-interfaces.ts
@@ -8,6 +8,7 @@ export enum NavigationType {
 	back,
 	forward,
 	replace,
+	user,
 }
 
 export interface TransitionState {
@@ -36,9 +37,7 @@ export interface NavigationEntry extends ViewEntry {
 }
 
 export interface NavigationContext {
-	entry: BackstackEntry;
-	// TODO: remove isBackNavigation for NativeScript 7.0
-	isBackNavigation: boolean;
+	entry?: BackstackEntry;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/frame-stack.ts
+++ b/packages/core/ui/frame/frame-stack.ts
@@ -11,6 +11,10 @@ export function topmost(): FrameBase {
 	return undefined;
 }
 
+export function _isFrameStackEmpty(): boolean {
+	return frameStack.length === 0;
+}
+
 export function _pushInFrameStack(frame: FrameBase): void {
 	if (frame._isInFrameStack && frameStack[frameStack.length - 1] === frame) {
 		return;

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -409,6 +409,7 @@ export interface NavigationContext {
 	 * @deprecated Use navigationType instead.
 	 */
 	isBackNavigation: boolean;
+	isUserInitiated: boolean;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -404,8 +404,7 @@ export interface NavigationEntry extends ViewEntry {
  * Represents a context passed to navigation methods.
  */
 export interface NavigationContext {
-	entry: BackstackEntry;
-	isBackNavigation: boolean;
+	entry?: BackstackEntry;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -405,6 +405,10 @@ export interface NavigationEntry extends ViewEntry {
  */
 export interface NavigationContext {
 	entry?: BackstackEntry;
+	/**
+	 * @deprecated Use navigationType instead.
+	 */
+	isBackNavigation: boolean;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/index.d.ts
+++ b/packages/core/ui/frame/index.d.ts
@@ -261,6 +261,10 @@ export class Frame extends FrameBase {
 	/**
 	 * @private
 	 */
+	_isFrameStackEmpty(): boolean;
+	/**
+	 * @private
+	 */
 	_pushInFrameStack();
 	/**
 	 * @private
@@ -409,7 +413,6 @@ export interface NavigationContext {
 	 * @deprecated Use navigationType instead.
 	 */
 	isBackNavigation: boolean;
-	isUserInitiated: boolean;
 	navigationType: NavigationType;
 }
 

--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -7,7 +7,6 @@ import { IOSHelper } from '../core/view/view-helper';
 import { profile } from '../../profiling';
 import { CORE_ANIMATION_DEFAULTS, ios as iOSUtils, layout } from '../../utils';
 import { Trace } from '../../trace';
-import type { PageTransition } from '../transition/page-transition';
 import { SlideTransition } from '../transition/slide-transition';
 import { FadeTransition } from '../transition/fade-transition';
 import { SharedTransition } from '../transition/shared-transition';
@@ -22,11 +21,11 @@ const NAV_DEPTH = '_navDepth';
 const TRANSITION = '_transition';
 const NON_ANIMATED_TRANSITION = 'non-animated';
 
-let navDepth = -1;
+let navDepth: number = -1;
+let navControllerDelegate: UINavigationControllerDelegate = null;
 
 export class Frame extends FrameBase {
 	viewController: UINavigationControllerImpl;
-	_animatedDelegate: UINavigationControllerDelegate;
 	public _ios: iOSFrame;
 	iosNavigationBarClass: typeof NSObject;
 	iosToolbarClass: typeof NSObject;
@@ -38,6 +37,11 @@ export class Frame extends FrameBase {
 	}
 
 	createNativeView() {
+		// Push frame back in frame stack since it was removed in disposeNativeView() method.
+		if (this._currentEntry) {
+			this._pushInFrameStack();
+		}
+
 		return this.viewController.view;
 	}
 
@@ -61,7 +65,12 @@ export class Frame extends FrameBase {
 
 		this._removeFromFrameStack();
 		this.viewController = null;
-		this._animatedDelegate = null;
+
+		// This was the last frame so we can get rid of the controller delegate reference
+		if (this._isFrameStackEmpty()) {
+			navControllerDelegate = null;
+		}
+
 		if (this._ios) {
 			this._ios.controller = null;
 			this._ios = null;
@@ -120,11 +129,12 @@ export class Frame extends FrameBase {
 
 		const nativeTransition = _getNativeTransition(navigationTransition, true);
 		if (!nativeTransition && navigationTransition) {
-			if (!this._animatedDelegate) {
-				this._animatedDelegate = <UINavigationControllerDelegate>UINavigationControllerAnimatedDelegate.initWithOwner(new WeakRef(this));
+			if (!navControllerDelegate) {
+				navControllerDelegate = <UINavigationControllerDelegate>UINavigationControllerAnimatedDelegate.new();
 			}
-			this._ios.controller.delegate = this._animatedDelegate;
-			viewController[DELEGATE] = this._animatedDelegate;
+
+			this._ios.controller.delegate = navControllerDelegate;
+			viewController[DELEGATE] = navControllerDelegate;
 			if (navigationTransition.instance) {
 				this.transitionId = navigationTransition.instance.id;
 				const transitionState = SharedTransition.getState(this.transitionId);
@@ -400,14 +410,6 @@ class TransitionDelegate extends NSObject {
 @NativeClass
 class UINavigationControllerAnimatedDelegate extends NSObject implements UINavigationControllerDelegate {
 	public static ObjCProtocols = [UINavigationControllerDelegate];
-	owner: WeakRef<Frame>;
-	transition: PageTransition;
-
-	static initWithOwner(owner: WeakRef<Frame>) {
-		const delegate = <UINavigationControllerAnimatedDelegate>UINavigationControllerAnimatedDelegate.new();
-		delegate.owner = owner;
-		return delegate;
-	}
 
 	navigationControllerAnimationControllerForOperationFromViewControllerToViewController(navigationController: UINavigationController, operation: number, fromVC: UIViewController, toVC: UIViewController): UIViewControllerAnimatedTransitioning {
 		let viewController: UIViewController;
@@ -432,29 +434,30 @@ class UINavigationControllerAnimatedDelegate extends NSObject implements UINavig
 		if (Trace.isEnabled()) {
 			Trace.write(`UINavigationControllerImpl.navigationControllerAnimationControllerForOperationFromViewControllerToViewController(${operation}, ${fromVC}, ${toVC}), transition: ${JSON.stringify(navigationTransition)}`, Trace.categories.NativeLifecycle);
 		}
-		this.transition = navigationTransition.instance;
 
-		if (!this.transition) {
+		let transition = navigationTransition.instance;
+
+		if (!transition) {
 			if (navigationTransition.name) {
 				const curve = _getNativeCurve(navigationTransition);
 				const name = navigationTransition.name.toLowerCase();
 				if (name.indexOf('slide') === 0) {
-					const direction = name.substring('slide'.length) || 'left'; //Extract the direction from the string
-					this.transition = new SlideTransition(direction, navigationTransition.duration, curve);
+					const direction = name.substring('slide'.length) || 'left'; // Extract the direction from the string
+					transition = new SlideTransition(direction, navigationTransition.duration, curve);
 				} else if (name === 'fade') {
-					this.transition = new FadeTransition(navigationTransition.duration, curve);
+					transition = new FadeTransition(navigationTransition.duration, curve);
 				}
 			}
 		}
 
-		if (this.transition?.iosNavigatedController) {
-			return this.transition.iosNavigatedController(navigationController, operation, fromVC, toVC);
+		if (transition?.iosNavigatedController) {
+			return transition.iosNavigatedController(navigationController, operation, fromVC, toVC);
 		}
 		return null;
 	}
 
-	navigationControllerInteractionControllerForAnimationController(navigationController: UINavigationController, animationController: UIViewControllerAnimatedTransitioning): UIViewControllerInteractiveTransitioning {
-		const owner = this.owner?.deref();
+	navigationControllerInteractionControllerForAnimationController(navigationController: UINavigationControllerImpl, animationController: UIViewControllerAnimatedTransitioning): UIViewControllerInteractiveTransitioning {
+		const owner = navigationController.owner;
 		if (owner) {
 			const state = SharedTransition.getState(owner.transitionId);
 			if (state?.instance?.iosInteractionDismiss) {

--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -347,18 +347,18 @@ export class Frame extends FrameBase {
 		//
 	}
 
-	public _onNavigatingTo(backstackEntry: BackstackEntry, isBack: boolean) {
-		// for now to not break iOS events chain (calling navigation events from controller delegates)
-		// we dont call super(which would also trigger events) but only notify the frame of the navigation
-		// though it means events are not triggered at the same time (lifecycle) on iOS / Android
-		this.notify({
-			eventName: Page.navigatingToEvent,
-			object: this,
-			isBack,
-			entry: backstackEntry,
-			fromEntry: this._currentEntry,
-		});
-	}
+	// public _onNavigatingTo(backstackEntry: BackstackEntry, isBack: boolean) {
+	// 	// for now to not break iOS events chain (calling navigation events from controller delegates)
+	// 	// we dont call super(which would also trigger events) but only notify the frame of the navigation
+	// 	// though it means events are not triggered at the same time (lifecycle) on iOS / Android
+	// 	this.notify({
+	// 		eventName: Page.navigatingToEvent,
+	// 		object: this,
+	// 		isBack,
+	// 		entry: backstackEntry,
+	// 		fromEntry: this._currentEntry,
+	// 	});
+	// }
 }
 
 const transitionDelegates = new Array<TransitionDelegate>();

--- a/packages/core/ui/frame/index.ios.ts
+++ b/packages/core/ui/frame/index.ios.ts
@@ -346,19 +346,6 @@ export class Frame extends FrameBase {
 	public _setNativeViewFrame(nativeView: UIView, frame: CGRect) {
 		//
 	}
-
-	// public _onNavigatingTo(backstackEntry: BackstackEntry, isBack: boolean) {
-	// 	// for now to not break iOS events chain (calling navigation events from controller delegates)
-	// 	// we dont call super(which would also trigger events) but only notify the frame of the navigation
-	// 	// though it means events are not triggered at the same time (lifecycle) on iOS / Android
-	// 	this.notify({
-	// 		eventName: Page.navigatingToEvent,
-	// 		object: this,
-	// 		isBack,
-	// 		entry: backstackEntry,
-	// 		fromEntry: this._currentEntry,
-	// 	});
-	// }
 }
 
 const transitionDelegates = new Array<TransitionDelegate>();

--- a/packages/core/ui/gestures/index.ios.ts
+++ b/packages/core/ui/gestures/index.ios.ts
@@ -37,7 +37,7 @@ class UIGestureRecognizerDelegateImpl extends NSObject implements UIGestureRecog
 		return false;
 	}
 }
-const recognizerDelegateInstance: UIGestureRecognizerDelegateImpl = <UIGestureRecognizerDelegateImpl>UIGestureRecognizerDelegateImpl.new();
+const recognizerDelegateInstance = <UIGestureRecognizerDelegateImpl>UIGestureRecognizerDelegateImpl.new();
 
 @NativeClass
 class UIGestureRecognizerImpl extends NSObject {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -18,19 +18,6 @@ const DELEGATE = '_delegate';
 const TRANSITION = '_transition';
 const NON_ANIMATED_TRANSITION = 'non-animated';
 
-function isBackNavigationFrom(controller: UIViewControllerImpl, page: Page): boolean {
-	if (!page.frame) {
-		return false;
-	}
-
-	// Controller is cleared or backstack skipped
-	if (controller.isBackstackCleared || controller.isBackstackSkipped) {
-		return false;
-	}
-
-	return controller.movingFromParentViewController;
-}
-
 @NativeClass
 class UIViewControllerImpl extends UIViewController {
 	// TODO: a11y
@@ -88,19 +75,23 @@ class UIViewControllerImpl extends UIViewController {
 		}
 
 		const frame: Frame = this.navigationController ? (<any>this.navigationController).owner : null;
-		const newEntry: BackstackEntry = this[ENTRY];
-
-		// Don't raise event if currentPage was showing modal page.
-		if (!owner._presentedViewController && newEntry && (!frame || (frame.currentPage !== owner && (!frame._executingContext || frame._executingContext.isUserInitiated)))) {
-			const isBack = frame._executingContext && frame._executingContext.navigationType === NavigationType.back;
-
-			owner.onNavigatingTo(newEntry.entry.context, isBack, newEntry.entry.bindingContext);
-			if (frame) {
-				frame._notifyFrameNavigatingTo(newEntry, isBack);
-			}
-		}
 
 		if (frame) {
+			const entry: BackstackEntry = this[ENTRY];
+			const currentPage = frame.currentPage;
+
+			// Don't raise event if currentPage was showing modal page.
+			if (!owner._presentedViewController && entry && currentPage !== owner && !frame._executingContext) {
+				const isBack: boolean = frame.backStack.includes(entry);
+
+				frame._executingContext = {
+					entry,
+					isBackNavigation: isBack,
+					navigationType: isBack ? NavigationType.back : NavigationType.forward,
+				};
+				frame._onNavigatingTo(entry, isBack);
+			}
+
 			frame._resolvedPage = owner;
 
 			if (owner.parent === frame) {
@@ -148,52 +139,59 @@ class UIViewControllerImpl extends UIViewController {
 
 		const navigationController = this.navigationController;
 		const frame: Frame = navigationController ? (<any>navigationController).owner : null;
-		// Skip navigation events if modal page is shown.
-		if (!owner._presentedViewController && frame) {
+
+		if (frame) {
 			const newEntry: BackstackEntry = this[ENTRY];
 
-			// frame.setCurrent(...) will reset executing context so retrieve it here
-			// if executing context is null here this most probably means back navigation through iOS back button
-			const navigationContext = frame._executingContext || {
-				navigationType: NavigationType.back,
-			};
-			const isReplace = navigationContext.navigationType === NavigationType.replace;
+			// There are cases like swipe back navigation that can be cancelled.
+			// When that's the case, stop here and unset executing context.
+			if (frame._executingContext && frame._executingContext.entry !== newEntry) {
+				frame._executingContext = null;
+				return;
+			}
 
-			frame.setCurrent(newEntry, navigationContext.navigationType);
+			// Skip navigation events if modal page is shown.
+			if (!owner._presentedViewController) {
+				// frame.setCurrent(...) will reset executing context so retrieve it here
+				const navigationType = frame._executingContext?.navigationType ?? NavigationType.back;
+				const isReplace = navigationType === NavigationType.replace;
 
-			if (isReplace) {
-				const controller = newEntry.resolvedPage.ios;
-				if (controller) {
-					const animated = frame._getIsAnimatedNavigation(newEntry.entry);
-					if (animated) {
-						controller[TRANSITION] = frame._getNavigationTransition(newEntry.entry);
-					} else {
-						controller[TRANSITION] = {
-							name: NON_ANIMATED_TRANSITION,
-						};
+				frame.setCurrent(newEntry, navigationType);
+
+				if (isReplace) {
+					const controller = newEntry.resolvedPage.ios;
+					if (controller) {
+						const animated = frame._getIsAnimatedNavigation(newEntry.entry);
+						if (animated) {
+							controller[TRANSITION] = frame._getNavigationTransition(newEntry.entry);
+						} else {
+							controller[TRANSITION] = {
+								name: NON_ANIMATED_TRANSITION,
+							};
+						}
 					}
 				}
-			}
 
-			// If page was shown with custom animation - we need to set the navigationController.delegate to the animatedDelegate.
-			if (frame.ios?.controller) {
-				frame.ios.controller.delegate = this[DELEGATE];
-			}
+				// If page was shown with custom animation - we need to set the navigationController.delegate to the animatedDelegate.
+				if (frame.ios?.controller) {
+					frame.ios.controller.delegate = this[DELEGATE];
+				}
 
-			frame._processNavigationQueue(owner);
+				frame._processNavigationQueue(owner);
 
-			if (!__VISIONOS__) {
-				// _processNavigationQueue will shift navigationQueue. Check canGoBack after that.
-				// Workaround for disabled backswipe on second custom native transition
-				if (frame.canGoBack()) {
-					const transitionState = SharedTransition.getState(owner.transitionId);
-					if (!transitionState?.interactive) {
-						// only consider when interactive transitions are not enabled
-						navigationController.interactivePopGestureRecognizer.delegate = navigationController;
-						navigationController.interactivePopGestureRecognizer.enabled = owner.enableSwipeBackNavigation;
+				if (!__VISIONOS__) {
+					// _processNavigationQueue will shift navigationQueue. Check canGoBack after that.
+					// Workaround for disabled backswipe on second custom native transition
+					if (frame.canGoBack()) {
+						const transitionState = SharedTransition.getState(owner.transitionId);
+						if (!transitionState?.interactive) {
+							// only consider when interactive transitions are not enabled
+							navigationController.interactivePopGestureRecognizer.delegate = navigationController;
+							navigationController.interactivePopGestureRecognizer.enabled = owner.enableSwipeBackNavigation;
+						}
+					} else {
+						navigationController.interactivePopGestureRecognizer.enabled = false;
 					}
-				} else {
-					navigationController.interactivePopGestureRecognizer.enabled = false;
 				}
 			}
 		}
@@ -221,21 +219,6 @@ class UIViewControllerImpl extends UIViewController {
 			owner._presentedViewController = this.presentedViewController;
 		}
 
-		const frame = owner.frame;
-		// Skip navigation events if we are hiding because we are about to show a modal page,
-		// or because we are not navigating back
-		// or because we are closing a modal page.
-		if (owner.onNavigatingFrom && this.movingFromParentViewController && !owner._presentedViewController && frame && !frame._executingContext && (!this.presentingViewController || frame.backStack.length > 0) && frame.currentPage === owner) {
-			const isBack = isBackNavigationFrom(this, owner);
-
-			// Create an executing context will also make navigation more secure as frame avoids some actions when it's defined
-			frame._executingContext = {
-				isBackNavigation: isBack,
-				isUserInitiated: true,
-				navigationType: isBack ? NavigationType.back : NavigationType.forward,
-			};
-			owner.onNavigatingFrom(isBack);
-		}
 		owner.updateWithWillDisappear(animated);
 	}
 

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -246,8 +246,9 @@ class UIViewControllerImpl extends UIViewController {
 		if (owner.onNavigatingFrom && this.movingFromParentViewController && !owner._presentedViewController && frame && !frame._executingContext && (!this.presentingViewController || frame.backStack.length > 0) && frame.currentPage === owner) {
 			const isBack = isBackNavigationFrom(this, owner);
 
-			// Assign a truthy value to executing context since it's used in certain conditions
+			// Create an executing context as frame avoids some actions when it's defined
 			frame._executingContext = {
+				isBackNavigation: true, // This property is no longer used so it doesn't really matter what it's set to
 				navigationType: NavigationType.user,
 			};
 			owner.onNavigatingFrom(isBack);

--- a/packages/core/ui/tab-view/index.ios.ts
+++ b/packages/core/ui/tab-view/index.ios.ts
@@ -111,11 +111,9 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 			owner._handleTwoNavigationBars(backToMoreWillBeVisible);
 		}
 
-		if ((<any>tabBarController).selectedViewController === viewController) {
+		if (tabBarController.selectedViewController === viewController) {
 			return false;
 		}
-
-		(<any>tabBarController)._willSelectViewController = viewController;
 
 		return true;
 	}
@@ -129,8 +127,6 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 		if (owner) {
 			owner._onViewControllerShown(viewController);
 		}
-
-		(<any>tabBarController)._willSelectViewController = undefined;
 	}
 }
 
@@ -535,7 +531,7 @@ export class TabView extends TabViewBase {
 	private updateBarItemAppearance(tabBar: UITabBar, states: TabStates) {
 		const appearance = this._getAppearance(tabBar);
 		const itemAppearances = ['stackedLayoutAppearance', 'inlineLayoutAppearance', 'compactInlineLayoutAppearance'];
-		for (let itemAppearance of itemAppearances) {
+		for (const itemAppearance of itemAppearances) {
 			appearance[itemAppearance].normal.titleTextAttributes = states.normalState;
 			appearance[itemAppearance].selected.titleTextAttributes = states.selectedState;
 		}
@@ -564,7 +560,6 @@ export class TabView extends TabViewBase {
 		}
 
 		if (value > -1) {
-			(<any>this._ios)._willSelectViewController = this._ios.viewControllers[value];
 			this._ios.selectedIndex = value;
 		}
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, we have Page navigation events handling inside iOS page ViewController to handle cases like back button navigation or swipe back navigation.
Unfortunately, the handling is quite messy with a couple of hackish solutions resulting in events being emitted when they shouldn't (e.g. @NathanWalker iOS 18 TabView navigation between frame that were already loaded once).

## What is the new behavior?
This PR focuses on improving how these events are emitted and decouple TabView from nested Page logic. Navigation events are now safely emitted from page ViewController when needed.

Few things to note:
- Added missing Frame `navigatingTo` event trigger for back button/swipe back navigations
- Assign Frame's executing context during those navigations since the property is essential for blocking unexpected calls during the transition
- Upon reusing a Frame, add it back to the Frame stack if it has a current entry
- Use a common navigation controller delegate for all Frames and unset it when the app has no Frames left in the stack