### PR TITLE
fix(android): missing inset props

### DIFF
--- a/packages/core/ui/core/view/view-interfaces.ts
+++ b/packages/core/ui/core/view/view-interfaces.ts
@@ -68,10 +68,20 @@ export interface Inset {
 	right: number;
 	bottom: number;
 	left: number;
+	imeBottom: number;
+	cutoutLeft: number;
+	cutoutTop: number;
+	cutoutRight: number;
+	cutoutBottom: number;
 	topConsumed: boolean;
 	rightConsumed: boolean;
 	bottomConsumed: boolean;
 	leftConsumed: boolean;
+	imeBottomConsumed: boolean;
+	cutoutLeftConsumed: boolean;
+	cutoutTopConsumed: boolean;
+	cutoutRightConsumed: boolean;
+	cutoutBottomConsumed: boolean;
 }
 
 /**


### PR DESCRIPTION
- extends the `Inset` interface in `view-interfaces.ts` to provide more detailed information about screen insets, specifically for IME (keyboard) and display cutouts. 