### PR TITLE
fix(android): Corrected TabView fragment manager resolution

### DIFF
--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -88,7 +88,7 @@ function initializeNativeClasses() {
 
 			// For offset limit 0, load view here only if the index is selected as the minimum offset on native side is 1
 			// and we want to avoid accidental loaded lifecycles
-			if (tabView.androidOffscreenTabLimit != 0 || tabView.selectedIndex === this.index) {
+			if (tabView.androidOffscreenTabLimit > 0 || tabView.selectedIndex === this.index) {
 				tabItem.loadView(tabItem.view);
 			}
 			return tabItem.view.nativeViewProtected;

--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -170,7 +170,7 @@ function initializeNativeClasses() {
 
 		getPageTitle(index: number) {
 			const items = this.items;
-			if (index < 0 || index >= items.length) {
+			if (!items || index < 0 || index >= items.length) {
 				return '';
 			}
 
@@ -648,11 +648,15 @@ export class TabView extends TabViewBase {
 	}
 
 	private disposeCurrentFragments(): void {
-		const fragmentManager = this._getFragmentManager();
+		const fragmentManager: androidx.fragment.app.FragmentManager = this._getFragmentManager();
 		const transaction = fragmentManager.beginTransaction();
-		const fragments = <Array<any>>fragmentManager.getFragments().toArray();
-		for (let i = 0; i < fragments.length; i++) {
-			transaction.remove(fragments[i]);
+		const fragments: androidNative.Array<androidx.fragment.app.Fragment> = fragmentManager.getFragments().toArray();
+
+		for (let i = 0, length = fragments.length; i < length; i++) {
+			const fragment = fragments[i];
+			if (fragment?.['owner'] === this) {
+				transaction.remove(fragment);
+			}
 		}
 		transaction.commitNowAllowingStateLoss();
 	}

--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -1,7 +1,7 @@
 import { TabViewItem as TabViewItemDefinition } from '.';
 import { Font } from '../styling/font';
 
-import { TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty, tabTextColorProperty, tabBackgroundColorProperty, tabTextFontSizeProperty, selectedTabTextColorProperty, androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty, traceCategory, traceMissingIcon, androidIconRenderingModeProperty } from './tab-view-common';
+import { TabViewBase, TabViewItemBase, itemsProperty, selectedIndexProperty, tabTextColorProperty, tabBackgroundColorProperty, tabTextFontSizeProperty, selectedTabTextColorProperty, androidSelectedTabHighlightColorProperty, androidOffscreenTabLimitProperty, traceCategory, traceMissingIcon, androidIconRenderingModeProperty, androidTabsPositionProperty } from './tab-view-common';
 import { textTransformProperty, getTransformedText } from '../text-base';
 import { CoreTypes } from '../../core-types';
 import { ImageSource } from '../../image-source';
@@ -29,7 +29,7 @@ const INDEX = '_index';
 let PagerAdapter: PagerAdapter;
 let appResources: android.content.res.Resources;
 
-function makeFragmentName(viewId: number, id: number): string {
+function computeFragmentName(viewId: number, id: number): string {
 	return 'android:viewpager:' + viewId + ':' + id;
 }
 
@@ -81,17 +81,26 @@ function initializeNativeClasses() {
 		}
 
 		public onCreateView(inflater: android.view.LayoutInflater, container: android.view.ViewGroup, savedInstanceState: android.os.Bundle): android.view.View {
-			const tabItem = this.owner.items[this.index];
+			const tabView = this.owner;
+			const tabItem = tabView.items[this.index];
 
+			tabItem.canBeLoaded = true;
+
+			// For offset limit 0, load view here only if the index is selected as the minimum offset on native side is 1
+			// and we want to avoid accidental loaded lifecycles
+			if (tabView.androidOffscreenTabLimit != 0 || tabView.selectedIndex === this.index) {
+				tabItem.loadView(tabItem.view);
+			}
 			return tabItem.view.nativeViewProtected;
 		}
 
 		public onDestroyView() {
+			const tabItem = this.owner.items[this.index];
 			const hasRemovingParent = this.getRemovingParentFragment();
 
 			// Get view as bitmap and set it as background. This is workaround for the disapearing nested fragments.
 			// TODO: Consider removing it when update to androidx.fragment:1.2.0
-			if (hasRemovingParent && this.owner.selectedIndex === this.index) {
+			if (hasRemovingParent && this.owner.selectedIndex === this.index && this.owner.nativeViewProtected) {
 				const bitmapDrawable = new android.graphics.drawable.BitmapDrawable(appResources, this.backgroundBitmap);
 				this.owner._originalBackground = this.owner.backgroundColor || new Color('White');
 				this.owner.nativeViewProtected.setBackground(bitmapDrawable);
@@ -99,6 +108,11 @@ function initializeNativeClasses() {
 			}
 
 			super.onDestroyView();
+
+			if (tabItem) {
+				tabItem.canBeLoaded = false;
+				tabItem.unloadView(tabItem.view);
+			}
 		}
 
 		public onPause(): void {
@@ -106,7 +120,7 @@ function initializeNativeClasses() {
 
 			// Get view as bitmap and set it as background. This is workaround for the disapearing nested fragments.
 			// TODO: Consider removing it when update to androidx.fragment:1.2.0
-			if (hasRemovingParent && this.owner.selectedIndex === this.index) {
+			if (hasRemovingParent && this.owner.selectedIndex === this.index && this.owner.nativeViewProtected) {
 				this.backgroundBitmap = this.loadBitmapFromView(this.owner.nativeViewProtected);
 			}
 
@@ -176,7 +190,7 @@ function initializeNativeClasses() {
 			}
 
 			const itemId = this.getItemId(position);
-			const name = makeFragmentName(container.getId(), itemId);
+			const name = computeFragmentName(container.getId(), itemId);
 
 			let fragment: androidx.fragment.app.Fragment = fragmentManager.findFragmentByTag(name);
 			if (fragment != null) {
@@ -189,12 +203,6 @@ function initializeNativeClasses() {
 			if (fragment !== this.mCurrentPrimaryItem) {
 				fragment.setMenuVisibility(false);
 				fragment.setUserVisibleHint(false);
-			}
-
-			const tabItems = this.owner.items;
-			const tabItem = tabItems ? tabItems[position] : null;
-			if (tabItem) {
-				tabItem.canBeLoaded = true;
 			}
 
 			return fragment;
@@ -216,17 +224,15 @@ function initializeNativeClasses() {
 			if (this.mCurrentPrimaryItem === fragment) {
 				this.mCurrentPrimaryItem = null;
 			}
-
-			const tabItems = this.owner.items;
-			const tabItem = tabItems ? tabItems[position] : null;
-			if (tabItem) {
-				tabItem.canBeLoaded = false;
-			}
 		}
 
 		setPrimaryItem(container: android.view.ViewGroup, position: number, object: java.lang.Object): void {
 			const fragment = <androidx.fragment.app.Fragment>object;
 			if (fragment !== this.mCurrentPrimaryItem) {
+				const tabView = this.owner;
+				const tabItems = tabView.items;
+				const newTabItem = tabItems ? tabItems[position] : null;
+
 				if (this.mCurrentPrimaryItem != null) {
 					this.mCurrentPrimaryItem.setMenuVisibility(false);
 					this.mCurrentPrimaryItem.setUserVisibleHint(false);
@@ -240,12 +246,8 @@ function initializeNativeClasses() {
 				this.mCurrentPrimaryItem = fragment;
 				this.owner.selectedIndex = position;
 
-				const tab = this.owner;
-				const tabItems = tab.items;
-				const newTabItem = tabItems ? tabItems[position] : null;
-
 				if (newTabItem) {
-					tab._loadUnloadTabItems(tab.selectedIndex);
+					tabView._loadUnloadTabItems(tabView.selectedIndex);
 				}
 			}
 		}
@@ -364,7 +366,7 @@ export class TabViewItem extends TabViewItemBase {
 	}
 
 	public disposeNativeView(): void {
-		(<TabViewItemDefinition>this).canBeLoaded = false;
+		this.canBeLoaded = false;
 		super.disposeNativeView();
 	}
 
@@ -383,23 +385,23 @@ export class TabViewItem extends TabViewItemBase {
 
 	public _getChildFragmentManager(): androidx.fragment.app.FragmentManager {
 		const tabView = this.parent as TabView;
-		let tabFragment = null;
 		const fragmentManager = tabView._getFragmentManager();
 		const fragments = fragmentManager.getFragments().toArray();
-		for (let i = 0; i < fragments.length; i++) {
+		let tabFragment = null;
+
+		for (let i = 0, length = fragments.length; i < length; i++) {
 			if (fragments[i].index === this.index) {
 				tabFragment = fragments[i];
 				break;
 			}
 		}
 
-		// TODO: can happen in a modal tabview scenario when the modal dialog fragment is already removed
 		if (!tabFragment) {
 			if (Trace.isEnabled()) {
 				Trace.write(`Could not get child fragment manager for tab item with index ${this.index}`, traceCategory);
 			}
 
-			return (<any>tabView)._getRootFragmentManager();
+			return tabView._getFragmentManager();
 		}
 
 		return tabFragment.getChildFragmentManager();
@@ -461,7 +463,10 @@ function iterateIndexRange(index: number, eps: number, lastIndex: number, callba
 export class TabView extends TabViewBase {
 	private _tabLayout: org.nativescript.widgets.TabLayout;
 	private _viewPager: androidx.viewpager.widget.ViewPager;
-	private _pagerAdapter: androidx.viewpager.widget.PagerAdapter;
+	private _pagerAdapter: androidx.viewpager.widget.PagerAdapter & {
+		owner: TabView;
+		items: Array<TabViewItemDefinition>;
+	};
 	private _androidViewId = -1;
 	public _originalBackground: any;
 
@@ -559,11 +564,11 @@ export class TabView extends TabViewBase {
 		const nativeView: any = this.nativeViewProtected;
 		this._tabLayout = (<any>nativeView).tabLayout;
 
-		const viewPager = (<any>nativeView).viewPager;
+		const viewPager: androidx.viewpager.widget.ViewPager = (<any>nativeView).viewPager;
 		viewPager.setId(this._androidViewId);
 		this._viewPager = viewPager;
 		this._pagerAdapter = (<any>viewPager).adapter;
-		(<any>this._pagerAdapter).owner = this;
+		this._pagerAdapter.owner = this;
 	}
 
 	public _loadUnloadTabItems(newIndex: number) {
@@ -628,7 +633,7 @@ export class TabView extends TabViewBase {
 
 	public disposeNativeView() {
 		this._tabLayout.setItems(null, null);
-		(<any>this._pagerAdapter).owner = null;
+		this._pagerAdapter.owner = null;
 		this._pagerAdapter = null;
 
 		this._tabLayout = null;
@@ -661,7 +666,7 @@ export class TabView extends TabViewBase {
 			return false;
 		}
 
-		const currentPagerAdapterItems = (<any>this._pagerAdapter).items;
+		const currentPagerAdapterItems = this._pagerAdapter.items;
 
 		// if both values are null, should not update
 		if (!items && !currentPagerAdapterItems) {
@@ -695,7 +700,7 @@ export class TabView extends TabViewBase {
 
 	private setAdapterItems(items: Array<TabViewItemDefinition>) {
 		if (this.shouldUpdateAdapter(items)) {
-			(<any>this._pagerAdapter).items = items;
+			this._pagerAdapter.items = items;
 
 			const length = items ? items.length : 0;
 			if (length === 0) {
@@ -742,7 +747,7 @@ export class TabView extends TabViewBase {
 		return this._viewPager.getOffscreenPageLimit();
 	}
 	[androidOffscreenTabLimitProperty.setNative](value: number) {
-		this._viewPager.setOffscreenPageLimit(value);
+		this._viewPager.setOffscreenPageLimit(this.androidTabsPosition === 'top' ? value : 1);
 	}
 
 	[androidIconRenderingModeProperty.getDefault](): 'alwaysOriginal' | 'alwaysTemplate' {
@@ -750,6 +755,10 @@ export class TabView extends TabViewBase {
 	}
 	[androidIconRenderingModeProperty.setNative](value: 'alwaysOriginal' | 'alwaysTemplate') {
 		this._tabLayout.setIconRenderingMode(this.getNativeRenderingMode(value));
+	}
+
+	[androidTabsPositionProperty.setNative](value: 'top' | 'bottom') {
+		this._viewPager.setOffscreenPageLimit(value === 'top' ? this.androidOffscreenTabLimit : 1);
 	}
 
 	[selectedIndexProperty.setNative](value: number) {

--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -29,8 +29,8 @@ const INDEX = '_index';
 let PagerAdapter: PagerAdapter;
 let appResources: android.content.res.Resources;
 
-function computeFragmentName(viewId: number, id: number): string {
-	return 'android:viewpager:' + viewId + ':' + id;
+function computeFragmentName(viewId: number, index: number): string {
+	return 'android:viewpager:' + viewId + ':' + index;
 }
 
 function getTabById(id: number): TabView {
@@ -189,8 +189,7 @@ function initializeNativeClasses() {
 				this.mCurTransaction = fragmentManager.beginTransaction();
 			}
 
-			const itemId = this.getItemId(position);
-			const name = computeFragmentName(container.getId(), itemId);
+			const name = computeFragmentName(container.getId(), position);
 
 			let fragment: androidx.fragment.app.Fragment = fragmentManager.findFragmentByTag(name);
 			if (fragment != null) {
@@ -272,9 +271,9 @@ function initializeNativeClasses() {
 			//
 		}
 
-		getItemId(position: number): number {
-			return position;
-		}
+		// getItemId(position: number): number {
+		// 	return position;
+		// }
 
 		private _commitCurrentTransaction() {
 			if (this.mCurTransaction != null && !this.transactionRunning) {
@@ -385,23 +384,16 @@ export class TabViewItem extends TabViewItemBase {
 
 	public _getChildFragmentManager(): androidx.fragment.app.FragmentManager {
 		const tabView = this.parent as TabView;
-		const fragmentManager = tabView._getFragmentManager();
-		const fragments = fragmentManager.getFragments().toArray();
-		let tabFragment = null;
-
-		for (let i = 0, length = fragments.length; i < length; i++) {
-			if (fragments[i].index === this.index) {
-				tabFragment = fragments[i];
-				break;
-			}
-		}
+		const fragmentManager: androidx.fragment.app.FragmentManager = tabView._getFragmentManager();
+		const tabFragmentTag = tabView._getTabFragmentTagByIndex(this.index);
+		const tabFragment = fragmentManager.findFragmentByTag(tabFragmentTag);
 
 		if (!tabFragment) {
 			if (Trace.isEnabled()) {
 				Trace.write(`Could not get child fragment manager for tab item with index ${this.index}`, traceCategory);
 			}
 
-			return tabView._getFragmentManager();
+			return fragmentManager;
 		}
 
 		return tabFragment.getChildFragmentManager();
@@ -611,6 +603,10 @@ export class TabView extends TabViewBase {
 				item.loadView(item.view);
 			}
 		});
+	}
+
+	public _getTabFragmentTagByIndex(index: number): string {
+		return computeFragmentName(this._androidViewId, index);
 	}
 
 	public onLoaded(): void {

--- a/packages/core/ui/tab-view/index.android.ts
+++ b/packages/core/ui/tab-view/index.android.ts
@@ -21,7 +21,7 @@ const PRIMARY_COLOR = 'colorPrimary';
 const DEFAULT_ELEVATION = 4;
 
 interface PagerAdapter {
-	new (owner: TabView): androidx.viewpager.widget.PagerAdapter;
+	new (owner: WeakRef<TabView>): androidx.viewpager.widget.PagerAdapter;
 }
 
 const TABID = '_tabId';
@@ -156,7 +156,7 @@ function initializeNativeClasses() {
 		// we prevent that here.
 		private transactionRunning = false;
 
-		constructor(public owner: TabView) {
+		constructor(private owner: WeakRef<TabView>) {
 			super();
 
 			return global.__native(this);
@@ -164,7 +164,6 @@ function initializeNativeClasses() {
 
 		getCount() {
 			const items = this.items;
-
 			return items ? items.length : 0;
 		}
 
@@ -184,7 +183,12 @@ function initializeNativeClasses() {
 		}
 
 		instantiateItem(container: android.view.ViewGroup, position: number): java.lang.Object {
-			const fragmentManager = this.owner._getFragmentManager();
+			const owner = this.owner?.get();
+			if (!owner) {
+				return null;
+			}
+
+			const fragmentManager = owner._getFragmentManager();
 			if (!this.mCurTransaction) {
 				this.mCurTransaction = fragmentManager.beginTransaction();
 			}
@@ -195,7 +199,7 @@ function initializeNativeClasses() {
 			if (fragment != null) {
 				this.mCurTransaction.attach(fragment);
 			} else {
-				fragment = TabFragmentImplementation.newInstance(this.owner._domId, position);
+				fragment = TabFragmentImplementation.newInstance(owner._domId, position);
 				this.mCurTransaction.add(container.getId(), fragment, name);
 			}
 
@@ -212,8 +216,13 @@ function initializeNativeClasses() {
 		}
 
 		destroyItem(container: android.view.ViewGroup, position: number, object: java.lang.Object): void {
+			const owner = this.owner?.get();
+			if (!owner) {
+				return;
+			}
+
 			if (!this.mCurTransaction) {
-				const fragmentManager = this.owner._getFragmentManager();
+				const fragmentManager = owner._getFragmentManager();
 				this.mCurTransaction = fragmentManager.beginTransaction();
 			}
 
@@ -226,10 +235,14 @@ function initializeNativeClasses() {
 		}
 
 		setPrimaryItem(container: android.view.ViewGroup, position: number, object: java.lang.Object): void {
+			const owner = this.owner?.get();
+			if (!owner) {
+				return;
+			}
+
 			const fragment = <androidx.fragment.app.Fragment>object;
 			if (fragment !== this.mCurrentPrimaryItem) {
-				const tabView = this.owner;
-				const tabItems = tabView.items;
+				const tabItems = owner.items;
 				const newTabItem = tabItems ? tabItems[position] : null;
 
 				if (this.mCurrentPrimaryItem != null) {
@@ -243,10 +256,10 @@ function initializeNativeClasses() {
 				}
 
 				this.mCurrentPrimaryItem = fragment;
-				this.owner.selectedIndex = position;
+				owner.selectedIndex = position;
 
 				if (newTabItem) {
-					tabView._loadUnloadTabItems(tabView.selectedIndex);
+					owner._loadUnloadTabItems(owner.selectedIndex);
 				}
 			}
 		}
@@ -456,7 +469,6 @@ export class TabView extends TabViewBase {
 	private _tabLayout: org.nativescript.widgets.TabLayout;
 	private _viewPager: androidx.viewpager.widget.ViewPager;
 	private _pagerAdapter: androidx.viewpager.widget.PagerAdapter & {
-		owner: TabView;
 		items: Array<TabViewItemDefinition>;
 	};
 	private _androidViewId = -1;
@@ -527,7 +539,7 @@ export class TabView extends TabViewBase {
 		nativeView.addView(viewPager);
 		(<any>nativeView).viewPager = viewPager;
 
-		const adapter = new PagerAdapter(this);
+		const adapter = new PagerAdapter(new WeakRef(this));
 		viewPager.setAdapter(adapter);
 		(<any>viewPager).adapter = adapter;
 
@@ -560,7 +572,6 @@ export class TabView extends TabViewBase {
 		viewPager.setId(this._androidViewId);
 		this._viewPager = viewPager;
 		this._pagerAdapter = (<any>viewPager).adapter;
-		this._pagerAdapter.owner = this;
 	}
 
 	public _loadUnloadTabItems(newIndex: number) {
@@ -629,7 +640,6 @@ export class TabView extends TabViewBase {
 
 	public disposeNativeView() {
 		this._tabLayout.setItems(null, null);
-		this._pagerAdapter.owner = null;
 		this._pagerAdapter = null;
 
 		this._tabLayout = null;

--- a/packages/core/ui/tab-view/index.ios.ts
+++ b/packages/core/ui/tab-view/index.ios.ts
@@ -244,6 +244,7 @@ export class TabViewItem extends TabViewItemBase {
 
 	public disposeNativeView() {
 		this.__controller = undefined;
+		this.canBeLoaded = false;
 		this.setNativeView(undefined);
 	}
 
@@ -565,7 +566,7 @@ export class TabView extends TabViewBase {
 				}
 
 				tabs.push(tab);
-				(<TabViewItemDefinition>item).canBeLoaded = true;
+				item.canBeLoaded = true;
 			});
 
 			try {
@@ -591,7 +592,7 @@ export class TabView extends TabViewBase {
 
 				controller.tabBarItem = tabBarItem;
 				controllers.push(controller);
-				(<TabViewItemDefinition>item).canBeLoaded = true;
+				item.canBeLoaded = true;
 			});
 
 			if (SDK_VERSION >= 15) {

--- a/packages/core/ui/tab-view/tab-view-common.ts
+++ b/packages/core/ui/tab-view/tab-view-common.ts
@@ -12,6 +12,8 @@ export const traceCategory = 'TabView';
 
 @CSSType('TabViewItem')
 export abstract class TabViewItemBase extends ViewBase implements TabViewItemDefinition, AddChildFromBuilder {
+	declare canBeLoaded?: boolean;
+
 	role: string;
 	private _title = '';
 	private _view: View;
@@ -76,7 +78,7 @@ export abstract class TabViewItemBase extends ViewBase implements TabViewItemDef
 		const tabView = this.parent as TabViewBase;
 		if (tabView && tabView.items) {
 			// Don't load items until their fragments are instantiated.
-			if ((<TabViewItemDefinition>this).canBeLoaded) {
+			if (this.canBeLoaded) {
 				super.loadView(view);
 			}
 		}
@@ -260,10 +262,16 @@ export const itemsProperty = new Property<TabViewBase, TabViewItemDefinition[]>(
 });
 itemsProperty.register(TabViewBase);
 
-export const iosIconRenderingModeProperty = new Property<TabViewBase, 'automatic' | 'alwaysOriginal' | 'alwaysTemplate'>({ name: 'iosIconRenderingMode', defaultValue: 'automatic' });
+export const iosIconRenderingModeProperty = new Property<TabViewBase, 'automatic' | 'alwaysOriginal' | 'alwaysTemplate'>({
+	name: 'iosIconRenderingMode',
+	defaultValue: 'automatic',
+});
 iosIconRenderingModeProperty.register(TabViewBase);
 
-export const androidIconRenderingModeProperty = new Property<TabViewBase, 'alwaysOriginal' | 'alwaysTemplate'>({ name: 'androidIconRenderingMode', defaultValue: 'alwaysOriginal' });
+export const androidIconRenderingModeProperty = new Property<TabViewBase, 'alwaysOriginal' | 'alwaysTemplate'>({
+	name: 'androidIconRenderingMode',
+	defaultValue: 'alwaysOriginal',
+});
 androidIconRenderingModeProperty.register(TabViewBase);
 
 export const androidOffscreenTabLimitProperty = new Property<TabViewBase, number>({
@@ -274,7 +282,10 @@ export const androidOffscreenTabLimitProperty = new Property<TabViewBase, number
 });
 androidOffscreenTabLimitProperty.register(TabViewBase);
 
-export const androidTabsPositionProperty = new Property<TabViewBase, 'top' | 'bottom'>({ name: 'androidTabsPosition', defaultValue: 'top' });
+export const androidTabsPositionProperty = new Property<TabViewBase, 'top' | 'bottom'>({
+	name: 'androidTabsPosition',
+	defaultValue: 'top',
+});
 androidTabsPositionProperty.register(TabViewBase);
 
 export const androidSwipeEnabledProperty = new Property<TabViewBase, boolean>({


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
This is the second attempt after #11217.
Apparently, entering tab item `loaded` lifecycle during adapter `attach` is too early and tab frame fragments don't get enough time to be added to the correct fragment manager.

## What is the new behavior?
This PR takes a few things from ui-material tabs plugin:
- Uses the fragment onCreateView/onDestroyView fragment lifecycles to ensure view `loaded` lifecycle is called at the right time (see [line](https://github.com/nativescript-community/ui-material-components/blob/master/src/core-tabs/tab-navigation/index.android.ts#L105), [commit](https://github.com/nativescript-community/ui-material-components/commit/1eff66f4cf797756e8987c2cc95159435ed39551#diff-0497289a88b4e03a422e5e01d4bf64edce775ac71f4d9069eafbdc56cb1442b2))
- Safety checks for opening/closing modals that contain a tab view

It seems we don't really need the material plugin [approach](https://github.com/nativescript-community/ui-material-components/blob/888a82acf541fdf879fb69d18dfdf8af686d9738/src/core-tabs/tab-content-item/index.android.ts#L45) for retrieving child fragment manager since adapter always adds/attaches fragments to `tabView._getFragmentManager()`, so this PR uses the fragment tag to resolve the tab fragment directly and consequently the child fragment manager [here](https://github.com/CatchABus/NativeScript/blob/01af9dd92ae1e75b9b8e83a1e87a54789e7ae571/packages/core/ui/tab-view/index.android.ts#L388).

Fixes https://github.com/NativeScript/NativeScript/issues/10165.