### PR TITLE
fix(android): proper image view scaling for ScaleTypes.CENTER

### DIFF
--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/ImageView.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/ImageView.java
@@ -364,6 +364,17 @@ public class ImageView extends androidx.appcompat.widget.AppCompatImageView impl
 			float uniformScale;
 			float pivotX, pivotY;
 			switch (this.getScaleType()) {
+				case CENTER:
+					uniformScale = 1;
+					matrix.postTranslate((innerWidth - bitmapWidth) / 2, (innerHeight - bitmapHeight) / 2);
+					matrix.postScale(uniformScale, uniformScale, innerWidth / 2, innerHeight / 2);
+					canvas.clipRect(
+						borderLeftWidth + (innerWidth - bitmapWidth * uniformScale) / 2,
+						borderTopWidth + (innerHeight - bitmapHeight * uniformScale) / 2,
+						borderLeftWidth + (innerWidth + bitmapWidth * uniformScale) / 2,
+						borderTopWidth + (innerHeight + bitmapHeight * uniformScale) / 2
+					);
+					break;
 				case FIT_CENTER: // aspectFit
 					uniformScale = Math.min(fittingScaleX, fittingScaleY);
 					matrix.postTranslate((innerWidth - bitmapWidth) / 2, (innerHeight - bitmapHeight) / 2);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ImageView's ScaleType.CENTER doesn't match Android's behaviour

## What is the new behavior?
<!-- Describe the changes. -->
ImageView's respects ScaleType.CENTER and will leave the image size unchanged no matter the view size.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

