### PR TITLE
feat: support independent android broadcast listeners

### DIFF
--- a/packages/core/application/application.d.ts
+++ b/packages/core/application/application.d.ts
@@ -113,8 +113,9 @@ export class AndroidApplication extends ApplicationCommon {
 	 * For more information, please visit 'http://developer.android.com/reference/android/content/Context.html#registerReceiver%28android.content.BroadcastReceiver,%20android.content.IntentFilter%29'
 	 * @param intentFilter A string containing the intent filter.
 	 * @param onReceiveCallback A callback function that will be called each time the receiver receives a broadcast.
+	 * @return A function that can be called to unregister the receiver.
 	 */
-	registerBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void): void;
+	registerBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void): () => void;
 
 	/**
 	 * Unregister a previously registered BroadcastReceiver.
@@ -126,8 +127,14 @@ export class AndroidApplication extends ApplicationCommon {
 	/**
 	 * Get a registered BroadcastReceiver, then you can get the result code of BroadcastReceiver in onReceiveCallback method.
 	 * @param intentFilter A string containing the intent filter.
+	 * @deprecated Use `getRegisteredBroadcastReceivers` instead.
 	 */
 	getRegisteredBroadcastReceiver(intentFilter: string): android.content.BroadcastReceiver;
+	/**
+	 * Get all registered BroadcastReceivers for a specific intent filter.
+	 * @param intentFilter a string containing the intent filter
+	 */
+	getRegisteredBroadcastReceivers(intentFilter: string): android.content.BroadcastReceiver[];
 
 	on(event: 'activityCreated', callback: (args: AndroidActivityBundleEventData) => void, thisArg?: any): void;
 	on(event: 'activityDestroyed', callback: (args: AndroidActivityEventData) => void, thisArg?: any): void;

--- a/packages/core/application/helpers.android.ts
+++ b/packages/core/application/helpers.android.ts
@@ -26,68 +26,6 @@ function getApplicationContext(): android.content.Context {
 	return getNativeApp<android.app.Application>().getApplicationContext();
 }
 
