### PR TITLE
Update image-asset-common.ts

### DIFF
--- a/packages/core/image-asset/image-asset-common.ts
+++ b/packages/core/image-asset/image-asset-common.ts
@@ -47,17 +47,26 @@ export function getAspectSafeDimensions(sourceWidth, sourceHeight, reqWidth, req
 }
 
 export function getRequestedImageSize(src: { width: number; height: number }, options: ImageAssetOptions): { width: number; height: number } {
-	let reqWidth = options.width || Math.min(src.width, Screen.mainScreen.widthPixels);
-	let reqHeight = options.height || Math.min(src.height, Screen.mainScreen.heightPixels);
 
-	if (options && options.keepAspectRatio) {
-		const safeAspectSize = getAspectSafeDimensions(src.width, src.height, reqWidth, reqHeight);
-		reqWidth = safeAspectSize.width;
-		reqHeight = safeAspectSize.height;
-	}
+		// Coerce width and height to numbers if they are strings
+		let reqWidth = options.width || Math.min(src.width, Screen.mainScreen.widthPixels);
+		let reqHeight = options.height || Math.min(src.height, Screen.mainScreen.heightPixels);
 
-	return {
-		width: reqWidth,
-		height: reqHeight,
-	};
+		if (typeof reqWidth === 'string') {
+			reqWidth = parseInt(reqWidth, 10);
+		}
+		if (typeof reqHeight === 'string') {
+			reqHeight = parseInt(reqHeight, 10);
+		}
+
+		if (options && options.keepAspectRatio) {
+			const safeAspectSize = getAspectSafeDimensions(src.width, src.height, reqWidth, reqHeight);
+			reqWidth = safeAspectSize.width;
+			reqHeight = safeAspectSize.height;
+		}
+
+		return {
+			width: reqWidth,
+			height: reqHeight,
+		};
 }


### PR DESCRIPTION
<--
- [x] The PR title follows our guidelines: `fix(android): coerce string width/height in ImageAssetOptions`
- [x] There is an issue for the bug/feature this PR is for: Fixes #6289
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing.
- [ ] Tests for the changes are included.

## What is the current behavior?
Setting a string value (e.g., `"300"`) for `width` or `height` in `ImageAssetOptions` causes a crash on Android API level 22 with the error:  
`java.lang.IllegalArgumentException: bitmap size exceeds 32 bits`.  
This happens because the string is not coerced to a number, resulting in an invalid bitmap size.

## What is the new behavior?
The function `getRequestedImageSize` now coerces `width` and `height` to numbers if they are passed as strings. This prevents the bitmap size error on Android and ensures compatibility with older API levels.

Fixes/Implements/Closes #6289.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:

None.
Migration steps:
No migration required.
-->
