### PR TITLE
feat(dialogs): allow using keyboard enter/return to confirm on iOS

### DIFF
--- a/packages/core/ui/dialogs/index.ios.ts
+++ b/packages/core/ui/dialogs/index.ios.ts
@@ -17,7 +17,7 @@ function addButtonsToAlertController(alertController: UIAlertController, options
 		alertController.addAction(
 			UIAlertAction.actionWithTitleStyleHandler(options.cancelButtonText, UIAlertActionStyle.Default, () => {
 				raiseCallback(callback, false);
-			})
+			}),
 		);
 	}
 
@@ -25,16 +25,16 @@ function addButtonsToAlertController(alertController: UIAlertController, options
 		alertController.addAction(
 			UIAlertAction.actionWithTitleStyleHandler(options.neutralButtonText, UIAlertActionStyle.Default, () => {
 				raiseCallback(callback, undefined);
-			})
+			}),
 		);
 	}
 
 	if (isString(options.okButtonText)) {
-		alertController.addAction(
-			UIAlertAction.actionWithTitleStyleHandler(options.okButtonText, UIAlertActionStyle.Default, () => {
-				raiseCallback(callback, true);
-			})
-		);
+		const action = UIAlertAction.actionWithTitleStyleHandler(options.okButtonText, UIAlertActionStyle.Default, () => {
+			raiseCallback(callback, true);
+		});
+		alertController.addAction(action);
+		alertController.preferredAction = action; // Allows using keyboard enter/return to confirm the dialog
 	}
 }
 
@@ -91,7 +91,7 @@ export function alert(arg: any): Promise<void> {
 						title: DialogStrings.ALERT,
 						okButtonText: DialogStrings.OK,
 						message: arg + '',
-				  }
+					}
 				: arg;
 			const alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
 
@@ -115,7 +115,7 @@ export function confirm(arg: any): Promise<boolean> {
 						okButtonText: DialogStrings.OK,
 						cancelButtonText: DialogStrings.CANCEL,
 						message: arg + '',
-				  }
+					}
 				: arg;
 			const alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(options.title, options.message, UIAlertControllerStyle.Alert);
 
@@ -301,7 +301,7 @@ export function action(...args): Promise<string> {
 						alertController.addAction(
 							UIAlertAction.actionWithTitleStyleHandler(action, dialogType, (arg: UIAlertAction) => {
 								resolve(arg.title);
-							})
+							}),
 						);
 					}
 				}
@@ -311,7 +311,7 @@ export function action(...args): Promise<string> {
 				alertController.addAction(
 					UIAlertAction.actionWithTitleStyleHandler(options.cancelButtonText, UIAlertActionStyle.Cancel, (arg: UIAlertAction) => {
 						resolve(arg.title);
-					})
+					}),
 				);
 			}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dialogs don't confirm when using keyboard enter/return on iOS

## What is the new behavior?
<!-- Describe the changes. -->

Keyboard enter confirms and closes dialogs

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

