### PR TITLE
Disable __dirname & __filename webpack polyfills

### DIFF
--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -267,12 +267,13 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		if (env === null || env === void 0 ? void 0 : env.uniqueBundle) {
 			config.output.filename(`[name].${env.uniqueBundle}.mjs`);
 		}
-		// Prevent webpack from polyfilling __dirname via `import {fileURLToPath} from "node:url"`.
-		// In ESM output mode, webpack auto-generates this import whenever bundled code references
-		// __dirname — but iOS's node:url does not export fileURLToPath, crashing workers.
-		// NativeScript's runtime already provides __dirname as a global, and
-		// @nativescript/core/globals/index.js handles the ESM case via import.meta.dirname,
-		// so webpack's polyfill is both redundant and broken on iOS.
+		// Prevent webpack from generating Node-style ESM shims for __dirname/__filename.
+		// For output modules, webpack defaults these to a fileURLToPath(import.meta.url) helper
+		// imported from bare "url", which does not match the NativeScript iOS runtime contract.
+		// The runtime already provides import.meta.dirname and initializes global.__dirname,
+		// so webpack's helper is redundant and can misresolve in bundle/worker contexts.
+		// ESM app or dependency code should use import.meta.dirname/import.meta.url instead
+		// of expecting webpack to synthesize __dirname/__filename.
 		config.node.set('__dirname', false);
 		config.node.set('__filename', false);
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As discussed here: https://discord.com/channels/603595811204366337/1481617562310676620/1487134181602361444, when importing ESM libraries in workers is causing an error on iOS.

For example:

```
Error instantiating module: [redacted_path]/src_workers_csv-generation-worker_js.mjs
  Native stack trace:
    [redacted_stack]
  JavaScript error:
  SyntaxError: The requested module 'node:url' does not provide an export named 'fileURLToPath'
  Module instantiation failed: [redacted_path]/src_workers_csv-generation-worker_js.mjs
  Debug mode - ES module returned empty namespace, but telling iOS it succeeded
```
To help explain the issue via claude code it described the issue with the following:

> The failure chain is:
> 
> 1. Your code: Worker imports `getNumberLocale` from `@my-scope/helpers` (now ESM)
> 2. helpers ESM causes webpack to output the worker as an ESM bundle (.mjs) instead of CJS
> 3. NativeScript itself — specifically `@nativescript/core/globals/index.js:15`:
> 
> `global.__dirname = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;`
> 
> This references `__dirname`, which webpack detects in ESM output mode and auto-generates:
> 
> `import {fileURLToPath} from "node:url";  // ← webpack's own generated code`
> 
> 4. iOS doesn't expose fileURLToPath from node:url → crash

## What is the new behavior?
<!-- Describe the changes. -->

The fix applied with this PR disables webpack's polyfills for `__dirname` and `__filename` as NativeScript already handles these.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

