### PR TITLE
fix(ios): update selected text color when selected background color changes

### DIFF
--- a/packages/core/ui/segmented-bar/index.ios.ts
+++ b/packages/core/ui/segmented-bar/index.ios.ts
@@ -78,6 +78,7 @@ export class SegmentedBar extends SegmentedBarBase {
 		} else {
 			this.ios.selectedSegmentTintColor = color;
 		}
+		this.setSelectedTextColor(this.ios);
 	}
 
 	[colorProperty.getDefault](): UIColor {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution!
-->

## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [ ] You have signed the CLA.
- [ ] All existing tests are passing.
- [ ] Tests for the changes are included.

## What is the current behavior?

On iOS, when `selectedBackgroundColor` is set on a `SegmentedBar`, the control may briefly display incorrect background colors at the corners until a segment is selected by the user.

This happens because the selected text color is not always reapplied immediately after the background color changes, which can lead to visual artifacts.

## What is the new behavior?

The selected text color is now reapplied whenever `selectedBackgroundColor` is updated, ensuring that text and background colors remain visually consistent without requiring user interaction.

This change only affects iOS and does not modify behavior on other platforms.

Fixes #11014


