### PR TITLE
feat(core): Ensure concurrency when firing events

### DIFF
--- a/packages/core/ui/gestures/index.android.ts
+++ b/packages/core/ui/gestures/index.android.ts
@@ -441,7 +441,7 @@ function _getPanArgs(deltaX: number, deltaY: number, view: View, state: GestureS
 
 function _executeCallback(observer: GesturesObserver, args: GestureEventData) {
 	if (observer && observer.callback) {
-		observer.callback.call((<any>observer)._context, args);
+		observer.callback.call(observer.context, args);
 	}
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, core has concurrency problems when it comes to firing events.
To mitigate this for regular events, listener callbacks are fired in the reverse order thanks to https://github.com/NativeScript/NativeScript/pull/854.
Also, in the case of gesture listeners, some callbacks aren't fired if `removeEventListener` is called inside one of them while firing the event.

## What is the new behavior?
Keep a copy of listener array when there's more than 1 of them.
This will ensure concurrency while firing events and event callbacks will fire in the correct order.

BREAKING CHANGES:

If by any chance there are users who rely in the faulty execution order, this change will affect them.