### PR TITLE
fix(webpack): hmr handling

### DIFF
--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -102,6 +102,11 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		env.commonjs = true;
 	}
 
+	if (env.hmr) {
+		// HMR webpack should use CommonJS
+		env.commonjs = true;
+	}
+
 	// config.stats({
 	// 	logging: 'verbose'
 	// })

--- a/packages/webpack5/src/loaders/nativescript-hot-loader/hmr.runtime.ts
+++ b/packages/webpack5/src/loaders/nativescript-hot-loader/hmr.runtime.ts
@@ -105,10 +105,19 @@ if (module.hot) {
 	};
 
 	const hasUpdate = () => {
-		return [
+		// Prefer platform-agnostic JS hot-update manifests; fall back to JSON
+		// if needed. On iOS, the .hot-update.js files are present under the
+		// app folder (see platforms/ios <app>/bundle.*.hot-update.js), while on
+		// Android the JSON manifests are used by HMR. Checking JS first keeps
+		// behavior correct for iOS without regressing Android.
+		const candidates = [
+			`~/bundle.${__webpack_hash__}.hot-update.js`,
+			`~/runtime.${__webpack_hash__}.hot-update.js`,
 			`~/bundle.${__webpack_hash__}.hot-update.json`,
 			`~/runtime.${__webpack_hash__}.hot-update.json`,
-		].some((path) => requireExists(path));
+		];
+
+		return candidates.some((path) => requireExists(path));
 	};
 
 	if (global.__onLiveSync !== global[hmrRuntimeLastLiveSyncSymbol]) {


### PR DESCRIPTION
Improves HMR support in the Webpack configuration.

Platform compatibility for hot-update manifests:

* [`packages/webpack5/src/loaders/nativescript-hot-loader/hmr.runtime.ts`](diffhunk://#diff-7abaefa34b7528142e7c142ed25c223cff798a0a0df993920d62ec7cf337db57L108-R120): Updates the `hasUpdate` function to prefer JavaScript hot-update manifests over JSON, maintaining correct behavior on iOS while preserving compatibility with Android. 