### PR TITLE
fix(vite): __dirname to work in windows

### DIFF
--- a/packages/vite/helpers/project.ts
+++ b/packages/vite/helpers/project.ts
@@ -8,7 +8,7 @@ export function getProjectRootPath(): string {
 }
 
 // Get current directory for ES modules (equivalent to __dirname)
-export const __dirname = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+export const __dirname = import.meta.dirname;
 
 interface IPackageJson {
 	name?: string;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->a

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In windows `__dirname` returns `/C:/Users...` which does not resolve properly

## What is the new behavior?

It now returns the correct dirname in windows
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

