### PR TITLE
fix(android): apply accessibility CSS classes and font scale on init

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -726,7 +726,7 @@ function updateAccessibilityState(): void {
 	if (!sharedA11YObservable) {
 		return;
 	}
-	
+
 	const accessibilityManager = getAndroidAccessibilityManager();
 	if (!accessibilityManager) {
 		sharedA11YObservable.set(accessibilityStateEnabledPropName, false);
@@ -885,6 +885,8 @@ export function updateCurrentHelperClasses(applyRootCssClass: (cssClasses: strin
 
 export function initAccessibilityCssHelper(): void {
 	ensureClasses();
+	updateCurrentHelperClasses(applyRootCssClass);
+	applyFontScaleToRootViews();
 
 	Application.on(Application.fontScaleChangedEvent, () => {
 		updateCurrentHelperClasses(applyRootCssClass);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
On iOS, initAccessibilityCssHelper already calls updateCurrentHelperClasses and applyFontScaleToRootViews immediately. On Android, these were only called inside the fontScaleChangedEvent listener, meaning accessibility CSS classes and font scale were not applied until the first font scale change event.

## What is the new behavior?
font scale and helpers are now applied correctly on android on init.
