### PR TITLE
fix(android): ListView margin handling on layout containers

### DIFF
--- a/packages/core/ui/list-view/index.android.ts
+++ b/packages/core/ui/list-view/index.android.ts
@@ -408,16 +408,16 @@ function ensureListViewAdapterClass() {
 					// Ensure margins defined on the template root are honored on Android ListView.
 					// ListView's children don't support layout margins, so we insert an outer wrapper
 					// and keep the original view (with its margins) inside. This mirrors iOS spacing.
-					const mt = PercentLength.toDevicePixels(args.view.marginTop, 0, Number.NaN);
-					const mb = PercentLength.toDevicePixels(args.view.marginBottom, 0, Number.NaN);
-					const ml = PercentLength.toDevicePixels(args.view.marginLeft, 0, Number.NaN);
-					const mr = PercentLength.toDevicePixels(args.view.marginRight, 0, Number.NaN);
-					const hasMargins = mt > 0 || mb > 0 || ml > 0 || mr > 0;
 
 					// If the view is already a LayoutBase (typical for templates like GridLayout),
 					// we wrap it so its margins take effect. For non-layout roots (labels, etc.)
 					// we already wrap below with a StackLayout.
 					if (args.view instanceof LayoutBase && !(args.view instanceof ProxyViewContainer)) {
+						const mt = PercentLength.toDevicePixels(args.view.marginTop, 0, Number.NaN);
+						const mb = PercentLength.toDevicePixels(args.view.marginBottom, 0, Number.NaN);
+						const ml = PercentLength.toDevicePixels(args.view.marginLeft, 0, Number.NaN);
+						const mr = PercentLength.toDevicePixels(args.view.marginRight, 0, Number.NaN);
+						const hasMargins = mt > 0 || mb > 0 || ml > 0 || mr > 0;
 						if (hasMargins) {
 							const outer = new StackLayout();
 							outer.addChild(args.view);


### PR DESCRIPTION
Margins are now honored for items in the Android `ListView` component, ensuring consistent spacing with iOS. 

Context: Android ListView ignores margins on the item root by design; each row’s root view is attached with AbsListView.LayoutParams, which doesn't support margins. These changes allow for consistent expectations for user layouts across iOS and Android.

When using a ListView with a setup similar to the following:
```xml
<ListView>
    <template>
        <GridLayout margin="2 6 2 6">
            <!-- Label's, etc. -->
        </GridLayout>
    </template>
</ListView>
```

Before:
<img width="1450" height="1076" alt="before-listview" src="https://github.com/user-attachments/assets/4ded13ed-ef94-4e61-8416-68c6ffb5e3c7" />

After:
<img width="1450" height="1076" alt="after-listview" src="https://github.com/user-attachments/assets/9ac44b96-f1d0-42a7-9808-085e22310596" />



