### PR TITLE
Fix 'occured' -> 'occurred' in debug.d.ts and AsyncTask

### DIFF
--- a/packages/core/utils/debug.d.ts
+++ b/packages/core/utils/debug.d.ts
@@ -57,7 +57,7 @@ export class SourceError extends ScopeError {
 	/**
 	 * Creates a new SourceError by child error, source and optional message.
 	 * @param child The child error to extend.
-	 * @param source The source where the error occured.
+	 * @param source The source where the error occurred.
 	 * @param message Additonal message to prepend along the source location and the child error's message.
 	 */
 	constructor(child: Error, source: Source, message?: string);

--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/image/AsyncTask.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/image/AsyncTask.java
@@ -326,7 +326,7 @@ public abstract class AsyncTask<Params, Progress, Result> {
 				} catch (InterruptedException e) {
 					android.util.Log.w(LOG_TAG, e);
 				} catch (ExecutionException e) {
-					throw new RuntimeException("An error occured while executing doInBackground()",
+					throw new RuntimeException("An error occurred while executing doInBackground()",
 						e.getCause());
 				} catch (CancellationException e) {
 					postResultIfNotInvoked(null);


### PR DESCRIPTION
Fix 2 typo instances:

- `packages/core/utils/debug.d.ts` line 60: TypeScript type declaration JSDoc
- `packages/ui-mobile-base/android/widgets/.../AsyncTask.java` line 329: RuntimeException message

Comment/exception-string-only change.