### PR TITLE
fix(android): Corrected invalid a11y listeners that crashed apps on exit

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -1267,7 +1267,7 @@ export function isAccessibilityServiceEnabled(): boolean {
 
 	accessibilityStateChangeListener = new android.view.accessibility.AccessibilityManager.AccessibilityStateChangeListener({
 		onAccessibilityStateChanged(enabled) {
-			updateAccessibilityState();
+			updateAccessibilityServiceState();
 
 			if (Trace.isEnabled()) {
 				Trace.write(`AccessibilityStateChangeListener state changed to: ${!!enabled}`, Trace.categories.Accessibility);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, android apps crash during exit due to inconsistent a11y listeners.

## What is the new behavior?
Updated a11y listeners to prevent crash.
This is a quick solution to solve the crash problem but a11y definitely needs some attention.

Fixes/Implements/Closes #10998.