### PR TITLE
feat(search-bar): add clear button color support

### DIFF
--- a/packages/core/ui/search-bar/index.android.ts
+++ b/packages/core/ui/search-bar/index.android.ts
@@ -275,7 +275,7 @@ export class SearchBar extends SearchBarBase {
 		textView.setHintTextColor(color);
 	}
 	[clearButtonColorProperty.setNative](value: Color) {
-		if (!this.nativeViewProtected) {
+		if (!this.nativeViewProtected || !value) {
 			return;
 		}
 
@@ -284,8 +284,10 @@ export class SearchBar extends SearchBarBase {
 			const closeButtonId = this.nativeViewProtected.getContext().getResources().getIdentifier('android:id/search_close_btn', null, null);
 			const closeButton = this.nativeViewProtected.findViewById(closeButtonId) as android.widget.ImageView;
 
-			if (closeButton && value) {
-				closeButton.setColorFilter(value.android);
+			const color = value instanceof Color ? value.android : new Color(value).android;
+
+			if (closeButton) {
+				closeButton.setColorFilter(color);
 			}
 		} catch (err) {
 			console.log('Error setting clear button color:', err);

--- a/packages/core/ui/search-bar/index.d.ts
+++ b/packages/core/ui/search-bar/index.d.ts
@@ -62,6 +62,13 @@ export class SearchBar extends View {
 	textFieldHintColor: Color;
 
 	/**
+	 * Gets or sets the Clear Button color of the SearchBar component.
+	 *
+	 * @nsProperty
+	 */
+	clearButtonColor: Color | string;
+
+	/**
 	 * Adds a listener for the specified event name.
 	 *
 	 * @param eventName The name of the event.

--- a/packages/core/ui/search-bar/index.ios.ts
+++ b/packages/core/ui/search-bar/index.ios.ts
@@ -222,11 +222,11 @@ export class SearchBar extends SearchBarBase {
 	}
 	[clearButtonColorProperty.setNative](value: Color | UIColor) {
 		const textField = this._getTextField();
+		if (!textField) return;
 		// Check if clear button is available in the text field
-		if (textField && textField.valueForKey('clearButton')) {
-			const button = textField.valueForKey('clearButton');
-			const color = value instanceof Color ? value.ios : value;
-			button.tintColor = color;
-		}
+		const clearButton = textField.valueForKey('clearButton');
+		if (!clearButton) return;
+
+		clearButton.tintColor = value instanceof Color ? value.ios : value;
 	}
 }

--- a/packages/core/ui/search-bar/search-bar-common.ts
+++ b/packages/core/ui/search-bar/search-bar-common.ts
@@ -12,6 +12,7 @@ export abstract class SearchBarBase extends View implements SearchBarDefinition 
 	public hint: string;
 	public textFieldBackgroundColor: Color;
 	public textFieldHintColor: Color;
+	public clearButtonColor: Color | string;
 
 	public abstract dismissSoftInput();
 }


### PR DESCRIPTION

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

## PR Checklist

- [x] The PR title follows the contribution guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages
- [x] There is an issue for the bug/feature this PR is for. (Issue #5193 )
- [x] You have signed the [CLA](http://www.nativescript.org/cla)
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md

---

## What is the current behavior?

Currently, the **SearchBar** component on **Android** does not allow developers to customize the **clear button color**.  
This results in inconsistency with iOS, where developers can already modify the color to match app themes.

---

## What is the new behavior?

This PR introduces support for customizing the **clear button color** in the **SearchBar** component on Android.  
Developers can now apply any desired color for consistent design and theming across platforms.

**Fixes #5193**

---

### Example Usage:

```ts
const searchBar = new SearchBar();
searchBar.clearButtonColor = new Color('#FF4081');
