### PR TITLE
ref(core): Application sdk css classes rework

### DIFF
--- a/apps/automated/src/ui/page/page-tests-common.ts
+++ b/apps/automated/src/ui/page/page-tests-common.ts
@@ -1,4 +1,4 @@
-import { Page, ShownModallyData, NavigatedData, View, PercentLength, unsetValue, EventData, Frame, NavigationEntry, TabView, TabViewItem, Button, Color, Label, StackLayout, Application, Utils, Builder } from '@nativescript/core';
+import { Page, ShownModallyData, NavigatedData, View, PercentLength, unsetValue, EventData, Frame, NavigationEntry, TabView, TabViewItem, Button, Color, Label, StackLayout, Utils, Builder } from '@nativescript/core';
 
 // >> article-set-bindingcontext
 export function pageLoaded(args) {

--- a/apps/automated/src/ui/styling/root-views-css-classes-tests.ts
+++ b/apps/automated/src/ui/styling/root-views-css-classes-tests.ts
@@ -54,6 +54,35 @@ function _test_platform_css_class(rootView: View, shouldSetClassName: boolean) {
 	}
 }
 
+function _test_platform_sdk_css_class(rootView: View, shouldSetClassName: boolean) {
+	if (shouldSetClassName) {
+		rootView.className = CLASS_NAME;
+	}
+
+	const cssClasses = rootView.cssClasses;
+	const deviceType = Device.os.toLowerCase();
+	const majorVersion = Math.floor(Utils.SDK_VERSION);
+	const sdkClass = `ns-${deviceType}-${majorVersion}`;
+
+	if (isAndroid) {
+		const iosSdkClass = `ns-ios-${majorVersion}`;
+		const visionosSdkClass = `ns-visionos-${majorVersion}`;
+
+		TKUnit.assertTrue(cssClasses.has(sdkClass), `${sdkClass} CSS class is missing`);
+		TKUnit.assertFalse(cssClasses.has(iosSdkClass), `${iosSdkClass} CSS class is present`);
+		TKUnit.assertFalse(cssClasses.has(visionosSdkClass), `${visionosSdkClass} CSS class is present`);
+	} else {
+		const androidSdkClass = `ns-android-${majorVersion}`;
+
+		TKUnit.assertTrue(cssClasses.has(sdkClass), `${sdkClass} CSS class is missing`);
+		TKUnit.assertFalse(cssClasses.has(androidSdkClass), `${androidSdkClass} CSS class is present`);
+	}
+
+	if (shouldSetClassName) {
+		TKUnit.assertTrue(cssClasses.has(CLASS_NAME), `${CLASS_NAME} CSS class is missing`);
+	}
+}
+
 function _test_device_type_css_class(rootView: View, shouldSetClassName: boolean) {
 	if (shouldSetClassName) {
 		rootView.className = CLASS_NAME;
@@ -188,6 +217,16 @@ export function test_root_view_class_name_preserve_platform_css_class() {
 	_test_platform_css_class(rootView, true);
 }
 
+export function test_root_view_platform_sdk_css_class() {
+	const rootView = Application.getRootView();
+	_test_platform_sdk_css_class(rootView, false);
+}
+
+export function test_root_view_class_name_preserve_platform_sdk_css_class() {
+	const rootView = Application.getRootView();
+	_test_platform_sdk_css_class(rootView, true);
+}
+
 export function test_root_view_device_type_css_class() {
 	const rootView = Application.getRootView();
 	_test_device_type_css_class(rootView, false);
@@ -216,6 +255,16 @@ export function test_root_view_system_appearance_css_class() {
 export function test_root_view_class_name_preserve_system_appearance_css_class() {
 	const rootView = Application.getRootView();
 	_test_system_appearance_css_class(rootView, true);
+}
+
+export function test_root_view_layout_direction_css_class() {
+	const rootView = Application.getRootView();
+	_test_layout_direction_css_class(rootView, false);
+}
+
+export function test_root_view_class_name_preserve_layout_direction_css_class() {
+	const rootView = Application.getRootView();
+	_test_layout_direction_css_class(rootView, true);
 }
 
 // Modal root view

--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -307,6 +307,9 @@ export class ApplicationCommon {
 			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}`);
 
 			// SDK Version CSS classes
+			// Add exact version class (e.g., .ns-ios-26 or .ns-android-36)
+			// this acts like 'gte' for that major version range
+			// e.g., if user wants iOS 27, they can add .ns-ios-27 specifiers
 			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}-${Math.floor(SDK_VERSION)}`);
 		}
 

--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -36,54 +36,6 @@ const LAYOUT_DIRECTION_CSS_CLASSES = [
 	`${CSSUtils.CLASS_PREFIX}${CoreTypes.LayoutDirection.rtl}`,
 ];
 
-// SDK Version CSS classes
-let sdkVersionClasses: string[] = [];
-
-export function initializeSdkVersionClass(rootView: View): void {
-	const majorVersion = Math.floor(SDK_VERSION);
-	sdkVersionClasses = [];
-
-	let platformPrefix = '';
-	if (__APPLE__) {
-		platformPrefix = __VISIONOS__ ? 'ns-visionos' : 'ns-ios';
-	} else if (__ANDROID__) {
-		platformPrefix = 'ns-android';
-	}
-
-	if (platformPrefix) {
-		// Add exact version class (e.g., .ns-ios-26 or .ns-android-36)
-		// this acts like 'gte' for that major version range
-		// e.g., if user wants iOS 27, they can add .ns-ios-27 specifiers
-		sdkVersionClasses.push(`${platformPrefix}-${majorVersion}`);
-	}
-
-	// Apply the SDK version classes to root views
-	applySdkVersionClass(rootView);
-}
-
-function applySdkVersionClass(rootView: View): void {
-	if (!sdkVersionClasses.length) {
-		return;
-	}
-
-	if (!rootView) {
-		return;
-	}
-
-	// Batch apply all SDK version classes to root view for better performance
-	const classesToAdd = sdkVersionClasses.filter((className) => !rootView.cssClasses.has(className));
-	classesToAdd.forEach((className) => rootView.cssClasses.add(className));
-
-	// Apply to modal views only if there are any
-	const rootModalViews = <Array<View>>rootView._getRootModalViews();
-	if (rootModalViews.length > 0) {
-		rootModalViews.forEach((rootModalView) => {
-			const modalClassesToAdd = sdkVersionClasses.filter((className) => !rootModalView.cssClasses.has(className));
-			modalClassesToAdd.forEach((className) => rootModalView.cssClasses.add(className));
-		});
-	}
-}
-
 const globalEvents = getNativeScriptGlobals().events;
 
 // Scene lifecycle event names
@@ -346,6 +298,7 @@ export class ApplicationCommon {
 
 	private setRootViewCSSClasses(rootView: View): void {
 		const platform = Device.os.toLowerCase();
+		const majorVersion = Math.floor(SDK_VERSION);
 		const deviceType = Device.deviceType.toLowerCase();
 		const orientation = this.orientation();
 		const systemAppearance = this.systemAppearance();
@@ -353,6 +306,9 @@ export class ApplicationCommon {
 
 		if (platform) {
 			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}`);
+
+			// SDK Version CSS classes
+			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}-${majorVersion}`);
 		}
 
 		if (deviceType) {

--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -298,7 +298,6 @@ export class ApplicationCommon {
 
 	private setRootViewCSSClasses(rootView: View): void {
 		const platform = Device.os.toLowerCase();
-		const majorVersion = Math.floor(SDK_VERSION);
 		const deviceType = Device.deviceType.toLowerCase();
 		const orientation = this.orientation();
 		const systemAppearance = this.systemAppearance();
@@ -308,7 +307,7 @@ export class ApplicationCommon {
 			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}`);
 
 			// SDK Version CSS classes
-			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}-${majorVersion}`);
+			CSSUtils.pushToSystemCssClasses(`${CSSUtils.CLASS_PREFIX}${platform}-${Math.floor(SDK_VERSION)}`);
 		}
 
 		if (deviceType) {

--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -4,7 +4,7 @@ import type { View } from '../ui/core/view';
 import { AndroidActivityCallbacks, NavigationEntry } from '../ui/frame/frame-common';
 import { SDK_VERSION } from '../utils/constants';
 import { android as androidUtils } from '../utils';
-import { ApplicationCommon, initializeSdkVersionClass } from './application-common';
+import { ApplicationCommon } from './application-common';
 import type { AndroidActivityBundleEventData, AndroidActivityEventData, ApplicationEventData } from './application-interfaces';
 import { Observable } from '../data/observable';
 import { Trace } from '../trace';
@@ -819,7 +819,7 @@ export class AccessibilityServiceEnabledObservable extends CommonA11YServiceEnab
 }
 
 let accessibilityServiceObservable: AccessibilityServiceEnabledObservable;
-export function ensureClasses() {
+export function ensureA11Classes() {
 	if (accessibilityServiceObservable) {
 		return;
 	}
@@ -827,9 +827,6 @@ export function ensureClasses() {
 	setFontScaleCssClasses(new Map(VALID_FONT_SCALES.map((fs) => [fs, `a11y-fontscale-${Number(fs * 100).toFixed(0)}`])));
 
 	accessibilityServiceObservable = new AccessibilityServiceEnabledObservable();
-
-	// Initialize SDK version CSS class once
-	initializeSdkVersionClass(Application.getRootView());
 }
 
 export function updateCurrentHelperClasses(applyRootCssClass: (cssClasses: string[], newCssClass: string) => void): void {
@@ -884,7 +881,7 @@ export function updateCurrentHelperClasses(applyRootCssClass: (cssClasses: strin
 }
 
 export function initAccessibilityCssHelper(): void {
-	ensureClasses();
+	ensureA11Classes();
 	updateCurrentHelperClasses(applyRootCssClass);
 	applyFontScaleToRootViews();
 

--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -819,7 +819,7 @@ export class AccessibilityServiceEnabledObservable extends CommonA11YServiceEnab
 }
 
 let accessibilityServiceObservable: AccessibilityServiceEnabledObservable;
-export function ensureA11Classes() {
+export function ensureA11yClasses() {
 	if (accessibilityServiceObservable) {
 		return;
 	}
@@ -881,7 +881,7 @@ export function updateCurrentHelperClasses(applyRootCssClass: (cssClasses: strin
 }
 
 export function initAccessibilityCssHelper(): void {
-	ensureA11Classes();
+	ensureA11yClasses();
 	updateCurrentHelperClasses(applyRootCssClass);
 	applyFontScaleToRootViews();
 

--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -1666,7 +1666,7 @@ export class AccessibilityServiceEnabledObservable extends CommonA11YServiceEnab
 }
 
 let accessibilityServiceObservable: AccessibilityServiceEnabledObservable;
-export function ensureA11Classes() {
+export function ensureA11yClasses() {
 	if (accessibilityServiceObservable) {
 		return;
 	}
@@ -1754,7 +1754,7 @@ function applyFontScaleToRootViews(): void {
 }
 
 export function initAccessibilityCssHelper(): void {
-	ensureA11Classes();
+	ensureA11yClasses();
 	updateCurrentHelperClasses(applyRootCssClass);
 	applyFontScaleToRootViews();
 

--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -6,7 +6,7 @@ import type { NavigationEntry } from '../ui/frame/frame-interfaces';
 import { getWindow } from '../utils/native-helper';
 import { SDK_VERSION } from '../utils/constants';
 import { ios as iosUtils, dataSerialize } from '../utils/native-helper';
-import { ApplicationCommon, initializeSdkVersionClass, SceneEvents } from './application-common';
+import { ApplicationCommon, SceneEvents } from './application-common';
 import { ApplicationEventData, SceneEventData } from './application-interfaces';
 import { Observable } from '../data/observable';
 import type { iOSApplication as IiOSApplication } from './application';
@@ -1666,7 +1666,7 @@ export class AccessibilityServiceEnabledObservable extends CommonA11YServiceEnab
 }
 
 let accessibilityServiceObservable: AccessibilityServiceEnabledObservable;
-export function ensureClasses() {
+export function ensureA11Classes() {
 	if (accessibilityServiceObservable) {
 		return;
 	}
@@ -1674,9 +1674,6 @@ export function ensureClasses() {
 	setFontScaleCssClasses(new Map(VALID_FONT_SCALES.map((fs) => [fs, `a11y-fontscale-${Number(fs * 100).toFixed(0)}`])));
 
 	accessibilityServiceObservable = new AccessibilityServiceEnabledObservable();
-
-	// Initialize SDK version CSS class once
-	initializeSdkVersionClass(Application.getRootView());
 }
 
 export function updateCurrentHelperClasses(applyRootCssClass: (cssClasses: string[], newCssClass: string) => void): void {
@@ -1757,7 +1754,7 @@ function applyFontScaleToRootViews(): void {
 }
 
 export function initAccessibilityCssHelper(): void {
-	ensureClasses();
+	ensureA11Classes();
 	updateCurrentHelperClasses(applyRootCssClass);
 	applyFontScaleToRootViews();
 

--- a/packages/core/ui/action-bar/index.ios.ts
+++ b/packages/core/ui/action-bar/index.ios.ts
@@ -509,8 +509,6 @@ export class ActionBar extends ActionBarBase {
 			return;
 		}
 
-		console.log('ActionBar._onTitlePropertyChanged', this.title);
-
 		if (page.frame) {
 			page.frame._updateActionBar(page);
 		}

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -1,7 +1,6 @@
 import { parse as convertToCSSWhatSelector, Selector as CSSWhatSelector, DataType as CSSWhatDataType } from 'css-what';
 import '../../globals';
 import { isCssVariable } from '../core/properties';
-import { Trace, CoreTypes } from './styling-shared';
 import { isNullOrUndefined } from '../../utils/types';
 
 import * as ReworkCSS from '../../css';


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
Right now, Application module contains a quite sloppy implementation of SDK version CSS classes.
Few things to note regarding the current implementation:
- Core keeps a needless cache of these css classes in application module top-level
- Core attempts to apply these classes to modal views during startup (there are no modals during app startup)
- Core attempts to initialize these classes using a function that is specifically for initializing a11y CSS classes

## What is the new behavior?
This PR removes what's not needed and follows core API for applying system CSS classes.