### PR TITLE
fix(android): setTextColor is non-nullable, prevent null exception

### DIFF
--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -408,11 +408,11 @@ export class TextBase extends TextBaseCommon {
 	[colorProperty.getDefault](): android.content.res.ColorStateList {
 		return this.nativeTextViewProtected.getTextColors();
 	}
-	[colorProperty.setNative](value: Color | android.content.res.ColorStateList) {
+	[colorProperty.setNative](value: Color | android.content.res.ColorStateList | null | undefined) {
 		if (!this.formattedText || !(value instanceof Color)) {
 			if (value instanceof Color) {
 				this.nativeTextViewProtected.setTextColor(value.android);
-			} else if (value) {
+			} else if (value != null) {
 				this.nativeTextViewProtected.setTextColor(value);
 			}
 		}


### PR DESCRIPTION
- ensures that `setTextColor` method is only called with a defined value, preventing crashes based on timing/race

Prevents innocent app crash due to bindings update timing (often on page navigations):
```
Error: java.lang.NullPointerException
StackTrace:
  [color:setNative](file:///data/data/com.example.app/files/files/app/vendor.mjs)
```

This occurs because `this.nativeTextViewProtected.setTextColor(value)` is not nullable.
<https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/widget/TextView.java#5602>