### PR TITLE
fix(core): rebuild nested-frame fragment when its view was destroyed on reattach

### DIFF
--- a/packages/core/ui/frame/frame-helper-for-android.ts
+++ b/packages/core/ui/frame/frame-helper-for-android.ts
@@ -236,8 +236,15 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 		// [nested frames / fragments] see https://github.com/NativeScript/NativeScript/issues/6629
 		// retaining reference to a destroyed fragment here somehow causes a cryptic
 		// "IllegalStateException: Failure saving state: active fragment has cleared index: -1"
-		// in a specific mixed parent / nested frame navigation scenario
-		entry.fragment = null;
+		// in a specific mixed parent / nested frame navigation scenario.
+		//
+		// Only null out entry.fragment if it still points to THIS fragment. _ensureEntryFragment
+		// may have already replaced it with a new fragment (when recovering one whose view was
+		// destroyed) — if THIS old fragment is destroyed afterwards, we must not overwrite the
+		// newer reference.
+		if (entry.fragment === fragment) {
+			entry.fragment = null;
+		}
 
 		const page = entry.resolvedPage;
 		if (!page) {

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -84,6 +84,12 @@ export class Frame extends FrameBase {
 	private _cachedTransitionState: TransitionState;
 	private _frameCreateTimeout: NodeJS.Timeout;
 
+	// True while inside an onLoaded()-driven _ensureEntryFragment call. _ensureEntryFragment
+	// also runs from _onAttachedToWindow during outgoing navigations, where the fragment's
+	// view is null because it's being torn down on purpose — we must not rebuild it then.
+	// This flag lets _ensureEntryFragment tell the two cases apart.
+	private _pendingFragmentCheck = false;
+
 	constructor() {
 		super();
 		this._android = new AndroidFrame(this);
@@ -245,6 +251,10 @@ export class Frame extends FrameBase {
 	}
 
 	onLoaded(): void {
+		// Tell _ensureEntryFragment this pass is from onLoaded (an incoming reattach)
+		// rather than from _onAttachedToWindow during an outgoing transition. See the
+		// field declaration of _pendingFragmentCheck for why this matters.
+		this._pendingFragmentCheck = true;
 		if (this._originalBackground) {
 			this.backgroundColor = null;
 			this.backgroundColor = this._originalBackground;
@@ -274,6 +284,7 @@ export class Frame extends FrameBase {
 		// though we should not do it on app "start"
 		// or it will create a "flash" to activity background color
 		if (this._isReset && !this._attachedToWindow) {
+			this._pendingFragmentCheck = false;
 			return;
 		}
 
@@ -282,7 +293,13 @@ export class Frame extends FrameBase {
 			// so we manually check on loaded event if the fragment is not recreated and recreate it
 			const currentEntry = this._currentEntry || this._executingContext?.entry;
 			if (currentEntry) {
-				if (!currentEntry.fragment) {
+				// Rebuild if either:
+				//   (a) there is no fragment at all, or
+				//   (b) the fragment exists but its view was destroyed AND we got here via
+				//       onLoaded (not via _onAttachedToWindow during an outgoing transition,
+				//       where a null view is expected and a rebuild would be wrong).
+				const fragmentNeedsRebuild = !currentEntry.fragment || (currentEntry.fragment.getView() == null && this._pendingFragmentCheck);
+				if (fragmentNeedsRebuild) {
 					const manager = this._getFragmentManager();
 					const transaction = manager.beginTransaction();
 					currentEntry.fragment = this.createFragment(currentEntry, currentEntry.fragmentTag);
@@ -292,6 +309,7 @@ export class Frame extends FrameBase {
 				}
 			}
 
+			this._pendingFragmentCheck = false;
 			this._frameCreateTimeout = null;
 		}, 0);
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As described on [discord](https://discord.com/channels/603595811204366337/1343512351529242645/1501909266347462716) I have encountered an issue where a nested frame results in having no content. As stated I have investigated this via claude, not mentioning it to not take any responsibility 😄 but to highlight that code changes and comments in the code were added by claude. I did direct it to simplify certain comments.

As I mentioned on discord I did try replicating this issue in a clean application but I didn't manage. My suspicion was that there's was minor issue in NativeScript that's being triggered by as specific use case in my application.

## What is the new behavior?
<!-- Describe the changes. -->
Short description via claude of this update:

The update here extends the `_ensureEntryFragment` recovery from #10713 to cover the case where the fragment object survives but its view has been destroyed. Without this, the nested frame renders blank after the parent is briefly covered and dismissed. Also guards entry.fragment = null in onDestroy so the old fragment's teardown doesn't overwrite the new reference assigned by the rebuild path.

Two changes under `packages/core/ui/frame`:

1. **`index.android.ts`** — `_ensureEntryFragment` also rebuilds when `fragment.getView() == null`, gated by a new `_pendingFragmentCheck` flag set by `onLoaded()`. The flag is needed because `_onAttachedToWindow` also calls `_ensureEntryFragment` during outgoing transitions, where a null view is expected and a rebuild would be wrong.

2. **`frame-helper-for-android.ts`** — `onDestroy` only nulls out `entry.fragment` if it still points to the destroying fragment. The rebuild above assigns a new fragment to `entry.fragment`, and without this guard the old fragment's destruction would overwrite that new reference.