### PR TITLE
chore(core): Got rid of setNative type errors

### DIFF
--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -196,7 +196,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 	public readonly key: symbol;
 
 	public readonly getDefault: symbol;
-	public readonly setNative: any;
+	public readonly setNative: symbol;
 
 	public readonly defaultValueKey: symbol;
 	public readonly defaultValue: U;
@@ -397,7 +397,7 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
 		const propertyName = options.name;
 		const key = this.key;
 		const getDefault: symbol = this.getDefault;
-		const setNative: any = this.setNative;
+		const setNative: symbol = this.setNative;
 		const defaultValueKey = this.defaultValueKey;
 		const defaultValue: U = this.defaultValue;
 
@@ -612,7 +612,7 @@ export class CssProperty<T extends Style, U> {
 
 	public readonly key: symbol;
 	public readonly getDefault: symbol;
-	public readonly setNative: any;
+	public readonly setNative: symbol;
 	public readonly sourceKey: symbol;
 	public readonly defaultValueKey: symbol;
 	public readonly defaultValue: U;
@@ -879,7 +879,7 @@ export class CssAnimationProperty<T extends Style, U> implements CssAnimationPro
 	public readonly cssLocalName: string;
 
 	public readonly getDefault: symbol;
-	public readonly setNative: any;
+	public readonly setNative: symbol;
 
 	public readonly register: (cls: { prototype }) => void;
 

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -807,6 +807,117 @@ export class View extends ViewCommon {
 		this.nativeViewProtected.setAlpha(float(value));
 	}
 
+	[accessibilityRoleProperty.setNative](value: AccessibilityRole): void {
+		this.accessibilityRole = value as AccessibilityRole;
+		updateAccessibilityProperties(this);
+
+		if (SDK_VERSION >= 28) {
+			this.nativeViewProtected?.setAccessibilityHeading(value === AccessibilityRole.Header);
+		}
+	}
+
+	[accessibilityLiveRegionProperty.setNative](value: AccessibilityLiveRegion): void {
+		switch (value as AccessibilityLiveRegion) {
+			case AccessibilityLiveRegion.Assertive: {
+				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_ASSERTIVE);
+				break;
+			}
+			case AccessibilityLiveRegion.Polite: {
+				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_POLITE);
+				break;
+			}
+			default: {
+				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_NONE);
+				break;
+			}
+		}
+	}
+
+	[accessibilityStateProperty.setNative](value: AccessibilityState): void {
+		this.accessibilityState = value as AccessibilityState;
+		updateAccessibilityProperties(this);
+	}
+
+	[horizontalAlignmentProperty.getDefault](): CoreTypes.HorizontalAlignmentType {
+		return <CoreTypes.HorizontalAlignmentType>org.nativescript.widgets.ViewHelper.getHorizontalAlignment(this.nativeViewProtected);
+	}
+	[horizontalAlignmentProperty.setNative](value: CoreTypes.HorizontalAlignmentType) {
+		const nativeView = this.nativeViewProtected;
+		const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
+		const gravity = lp.gravity;
+		const weight = lp.weight;
+		// Set only if params gravity exists.
+		if (gravity !== undefined) {
+			switch (value) {
+				case 'left':
+					lp.gravity = GRAVITY_LEFT | (gravity & VERTICAL_GRAVITY_MASK);
+					if (weight < 0) {
+						lp.weight = -2;
+					}
+					break;
+				case 'center':
+					lp.gravity = GRAVITY_CENTER_HORIZONTAL | (gravity & VERTICAL_GRAVITY_MASK);
+					if (weight < 0) {
+						lp.weight = -2;
+					}
+					break;
+				case 'right':
+					lp.gravity = GRAVITY_RIGHT | (gravity & VERTICAL_GRAVITY_MASK);
+					if (weight < 0) {
+						lp.weight = -2;
+					}
+					break;
+				case 'stretch':
+					lp.gravity = GRAVITY_FILL_HORIZONTAL | (gravity & VERTICAL_GRAVITY_MASK);
+					if (weight < 0) {
+						lp.weight = -1;
+					}
+					break;
+			}
+			nativeView.setLayoutParams(lp);
+		}
+	}
+
+	[verticalAlignmentProperty.getDefault](): CoreTypes.VerticalAlignmentType {
+		return <CoreTypes.VerticalAlignmentType>org.nativescript.widgets.ViewHelper.getVerticalAlignment(this.nativeViewProtected);
+	}
+	[verticalAlignmentProperty.setNative](value: CoreTypes.VerticalAlignmentType) {
+		const nativeView = this.nativeViewProtected;
+		const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
+		const gravity = lp.gravity;
+		const height = lp.height;
+		// Set only if params gravity exists.
+		if (gravity !== undefined) {
+			switch (value) {
+				case 'top':
+					lp.gravity = GRAVITY_TOP | (gravity & HORIZONTAL_GRAVITY_MASK);
+					if (height < 0) {
+						lp.height = -2;
+					}
+					break;
+				case 'middle':
+					lp.gravity = GRAVITY_CENTER_VERTICAL | (gravity & HORIZONTAL_GRAVITY_MASK);
+					if (height < 0) {
+						lp.height = -2;
+					}
+					break;
+				case 'bottom':
+					lp.gravity = GRAVITY_BOTTOM | (gravity & HORIZONTAL_GRAVITY_MASK);
+					if (height < 0) {
+						lp.height = -2;
+					}
+					break;
+				case 'stretch':
+					lp.gravity = GRAVITY_FILL_VERTICAL | (gravity & HORIZONTAL_GRAVITY_MASK);
+					if (height < 0) {
+						lp.height = -1;
+					}
+					break;
+			}
+			nativeView.setLayoutParams(lp);
+		}
+	}
+
 	[testIDProperty.setNative](value: string) {
 		this.setAccessibilityIdentifier(this.nativeViewProtected, value);
 	}
