### PR TITLE
fix: parse width and height from string to int in ImageAsset options …

### DIFF
--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -26,6 +26,15 @@ export class ImageAsset extends ImageAssetBase {
 	}
 
 	public getImageAsync(callback: (image, error) => void) {
+		if (this.options) {
+			if (typeof this.options.width === 'string') {
+				this.options.width = parseInt(this.options.width, 10) || 0;
+			}
+			if (typeof this.options.height === 'string') {
+				this.options.height = parseInt(this.options.height, 10) || 0;
+			}
+		}
+
 		org.nativescript.widgets.Utils.loadImageAsync(
 			ad.getApplicationContext(),
 			this.android,
@@ -42,4 +51,5 @@ export class ImageAsset extends ImageAssetBase {
 			})
 		);
 	}
+
 }


### PR DESCRIPTION
This fix ensures that the width and height options in the ImageAsset class are properly converted from string to integer before being passed to the native image loading utility.
Previously, if these values were provided as strings, it could cause unexpected behavior or errors during image processing on Android.

Added type checks and parsing of width and height in getImageAsync method

Ensured fallback to 0 if parsing fails, maintaining backward compatibility

This resolves issues related to incorrect image sizing and improves robustness in handling image options

Here is the code that i have changed in the getImageAsync function placed in index.android.ts

public getImageAsync(callback: (image, error) => void) {
		if (this.options) {
			if (typeof this.options.width === 'string') {
				this.options.width = parseInt(this.options.width, 10) || 0;
			}
			if (typeof this.options.height === 'string') {
				this.options.height = parseInt(this.options.height, 10) || 0;
			}
		}

		org.nativescript.widgets.Utils.loadImageAsync(
			ad.getApplicationContext(),
			this.android,
			JSON.stringify(this.options || {}),
			Screen.mainScreen.widthPixels,
			Screen.mainScreen.heightPixels,
			new org.nativescript.widgets.Utils.AsyncImageCallback({
				onSuccess(bitmap) {
					callback(bitmap, null);
				},
				onError(ex) {
					callback(null, ex);
				},
			})
		);
	}