### PR TITLE
fix(android): guard TextBase fontSize reset values

### DIFF
--- a/packages/core/ui/text-base/index.android.ts
+++ b/packages/core/ui/text-base/index.android.ts
@@ -421,7 +421,11 @@ export class TextBase extends TextBaseCommon {
 	[fontSizeProperty.getDefault](): { nativeSize: number } {
 		return { nativeSize: this.nativeTextViewProtected.getTextSize() };
 	}
-	[fontSizeProperty.setNative](value: number | { nativeSize: number }) {
+	[fontSizeProperty.setNative](value: number | { nativeSize: number } | null | undefined) {
+		if (value == null) {
+			return;
+		}
+
 		if (!this.formattedText || typeof value !== 'number') {
 			if (typeof value === 'number') {
 				this.nativeTextViewProtected.setTextSize(value);


### PR DESCRIPTION
Fixes #11221.

## Summary
- Add a null guard to Android `TextBase` font-size native setter so style resets do not crash when `fontSize` resolves to `null` or `undefined`.
- Preserve existing behavior for numeric font sizes and `{ nativeSize }` default values.
- Leave Android font scaling behavior unchanged.

## Reproduction
Using `nativescript-vue`, toggling an inline font-size style off can reset the previous style value to `null`:

```vue
<script setup lang="ts">
import { ref } from 'nativescript-vue'

const enabled = ref(true)
</script>

<template>
  <Button
    text="Toggle"
    @tap="enabled = !enabled"
  />

  <Label
    text="Font size repro"
    :style="enabled ? { fontSize: 20 } : {}"
  />
</template>
```

On Android, that reset can reach `TextBase` and throw:

```text
TypeError: Cannot read properties of null (reading 'nativeSize')
```

## Testing
- Verified the patch in an app-level NativeScript Vue repro where the crash occurred before the guard.
- Ran `git diff --check` locally.

No full NativeScript test suite was run locally because this clone did not have repo dependencies installed.