### PR TITLE
fix(webpack): build with dep updates

### DIFF
--- a/packages/webpack5/package.json
+++ b/packages/webpack5/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@babel/core": "^7.0.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "~0.6.1",
+		"@vue/compiler-sfc": "^3.5.17",
 		"acorn": "^8.0.0",
 		"acorn-stage3": "^4.0.0",
 		"ansi-colors": "^4.1.3",

--- a/packages/webpack5/src/bin/index.ts
+++ b/packages/webpack5/src/bin/index.ts
@@ -47,6 +47,7 @@ program
 	.option('--config [path]', 'config path')
 	.option('--watch', 'watch for changes')
 	.allowUnknownOption()
+	.allowExcessArguments()
 	.action((options, command) => {
 		const env = parseEnvFlags(command.args);
 		// add --env <val> into the env object


### PR DESCRIPTION
- Fixes the following issues related to transient dep updates from [here](https://github.com/NativeScript/NativeScript/commit/eab726b5d69c9c9b2bf790498225aa2dcbc5521d)

Reference: https://github.com/vuejs/vue-loader/releases/tag/v17.0.1
```
Error: @vitejs/plugin-vue requires vue (>=3.2.13) or @vue/compiler-sfc to be present in the dependency tree.
    at Object.<anonymous> (node_modules/vue-loader/dist/compiler.js:14:15)
```

Reference: https://github.com/tj/commander.js/releases/tag/v13.0.0
```
build error: too many arguments. Expected 0 arguments but got 11.
```