### PR TITLE
feat(ios): ease of use on explicit preferredStatusBarStyle

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -79,6 +79,10 @@ export interface ShowModalOptions {
 		 * height of the popup dialog
 		 */
 		height?: number;
+		/**
+		 * The preferred status bar style for the modal view
+		 */
+		statusBarStyle?: 'light' | 'dark';
 	};
 	android?: {
 		/**

--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -631,6 +631,20 @@ export abstract class View extends ViewCommon {
 	 */
 	cssType: string;
 
+	/**
+	 * (iOS only) Gets or sets the status bar style for this view.
+	 * Note: You must remove Info.plist key `UIViewControllerBasedStatusBarAppearance`
+	 * It defaults to true when not present: https://developer.apple.com/documentation/bundleresources/information-property-list/uiviewcontrollerbasedstatusbarappearance
+	 * Or you can explicitly set it to true:
+	 * <key>UIViewControllerBasedStatusBarAppearance</key>
+	 * <true/>
+	 *
+	 * False value will make this property have no effect.
+	 *
+	 * @nsProperty
+	 */
+	statusBarStyle: 'light' | 'dark';
+
 	cssClasses: Set<string>;
 	cssPseudoClasses: Set<string>;
 

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -560,12 +560,21 @@ export class View extends ViewCommon {
 			}
 		}
 
-		if (options.ios && options.ios.presentationStyle) {
-			const presentationStyle = options.ios.presentationStyle;
-			controller.modalPresentationStyle = presentationStyle;
+		if (options.ios) {
+			if (options.ios.presentationStyle) {
+				const presentationStyle = options.ios.presentationStyle;
+				controller.modalPresentationStyle = presentationStyle;
 
-			if (presentationStyle === UIModalPresentationStyle.Popover) {
-				this._setupPopoverControllerDelegate(controller, parent);
+				if (presentationStyle === UIModalPresentationStyle.Popover) {
+					this._setupPopoverControllerDelegate(controller, parent);
+				}
+			}
+			if (options.ios.statusBarStyle) {
+				/**
+				 * https://developer.apple.com/documentation/uikit/uiviewcontroller/modalpresentationcapturesstatusbarappearance
+				 */
+				controller.modalPresentationCapturesStatusBarAppearance = true;
+				this.statusBarStyle = options.ios.statusBarStyle;
 			}
 		}
 

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -995,6 +995,13 @@ export abstract class ViewCommon extends ViewBase {
 		this._cssType = type.toLowerCase();
 	}
 
+	get statusBarStyle(): 'light' | 'dark' {
+		return this.style.statusBarStyle;
+	}
+	set statusBarStyle(value: 'light' | 'dark') {
+		this.style.statusBarStyle = value;
+	}
+
 	get isLayoutRequired(): boolean {
 		return true;
 	}

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -127,6 +127,20 @@ class UILayoutViewController extends UIViewController {
 			}
 		}
 	}
+
+	// @ts-ignore
+	public get preferredStatusBarStyle(): UIStatusBarStyle {
+		const owner = this.owner?.deref();
+		if (owner) {
+			if (SDK_VERSION >= 13) {
+				return owner.statusBarStyle === 'dark' ? UIStatusBarStyle.DarkContent : UIStatusBarStyle.LightContent;
+			} else {
+				return owner.statusBarStyle === 'dark' ? UIStatusBarStyle.LightContent : UIStatusBarStyle.Default;
+			}
+		} else {
+			return UIStatusBarStyle.Default;
+		}
+	}
 }
 
 @NativeClass

--- a/packages/core/ui/page/index.d.ts
+++ b/packages/core/ui/page/index.d.ts
@@ -66,14 +66,6 @@ export declare class Page extends PageBase {
 	public backgroundSpanUnderStatusBar: boolean;
 
 	/**
-	 * Gets or sets the style of the status bar.
-	 *
-	 * @nsProperty
-	 */
-	// @ts-ignore
-	public statusBarStyle: 'light' | 'dark';
-
-	/**
 	 * Gets or sets the color of the status bar in Android.
 	 *
 	 * @nsProperty

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -349,7 +349,11 @@ class UIViewControllerImpl extends UIViewController {
 	public get preferredStatusBarStyle(): UIStatusBarStyle {
 		const owner = this._owner?.deref();
 		if (owner) {
-			return owner.statusBarStyle === 'dark' ? UIStatusBarStyle.LightContent : UIStatusBarStyle.Default;
+			if (SDK_VERSION >= 13) {
+				return owner.statusBarStyle === 'dark' ? UIStatusBarStyle.DarkContent : UIStatusBarStyle.LightContent;
+			} else {
+				return owner.statusBarStyle === 'dark' ? UIStatusBarStyle.LightContent : UIStatusBarStyle.Default;
+			}
 		} else {
 			return UIStatusBarStyle.Default;
 		}

--- a/packages/core/ui/page/page-common.ts
+++ b/packages/core/ui/page/page-common.ts
@@ -63,13 +63,6 @@ export class PageBase extends ContentView {
 		}
 	}
 
-	get statusBarStyle(): 'light' | 'dark' {
-		return this.style.statusBarStyle;
-	}
-	set statusBarStyle(value: 'light' | 'dark') {
-		this.style.statusBarStyle = value;
-	}
-
 	public get androidStatusBarBackground(): Color {
 		return this.style.androidStatusBarBackground;
 	}


### PR DESCRIPTION
Allows statusBarStyle to be defined on any view for explicit per view control, whether presented in modal or not. 

Note: You must remove Info.plist key `UIViewControllerBasedStatusBarAppearance`
It defaults to true when not present: https://developer.apple.com/documentation/bundleresources/information-property-list/uiviewcontrollerbasedstatusbarappearance 

Or you can explicitly set it to true:
```xml
<key>UIViewControllerBasedStatusBarAppearance</key> 
<true/>
```

False value will make this property have no effect.

## Before

You could patch-package to control some cases but was dificult to have explicit control over status bar color in varied acute cases.
<img width="416" height="180" alt="Screenshot 2025-09-24 at 11 02 24 AM" src="https://github.com/user-attachments/assets/7a7db59f-a87a-462a-aa98-15742d2b4ea7" />

## After

<img width="422" height="198" alt="Screenshot 2025-09-24 at 11 15 20 AM" src="https://github.com/user-attachments/assets/5f98c5bc-e9a7-43e5-9ac8-f6a9ba5591a6" />

`ShowModalOptions` now allows `statusBarStyle` to be set within `ios` options. Individual views (different pages in navigation stacks) can define them as well if needed.