### PR TITLE
fix(RootLayout): Close shade cover when topmost popup doesn't need it

### DIFF
--- a/packages/core/ui/layouts/root-layout/root-layout-common.ts
+++ b/packages/core/ui/layouts/root-layout/root-layout-common.ts
@@ -161,16 +161,20 @@ export class RootLayoutBase extends GridLayout {
 			);
 
 			if (this._shadeCover) {
-				// Update shade cover with the topmost popupView options (if not specifically told to ignore)
-				if (this._popupViews.length) {
-					if (!poppedView?.options?.shadeCover?.ignoreShadeRestore) {
-						const shadeCoverOptions = this._popupViews[this._popupViews.length - 1].options?.shadeCover;
-						if (shadeCoverOptions) {
-							toClose.push(this.updateShadeCover(this._shadeCover, shadeCoverOptions));
-						}
-					}
+				let nextShadeCoverOpts: ShadeCoverOptions;
+
+				// Get the topmost popup view options if any
+				if (this._popupViews.length && !poppedView?.options?.shadeCover?.ignoreShadeRestore) {
+					nextShadeCoverOpts = this._popupViews[this._popupViews.length - 1].options?.shadeCover;
 				} else {
-					// Remove shade cover animation if this is the last opened popup view
+					nextShadeCoverOpts = null;
+				}
+
+				// Update shade cover with the topmost popupView options if any and if not specifically told to ignore
+				if (nextShadeCoverOpts) {
+					toClose.push(this.updateShadeCover(this._shadeCover, nextShadeCoverOpts));
+				} else {
+					// Remove shade cover animation otherwise
 					toClose.push(this.closeShadeCover(poppedView?.options?.shadeCover));
 				}
 			}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When a RootLayout popup closes, its shade cover remains even if the new topmost popup doesn't need it.

## What is the new behavior?
Close RootLayout shade cover if it's not needed by new topmost popup view.