### PR TITLE
fix(ios): Correct layout validity status during layout changed event

### DIFF
--- a/apps/automated/src/ui/image/image-tests.ts
+++ b/apps/automated/src/ui/image/image-tests.ts
@@ -268,10 +268,8 @@ export const test_SettingImageSourceWhenSizedToParentDoesNotRequestLayout = ios(
 	let mainPage = helper.getCurrentPage();
 	mainPage.content = host;
 
-	const nativeHostView = host.nativeViewProtected as UIView;
-
-	// Check if native view layer is still marked as dirty before proceeding
-	TKUnit.waitUntilReady(() => host.isLoaded && nativeHostView?.layer && !nativeHostView.layer.needsLayout());
+	// Check if view is loaded and layout is valid
+	TKUnit.waitUntilReady(() => host.isLoaded && host.isLayoutValid);
 
 	let called = false;
 	image.requestLayout = () => (called = true);
@@ -290,10 +288,8 @@ export const test_SettingImageSourceWhenFixedWidthAndHeightDoesNotRequestLayout 
 	let mainPage = helper.getCurrentPage();
 	mainPage.content = host;
 
-	const nativeHostView = host.nativeViewProtected as UIView;
-
-	// Check if native view layer is still marked as dirty before proceeding
-	TKUnit.waitUntilReady(() => host.isLoaded && nativeHostView?.layer && !nativeHostView.layer.needsLayout());
+	// Check if view is loaded and layout is valid
+	TKUnit.waitUntilReady(() => host.isLoaded && host.isLayoutValid);
 
 	let called = false;
 	image.requestLayout = () => (called = true);

--- a/apps/automated/src/ui/label/label-tests.ts
+++ b/apps/automated/src/ui/label/label-tests.ts
@@ -602,10 +602,8 @@ export class LabelTest extends testModule.UITest<Label> {
 		let mainPage = helper.getCurrentPage();
 		mainPage.content = host;
 
-		const nativeHostView = host.nativeViewProtected as UIView;
-
-		// Check if native view layer is still marked as dirty before proceeding
-		TKUnit.waitUntilReady(() => host.isLoaded && nativeHostView?.layer && !nativeHostView.layer.needsLayout());
+		// Check if view is loaded and layout is valid
+		TKUnit.waitUntilReady(() => host.isLoaded && host.isLayoutValid);
 
 		let called = false;
 		label.requestLayout = () => (called = true);

--- a/apps/automated/src/ui/view/view-tests-layout-event.ts
+++ b/apps/automated/src/ui/view/view-tests-layout-event.ts
@@ -18,6 +18,23 @@ export function test_event_LayoutChanged_GetActualSize() {
 	helper.do_PageTest_WithStackLayout_AndButton(test);
 }
 
+export function test_event_LayoutChanged_IsLayoutValid() {
+	const test = function (views: Array<View>) {
+		let buttonLayoutChanged = false;
+		let expectedValidResult;
+
+		views[1].on(View.layoutChangedEvent, (args) => {
+			expectedValidResult = (args.object as View).isLayoutValid;
+			buttonLayoutChanged = true;
+		});
+
+		TKUnit.waitUntilReady(() => buttonLayoutChanged, 5);
+		TKUnit.assertFalse(expectedValidResult);
+	};
+
+	helper.do_PageTest_WithStackLayout_AndButton(test);
+}
+
 export function test_event_LayoutChanged_Listeners() {
 	const test = function (views: Array<View>) {
 		let buttonLayoutChanged = false;

--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -95,8 +95,7 @@ export class View extends ViewCommon {
 
 	public measure(widthMeasureSpec: number, heightMeasureSpec: number): void {
 		const measureSpecsChanged = this._setCurrentMeasureSpecs(widthMeasureSpec, heightMeasureSpec);
-		const forceLayout = (this._privateFlags & PFLAG_FORCE_LAYOUT) === PFLAG_FORCE_LAYOUT;
-		if (this.nativeViewProtected && (forceLayout || measureSpecsChanged)) {
+		if (this.nativeViewProtected && (this.isLayoutRequested || measureSpecsChanged)) {
 			// first clears the measured dimension flag
 			this._privateFlags &= ~PFLAG_MEASURED_DIMENSION_SET;
 
@@ -122,7 +121,7 @@ export class View extends ViewCommon {
 			this.layoutNativeView(left, top, right, bottom);
 		}
 
-		const needsLayout = boundsChanged || (this._privateFlags & PFLAG_LAYOUT_REQUIRED) === PFLAG_LAYOUT_REQUIRED;
+		const needsLayout = boundsChanged || this.isLayoutRequired;
 		if (needsLayout) {
 			let position: Position;
 
@@ -259,9 +258,8 @@ export class View extends ViewCommon {
 
 	get isLayoutValid(): boolean {
 		if (this.nativeViewProtected) {
-			return this._isLayoutValid;
+			return !this.isLayoutRequested;
 		}
-
 		return false;
 	}
 

--- a/packages/core/ui/core/view/view-common.ts
+++ b/packages/core/ui/core/view/view-common.ts
@@ -128,7 +128,6 @@ export abstract class ViewCommon extends ViewBase {
 	private _measuredWidth: number;
 	private _measuredHeight: number;
 
-	protected _isLayoutValid: boolean;
 	private _cssType: string;
 
 	private _localAnimations: Set<Animation>;
@@ -1009,7 +1008,7 @@ export abstract class ViewCommon extends ViewBase {
 	//END Style property shortcuts
 
 	get isLayoutValid(): boolean {
-		return this._isLayoutValid;
+		return false;
 	}
 
 	get cssType(): string {
@@ -1070,11 +1069,6 @@ export abstract class ViewCommon extends ViewBase {
 		}
 	}
 
-	public requestLayout(): void {
-		this._isLayoutValid = false;
-		super.requestLayout();
-	}
-
 	public abstract onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void;
 	public abstract onLayout(left: number, top: number, right: number, bottom: number): void;
 	public abstract layoutNativeView(left: number, top: number, right: number, bottom: number): void;
@@ -1111,7 +1105,6 @@ export abstract class ViewCommon extends ViewBase {
 	 * Returns two booleans - the first if "boundsChanged" the second is "sizeChanged".
 	 */
 	_setCurrentLayoutBounds(left: number, top: number, right: number, bottom: number): { boundsChanged: boolean; sizeChanged: boolean } {
-		this._isLayoutValid = true;
 		const boundsChanged: boolean = this._oldLeft !== left || this._oldTop !== top || this._oldRight !== right || this._oldBottom !== bottom;
 		const sizeChanged: boolean = this._oldRight - this._oldLeft !== right - left || this._oldBottom - this._oldTop !== bottom - top;
 		this._oldLeft = left;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
On iOS, the `isLayoutValid` getter can be true when checked in a `layoutChanged` event listener.
This causes platform inconsistency and reports a valid layout before computations are over.

## What is the new behavior?
Updated the getter to reflect the android approach since the core layout system for iOS is inspired from it and added an automated test to cover the case explained.
This is helpful for plugins to make use of that flag and have identical results for both platforms.
Additionally, causing the flag to be truthy at a later point makes it wait for `layoutIfNeeded` call, thus making it usable for tests that didn't pass till now.