### PR TITLE
fix(android): edge to edge default behaviour

### DIFF
--- a/packages/core/ui/core/view/index.android.ts
+++ b/packages/core/ui/core/view/index.android.ts
@@ -1806,7 +1806,7 @@ export class ContainerView extends View {
 
 	constructor() {
 		super();
-		this.androidOverflowEdge = 'none';
+		this.androidOverflowEdge = 'ignore';
 	}
 }
 

--- a/packages/core/ui/page/index.android.ts
+++ b/packages/core/ui/page/index.android.ts
@@ -13,6 +13,11 @@ export * from './page-common';
 export class Page extends PageBase {
 	nativeViewProtected: org.nativescript.widgets.GridLayout;
 
+	constructor() {
+		super();
+		this.androidOverflowEdge = 'none';
+	}
+
 	public createNativeView() {
 		const layout = new org.nativescript.widgets.GridLayout(this._context);
 		layout.addRowsFromJSON(


### PR DESCRIPTION
This pull request updates the handling of the `androidOverflowEdge` property in Android-specific UI components. The main change is to align the default behavior of overflow edge handling between the `ContainerView` and `Page` classes.

Android overflow edge handling:

* Changed the default value of `androidOverflowEdge` in the `ContainerView` constructor from `'none'` to `'ignore'`, which alters how overflow is managed for container views.
* Added an explicit initialization of `androidOverflowEdge` to `'none'` in the `Page` class constructor, ensuring consistent overflow edge behavior for pages.