-export const androidRegisteredReceivers: { [key: string]: android.content.BroadcastReceiver } = {};
-export const androidPendingReceiverRegistrations = new Array<(context: android.content.Context) => void>();
-
-declare class BroadcastReceiver extends android.content.BroadcastReceiver {
-	constructor(onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void);
-}
-
-let BroadcastReceiver_: typeof BroadcastReceiver;
-function initBroadcastReceiver() {
-	if (BroadcastReceiver_) {
-		return BroadcastReceiver_;
-	}
-
-	@NativeClass
-	class BroadcastReceiverImpl extends android.content.BroadcastReceiver {
-		private _onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void;
-
-		constructor(onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void) {
-			super();
-			this._onReceiveCallback = onReceiveCallback;
-
-			return global.__native(this);
-		}
-
-		public onReceive(context: android.content.Context, intent: android.content.Intent) {
-			if (this._onReceiveCallback) {
-				this._onReceiveCallback(context, intent);
-			}
-		}
-	}
-
-	BroadcastReceiver_ = BroadcastReceiverImpl;
-	return BroadcastReceiver_;
-}
-
-export function androidRegisterBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void, flags = 2): void {
-	const registerFunc = (context: android.content.Context) => {
-		const receiver: android.content.BroadcastReceiver = new (initBroadcastReceiver())(onReceiveCallback);
-		if (SDK_VERSION >= 26) {
-			context.registerReceiver(receiver, new android.content.IntentFilter(intentFilter), flags);
-		} else {
-			context.registerReceiver(receiver, new android.content.IntentFilter(intentFilter));
-		}
-		androidRegisteredReceivers[intentFilter] = receiver;
-	};
-
-	if (getApplicationContext()) {
-		registerFunc(getApplicationContext());
-	} else {
-		androidPendingReceiverRegistrations.push(registerFunc);
-	}
-}
-
-export function androidUnregisterBroadcastReceiver(intentFilter: string): void {
-	const receiver = androidRegisteredReceivers[intentFilter];
-	if (receiver) {
-		getApplicationContext().unregisterReceiver(receiver);
-		androidRegisteredReceivers[intentFilter] = undefined;
-		delete androidRegisteredReceivers[intentFilter];
-	}
-}
-
 export function updateContentDescription(view: any /* View */, forceUpdate?: boolean): string | null {
 	if (!view.nativeViewProtected) {
 		return;
@@ -204,6 +142,3 @@ export function setupAccessibleView(view: any /* any */): void {
 }
 
 // stubs
-export const iosNotificationObservers: Array<any> = [];
-export function iosAddNotificationObserver(notificationName: string, onReceiveCallback: (notification: any) => void) {}
-export function iosRemoveNotificationObserver(observer: any, notificationName: string) {}

--- a/packages/core/application/helpers.d.ts
+++ b/packages/core/application/helpers.d.ts
@@ -8,18 +8,8 @@ export function setupAccessibleView(view: View): void;
 export const updateContentDescription: (view: any /* View */, forceUpdate?: boolean) => string | null;
 export function applyContentDescription(view: any /* View */, forceUpdate?: boolean);
 /* Android app-wide helpers */
-export const androidRegisteredReceivers: { [key: string]: android.content.BroadcastReceiver };
-export const androidPendingReceiverRegistrations: Array<(context: android.content.Context) => void>;
-export function androidRegisterBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void, flags = 2): void;
-export function androidUnregisterBroadcastReceiver(intentFilter: string): void;
 export function androidGetCurrentActivity(): androidx.appcompat.app.AppCompatActivity;
 export function androidGetForegroundActivity(): androidx.appcompat.app.AppCompatActivity;
 export function androidSetForegroundActivity(activity: androidx.appcompat.app.AppCompatActivity): void;
 export function androidGetStartActivity(): androidx.appcompat.app.AppCompatActivity;
 export function androidSetStartActivity(activity: androidx.appcompat.app.AppCompatActivity): void;
-
-/* iOS app-wide helpers */
-export const iosNotificationObservers: NotificationObserver[];
-class NotificationObserver extends NSObject {}
-export function iosAddNotificationObserver(notificationName: string, onReceiveCallback: (notification: NSNotification) => void): NotificationObserver;
-export function iosRemoveNotificationObserver(observer: NotificationObserver, notificationName: string): void;

--- a/packages/core/application/helpers.ios.ts
+++ b/packages/core/application/helpers.ios.ts
@@ -3,54 +3,11 @@ export const updateContentDescription = (view: any /* View */, forceUpdate?: boo
 export function applyContentDescription(view: any /* View */, forceUpdate?: boolean) {
 	return null;
 }
-export const androidRegisteredReceivers = undefined;
-export const androidPendingReceiverRegistrations = undefined;
-export function androidRegisterBroadcastReceiver(intentFilter: string, onReceiveCallback: (context: android.content.Context, intent: android.content.Intent) => void, flags = 2): void {}
-export function androidUnregisterBroadcastReceiver(intentFilter: string): void {}
 export function androidGetCurrentActivity() {}
 export function androidGetForegroundActivity() {}
 export function androidSetForegroundActivity(activity: androidx.appcompat.app.AppCompatActivity): void {}
 export function androidGetStartActivity() {}
 export function androidSetStartActivity(activity: androidx.appcompat.app.AppCompatActivity): void {}
-
-@NativeClass
-class NotificationObserver extends NSObject {
-	private _onReceiveCallback: (notification: NSNotification) => void;
-
-	public static initWithCallback(onReceiveCallback: (notification: NSNotification) => void): NotificationObserver {
-		const observer = <NotificationObserver>super.new();
-		observer._onReceiveCallback = onReceiveCallback;
-
-		return observer;
-	}
-
-	public onReceive(notification: NSNotification): void {
-		this._onReceiveCallback(notification);
-	}
-
-	public static ObjCExposedMethods = {
-		onReceive: { returns: interop.types.void, params: [NSNotification] },
-	};
-}
-
-export const iosNotificationObservers: NotificationObserver[] = [];
-export function iosAddNotificationObserver(notificationName: string, onReceiveCallback: (notification: NSNotification) => void) {
-	const observer = NotificationObserver.initWithCallback(onReceiveCallback);
-	NSNotificationCenter.defaultCenter.addObserverSelectorNameObject(observer, 'onReceive', notificationName, null);
-	iosNotificationObservers.push(observer);
-
-	return observer;
-}
-
-export function iosRemoveNotificationObserver(observer: NotificationObserver, notificationName: string) {
-	// TODO: test if this finds the right observer instance match everytime
-	// after circular dependencies are resolved
-	const index = iosNotificationObservers.indexOf(observer);
-	if (index >= 0) {
-		iosNotificationObservers.splice(index, 1);
-		NSNotificationCenter.defaultCenter.removeObserverNameObject(observer, notificationName, null);
-	}
-}
 
 export function setupAccessibleView(view: any /* any */): void {
 	const uiView = view.nativeViewProtected as UIView;

--- a/packages/core/connectivity/index.android.ts
+++ b/packages/core/connectivity/index.android.ts
@@ -1,6 +1,6 @@
 import { getNativeApp } from '../application/helpers-common';
-import { androidRegisterBroadcastReceiver, androidUnregisterBroadcastReceiver } from '../application/helpers';
 import { SDK_VERSION } from '../utils/constants';
+import { Application } from '../application';
 
 export enum connectionType {
 	none = 0,
@@ -110,7 +110,7 @@ function startMonitoringLegacy(connectionTypeChangedCallback) {
 		connectionTypeChangedCallback(newConnectionType);
 	};
 	const zoneCallback = zonedCallback(onReceiveCallback);
-	androidRegisterBroadcastReceiver(android.net.ConnectivityManager.CONNECTIVITY_ACTION, zoneCallback);
+	Application.android.registerBroadcastReceiver(android.net.ConnectivityManager.CONNECTIVITY_ACTION, zoneCallback);
 }
 
 let callback;
@@ -171,6 +171,6 @@ export function stopMonitoring(): void {
 			callback = null;
 		}
 	} else {
-		androidUnregisterBroadcastReceiver(android.net.ConnectivityManager.CONNECTIVITY_ACTION);
+		Application.android.unregisterBroadcastReceiver(android.net.ConnectivityManager.CONNECTIVITY_ACTION);
 	}
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -3,7 +3,6 @@
 // Init globals first (use import to ensure it's always at the top)
 import './globals';
 export * from './application';
-export { androidRegisterBroadcastReceiver, androidUnregisterBroadcastReceiver, androidRegisteredReceivers, iosAddNotificationObserver, iosRemoveNotificationObserver, iosNotificationObservers } from './application/helpers';
 export { getNativeApp, setNativeApp } from './application/helpers-common';
 export * as ApplicationSettings from './application-settings';
 import * as Accessibility from './accessibility';


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When registering multiple listeners, it's impossible to unregister any other than the last one created. This creates leaks and weird behavor

## What is the new behavior?
When creating a listener it'll now return a function you can call to unregister it. Calling unregister with only the intent name unregisters all listeners.

Additionally, this reverts a few things back to the application files