### PR TITLE
fix(android): prevent crash when accessibility callback fires early

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -723,6 +723,10 @@ let touchExplorationStateChangeListener: android.view.accessibility.Accessibilit
 let sharedA11YObservable: AndroidSharedA11YObservable;
 
 function updateAccessibilityState(): void {
+	if (!sharedA11YObservable) {
+		return;
+	}
+	
 	const accessibilityManager = getAndroidAccessibilityManager();
 	if (!accessibilityManager) {
 		sharedA11YObservable.set(accessibilityStateEnabledPropName, false);


### PR DESCRIPTION
## What is the current behavior?
In some startup/teardown timing scenarios, Android accessibility callbacks can invoke `updateAccessibilityState()` when `sharedA11YObservable` is not initialized, causing a crash on `.set(...)`.

## What is the new behavior?
Adds a defensive guard in `updateAccessibilityState()` to no-op when `sharedA11YObservable` is not available.

Fixes #11049
