### PR TITLE
fix: sourceMap path when using CommonJS

### DIFF
--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -185,7 +185,7 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	config.devtool(sourceMapType);
 
 	// For ESM builds, fix the sourceMappingURL to use correct paths
-	if (!env.commonjs && sourceMapType && sourceMapType !== 'hidden-source-map') {
+	if (sourceMapType && sourceMapType !== 'hidden-source-map') {
 		config
 			.plugin('FixSourceMapUrlPlugin')
 			.use(FixSourceMapUrlPlugin as any, [{ outputPath }]);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using CommonJS the source map path is not expanded to it's location in the platforms folder, resulting in the source pane in the debugger only showing the transpiled JS code.
## What is the new behavior?
<!-- Describe the changes. -->

Source Map files are loaded correctly in the debugger.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

