### PR TITLE
fix: Android 10 crash (refactor status bar style handling for API 30+)

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -1329,22 +1329,24 @@ export class View extends ViewCommon {
 		const decorView = window.getDecorView();
 
 		// API 30+ path (preferred)
-		const controller = window.getInsetsController?.();
-		if (controller && SDK_VERSION >= 30) {
-			const APPEARANCE_LIGHT_STATUS_BARS = android.view.WindowInsetsController?.APPEARANCE_LIGHT_STATUS_BARS;
-
-			if (typeof value === 'string') {
-				this.style.statusBarStyle = value;
-				if (value === 'light') {
-					// light icons/text
-					controller.setSystemBarsAppearance(0, APPEARANCE_LIGHT_STATUS_BARS);
+		if (SDK_VERSION >= 30) {
+			const controller = window.getInsetsController?.();
+			if (controller) {
+				const APPEARANCE_LIGHT_STATUS_BARS = android.view.WindowInsetsController?.APPEARANCE_LIGHT_STATUS_BARS;
+	
+				if (typeof value === 'string') {
+					this.style.statusBarStyle = value;
+					if (value === 'light') {
+						// light icons/text
+						controller.setSystemBarsAppearance(0, APPEARANCE_LIGHT_STATUS_BARS);
+					} else {
+						// dark icons/text
+						controller.setSystemBarsAppearance(APPEARANCE_LIGHT_STATUS_BARS, APPEARANCE_LIGHT_STATUS_BARS);
+					}
 				} else {
-					// dark icons/text
-					controller.setSystemBarsAppearance(APPEARANCE_LIGHT_STATUS_BARS, APPEARANCE_LIGHT_STATUS_BARS);
+					if (value.color != null) window.setStatusBarColor(value.color);
+					// No direct passthrough for systemUiVisibility on API 30+, use appearances instead
 				}
-			} else {
-				if (value.color != null) window.setStatusBarColor(value.color);
-				// No direct passthrough for systemUiVisibility on API 30+, use appearances instead
 			}
 			return;
 		}


### PR DESCRIPTION
Prevents crash when using Android 10
fix: Android 10 crash (refactor status bar style handling for API 30+)

Corrects https://github.com/NativeScript/NativeScript/issues/11101

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.

## What is the current behavior?
NS application currently crashes when ran on Android 10 OS.

## What is the new behavior?
NS application does not crash when ran on Android 10 OS.

Fixes/Implements/Closes #[Issue Number].
https://github.com/NativeScript/NativeScript/issues/11101

