### PR TITLE
fix(ios): guard against non-string imageURI in createUIImageFromURI

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -185,9 +185,9 @@ export namespace ios {
 
 		if (imageURI) {
 			if (typeof imageURI !== 'string') {
-                callback(null);
-                return;
-            }
+				callback(null);
+				return;
+			}
 			const match = imageURI.match(uriPattern);
 			if (match && match[2]) {
 				imageURI = match[2];


### PR DESCRIPTION
                                                                                                                                                                                                
  Title:
                                                                                                                                                                                                         
  fix(ios): guard against non-string imageURI in createUIImageFromURI
                                                                                                                                                                                                         
  Body:           

  Summary
                                                                                                                                                                                                         
  When the CSS shorthand property background is used with a plain color value (e.g. background: #1A1A1A), the imageURI parameter passed to createUIImageFromURI in background.ios.ts can be a non-string
  type (such as a Color object). This causes imageURI.match(uriPattern) to throw a TypeError at runtime, crashing the application on iOS.                                                                
                  
  Root Cause                                                                                                                                                                                             
                  
  The background CSS shorthand is parsed into multiple sub-properties (background-color, background-image, etc.). In certain cases, a Color object rather than a string is passed through as the imageURI
   argument. The existing code assumes imageURI is always a string when truthy, and calls .match() on it directly without a type check.
                                                                                                                                                                                                         
  Fix             

  Added a typeof imageURI !== 'string' guard before the .match() call. When imageURI is not a string, the function invokes the callback with null and returns early, allowing the rest of the background 
  rendering pipeline (e.g. background-color) to proceed normally.
                                                                                                                                                                                                         
  if (imageURI) { 
      if (typeof imageURI !== 'string') {
          callback(null);
          return;
      }
      const match = imageURI.match(uriPattern);
      // ...                                                                                                                                                                                             
  }
                                                                                                                                                                                                         
  How to Reproduce

  1. Set a background on any view using the CSS shorthand with a plain color:                                                                                                                            
  ActionBar {
    background: #1A1A1A;                                                                                                                                                                                 
  }               
  2. Run on iOS                                                                                                                                                                                          
  3. App crashes with TypeError: imageURI.match is not a function
                                                                                                                                                                                                         
  Workaround (before this fix): Replace background with background-color to avoid triggering createUIImageFromURI entirely.                                                                              
                                                                                                                                                                                                         
  Affected                                                                                                                                                                                   
                  
  @nativescript/core 

