### PR TITLE
fix(android): prevent clipped font icons on Android

### DIFF
--- a/packages/core/image-source/index.android.ts
+++ b/packages/core/image-source/index.android.ts
@@ -181,13 +181,14 @@ export class ImageSource implements ImageSourceDefinition {
 		const textBounds = new android.graphics.Rect();
 		paint.getTextBounds(source, 0, source.length, textBounds);
 
-		const textWidth = textBounds.width();
-		const textHeight = textBounds.height();
+		const padding = 1;
+		const textWidth = textBounds.width() + padding * 2;
+		const textHeight = textBounds.height() + padding * 2;
 		if (textWidth > 0 && textHeight > 0) {
 			const bitmap = android.graphics.Bitmap.createBitmap(textWidth, textHeight, android.graphics.Bitmap.Config.ARGB_8888);
 
 			const canvas = new android.graphics.Canvas(bitmap);
-			canvas.drawText(source, -textBounds.left, -textBounds.top, paint);
+			canvas.drawText(source, -textBounds.left + padding, -textBounds.top + padding, paint);
 
 			return new ImageSource(bitmap);
 		}


### PR DESCRIPTION
Add a 1px padding on each edge when creating the bitmap, this guarantees enough space for fractional/anti-aliased edges across all DPIs and devices.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, font icons used in Image or ActionItem etc (font://...) mitght get clipped on the top and right on certain devices/dpis, 1px is missing on top and right.

<img width="74" height="27" alt="Bildschirmfoto 2025-09-23 um 16 38 46" src="https://github.com/user-attachments/assets/afaba75a-c4b1-4f23-b579-0ff8b359c471" />


This is because NativeScript currently uses:

```
paint.getTextBounds(source, 0, source.length, textBounds);
const bitmap = Bitmap.createBitmap(textBounds.width(), textBounds.height(), ...);
canvas.drawText(source, -textBounds.left, -textBounds.top, paint);
```
`getTextBounds` returns an integer rectangle, rounded down.
The actual glyph rasterization may extend slightly beyond this box due to fractional scaling and anti-aliasing.

## What is the new behavior?
1px padding is added on each edge when creating the bitmap:

```
const padding = 1;
const bitmap = Bitmap.createBitmap(
    textBounds.width() + padding * 2,
    textBounds.height() + padding * 2,
    Bitmap.Config.ARGB_8888
);
canvas.drawText(
    source,
    -textBounds.left + padding,
    -textBounds.top + padding,
    paint
);
```

This guarantees enough space for fractional/anti-aliased edges across all DPIs and devices.

<img width="76" height="30" alt="Bildschirmfoto 2025-09-23 um 16 41 02" src="https://github.com/user-attachments/assets/a8eb3bcb-fe47-4363-bf92-ea29512d91ef" />



Fixes/Implements/Closes #10857 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

