### PR TITLE
feat(style): add support for origin-x and origin-y CSS properties

### DIFF
--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -587,8 +587,6 @@ export abstract class View extends ViewCommon {
 	 */
 	scaleY: number;
 
-	//END Style property shortcuts
-
 	/**
 	 * Gets or sets the X component of the origin point around which the view will be transformed. The default value is 0.5 representing the center of the view.
 	 *
@@ -602,6 +600,8 @@ export abstract class View extends ViewCommon {
 	 * @nsProperty
 	 */
 	originY: number;
+
+	//END Style property shortcuts
 
 	/**
 	 * The flex-flow Shorthand property specifies the direction of a flex container, as well as its wrapping behavior.

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -1268,20 +1268,6 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 	}
 }
 
-export const originXProperty = new Property<ViewCommon, number>({
-	name: 'originX',
-	defaultValue: 0.5,
-	valueConverter: (v) => parseFloat(v),
-});
-originXProperty.register(ViewCommon);
-
-export const originYProperty = new Property<ViewCommon, number>({
-	name: 'originY',
-	defaultValue: 0.5,
-	valueConverter: (v) => parseFloat(v),
-});
-originYProperty.register(ViewCommon);
-
 export const isEnabledProperty = new Property<ViewCommon, boolean>({
 	name: 'isEnabled',
 	defaultValue: true,

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -993,8 +993,6 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 
 	//END Style property shortcuts
 
-	public originX: number;
-	public originY: number;
 	public isEnabled: boolean;
 	public isUserInteractionEnabled: boolean;
 	public iosOverflowSafeArea: boolean;

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -871,6 +871,20 @@ export abstract class ViewCommon extends ViewBase implements ViewDefinition {
 		this.style.translateY = value;
 	}
 
+	get originX(): number {
+		return this.style.originX;
+	}
+	set originX(value: number) {
+		this.style.originX = value;
+	}
+
+	get originY(): number {
+		return this.style.originY;
+	}
+	set originY(value: number) {
+		this.style.originY = value;
+	}
+
 	get scaleX(): number {
 		return this.style.scaleX;
 	}

--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -639,6 +639,22 @@ export const perspectiveProperty = new CssAnimationProperty<Style, number>({
 });
 perspectiveProperty.register(Style);
 
+export const originXProperty = new CssProperty<Style, number>({
+	name: 'originX',
+	cssName: 'origin-x',
+	defaultValue: 0.5,
+	valueConverter: parseFloat,
+});
+originXProperty.register(Style);
+
+export const originYProperty = new CssProperty<Style, number>({
+	name: 'originY',
+	cssName: 'origin-y',
+	defaultValue: 0.5,
+	valueConverter: parseFloat,
+});
+originYProperty.register(Style);
+
 export const scaleXProperty = new CssAnimationProperty<Style, number>({
 	name: 'scaleX',
 	cssName: 'scaleX',

--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -689,6 +689,25 @@ export const translateYProperty = new CssAnimationProperty<Style, CoreTypes.Fixe
 });
 translateYProperty.register(Style);
 
+const transformOriginProperty = new ShorthandProperty<Style, string>({
+	name: 'transformOrigin',
+	cssName: 'transform-origin',
+
+	getter(this: Style) {
+		return `${this.originX} ${this.originY}`;
+	},
+
+	converter(value: string) {
+		const [x, y] = value.trim().split(/\s+/).map(parseFloat);
+		return [
+			[originXProperty, isNaN(x) ? 0.5 : x],
+			[originYProperty, isNaN(y) ? 0.5 : y],
+		];
+	},
+});
+
+transformOriginProperty.register(Style);
+
 const transformProperty = new ShorthandProperty<Style, string>({
 	name: 'transform',
 	cssName: 'transform',

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -112,6 +112,9 @@ export class Style extends Observable {
 	public fontScaleInternal: number;
 	public backgroundInternal: Background;
 
+	public originX: number;
+	public originY: number;
+
 	public rotate: number;
 	public rotateX: number;
 	public rotateY: number;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for: Fixes #5991
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - Verified manually in demo app.

---


## What is the current behavior?

CSS properties `origin-x` and `origin-y` are not supported. Developers must use `view.originX` and `view.originY` in code-behind to set transform origins.

---

## What is the new behavior?

This PR adds CSS support for `origin-x` and `origin-y`:

* These properties set the pivot point for transform-based animations like `rotate`, `scale`, etc.
* Now you can define them via CSS like:

```css
.my-view {
  origin-x: 1;
  origin-y: 0;
  rotate: 45;
}
```

---

## Notes

Fixes #5991

Happy to add unit or UI tests if requested by maintainers — just let me know 🙌
