### PR TITLE
fix(android): coerce string width/height in ImageAssetOptions #6289

### DIFF
--- a/packages/core/image-asset/index.android.ts
+++ b/packages/core/image-asset/index.android.ts
@@ -26,6 +26,16 @@ export class ImageAsset extends ImageAssetBase {
 	}
 
 	public getImageAsync(callback: (image, error) => void) {
+		// Fix for issue #6289: ensure numeric width/height
+		if (this.options) {
+			if (typeof this.options.width === "string") {
+				this.options.width = parseInt(this.options.width, 10);
+			}
+			if (typeof this.options.height === "string") {
+				this.options.height = parseInt(this.options.height, 10);
+			}
+		}
+	
 		org.nativescript.widgets.Utils.loadImageAsync(
 			getNativeApp<android.app.Application>().getApplicationContext(),
 			this.android,
@@ -42,4 +52,5 @@ export class ImageAsset extends ImageAssetBase {
 			}),
 		);
 	}
+	
 }


### PR DESCRIPTION
### Summary

This PR fixes issue [#6289](https://github.com/NativeScript/NativeScript/issues/6289), where setting `width` or `height` as a string in `ImageAssetOptions` caused an error on Android (`bitmap size exceeds 32 bits`).

### Problem

When `width` or `height` were provided as strings (e.g., `"300"` instead of `300`), the Android code failed to process them correctly, leading to a crash, especially on older API levels (e.g., API 22).

### How to test

Create an ImageAsset instance with width/height as strings and call getImageAsync.
Before this fix, Android API 22 would crash.
After this fix, the image loads successfully without errors.


### Solution

Before passing the options to the native method, this PR checks if `width` or `height` are strings and converts them to numbers using `parseInt`. 

```ts
if (typeof this.options.width === "string") {
  this.options.width = parseInt(this.options.width, 10);
}
if (typeof this.options.height === "string") {
  this.options.height = parseInt(this.options.height, 10);
}


