### PR TITLE
chore: NativeClass transformer now supports ts-patch and ts-loader.

### DIFF
--- a/packages/vite/helpers/nativeclass-transform.ts
+++ b/packages/vite/helpers/nativeclass-transform.ts
@@ -98,7 +98,7 @@ export function transformNativeClassSource(code: string, fileName: string) {
 								module: ts.ModuleKind.ESNext,
 								target: ts.ScriptTarget.ES5,
 								experimentalDecorators: true,
-								emitDecoratorMetadata: true,
+								emitDecoratorMetadata: false,
 								noEmitHelpers: true,
 								useDefineForClassFields: false,
 							},

--- a/packages/vite/tsconfig.lib.json
+++ b/packages/vite/tsconfig.lib.json
@@ -6,7 +6,7 @@
 		"declaration": true,
 		"ignoreDeprecations": "5.0",
 		"removeComments": false,
-		"emitDecoratorMetadata": true,
+		"emitDecoratorMetadata": false,
 		"experimentalDecorators": true,
 		"diagnostics": true,
 		"sourceMap": true,

--- a/packages/webpack5/src/loaders/native-class-downlevel-loader/index.ts
+++ b/packages/webpack5/src/loaders/native-class-downlevel-loader/index.ts
@@ -71,7 +71,7 @@ export default function nativeClassDownlevelLoader(
 				target: ts.ScriptTarget.ES5,
 				noEmitHelpers: true,
 				experimentalDecorators: true,
-				emitDecoratorMetadata: true,
+				emitDecoratorMetadata: false,
 				useDefineForClassFields: false,
 			},
 			fileName: this.resourcePath.endsWith('.ts')

--- a/packages/webpack5/tsconfig.json
+++ b/packages/webpack5/tsconfig.json
@@ -5,7 +5,7 @@
 		"target": "es2018",
 		"module": "commonjs",
 		"declaration": true,
-		"emitDecoratorMetadata": true,
+		"emitDecoratorMetadata": false,
 		"experimentalDecorators": true,
 		"lib": ["es2018"],
 		"sourceMap": true,

--- a/tools/transformers/native-class.js
+++ b/tools/transformers/native-class.js
@@ -135,7 +135,7 @@ module: ts.ModuleKind.ESNext,
 target: ts.ScriptTarget.ES5,
 noEmitHelpers: true,
 experimentalDecorators: true,
-emitDecoratorMetadata: true,
+emitDecoratorMetadata: false,
 useDefineForClassFields: false,
 },
 })


### PR DESCRIPTION
Also disabled emitDecoratorMetadata as it is heavy and not used

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

This PR brings back support for ts-patch (with typescript > 5.8)
