### PR TITLE
fix(core): prevent exponential traversal in _dialogClosed and _onRootViewReset

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -1502,7 +1502,7 @@ export abstract class ViewBase extends Observable {
 	 * Method is intended to be overridden by inheritors and used as "protected"
 	 */
 	public _dialogClosed(): void {
-		eachDescendant(this, (child: ViewBase) => {
+		this.eachChild((child: ViewBase) => {
 			child._dialogClosed();
 
 			return true;
@@ -1513,7 +1513,7 @@ export abstract class ViewBase extends Observable {
 	 * Method is intended to be overridden by inheritors and used as "protected"
 	 */
 	public _onRootViewReset(): void {
-		eachDescendant(this, (child: ViewBase) => {
+		this.eachChild((child: ViewBase) => {
 			child._onRootViewReset();
 
 			return true;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Both methods used eachDescendant to walk the full subtree, then each visited child recursively called the same method—which walked its own subtree again. For a tree of depth n this produced O(2^n) visits.

## What is the new behavior?

Replace eachDescendant with eachChild so each node is visited exactly once via natural recursion, reducing traversal to O(n).
