### PR TITLE
fix(vite): fix windows path separator for static copy targets

### DIFF
--- a/packages/vite/configuration/base.ts
+++ b/packages/vite/configuration/base.ts
@@ -230,10 +230,11 @@ export const baseConfig = ({ mode, flavor }: { mode: string; flavor?: string }):
 	const fontsDir = resolveFromAppRoot('fonts');
 	const staticCopyTargets = [];
 	if (existsSync(assetsDir)) {
-		staticCopyTargets.push({ src: `${assetsDir}/**/*`, dest: 'assets' });
+		// Replace \ with / to avoid issues with glob in windows
+		staticCopyTargets.push({ src: `${assetsDir}/**/*`.replace(/\\/g,'/'), dest: 'assets' });
 	}
 	if (existsSync(fontsDir)) {
-		staticCopyTargets.push({ src: `${fontsDir}/**/*`, dest: 'fonts' });
+		staticCopyTargets.push({ src: `${fontsDir}/**/*`.replace(/\\/g,'/'), dest: 'fonts' });
 	}
 
 	let disableOptimizeDeps = false;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
In windows creating any static directory like `fonts` results in the build failing, because the copy plugin is unable to find any file in the directory under any circumstances

## What is the new behavior?
It now finds the files in the directory in windows


Fixes #11047 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

