### PR TITLE
chore(ios): Removed forced background update during safe area inset calculation

### DIFF
--- a/apps/automated/src/ui/view/view-tests.ios.ts
+++ b/apps/automated/src/ui/view/view-tests.ios.ts
@@ -77,15 +77,10 @@ export function testBackgroundInternalChangedOnceOnResize() {
 
 	TKUnit.assertEqual(trackCount(), 1, 'Expected background to be re-applied at most once when the view is laid-out on 0 0 200 200.');
 
-	// Ignore safe area as it may result in re-calculating view position, invalidating background
-	layout.iosIgnoreSafeArea = true;
-
 	layout.requestLayout();
 	layout.layout(50, 50, 250, 250);
 
 	TKUnit.assertEqual(trackCount(), 0, 'Expected background to NOT change when view is laid-out from 0 0 200 200 to 50 50 250 250.');
-
-	layout.iosIgnoreSafeArea = false;
 
 	layout.requestLayout();
 	layout.layout(0, 0, 250, 250);

--- a/apps/automated/src/ui/view/view-tests.ios.ts
+++ b/apps/automated/src/ui/view/view-tests.ios.ts
@@ -77,7 +77,7 @@ export function testBackgroundInternalChangedOnceOnResize() {
 
 	TKUnit.assertEqual(trackCount(), 1, 'Expected background to be re-applied at most once when the view is laid-out on 0 0 200 200.');
 
-	// Ignore safe area as it may result in re-calculating view frame, thus trigger a size change regardless
+	// Ignore safe area as it may result in re-calculating view position, invalidating background
 	layout.iosIgnoreSafeArea = true;
 
 	layout.requestLayout();

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -106,14 +106,13 @@ export class View extends ViewCommon implements ViewDefinition {
 
 	@profile
 	public layout(left: number, top: number, right: number, bottom: number, setFrame = true): void {
-		const result = this._setCurrentLayoutBounds(left, top, right, bottom);
-		let { sizeChanged } = result;
+		const { boundsChanged, sizeChanged } = this._setCurrentLayoutBounds(left, top, right, bottom);
 
 		if (setFrame) {
 			this.layoutNativeView(left, top, right, bottom);
 		}
 
-		const needsLayout = result.boundsChanged || (this._privateFlags & PFLAG_LAYOUT_REQUIRED) === PFLAG_LAYOUT_REQUIRED;
+		const needsLayout = boundsChanged || (this._privateFlags & PFLAG_LAYOUT_REQUIRED) === PFLAG_LAYOUT_REQUIRED;
 		if (needsLayout) {
 			let position: Position;
 
@@ -122,11 +121,11 @@ export class View extends ViewCommon implements ViewDefinition {
 				// get the frame and adjust the position, so that onLayout works correctly
 				position = IOSHelper.getPositionFromFrame(this.nativeViewProtected.frame);
 
-				if (!sizeChanged) {
-					// If frame has actually changed, there is the need to update view background and border styles as they depend on native view bounds
-					// To trigger the needed visual update, mark size as changed
+				if (this._nativeBackgroundState !== 'invalid') {
+					// If frame position was updated due to safe area, there is the need to update view background and border styles as they depend on native view bounds
+					// To trigger the needed visual update, invalidate the background state
 					if (position.left !== left || position.top !== top || position.right !== right || position.bottom !== bottom) {
-						sizeChanged = true;
+						this._nativeBackgroundState = 'invalid';
 					}
 				}
 			} else {

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -120,14 +120,6 @@ export class View extends ViewCommon implements ViewDefinition {
 				// on iOS 11+ it is possible to have a changed layout frame due to safe area insets
 				// get the frame and adjust the position, so that onLayout works correctly
 				position = IOSHelper.getPositionFromFrame(this.nativeViewProtected.frame);
-
-				if (this._nativeBackgroundState !== 'invalid') {
-					// If frame position was updated due to safe area, there is the need to update view background and border styles as they depend on native view bounds
-					// To trigger the needed visual update, invalidate the background state
-					if (position.left !== left || position.top !== top || position.right !== right || position.bottom !== bottom) {
-						this._nativeBackgroundState = 'invalid';
-					}
-				}
 			} else {
 				position = { left, top, right, bottom };
 			}

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -9,7 +9,6 @@ import { ImageSource } from '../../image-source';
 import type { CSSValue } from '../../css-value/reworkcss-value';
 import { parse as cssParse } from '../../css-value/reworkcss-value.js';
 import { BoxShadow } from './box-shadow';
-import { Length } from './style-properties';
 import { BackgroundClearFlags } from './background-common';
 import { ClipPathFunction } from './clip-path-function';
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the new behavior?
This PR removes the background redraw check that was added in #10661, as it doesn't fully solve the problem.
If developers experience visual glitches on layouts, it's best to set `iosOverflowSafeArea` to false.
The safe area support has flaws that need to be revisited in the future.