### PR TITLE
fix(android): enable edge-to-edge only for fullscreen modals

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -259,15 +259,12 @@ function initializeDialogFragment() {
 			this._windowSoftInputMode = options.windowSoftInputMode;
 			this.setStyle(androidx.fragment.app.DialogFragment.STYLE_NO_TITLE, 0);
 
-			let theme = this.getTheme();
-			if (this._fullscreen) {
-				// In fullscreen mode, get the application's theme.
-				theme = this.getActivity().getApplicationInfo().theme;
-			}
-
+			const theme = this._fullscreen ? this.getActivity().getApplicationInfo().theme : this.getTheme();
 			const dialog = new DialogImpl(this, this.getActivity(), theme);
 
-			Utils.android.enableEdgeToEdge(this.getActivity(), dialog.getWindow());
+			if (this._fullscreen) {
+				Utils.android.enableEdgeToEdge(this.getActivity(), dialog.getWindow());
+			}
 
 			// do not override alignment unless fullscreen modal will be shown;
 			// otherwise we might break component-level layout:
@@ -1333,7 +1330,7 @@ export class View extends ViewCommon {
 			const controller = window.getInsetsController?.();
 			if (controller) {
 				const APPEARANCE_LIGHT_STATUS_BARS = android.view.WindowInsetsController?.APPEARANCE_LIGHT_STATUS_BARS;
-	
+
 				if (typeof value === 'string') {
 					this.style.statusBarStyle = value;
 					if (value === 'light') {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Edge-to-edge is getting enabled for all modals, which is causing layout issues on non-fullscreen modals on Android.

## What is the new behavior?
Edge-to-edge is getting enabled only for fullscreen-modals to prevent layout issues for non-fullscreen modals on Android.

Fixes/Implements/Closes #11139.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:

[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

