### PR TITLE
fix(android): reapply tintColor when Image src changes

### DIFF
--- a/apps/toolbox/src/pages/image-handling.ts
+++ b/apps/toolbox/src/pages/image-handling.ts
@@ -10,10 +10,15 @@ export function navigatingTo(args: EventData) {
 
 export class DemoModel extends Observable {
 	addingPhoto = false;
+	tintTestSrc = 'res://icon';
 	symbolWiggleEffect = ImageSymbolEffects.Wiggle;
 	symbolBounceEffect = ImageSymbolEffects.Bounce;
 	symbolBreathEffect = ImageSymbolEffects.Breathe;
 	symbolRotateEffect = ImageSymbolEffects.Rotate;
+
+	toggleTintTestSrc() {
+		this.set('tintTestSrc', this.tintTestSrc === 'res://icon' ? 'res://add_to_fav' : 'res://icon');
+	}
 
 	pickImage() {
 		const context = create({

--- a/apps/toolbox/src/pages/image-handling.xml
+++ b/apps/toolbox/src/pages/image-handling.xml
@@ -6,6 +6,19 @@
 
     <StackLayout class="p-20">
 
+        <Label text="tintColor + dynamic src" class="h2" />
+        <Label text="Tap the image to swap src between icon and add_to_fav. The red tint should persist after each swap." textWrap="true" />
+        <GridLayout columns="auto, *, auto" rows="auto" class="m-t-10 m-b-10">
+            <Image col="0" src="{{ tintTestSrc }}" tintColor="#E53935" width="80" height="80" tap="{{ toggleTintTestSrc }}" stretch="aspectFit" />
+            <StackLayout col="1" verticalAlignment="center" class="m-l-10">
+                <Label text="{{ 'src: ' + tintTestSrc }}" textWrap="true" />
+                <Label text="tintColor: #E53935" />
+                <Label text="(tap image to toggle)" class="footnote" />
+            </StackLayout>
+        </GridLayout>
+
+        <ContentView height="1" width="100%" backgroundColor="#efefef" margin="10" />
+
         <Label text="Test Memory leaks with image picking and saving to device. Best to profile from platform IDE like Xcode." textWrap="true" />
 
         <Button text="Pick and Save Image" tap="{{ pickImage }}" />

--- a/packages/core/ui/image/index.android.ts
+++ b/packages/core/ui/image/index.android.ts
@@ -37,6 +37,9 @@ function initializeImageLoadedListener() {
 			const owner = this.owner;
 			if (owner) {
 				owner.isLoading = false;
+				if (success) {
+					owner._reapplyTintColor();
+				}
 			}
 		}
 	}
@@ -76,6 +79,13 @@ export class Image extends ImageBase {
 	public resetNativeView(): void {
 		super.resetNativeView();
 		this.nativeViewProtected.setImageMatrix(new android.graphics.Matrix());
+	}
+
+	public _reapplyTintColor(): void {
+		const tintColor = this.style?.tintColor;
+		if (tintColor && this.nativeViewProtected) {
+			this.nativeViewProtected.setColorFilter(tintColor.android);
+		}
 	}
 
 	public _createImageSourceFromSrc(value: string | ImageSource | ImageAsset) {
@@ -181,6 +191,7 @@ export class Image extends ImageBase {
 			nativeView.setRotationAngle(0);
 			nativeView.setImageBitmap(null);
 		}
+		this._reapplyTintColor();
 	}
 
 	[srcProperty.getDefault](): any {


### PR DESCRIPTION
On Android, ColorFilter is applied to the Drawable, not the ImageView itself. When src changes dynamically (e.g. via binding), the new drawable replaces the old one and the tint is lost. This differs from iOS, where tintColor is a view-level property that persists across image changes.

This adds `_reapplyTintColor()` to the Android Image implementation and calls it from both code paths that load a new image:

- `onImageLoaded` -- for images loaded natively via setUri (file/resource paths)
- `[imageSourceProperty.setNative]` -- for images set via `setImageBitmap` (font icons, data URIs, ImageSource/ImageAsset)