### PR TITLE
fix(android): Removed invalid default padding conversion

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -991,10 +991,10 @@ export class View extends ViewCommon {
 
 	public override _setDefaultPaddings(insets: android.graphics.Rect): void {
 		if (insets) {
-			this._defaultPaddingTop = layout.toDevicePixels(insets.top);
-			this._defaultPaddingRight = layout.toDevicePixels(insets.right);
-			this._defaultPaddingBottom = layout.toDevicePixels(insets.bottom);
-			this._defaultPaddingLeft = layout.toDevicePixels(insets.left);
+			this._defaultPaddingTop = insets.top;
+			this._defaultPaddingRight = insets.right;
+			this._defaultPaddingBottom = insets.bottom;
+			this._defaultPaddingLeft = insets.left;
 		} else {
 			this._defaultPaddingTop = 0;
 			this._defaultPaddingRight = 0;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.


## What is the new behavior?
This PR fixes an android padding regression caused originally by #11216
