### PR TITLE
fix(android): Corrected TabView fragment manager resolution

### DIFF
--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -383,26 +383,7 @@ export class TabViewItem extends TabViewItemBase {
 
 	public _getChildFragmentManager(): androidx.fragment.app.FragmentManager {
 		const tabView = this.parent as TabView;
-		let tabFragment = null;
-		const fragmentManager = tabView._getFragmentManager();
-		const fragments = fragmentManager.getFragments().toArray();
-		for (let i = 0; i < fragments.length; i++) {
-			if (fragments[i].index === this.index) {
-				tabFragment = fragments[i];
-				break;
-			}
-		}
-
-		// TODO: can happen in a modal tabview scenario when the modal dialog fragment is already removed
-		if (!tabFragment) {
-			if (Trace.isEnabled()) {
-				Trace.write(`Could not get child fragment manager for tab item with index ${this.index}`, traceCategory);
-			}
-
-			return (<any>tabView)._getRootFragmentManager();
-		}
-
-		return tabFragment.getChildFragmentManager();
+		return (<any>tabView)._getRootFragmentManager();
 	}
 
 	[fontSizeProperty.getDefault](): { nativeSize: number } {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, there's an issue that causes android TabView tabs to become blank if users switches tabs quickly.
This triggers a chain of events:

- User switches tabs fast
- ViewPager chooses to cache the tabs skipping instantiateItem/destroyItem call steps
- The TabViewItem `_getChildFragmentManager` overridden method returns the wrong fragment manager because the previous fragment wasn't detached from fragment manager during tab navigation
- Frame workarounds are triggered during tab load/unload lifecycle but resolve to the wrong `FragmentManager`.

## What is the new behavior?
This PR will remove the faulty child fragment resolution code since it has no merits but causes problems instead.
Partially reverts #6293 which seems to be the culprit.

Fixes #10165.

Note: We can consider a huge refactor for TabView in the future and see if it's possible to use [ViewPager2](https://developer.android.com/reference/androidx/viewpager2/widget/ViewPager2) or [FragmentStatePagerAdapter](https://developer.android.com/reference/androidx/fragment/app/FragmentStatePagerAdapter)