### PR TITLE
fix: size export in View object

### DIFF
--- a/packages/core/ui/core/view/index.d.ts
+++ b/packages/core/ui/core/view/index.d.ts
@@ -9,7 +9,7 @@ import { LinearGradient } from '../../styling/linear-gradient';
 import { InheritedProperty, Property } from '../properties';
 import { ViewBase } from '../view-base';
 import { GlassEffectType, ViewCommon } from './view-common';
-import type { Point, ShownModallyData } from './view-interfaces';
+import type { Point, ShownModallyData, Size } from './view-interfaces';
 
 export * from './view-common';
 // helpers (these are okay re-exported here)


### PR DESCRIPTION
Currently, Size is not imported, and doing something like the following does not autocomplete:

```
(object as View).getActualSize().
```