### PR TITLE
feat(TextField): decimal keyboardType 

### DIFF
--- a/apps/automated/src/ui/text-field/text-field-tests.ts
+++ b/apps/automated/src/ui/text-field/text-field-tests.ts
@@ -339,6 +339,32 @@ export var testSetKeyboardTypeNumberAndSecure = function () {
 	});
 };
 
+export var testSetSecureAndKeyboardTypeDecimal = function () {
+	helper.buildUIAndRunTest(_createTextFieldFunc(), function (views: Array<View>) {
+		var textField = <TextField>views[0];
+
+		textField.secure = true;
+		textField.keyboardType = 'decimal';
+
+		var expectedValue = true;
+		var actualValue = getNativeSecure(textField);
+		TKUnit.assert(actualValue === expectedValue, 'Actual: ' + actualValue + '; Expected: ' + expectedValue);
+	});
+};
+
+export var testSetKeyboardTypeDecimalAndSecure = function () {
+	helper.buildUIAndRunTest(_createTextFieldFunc(), function (views: Array<View>) {
+		var textField = <TextField>views[0];
+
+		textField.keyboardType = 'decimal';
+		textField.secure = true;
+
+		var expectedValue = true;
+		var actualValue = getNativeSecure(textField);
+		TKUnit.assert(actualValue === expectedValue, 'Actual: ' + actualValue + '; Expected: ' + expectedValue);
+	});
+};
+
 export var testBindSecureDirectlyToModel = function () {
 	helper.buildUIAndRunTest(_createTextFieldFunc(), function (views: Array<View>) {
 		var textField = <TextField>views[0];

--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -40,11 +40,12 @@ export namespace CoreTypes {
 		unit: 'px',
 	};
 
-	export type KeyboardInputType = 'datetime' | 'phone' | 'number' | 'url' | 'email' | 'integer';
+	export type KeyboardInputType = 'datetime' | 'phone' | 'number' | 'decimal' | 'url' | 'email' | 'integer';
 	export namespace KeyboardType {
 		export const datetime = 'datetime';
 		export const phone = 'phone';
 		export const number = 'number';
+		export const decimal = 'decimal';
 		export const url = 'url';
 		export const email = 'email';
 		export const integer = 'integer';

--- a/packages/core/ui/editable-text-base/editable-text-base-common.ts
+++ b/packages/core/ui/editable-text-base/editable-text-base-common.ts
@@ -67,7 +67,7 @@ export const placeholderColorProperty = new CssProperty<Style, Color>({
 });
 placeholderColorProperty.register(Style);
 
-const keyboardTypeConverter = makeParser<CoreTypes.KeyboardInputType>(makeValidator<CoreTypes.KeyboardInputType>(CoreTypes.KeyboardType.datetime, CoreTypes.KeyboardType.phone, CoreTypes.KeyboardType.number, CoreTypes.KeyboardType.url, CoreTypes.KeyboardType.email, CoreTypes.KeyboardType.integer), true);
+const keyboardTypeConverter = makeParser<CoreTypes.KeyboardInputType>(makeValidator<CoreTypes.KeyboardInputType>(CoreTypes.KeyboardType.datetime, CoreTypes.KeyboardType.phone, CoreTypes.KeyboardType.number, CoreTypes.KeyboardType.decimal, CoreTypes.KeyboardType.url, CoreTypes.KeyboardType.email, CoreTypes.KeyboardType.integer), true);
 
 export const autofillTypeProperty = new Property<EditableTextBase, CoreTypes.AutofillType>({ name: 'autofillType' });
 autofillTypeProperty.register(EditableTextBase);

--- a/packages/core/ui/editable-text-base/index.android.ts
+++ b/packages/core/ui/editable-text-base/index.android.ts
@@ -204,7 +204,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 	[keyboardTypeProperty.getDefault](): number {
 		return this.nativeTextViewProtected.getInputType();
 	}
-	[keyboardTypeProperty.setNative](value: 'datetime' | 'phone' | 'number' | 'url' | 'email' | 'integer' | number) {
+	[keyboardTypeProperty.setNative](value: 'datetime' | 'phone' | 'number' | 'decimal' | 'url' | 'email' | 'integer' | number) {
 		let newInputType;
 
 		switch (value) {
@@ -218,6 +218,10 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
 			case 'number':
 				newInputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_NORMAL | android.text.InputType.TYPE_NUMBER_FLAG_SIGNED | android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL;
+				break;
+
+			case 'decimal':
+				newInputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL | android.text.InputType.TYPE_NUMBER_FLAG_SIGNED;
 				break;
 
 			case 'url':

--- a/packages/core/ui/editable-text-base/index.ios.ts
+++ b/packages/core/ui/editable-text-base/index.ios.ts
@@ -34,7 +34,7 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 				return keyboardType.toString();
 		}
 	}
-	[keyboardTypeProperty.setNative](value: 'datetime' | 'phone' | 'number' | 'url' | 'email' | 'integer' | string) {
+	[keyboardTypeProperty.setNative](value: 'datetime' | 'phone' | 'number' | 'decimal' | 'url' | 'email' | 'integer' | string) {
 		let newKeyboardType: UIKeyboardType;
 		switch (value) {
 			case 'datetime':
@@ -47,6 +47,10 @@ export abstract class EditableTextBase extends EditableTextBaseCommon {
 
 			case 'number':
 				newKeyboardType = UIKeyboardType.NumbersAndPunctuation;
+				break;
+
+			case 'decimal':
+				newKeyboardType = UIKeyboardType.DecimalPad;
 				break;
 
 			case 'url':

--- a/packages/core/ui/text-field/index.android.ts
+++ b/packages/core/ui/text-field/index.android.ts
@@ -78,6 +78,9 @@ export class TextField extends TextFieldBase {
 				case 'number':
 					inputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_VARIATION_NORMAL | android.text.InputType.TYPE_NUMBER_FLAG_SIGNED | android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL;
 					break;
+				case 'decimal':
+					inputType = android.text.InputType.TYPE_CLASS_NUMBER | android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL | android.text.InputType.TYPE_NUMBER_FLAG_SIGNED;
+					break;
 				case 'url':
 					inputType = android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_URI;
 					break;


### PR DESCRIPTION
## What is the current behavior?

Users could patch-package on core to allow decimal keyboardType.

## What is the new behavior?

Setting `keyboardType="decimal"` shows numeric keyboard with ability to enter decimals.