### PR TITLE
Revert "fix(ios): corrected rotate animation (#10676)"

### DIFF
--- a/apps/automated/src/ui/animation/animation-tests.ts
+++ b/apps/automated/src/ui/animation/animation-tests.ts
@@ -79,7 +79,7 @@ export function test_PlayRejectsWhenAlreadyPlayingAnimation(done) {
 			if (e === 'Animation is already playing.') {
 				done();
 			}
-		},
+		}
 	);
 }
 
@@ -164,8 +164,8 @@ export function test_ChainingAnimations(done) {
 		.then(() => label.animate({ translate: { x: 0, y: 0 }, duration: duration }))
 		.then(() => label.animate({ scale: { x: 5, y: 5 }, duration: duration }))
 		.then(() => label.animate({ scale: { x: 1, y: 1 }, duration: duration }))
-		.then(() => label.animate({ rotate: { x: 90, y: 0, z: 180 }, duration: duration }))
-		.then(() => label.animate({ rotate: { x: 0, y: 0, z: 0 }, duration: duration }))
+		.then(() => label.animate({ rotate: 180, duration: duration }))
+		.then(() => label.animate({ rotate: 0, duration: duration }))
 		.then(() => {
 			//console.log("Animation finished");
 			// >> (hide)
@@ -610,7 +610,7 @@ export function test_PlayPromiseIsResolvedWhenAnimationFinishes(done) {
 		function onRejected(e) {
 			TKUnit.assert(false, 'Animation play promise should be resolved, not rejected.');
 			done(e);
-		},
+		}
 	);
 }
 
@@ -627,7 +627,7 @@ export function test_PlayPromiseIsRejectedWhenAnimationIsCancelled(done) {
 		function onRejected(e) {
 			TKUnit.assert(animation.isPlaying === false, 'Animation.isPlaying should be false when animation play promise is rejected.');
 			done();
-		},
+		}
 	);
 
 	animation.cancel();

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -335,6 +335,8 @@ export class Animation extends AnimationBase {
 					};
 					fromValue = nativeView.layer.opacity;
 					break;
+				// In the case of rotation, avoid animating affine transform directly as it will animate to the closest result
+				// that is visually the same. For example, 0 -> 360 will leave view as is.
 				case Properties.rotate:
 					animation._originalValue = {
 						x: view.rotateX,

--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -522,6 +522,8 @@ export class Animation extends AnimationBase {
 
 	private static _createGroupAnimation(args: AnimationInfo, animation: PropertyAnimation) {
 		const groupAnimation = CAAnimationGroup.new();
+		const animations = NSMutableArray.alloc<CAAnimation>().initWithCapacity(args.subPropertiesToAnimate.length);
+
 		groupAnimation.duration = args.duration;
 		if (args.repeatCount !== undefined) {
 			groupAnimation.repeatCount = args.repeatCount;
@@ -532,7 +534,6 @@ export class Animation extends AnimationBase {
 		if (animation.curve !== undefined) {
 			groupAnimation.timingFunction = animation.curve;
 		}
-		const animations = NSMutableArray.alloc<CAAnimation>().initWithCapacity(3);
 
 		args.subPropertiesToAnimate.forEach((property) => {
 			const basicAnimationArgs = { ...args, duration: undefined, repeatCount: undefined, delay: undefined, curve: undefined };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Changes in #10676 causes rotate animation to break as animating affine transform will animate rotation to closest value.
For example, 0 -> 300 will rotate backwards since it's closer and 0 -> 360 won't rotate the view at all.

## What is the new behavior?
Reverted changes of #10676

Fixes #10764