### PR TITLE
docs(dialogs): clarify CancelableOptions comment

### DIFF
--- a/packages/core/ui/dialogs/index.d.ts
+++ b/packages/core/ui/dialogs/index.d.ts
@@ -135,7 +135,7 @@ export function action(message: string, cancelButtonText: string, actions: Array
 export function action(options: ActionOptions): Promise<string>;
 
 /**
- * Provides options for the dialog.
+ * Provides options for dialog behavior, including Android-specific settings.
  */
 export interface CancelableOptions {
 	/**


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution!
To help the rest of the community review your change, please follow the instructions in the template.
-->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages
- [x] There is an issue for the bug/feature this PR is for, or it is a minor docs improvement
- [x] You have signed the [CLA](http://www.nativescript.org/cla)
- [x] All existing tests are passing
- [x] Tests are not applicable (documentation-only change)

## What is the current behavior?
Currently, the documentation comment for `CancelableOptions` in `packages/ui/dialogs/index.d.ts` does not clearly describe what this option represents.

## What is the new behavior?
Improved the comment for `CancelableOptions` to clarify that it defines options controlling whether dialogs can be cancelled and includes Android-specific configuration properties.

Fixes #<issue-number> (if applicable)

---

### Notes
This is a small **documentation clarity improvement** for `CancelableOptions`.  
It’s part of my **Hacktoberfest 2025** contributions. Thanks for reviewing! 😊

