### PR TITLE
feat(android): allow transparent modal backgrounds

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -223,6 +223,10 @@ function initializeDialogFragment() {
 
 			dialog.setCanceledOnTouchOutside(this._cancelable);
 
+			dialog.getWindow().setBackgroundDrawable(
+      	new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT)
+      );
+
 			return dialog;
 		}
 


### PR DESCRIPTION
For the modal dialogs, this removes the white with shape edges that can appear when a modal with radiused borders is used.

BREAKING CHANGES: Dialogs with no background colour set may become transparent.

Tests run forked repository all passed

An example app showing the changes can be accessed at https://github.com/SeanKelly369/native_dialog_tut

![Presidents_modal_android](https://github.com/user-attachments/assets/69e2fbb2-53d3-4723-8272-90faa5b9375c)
