### PR TITLE
chore(core): updated layout tests to wait for native layer layout

### DIFF
--- a/apps/automated/src/ui/image/image-tests.ts
+++ b/apps/automated/src/ui/image/image-tests.ts
@@ -1,7 +1,7 @@
 import { Image } from '@nativescript/core/ui/image';
 import { StackLayout } from '@nativescript/core/ui/layouts/stack-layout';
 import { GridLayout } from '@nativescript/core/ui/layouts/grid-layout';
-import { PropertyChangeData, Utils } from '@nativescript/core';
+import { PropertyChangeData } from '@nativescript/core';
 import * as utils from '@nativescript/core/utils';
 import * as TKUnit from '../../tk-unit';
 import { getColor } from '../../ui-helper';
@@ -26,8 +26,6 @@ export function test_recycling() {
 if (__ANDROID__) {
 	appHelpers.initImageCache(Application.android.startActivity, appHelpers.CacheMode.memory); // use memory cache only.
 }
-
-const expectLayoutRequest = __APPLE__ && Utils.SDK_VERSION >= 18;
 
 export const test_Image_Members = function () {
 	const image = new ImageModule.Image();
@@ -269,17 +267,17 @@ export const test_SettingImageSourceWhenSizedToParentDoesNotRequestLayout = ios(
 
 	let mainPage = helper.getCurrentPage();
 	mainPage.content = host;
-	TKUnit.waitUntilReady(() => host.isLoaded);
+
+	const nativeHostView = host.nativeViewProtected as UIView;
+
+	// Check if native view layer is still marked as dirty before proceeding
+	TKUnit.waitUntilReady(() => host.isLoaded && nativeHostView?.layer && !nativeHostView.layer.needsLayout());
 
 	let called = false;
 	image.requestLayout = () => (called = true);
 	image.src = '~/assets/logo.png';
 
-	if (expectLayoutRequest) {
-		TKUnit.assertTrue(called, 'image.requestLayout should be called.');
-	} else {
-		TKUnit.assertFalse(called, 'image.requestLayout should not be called.');
-	}
+	TKUnit.assertFalse(called, 'image.requestLayout should not be called.');
 });
 
 export const test_SettingImageSourceWhenFixedWidthAndHeightDoesNotRequestLayout = ios(() => {
@@ -291,17 +289,17 @@ export const test_SettingImageSourceWhenFixedWidthAndHeightDoesNotRequestLayout 
 
 	let mainPage = helper.getCurrentPage();
 	mainPage.content = host;
-	TKUnit.waitUntilReady(() => host.isLoaded);
+
+	const nativeHostView = host.nativeViewProtected as UIView;
+
+	// Check if native view layer is still marked as dirty before proceeding
+	TKUnit.waitUntilReady(() => host.isLoaded && nativeHostView?.layer && !nativeHostView.layer.needsLayout());
 
 	let called = false;
 	image.requestLayout = () => (called = true);
 	image.src = '~/assets/logo.png';
 
-	if (expectLayoutRequest) {
-		TKUnit.assertTrue(called, 'image.requestLayout should be called.');
-	} else {
-		TKUnit.assertFalse(called, 'image.requestLayout should not be called.');
-	}
+	TKUnit.assertFalse(called, 'image.requestLayout should not be called.');
 });
 
 export const test_SettingImageSourceWhenSizedToContentShouldInvalidate = ios(() => {

--- a/apps/automated/src/ui/label/label-tests.ts
+++ b/apps/automated/src/ui/label/label-tests.ts
@@ -6,8 +6,6 @@ import * as helper from '../../ui-helper';
 
 const testDir = 'ui/label';
 
-const expectLayoutRequest = __APPLE__ && Utils.SDK_VERSION >= 18;
-
 export class LabelTest extends testModule.UITest<Label> {
 	public create(): Label {
 		const label = new Label();
@@ -603,7 +601,11 @@ export class LabelTest extends testModule.UITest<Label> {
 
 		let mainPage = helper.getCurrentPage();
 		mainPage.content = host;
-		TKUnit.waitUntilReady(() => host.isLoaded);
+
+		const nativeHostView = host.nativeViewProtected as UIView;
+
+		// Check if native view layer is still marked as dirty before proceeding
+		TKUnit.waitUntilReady(() => host.isLoaded && nativeHostView?.layer && !nativeHostView.layer.needsLayout());
 
 		let called = false;
 		label.requestLayout = () => (called = true);
@@ -618,7 +620,7 @@ export class LabelTest extends testModule.UITest<Label> {
 	}
 
 	public test_SettingTextWhenInFixedSizeGridShouldNotRequestLayout() {
-		this.requestLayoutFixture(expectLayoutRequest, '', (label) => {
+		this.requestLayoutFixture(false, '', (label) => {
 			label.textWrap = false;
 			let host = new GridLayout();
 			host.width = 100;
@@ -629,7 +631,7 @@ export class LabelTest extends testModule.UITest<Label> {
 	}
 
 	public test_ChangingTextWhenInFixedSizeGridShouldNotRequestLayout() {
-		this.requestLayoutFixture(expectLayoutRequest, 'Hello World', (label) => {
+		this.requestLayoutFixture(false, 'Hello World', (label) => {
 			label.textWrap = false;
 			let host = new GridLayout();
 			host.width = 100;
@@ -640,7 +642,7 @@ export class LabelTest extends testModule.UITest<Label> {
 	}
 
 	public test_SettingTextWhenFixedWidthAndHeightDoesNotRequestLayout() {
-		this.requestLayoutFixture(expectLayoutRequest, '', (label) => {
+		this.requestLayoutFixture(false, '', (label) => {
 			label.textWrap = false;
 			let host = new StackLayout();
 			label.width = 100;
@@ -651,7 +653,7 @@ export class LabelTest extends testModule.UITest<Label> {
 	}
 
 	public test_ChangingTextWhenFixedWidthAndHeightDoesNotRequestLayout() {
-		this.requestLayoutFixture(expectLayoutRequest, 'Hello World', (label) => {
+		this.requestLayoutFixture(false, 'Hello World', (label) => {
 			label.textWrap = false;
 			let host = new StackLayout();
 			label.width = 100;
@@ -692,7 +694,7 @@ export class LabelTest extends testModule.UITest<Label> {
 	}
 
 	public test_ChangingTextOnSingleLineTextWhenWidthIsSizedToParentAndHeightIsSizedToContentShouldNotRequestLayout() {
-		this.requestLayoutFixture(expectLayoutRequest, 'Hello World', (label) => {
+		this.requestLayoutFixture(false, 'Hello World', (label) => {
 			label.textWrap = false;
 			let host = new StackLayout();
 			host.width = 100;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, a couple of iOS automated layout tests are randomly failing.
The problem seems to be the timing as core does not expect for the native layout to complete. In the past, we attempted to get rid of the problem using OS version checks but that doesn't seem to be 100% accurate.

## What is the new behavior?
Check if UIView layer is still marked as layout dirty before proceeding. This will give the tests enough time to run properly.
I'm not sure if it's the best approach, we could definitely force the layout to finish earlier using `layoutIfNeeded` but I think it's also good to make use of the TKUnit `waitUntilReady` call.