### PR TITLE
fix(core): Corrected fetch module DOMException reference

### DIFF
--- a/packages/core/fetch/index.mjs
+++ b/packages/core/fetch/index.mjs
@@ -459,7 +459,7 @@ try {
             var request = new Request(input, init);
 
             if (request.signal && request.signal.aborted) {
-                return reject(new exports.DOMException("Aborted", "AbortError"));
+                return reject(new DOMException("Aborted", "AbortError"));
             }
 
             var xhr = new XMLHttpRequest();
@@ -491,7 +491,7 @@ try {
             };
 
             xhr.onabort = function () {
-                reject(new exports.DOMException("Aborted", "AbortError"));
+                reject(new DOMException("Aborted", "AbortError"));
             };
 
             xhr.open(request.method, request.url, true);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In `@nativescript/core/fetch/index.mjs` `signal.aborted` and `xhr.onabort` are both still referencing `exports.DOMException` which seems to be the old CommonJS pattern. From my tests, without the change any fetch / axios `CancelToken` / `AbortController` cancellation will trigger `ReferenceError: exports is not defined at xhr.onabort`.

## What is the new behavior?
<!-- Describe the changes. -->
Updated `@nativescript/core/fetch/index.mjs` so that `DOMException` is referenced correctly. Rather than using `exports.DOMException` code now simply uses `DOMException`.

Fixes/Implements/Closes #11238.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