@@ -833,15 +944,6 @@ export class View extends ViewCommon {
 		this.setAccessibilityIdentifier(this.nativeViewProtected, value);
 	}
 
-	[accessibilityRoleProperty.setNative](value: string): void {
-		this.accessibilityRole = value as AccessibilityRole;
-		updateAccessibilityProperties(this);
-
-		if (SDK_VERSION >= 28) {
-			this.nativeViewProtected?.setAccessibilityHeading(value === AccessibilityRole.Header);
-		}
-	}
-
 	[accessibilityValueProperty.setNative](value: string): void {
 		this._androidContentDescriptionUpdated = true;
 		updateContentDescription(this);
@@ -863,28 +965,6 @@ export class View extends ViewCommon {
 		} else {
 			this.nativeViewProtected.setImportantForAccessibility(android.view.View.IMPORTANT_FOR_ACCESSIBILITY_YES);
 		}
-	}
-
-	[accessibilityLiveRegionProperty.setNative](value: string): void {
-		switch (value as AccessibilityLiveRegion) {
-			case AccessibilityLiveRegion.Assertive: {
-				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_ASSERTIVE);
-				break;
-			}
-			case AccessibilityLiveRegion.Polite: {
-				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_POLITE);
-				break;
-			}
-			default: {
-				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_NONE);
-				break;
-			}
-		}
-	}
-
-	[accessibilityStateProperty.setNative](value: string): void {
-		this.accessibilityState = value as AccessibilityState;
-		updateAccessibilityProperties(this);
 	}
 
 	[accessibilityMediaSessionProperty.setNative](value: string): void {
@@ -969,86 +1049,6 @@ export class View extends ViewCommon {
 			currentAnimator.jumpToCurrentState();
 		}
 		nativeView.setStateListAnimator(stateListAnimator);
-	}
-
-	[horizontalAlignmentProperty.getDefault](): CoreTypes.HorizontalAlignmentType {
-		return <CoreTypes.HorizontalAlignmentType>org.nativescript.widgets.ViewHelper.getHorizontalAlignment(this.nativeViewProtected);
-	}
-	[horizontalAlignmentProperty.setNative](value: string) {
-		const nativeView = this.nativeViewProtected;
-		const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
-		const gravity = lp.gravity;
-		const weight = lp.weight;
-		// Set only if params gravity exists.
-		if (gravity !== undefined) {
-			switch (value as CoreTypes.HorizontalAlignmentType) {
-				case 'left':
-					lp.gravity = GRAVITY_LEFT | (gravity & VERTICAL_GRAVITY_MASK);
-					if (weight < 0) {
-						lp.weight = -2;
-					}
-					break;
-				case 'center':
-					lp.gravity = GRAVITY_CENTER_HORIZONTAL | (gravity & VERTICAL_GRAVITY_MASK);
-					if (weight < 0) {
-						lp.weight = -2;
-					}
-					break;
-				case 'right':
-					lp.gravity = GRAVITY_RIGHT | (gravity & VERTICAL_GRAVITY_MASK);
-					if (weight < 0) {
-						lp.weight = -2;
-					}
-					break;
-				case 'stretch':
-					lp.gravity = GRAVITY_FILL_HORIZONTAL | (gravity & VERTICAL_GRAVITY_MASK);
-					if (weight < 0) {
-						lp.weight = -1;
-					}
-					break;
-			}
-			nativeView.setLayoutParams(lp);
-		}
-	}
-
-	[verticalAlignmentProperty.getDefault](): CoreTypes.VerticalAlignmentType {
-		return <CoreTypes.VerticalAlignmentType>org.nativescript.widgets.ViewHelper.getVerticalAlignment(this.nativeViewProtected);
-	}
-	[verticalAlignmentProperty.setNative](value: string) {
-		const nativeView = this.nativeViewProtected;
-		const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
-		const gravity = lp.gravity;
-		const height = lp.height;
-		// Set only if params gravity exists.
-		if (gravity !== undefined) {
-			switch (value as CoreTypes.VerticalAlignmentType) {
-				case 'top':
-					lp.gravity = GRAVITY_TOP | (gravity & HORIZONTAL_GRAVITY_MASK);
-					if (height < 0) {
-						lp.height = -2;
-					}
-					break;
-				case 'middle':
-					lp.gravity = GRAVITY_CENTER_VERTICAL | (gravity & HORIZONTAL_GRAVITY_MASK);
-					if (height < 0) {
-						lp.height = -2;
-					}
-					break;
-				case 'bottom':
-					lp.gravity = GRAVITY_BOTTOM | (gravity & HORIZONTAL_GRAVITY_MASK);
-					if (height < 0) {
-						lp.height = -2;
-					}
-					break;
-				case 'stretch':
-					lp.gravity = GRAVITY_FILL_VERTICAL | (gravity & HORIZONTAL_GRAVITY_MASK);
-					if (height < 0) {
-						lp.height = -1;
-					}
-					break;
-			}
-			nativeView.setLayoutParams(lp);
-		}
 	}
 
 	[rotateProperty.setNative](value: number) {

--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -833,9 +833,8 @@ export class View extends ViewCommon {
 		this.setAccessibilityIdentifier(this.nativeViewProtected, value);
 	}
 
-	// @ts-expect-error
-	[accessibilityRoleProperty.setNative](value: AccessibilityRole): void {
-		this.accessibilityRole = value;
+	[accessibilityRoleProperty.setNative](value: string): void {
+		this.accessibilityRole = value as AccessibilityRole;
 		updateAccessibilityProperties(this);
 
 		if (SDK_VERSION >= 28) {
@@ -843,17 +842,17 @@ export class View extends ViewCommon {
 		}
 	}
 
-	[accessibilityValueProperty.setNative](): void {
+	[accessibilityValueProperty.setNative](value: string): void {
 		this._androidContentDescriptionUpdated = true;
 		updateContentDescription(this);
 	}
 
-	[accessibilityLabelProperty.setNative](): void {
+	[accessibilityLabelProperty.setNative](value: string): void {
 		this._androidContentDescriptionUpdated = true;
 		updateContentDescription(this);
 	}
 
-	[accessibilityHintProperty.setNative](): void {
+	[accessibilityHintProperty.setNative](value: string): void {
 		this._androidContentDescriptionUpdated = true;
 		updateContentDescription(this);
 	}
@@ -866,9 +865,8 @@ export class View extends ViewCommon {
 		}
 	}
 
-	// @ts-expect-error
-	[accessibilityLiveRegionProperty.setNative](value: AccessibilityLiveRegion): void {
-		switch (value) {
+	[accessibilityLiveRegionProperty.setNative](value: string): void {
+		switch (value as AccessibilityLiveRegion) {
 			case AccessibilityLiveRegion.Assertive: {
 				this.nativeViewProtected.setAccessibilityLiveRegion(android.view.View.ACCESSIBILITY_LIVE_REGION_ASSERTIVE);
 				break;
@@ -884,13 +882,12 @@ export class View extends ViewCommon {
 		}
 	}
 
-	// @ts-expect-error
-	[accessibilityStateProperty.setNative](value: AccessibilityState): void {
-		this.accessibilityState = value;
+	[accessibilityStateProperty.setNative](value: string): void {
+		this.accessibilityState = value as AccessibilityState;
 		updateAccessibilityProperties(this);
 	}
 
-	[accessibilityMediaSessionProperty.setNative](): void {
+	[accessibilityMediaSessionProperty.setNative](value: string): void {
 		updateAccessibilityProperties(this);
 	}
 
@@ -977,15 +974,14 @@ export class View extends ViewCommon {
 	[horizontalAlignmentProperty.getDefault](): CoreTypes.HorizontalAlignmentType {
 		return <CoreTypes.HorizontalAlignmentType>org.nativescript.widgets.ViewHelper.getHorizontalAlignment(this.nativeViewProtected);
 	}
-	// @ts-expect-error
-	[horizontalAlignmentProperty.setNative](value: CoreTypes.HorizontalAlignmentType) {
+	[horizontalAlignmentProperty.setNative](value: string) {
 		const nativeView = this.nativeViewProtected;
 		const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
 		const gravity = lp.gravity;
 		const weight = lp.weight;
 		// Set only if params gravity exists.
 		if (gravity !== undefined) {
-			switch (value) {
+			switch (value as CoreTypes.HorizontalAlignmentType) {
 				case 'left':
 					lp.gravity = GRAVITY_LEFT | (gravity & VERTICAL_GRAVITY_MASK);
 					if (weight < 0) {
@@ -1018,15 +1014,14 @@ export class View extends ViewCommon {
 	[verticalAlignmentProperty.getDefault](): CoreTypes.VerticalAlignmentType {
 		return <CoreTypes.VerticalAlignmentType>org.nativescript.widgets.ViewHelper.getVerticalAlignment(this.nativeViewProtected);
 	}
-	// @ts-expect-error
-	[verticalAlignmentProperty.setNative](value: CoreTypes.VerticalAlignmentType) {
+	[verticalAlignmentProperty.setNative](value: string) {
 		const nativeView = this.nativeViewProtected;
 		const lp: any = nativeView.getLayoutParams() || new org.nativescript.widgets.CommonLayoutParams();
 		const gravity = lp.gravity;
 		const height = lp.height;
 		// Set only if params gravity exists.
 		if (gravity !== undefined) {
-			switch (value) {
+			switch (value as CoreTypes.VerticalAlignmentType) {
 				case 'top':
 					lp.gravity = GRAVITY_TOP | (gravity & HORIZONTAL_GRAVITY_MASK);
 					if (height < 0) {

--- a/packages/core/ui/image/index.ios.ts
+++ b/packages/core/ui/image/index.ios.ts
@@ -1,5 +1,5 @@
 import { ImageBase, stretchProperty, imageSourceProperty, tintColorProperty, srcProperty, iosSymbolEffectProperty, ImageSymbolEffect, ImageSymbolEffects, iosSymbolScaleProperty } from './image-common';
-import { ImageSource, iosSymbolScaleType } from '../../image-source';
+import { ImageSource } from '../../image-source';
 import { ImageAsset } from '../../image-asset';
 import { Color } from '../../color';
 import { Trace } from '../../trace';
@@ -157,7 +157,7 @@ export class Image extends ImageBase {
 		return { width: scaleW, height: scaleH };
 	}
 
-	[stretchProperty.setNative](value: string) {
+	[stretchProperty.setNative](value: 'none' | 'aspectFill' | 'aspectFit' | 'fill') {
 		if (this.nativeViewProtected) {
 			switch (value) {
 				case 'aspectFit':
@@ -219,7 +219,7 @@ export class Image extends ImageBase {
 		}
 	}
 
-	[iosSymbolScaleProperty.setNative](value: iosSymbolScaleType) {
+	[iosSymbolScaleProperty.setNative](value: string) {
 		// reset src to configure scale
 		this._setSrc(this.src);
 	}

--- a/packages/core/ui/image/index.ios.ts
+++ b/packages/core/ui/image/index.ios.ts
@@ -157,7 +157,7 @@ export class Image extends ImageBase {
 		return { width: scaleW, height: scaleH };
 	}
 
-	[stretchProperty.setNative](value: 'none' | 'aspectFill' | 'aspectFit' | 'fill') {
+	[stretchProperty.setNative](value: string) {
 		if (this.nativeViewProtected) {
 			switch (value) {
 				case 'aspectFit':
@@ -219,7 +219,6 @@ export class Image extends ImageBase {
 		}
 	}
 
-	// @ts-expect-error
 	[iosSymbolScaleProperty.setNative](value: iosSymbolScaleType) {
 		// reset src to configure scale
 		this._setSrc(this.src);

--- a/packages/core/ui/search-bar/index.android.ts
+++ b/packages/core/ui/search-bar/index.android.ts
@@ -4,6 +4,7 @@ import { isUserInteractionEnabledProperty, isEnabledProperty } from '../core/vie
 import { ad } from '../../utils';
 import { Color } from '../../color';
 import { colorProperty, backgroundColorProperty, backgroundInternalProperty, fontInternalProperty, fontSizeProperty } from '../styling/style-properties';
+import { Background } from '../styling/background';
 
 export * from './search-bar-common';
 
@@ -227,14 +228,13 @@ export class SearchBar extends SearchBarBase {
 	[backgroundInternalProperty.getDefault](): any {
 		return null;
 	}
-	[backgroundInternalProperty.setNative](value: any) {
+	[backgroundInternalProperty.setNative](value: android.graphics.drawable.Drawable | Background) {
 		//
 	}
 
 	[textProperty.getDefault](): string {
 		return '';
 	}
-	// @ts-expect-error
 	[textProperty.setNative](value: string) {
 		const text = value === null || value === undefined ? '' : value.toString();
 		this.nativeViewProtected.setQuery(text, false);
@@ -242,7 +242,6 @@ export class SearchBar extends SearchBarBase {
 	[hintProperty.getDefault](): string {
 		return null;
 	}
-	// @ts-expect-error
 	[hintProperty.setNative](value: string) {
 		if (value === null || value === undefined) {
 			this.nativeViewProtected.setQueryHint(null);

--- a/packages/core/ui/search-bar/index.ios.ts
+++ b/packages/core/ui/search-bar/index.ios.ts
@@ -158,14 +158,13 @@ export class SearchBar extends SearchBarBase {
 	[backgroundInternalProperty.getDefault](): any {
 		return null;
 	}
-	[backgroundInternalProperty.setNative](value: any) {
+	[backgroundInternalProperty.setNative](value: UIColor) {
 		//
 	}
 
 	[textProperty.getDefault](): string {
 		return '';
 	}
-	// @ts-expect-error
 	[textProperty.setNative](value: string) {
 		const text = value === null || value === undefined ? '' : value.toString();
 		this.ios.text = text;
@@ -174,7 +173,6 @@ export class SearchBar extends SearchBarBase {
 	[hintProperty.getDefault](): string {
 		return '';
 	}
-	// @ts-expect-error
 	[hintProperty.setNative](value: string) {
 		this._updateAttributedPlaceholder();
 	}

--- a/packages/core/ui/styling/style-properties.d.ts
+++ b/packages/core/ui/styling/style-properties.d.ts
@@ -87,7 +87,6 @@ export const minWidthProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.Leng
 export const minHeightProperty: CssProperty<Style, CoreTypes.dip | CoreTypes.LengthDipUnit | CoreTypes.LengthPxUnit>;
 export const widthProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
 export const heightProperty: CssAnimationProperty<Style, CoreTypes.PercentLengthType>;
-export const lineHeightProperty: CssProperty<Style, number>;
 export const marginProperty: ShorthandProperty<Style, string | CoreTypes.PercentLengthType>;
 export const marginLeftProperty: CssProperty<Style, CoreTypes.PercentLengthType>;
 export const marginRightProperty: CssProperty<Style, CoreTypes.PercentLengthType>;

--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -4,7 +4,6 @@ import { ShadowCSSValues } from '../styling/css-shadow';
 
 // Requires
 import { Font } from '../styling/font';
-import { backgroundColorProperty } from '../styling/style-properties';
 import { TextBaseCommon, formattedTextProperty, textAlignmentProperty, textDecorationProperty, textProperty, textTransformProperty, textShadowProperty, textStrokeProperty, letterSpacingProperty, whiteSpaceProperty, lineHeightProperty, resetSymbol } from './text-base-common';
 import { Color } from '../../color';
 import { colorProperty, fontSizeProperty, fontInternalProperty, paddingLeftProperty, paddingTopProperty, paddingRightProperty, paddingBottomProperty, Length } from '../styling/style-properties';
@@ -388,13 +387,6 @@ export class TextBase extends TextBaseCommon {
 		}
 	}
 
-	[lineHeightProperty.getDefault](): number {
-		return this.nativeTextViewProtected.getLineSpacingExtra() / layout.getDisplayDensity();
-	}
-	[lineHeightProperty.setNative](value: number) {
-		this.nativeTextViewProtected.setLineSpacing(value * layout.getDisplayDensity(), 1);
-	}
-
 	[fontInternalProperty.getDefault](): android.graphics.Typeface {
 		return this.nativeTextViewProtected.getTypeface();
 	}
@@ -448,17 +440,9 @@ export class TextBase extends TextBaseCommon {
 		);
 	}
 
-	[letterSpacingProperty.getDefault](): number {
-		return org.nativescript.widgets.ViewHelper.getLetterspacing(this.nativeTextViewProtected);
-	}
-	[letterSpacingProperty.setNative](value: number) {
-		org.nativescript.widgets.ViewHelper.setLetterspacing(this.nativeTextViewProtected, value);
-	}
-
 	[paddingTopProperty.getDefault](): CoreTypes.LengthType {
 		return { value: this._defaultPaddingTop, unit: 'px' };
 	}
-	// @ts-expect-error
 	[paddingTopProperty.setNative](value: CoreTypes.LengthType) {
 		org.nativescript.widgets.ViewHelper.setPaddingTop(this.nativeTextViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderTopWidth, 0));
 	}
@@ -466,7 +450,6 @@ export class TextBase extends TextBaseCommon {
 	[paddingRightProperty.getDefault](): CoreTypes.LengthType {
 		return { value: this._defaultPaddingRight, unit: 'px' };
 	}
-	// @ts-expect-error
 	[paddingRightProperty.setNative](value: CoreTypes.LengthType) {
 		org.nativescript.widgets.ViewHelper.setPaddingRight(this.nativeTextViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderRightWidth, 0));
 	}
@@ -474,7 +457,6 @@ export class TextBase extends TextBaseCommon {
 	[paddingBottomProperty.getDefault](): CoreTypes.LengthType {
 		return { value: this._defaultPaddingBottom, unit: 'px' };
 	}
-	// @ts-expect-error
 	[paddingBottomProperty.setNative](value: CoreTypes.LengthType) {
 		org.nativescript.widgets.ViewHelper.setPaddingBottom(this.nativeTextViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderBottomWidth, 0));
 	}
@@ -482,9 +464,22 @@ export class TextBase extends TextBaseCommon {
 	[paddingLeftProperty.getDefault](): CoreTypes.LengthType {
 		return { value: this._defaultPaddingLeft, unit: 'px' };
 	}
-	// @ts-expect-error
 	[paddingLeftProperty.setNative](value: CoreTypes.LengthType) {
 		org.nativescript.widgets.ViewHelper.setPaddingLeft(this.nativeTextViewProtected, Length.toDevicePixels(value, 0) + Length.toDevicePixels(this.style.borderLeftWidth, 0));
+	}
+
+	[lineHeightProperty.getDefault](): number {
+		return this.nativeTextViewProtected.getLineSpacingExtra() / layout.getDisplayDensity();
+	}
+	[lineHeightProperty.setNative](value: number) {
+		this.nativeTextViewProtected.setLineSpacing(value * layout.getDisplayDensity(), 1);
+	}
+
+	[letterSpacingProperty.getDefault](): number {
+		return org.nativescript.widgets.ViewHelper.getLetterspacing(this.nativeTextViewProtected);
+	}
+	[letterSpacingProperty.setNative](value: number) {
+		org.nativescript.widgets.ViewHelper.setLetterspacing(this.nativeTextViewProtected, value);
 	}
 
 	[testIDProperty.setNative](value: string): void {
@@ -495,7 +490,7 @@ export class TextBase extends TextBaseCommon {
 		this.setAccessibilityIdentifier(this.nativeTextViewProtected, value);
 	}
 
-	[maxLinesProperty.setNative](value: number) {
+	[maxLinesProperty.setNative](value: CoreTypes.MaxLinesType) {
 		const nativeTextViewProtected = this.nativeTextViewProtected;
 		if (value <= 0) {
 			nativeTextViewProtected.setMaxLines(Number.MAX_SAFE_INTEGER);

--- a/packages/core/ui/text-field/index.ios.ts
+++ b/packages/core/ui/text-field/index.ios.ts
@@ -350,7 +350,7 @@ export class TextField extends TextFieldBase {
 		}
 
 		if (paragraphStyle) {
-			let attributedString = NSMutableAttributedString.alloc().initWithString(this.nativeViewProtected.text || '');
+			const attributedString = NSMutableAttributedString.alloc().initWithString(this.nativeViewProtected.text || '');
 			attributedString.addAttributeValueRange(NSParagraphStyleAttributeName, paragraphStyle, NSRangeFromString(`{0,${attributedString.length}}`));
 
 			this.nativeViewProtected.attributedText = attributedString;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the new behavior?
This PR gets rid of type errors related to some computed `setNative` methods.
Since we use symbols to define methods with a single argument, TypeScript may complain about union string types for prototype's `[prop: symbol]`.
Things can get a bad turn if some methods use `any` as an argument type or unions/enums end up in conflict with string type.

To solve this, the following actions have been performed:
- Replaced argument `any` with the corresponding type
- Replaced string enum with string type
- Switched order of some computed method declarations to get rid of union type conflicts

A small example to understand the conflict:
```ts
	[testIDProperty.setNative](value: string) {
		this.setAccessibilityIdentifier(this.nativeViewProtected, value);
	}

        // This throws error as TS with cause enum to have conflict with expected string type
        [accessibilityStateProperty.setNative](value: AccessibilityState): void {
		this.accessibilityState = value as AccessibilityState;
		updateAccessibilityProperties(this);
	}
```

And this will work because TS doesn't know about expected string argument yet.
```ts
	[accessibilityStateProperty.setNative](value: AccessibilityState): void {
		this.accessibilityState = value as AccessibilityState;
		updateAccessibilityProperties(this);
	}
	
	[testIDProperty.setNative](value: string) {
		this.setAccessibilityIdentifier(this.nativeViewProtected, value);
	}
```