### PR TITLE
fix(ios): improve TabView handling around more navigation controller

### DIFF
--- a/packages/core/ui/tab-view/index.ios.ts
+++ b/packages/core/ui/tab-view/index.ios.ts
@@ -134,6 +134,14 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 
 		const owner = this._owner?.deref();
 		if (owner) {
+			// iOS lazily initializes moreNavigationController (e.g. on first access of
+			// topViewController, or on first tap of the More tab) and can clear the
+			// delegate we set in setViewControllers. Re-assert it whenever any tab is
+			// selected so moreNav push/pop callbacks for tabs >= 5 still reach us.
+			const moreNav = tabBarController.moreNavigationController;
+			if (moreNav && moreNav.delegate !== owner.moreNavigationControllerDelegate) {
+				moreNav.delegate = owner.moreNavigationControllerDelegate;
+			}
 			owner._onViewControllerShown(tabBarController, viewController);
 		}
 	}
@@ -175,6 +183,12 @@ class UINavigationControllerDelegateImpl extends NSObject implements UINavigatio
 		const owner = this._owner?.deref();
 		if (owner) {
 			owner._onViewControllerShown(navigationController.tabBarController, viewController);
+
+			// The cascade above may have just attached a queued Page to a Frame whose
+			// Frame.onLoaded only fired post-animation. iOS won't re-layout on its own
+			// after the push completes — trigger one so the late attachment becomes visible.
+			viewController?.view?.setNeedsLayout();
+			viewController?.view?.layoutIfNeeded();
 		}
 	}
 }
@@ -303,9 +317,8 @@ export class TabViewItem extends TabViewItemBase {
 export class TabView extends TabViewBase {
 	public viewController: UITabBarControllerImpl;
 	public items: TabViewItem[];
-
+	public moreNavigationControllerDelegate: UINavigationControllerDelegateImpl;
 	private _delegate: UITabBarControllerDelegateImpl;
-	private _moreNavigationControllerDelegate: UINavigationControllerDelegateImpl;
 	private _iconsCache = {};
 	private _bottomAccessoryNsView: View;
 	private _ios: UITabBarControllerImpl;
@@ -327,12 +340,12 @@ export class TabView extends TabViewBase {
 	initNativeView() {
 		super.initNativeView();
 		this._delegate = UITabBarControllerDelegateImpl.initWithOwner(new WeakRef(this));
-		this._moreNavigationControllerDelegate = UINavigationControllerDelegateImpl.initWithOwner(new WeakRef(this));
+		this.moreNavigationControllerDelegate = UINavigationControllerDelegateImpl.initWithOwner(new WeakRef(this));
 	}
 
 	disposeNativeView() {
 		this._delegate = null;
-		this._moreNavigationControllerDelegate = null;
+		this.moreNavigationControllerDelegate = null;
 		this.viewController = null;
 		this._ios = null;
 		super.disposeNativeView();
@@ -590,7 +603,7 @@ export class TabView extends TabViewBase {
 		}
 
 		// When we set this._ios.viewControllers, someone is clearing the moreNavigationController.delegate, so we have to reassign it each time here.
-		this._ios.moreNavigationController.delegate = this._moreNavigationControllerDelegate;
+		this._ios.moreNavigationController.delegate = this.moreNavigationControllerDelegate;
 	}
 
 	private _getIconRenderingMode(): UIImageRenderingMode {

--- a/packages/core/ui/tab-view/index.ios.ts
+++ b/packages/core/ui/tab-view/index.ios.ts
@@ -139,7 +139,7 @@ class UITabBarControllerDelegateImpl extends NSObject implements UITabBarControl
 			// delegate we set in setViewControllers. Re-assert it whenever any tab is
 			// selected so moreNav push/pop callbacks for tabs >= 5 still reach us.
 			const moreNav = tabBarController.moreNavigationController;
-			if (moreNav && moreNav.delegate !== owner.moreNavigationControllerDelegate) {
+			if (moreNav && owner.moreNavigationControllerDelegate && moreNav.delegate !== owner.moreNavigationControllerDelegate) {
 				moreNav.delegate = owner.moreNavigationControllerDelegate;
 			}
 			owner._onViewControllerShown(tabBarController, viewController);
@@ -603,7 +603,9 @@ export class TabView extends TabViewBase {
 		}
 
 		// When we set this._ios.viewControllers, someone is clearing the moreNavigationController.delegate, so we have to reassign it each time here.
-		this._ios.moreNavigationController.delegate = this.moreNavigationControllerDelegate;
+		if (this._ios.moreNavigationController) {
+            this._ios.moreNavigationController.delegate = this.moreNavigationControllerDelegate;
+        }
 	}
 
 	private _getIconRenderingMode(): UIImageRenderingMode {


### PR DESCRIPTION
- Fixes cases when iOS auto rolls up extended `TabView` items which could result in white screens on the `Page`/`Frame` due to timing around delegate events.