### PR TITLE
fix(android): shared element with target name already added to transaction

### DIFF
--- a/packages/core/ui/transition/page-transition.android.ts
+++ b/packages/core/ui/transition/page-transition.android.ts
@@ -262,9 +262,22 @@ export class PageTransition extends Transition {
 		newFragment.setSharedElementEnterTransition(transitionSet);
 		newFragment.setSharedElementReturnTransition(transitionSet);
 
+		// Guard against duplicate shared element names being added to the same transaction
+		const addedSharedElementNames = new Set();
 		presenting.forEach((v) => {
+			const name = v?.sharedTransitionTag;
+			const nativeView = v?.nativeView;
+			if (!name || !nativeView || addedSharedElementNames.has(name)) {
+				// prevent duplicates or invalid items
+				return;
+			}
 			setTransitionName(v);
-			fragmentTransaction.addSharedElement(v.nativeView, v.sharedTransitionTag);
+			try {
+				fragmentTransaction.addSharedElement(nativeView, name);
+				addedSharedElementNames.add(name);
+			} catch (err) {
+				// ignore duplicates or issues adding shared element to avoid crashing
+			}
 		});
 		if (toPage.isLoaded) {
 			onPageLoaded();


### PR DESCRIPTION
## What is the current behavior?

Different timing conditions during shared element transitions can cause the following error:

```
java.lang.IllegalArgumentException: A shared element with the target name 'image-1234567890' has already been added to the transaction.
androidFragmentTransactionCallback file: @nativescript/core/ui/transition/page-transition.android.js:245:0
```

## What is the new behavior?

Prevention to a target already being added to the transaction.