### PR TITLE
fix(application): Remove duplicate cssChanged event handler definition

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -98,11 +98,6 @@ interface ApplicationEvents {
 	on(event: 'livesync', callback: (args: ApplicationEventData) => void, thisArg?: any): void;
 
 	/**
-	 * This event is raised when application css is changed.
-	 */
-	on(event: 'cssChanged', callback: (args: CssChangedEventData) => void, thisArg?: any): void;
-
-	/**
 	 * This event is raised on application launchEvent.
 	 */
 	on(event: 'launch', callback: (args: LaunchEventData) => void, thisArg?: any): void;


### PR DESCRIPTION
Remove duplicate cssChanged event handler definition in ApplicationEvents interface. The duplicate definition was redundant as the same handler was already defined ( see line no. 103 and 93)

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

