### PR TITLE
fix(image-source): url loading under different conditions

### DIFF
--- a/apps/toolbox/src/pages/image-async.ts
+++ b/apps/toolbox/src/pages/image-async.ts
@@ -8,7 +8,7 @@ export function navigatingTo(args: EventData) {
 }
 
 export class SampleData extends Observable {
-	src: string = 'https://source.unsplash.com/random';
+	src: string = 'https://i.pravatar.cc/300';
 	savedData: string = '';
 	resizedImage: ImageSource;
 	async save() {

--- a/packages/core/http/http-shared.ts
+++ b/packages/core/http/http-shared.ts
@@ -1,21 +1,7 @@
-// Shared types and interfaces for http and image-source modules.
-// Only put platform-agnostic types/interfaces here.
-
 // Example: (add more as needed)
-// TODO: look at removing this after circulars are completely resolved.
+// Note: Circular dep help between http and image-source.
+// Interfaces can be moved around further in future to help avoid.
 export interface ImageSourceLike {
 	toBase64String(format: string, quality?: number): string;
 	// ... add other shared methods/properties as needed
-}
-
-// Circular dependency resolution handling (http <--> image-source)
-let _getImage: (arg: any) => Promise<ImageSourceLike>;
-export function getImageRequest(arg: any): Promise<ImageSourceLike> {
-	if (_getImage) {
-		return _getImage(arg);
-	}
-	return Promise.reject(new Error('No getImage request handler set.'));
-}
-export function setGetImageRequest(fn: (arg: any) => Promise<ImageSourceLike>) {
-	_getImage = fn;
 }

--- a/packages/core/http/index.ts
+++ b/packages/core/http/index.ts
@@ -1,4 +1,4 @@
-import { setGetImageRequest, type ImageSourceLike } from './http-shared';
+import { type ImageSourceLike } from './http-shared';
 import { request } from './http-request';
 export { request } from './http-request';
 export * from './http-interfaces';
@@ -51,7 +51,6 @@ export function getImage(arg: any): Promise<ImageSourceLike> {
 		);
 	});
 }
-setGetImageRequest(getImage);
 
 export function getFile(arg: any, destinationFilePath?: string): Promise<any> {
 	return new Promise<any>((resolve, reject) => {

--- a/packages/core/image-source/index.android.ts
+++ b/packages/core/image-source/index.android.ts
@@ -1,6 +1,6 @@
 import { ImageSource as ImageSourceDefinition, iosSymbolScaleType } from '.';
 import { ImageAsset } from '../image-asset';
-import { getImageRequest } from '../http/http-shared';
+import { getImage } from '../http';
 import { path as fsPath, knownFolders } from '../file-system';
 import { isFileOrResourcePath, RESOURCE_PREFIX, layout } from '../utils';
 import { getNativeApp } from '../application/helpers-common';
@@ -63,7 +63,7 @@ export class ImageSource implements ImageSourceDefinition {
 	}
 
 	static fromUrl(url: string): Promise<ImageSource> {
-		return getImageRequest(url) as Promise<ImageSource>;
+		return getImage(url) as Promise<ImageSource>;
 	}
 
 	static fromResourceSync(name: string): ImageSource {

--- a/packages/core/image-source/index.ios.ts
+++ b/packages/core/image-source/index.ios.ts
@@ -7,7 +7,7 @@ import { Trace } from '../trace';
 import { path as fsPath, knownFolders } from '../file-system';
 import { isFileOrResourcePath, RESOURCE_PREFIX, layout, releaseNativeObject, SYSTEM_PREFIX } from '../utils';
 import { getScaledDimensions } from './image-source-common';
-import { getImageRequest } from '../http/http-shared';
+import { getImage } from '../http';
 
 export { isFileOrResourcePath };
 
@@ -58,7 +58,7 @@ export class ImageSource implements ImageSourceDefinition {
 	}
 
 	static fromUrl(url: string): Promise<ImageSource> {
-		return getImageRequest(url) as Promise<ImageSource>;
+		return getImage(url) as Promise<ImageSource>;
 	}
 
 	static iosSystemScaleFor(scale: iosSymbolScaleType) {


### PR DESCRIPTION
A few circular prevention cases can be relaxed now that other larger circulars have been resolved.
This case will help various conditions around when request had been set considering circular resolution.