### PR TITLE
fix: activity recreation crashes with tabs and complex view hierarchies

### DIFF
--- a/packages/core/ui/action-bar/action-bar-common.ts
+++ b/packages/core/ui/action-bar/action-bar-common.ts
@@ -29,7 +29,6 @@ export class ActionBarBase extends View implements ActionBarDefinition {
 	public effectiveContentInsetRight: number;
 
 	disposeNativeView() {
-		this._actionItems = null;
 		super.disposeNativeView();
 	}
 

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -869,10 +869,11 @@ export class ActivityCallbacksImplementation implements AndroidActivityCallbacks
 			// handled by _processNextNavigationEntry. We remove all non-NativeScript fragments.
 			const fm = activity.getSupportFragmentManager();
 			const fragments = fm.getFragments();
-			if (fragments && fragments.size() > 0) {
+			const size = fragments?.size?.() ?? 0;
+			if (size > 0) {
 				const ft = fm.beginTransaction();
 				let removed = false;
-				for (let i = fragments.size() - 1; i >= 0; i--) {
+				for (let i = size - 1; i >= 0; i--) {
 					const f = fragments.get(i);
 					if (!f) continue;
 					const tag = f.getTag();

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -861,6 +861,33 @@ export class ActivityCallbacksImplementation implements AndroidActivityCallbacks
 		const isRestart = !!savedInstanceState && moduleLoaded;
 		superFunc.call(activity, isRestart ? savedInstanceState : null);
 
+		if (isRestart && activity.getSupportFragmentManager) {
+			// Remove restored fragments that NativeScript will recreate via _setupUI/createNativeView.
+			// NativeScript tears down and rebuilds the entire view tree on activity recreation,
+			// so restored fragments (especially from ViewPager2/tabs) become orphaned without views.
+			// NativeScript core's own fragments use tags like "fragment{id}[{depth}]" and are
+			// handled by _processNextNavigationEntry. We remove all non-NativeScript fragments.
+			const fm = activity.getSupportFragmentManager();
+			const fragments = fm.getFragments();
+			if (fragments && fragments.size() > 0) {
+				const ft = fm.beginTransaction();
+				let removed = false;
+				for (let i = fragments.size() - 1; i >= 0; i--) {
+					const f = fragments.get(i);
+					if (!f) continue;
+					const tag = f.getTag();
+					if (tag && tag.startsWith('fragment')) {
+						continue;
+					}
+					ft.remove(f);
+					removed = true;
+				}
+				if (removed) {
+					ft.commitNowAllowingStateLoss();
+				}
+			}
+		}
+
 		// Try to get the rootViewId form the saved state in case the activity
 		// was destroyed and we are now recreating it.
 		if (savedInstanceState) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
When "Don't keep activities" is enabled (or the system destroys the activity
to reclaim memory), NativeScript apps using ViewPager2-based tabs (e.g.
@nativescript-community/ui-material-tabs) crash on foregrounding.

## What is the new behavior?

Two root causes are addressed:

1. ActionBar's disposeNativeView() nulled _actionItems, causing
   "Cannot read properties of null (reading 'addItem')" when the action bar
   was recreated during _setupUI after activity destruction.

2. Android's FragmentManager restores all fragments from savedInstanceState
   during super.onCreate(), including third-party fragments (ViewPager2's
   f0, f1, etc.). NativeScript's _tearDownUI/_setupUI cycle rebuilds the
   entire view tree from scratch, leaving these restored fragments orphaned
   — they reference container views that no longer exist, causing "Fragment
   does not have a view" errors. We now remove non-NativeScript fragments
   immediately after super.onCreate() while preserving core's own fragments
   (tagged fragment{id}[{depth}]) which have a proper restoration path via
   _processNextNavigationEntry and FragmentCallbacksImplementation.onCreateView.
