### PR TITLE
fix(core): avoid firing removed event listeners

### DIFF
--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -40,6 +40,7 @@ interface ListenerEntry {
 	callback: (data: EventData) => void;
 	thisArg?: any;
 	once?: true;
+	_isRemoved?: true;
 }
 
 interface ListEntryMap {
@@ -301,7 +302,7 @@ export class Observable {
 
 			// If we have neither `thisArg` nor `callback`, just remove all events
 			// of this type regardless.
-
+			entry._isRemoved = true;
 			entries.splice(i, 1);
 			i--;
 		}
@@ -443,7 +444,7 @@ export class Observable {
 	}
 
 	private static _handleListenerEntry<T extends EventData>(entry: ListenerEntry, index: number, observers: Array<ListenerEntry>, data: T): void {
-		if (!entry) {
+		if (!entry || entry._isRemoved) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the new behavior?
Maintain the old behaviour before #10946 and avoid executing callbacks for removed entries.