### PR TITLE
fix(android): Prevent splash screen from being shown during navigation

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -45,6 +45,7 @@ import { androidGetForegroundActivity, androidGetStartActivity, androidSetForegr
 import { getImageFetcher, getNativeApp, getRootView, initImageCache, setA11yUpdatePropertiesCallback, setApplicationPropertiesCallback, setAppMainEntry, setNativeApp, setRootView, setToggleApplicationEventListenersCallback } from './helpers-common';
 import { getNativeScriptGlobals } from '../globals/global-utils';
 import type { AndroidApplication as IAndroidApplication } from './application';
+import { enableEdgeToEdge } from '../utils/native-helper-for-android';
 import lazy from '../utils/lazy';
 
 declare class NativeScriptLifecycleCallbacks extends android.app.Application.ActivityLifecycleCallbacks {}
@@ -65,6 +66,9 @@ function initNativeScriptLifecycleCallbacks() {
 		public onActivityCreated(activity: androidx.appcompat.app.AppCompatActivity, savedInstanceState: android.os.Bundle): void {
 			// console.log('NativeScriptLifecycleCallbacks onActivityCreated');
 			this.setThemeOnLaunch(activity);
+
+			// Make sure to call this after setThemeOnLaunch, otherwise it'll cause issues with window decoration
+			enableEdgeToEdge(activity);
 
 			if (!Application.android.startActivity) {
 				Application.android.setStartActivity(activity);

--- a/packages/core/ui/frame/activity.android.ts
+++ b/packages/core/ui/frame/activity.android.ts
@@ -2,7 +2,6 @@ import '../../globals';
 import { setActivityCallbacks } from '.';
 import { Application } from '../../application';
 import { isEmbedded } from '../embedding';
-import { enableEdgeToEdge } from '../../utils/native-helper-for-android';
 const EMPTY_FN = () => {};
 declare const com: any;
 
@@ -22,7 +21,7 @@ if (!isEmbedded()) {
 			// Set isNativeScriptActivity in onCreate.
 			// The JS constructor might not be called because the activity is created from Android.
 			this.isNativeScriptActivity = true;
-			enableEdgeToEdge(this);
+
 			if (!this._callbacks) {
 				setActivityCallbacks(this);
 			}
@@ -79,7 +78,7 @@ if (!isEmbedded()) {
 			// Set isNativeScriptActivity in onCreate.
 			// The JS constructor might not be called because the activity is created from Android.
 			activity.isNativeScriptActivity = true;
-			enableEdgeToEdge(this);
+
 			if (!activity._callbacks) {
 				setActivityCallbacks(activity);
 			}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In core v9, splash screen is visible during android navigation for an instant.

## What is the new behavior?
Apply edge-to-edge settings after setting app theme. This will get rid of the splash screen problem.

Fixes #10997