### PR TITLE
fix: improve view teardown process for reusable views

### DIFF
--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -1264,7 +1264,7 @@ export abstract class ViewBase extends Observable {
 	 */
 	public destroyNode(forceDestroyChildren?: boolean): void {
 		this.reusable = false;
-		this.callUnloaded();
+		this.unloadView(this);
 		this._tearDownUI(forceDestroyChildren);
 	}
 
@@ -1284,7 +1284,9 @@ export abstract class ViewBase extends Observable {
 
 		if (!preserveNativeView) {
 			this.eachChild((child) => {
-				child._tearDownUI(force);
+				// if we decided to tear down the current view, we should also tear down the children, even if they are reusable
+				// the developer is responsible to detach them if they need to reuse them somewhere else
+				child._tearDownUI(true);
 
 				return true;
 			});


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When destroying a reusable view's node, two issues exist:

1. `destroyNode()` calls `callUnloaded()` unconditionally, even when the view was never loaded. This can fire `unloaded` lifecycle events (and run unload logic) on views that are not in a loaded state.
2. During `_tearDownUI()`, children are torn down by inheriting the parent's `force` flag (`child._tearDownUI(force)`). When the parent is being destroyed but a child is marked as `reusable`, the child's native view is preserved and skipped, leaving orphaned/leaked native views behind.

## What is the new behavior?
<!-- Describe the changes. -->

1. `destroyNode()` now uses `unloadView(this)`, which guards on `view.isLoaded` before calling `callUnloaded()`, so the unloaded path only runs for views that are actually loaded.
2. When a view is torn down, its children are now always torn down with `force = true` (`child._tearDownUI(true)`), regardless of whether they are marked reusable. Once a parent is being destroyed, its children are destroyed too. Developers who want to reuse a child elsewhere are responsible for detaching it beforehand.

Together these changes make the teardown process for reusable views more correct and prevent native view leaks.

