### PR TITLE
fix(android): make button default text not all caps for improved consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"eslint": "~8.57.0",
 		"eslint-config-prettier": "^10.0.0",
 		"fork-ts-checker-webpack-plugin": "^7.0.0",
-    "form-data": ">=4.0.4",
+		"form-data": ">=4.0.4",
 		"gonzales": "^1.0.7",
 		"husky": "^9.0.0",
 		"jest": "30.0.5",
@@ -104,9 +104,9 @@
 		"zx": "^8.3.0",
 		"jest-util": "30.0.5"
 	},
-  "overrides": {
-    "form-data": ">=4.0.4"
-  },
+	"overrides": {
+		"form-data": ">=4.0.4"
+	},
 	"lint-staged": {
 		"**/*.{js,ts,css,scss,json,html}": [
 			"npx prettier --write"

--- a/packages/core/ui/button/index.android.ts
+++ b/packages/core/ui/button/index.android.ts
@@ -75,6 +75,8 @@ export class Button extends ButtonBase {
 	public initNativeView(): void {
 		super.initNativeView();
 		const nativeView = this.nativeViewProtected;
+		// make consistent with iOS, easier on users given css styling
+		nativeView.setAllCaps(false);
 		initializeClickListener();
 		const clickListener = new ClickListener(this);
 		nativeView.setOnClickListener(clickListener);


### PR DESCRIPTION
For a long time out of the box, users get the following due to legacy defaults with material on Android.
<img width="799" height="745" alt="Screenshot 2025-09-15 at 10 06 55 PM" src="https://github.com/user-attachments/assets/bc317988-fcd5-4e9f-86ab-68414fbafabc" />

This makes Android 100% consistent with iOS now and easier out of the box experience; ease of css styling.
<img width="794" height="741" alt="Screenshot 2025-09-15 at 10 07 10 PM" src="https://github.com/user-attachments/assets/901b6872-2af0-4d5c-a4d8-38f680d6d04b" />
