### PR TITLE
fix(android): don't crash in Fragment.onCreateView on stale-fragment race

### DIFF
--- a/packages/core/ui/frame/frame-helper-for-android.ts
+++ b/packages/core/ui/frame/frame-helper-for-android.ts
@@ -112,21 +112,33 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 
 		const entry = this.entry;
 		if (!entry) {
-			Trace.error(`${fragment}.onCreateView: entry is null or undefined`);
+			// Recoverable race: a stale fragment is being driven to onCreateView by the
+			// FragmentManager after its entry was cleared.
+			// Using Trace.error (routes to an error handler, which throws) would be fatal as the error handler rethrows across the JNI boundary.
+			if (Trace.isEnabled()) {
+				Trace.write(`${fragment}.onCreateView: entry is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
+			}
 
 			return null;
 		}
 
 		const page = entry.resolvedPage;
 		if (!page) {
-			Trace.error(`${fragment}.onCreateView: entry has no resolvedPage`);
+			// Logging via Trace.error (routes to an error handler, which throws) here is fatal because the registered error handler rethrows across the JNI boundary.
+			if (Trace.isEnabled()) {
+				Trace.write(`${fragment}.onCreateView: entry has no resolvedPage`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
+			}
 
 			return null;
 		}
 
 		const frame = this.frame;
 		if (!frame) {
-			Trace.error(`${fragment}.onCreateView: this.frame is null or undefined`);
+			// Recoverable race: the owning frame was already torn down. Returning null discards
+			// this fragment; using Trace.error (routes to an error handler, which throws) would be fatal as the error handler rethrows across the JNI boundary.
+			if (Trace.isEnabled()) {
+				Trace.write(`${fragment}.onCreateView: this.frame is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
+			}
 
 			return null;
 		}

--- a/packages/core/ui/frame/frame-helper-for-android.ts
+++ b/packages/core/ui/frame/frame-helper-for-android.ts
@@ -115,6 +115,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 			// Recoverable race: a stale fragment is being driven to onCreateView by the
 			// FragmentManager after its entry was cleared.
 			// Using Trace.error (routes to an error handler, which throws) would be fatal as the error handler rethrows across the JNI boundary.
+			// Trace.write(..., Trace.messageType.error) logs without routing through that throwing path.
 			Trace.write(`${fragment}.onCreateView: entry is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;
@@ -123,6 +124,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 		const page = entry.resolvedPage;
 		if (!page) {
 			// Logging via Trace.error (routes to an error handler, which throws) here is fatal because the registered error handler rethrows across the JNI boundary.
+			// Trace.write(..., Trace.messageType.error) keeps this recoverable path non-fatal.
 			Trace.write(`${fragment}.onCreateView: entry has no resolvedPage`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;
@@ -132,6 +134,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 		if (!frame) {
 			// Recoverable race: the owning frame was already torn down. Returning null discards
 			// this fragment; using Trace.error (routes to an error handler, which throws) would be fatal as the error handler rethrows across the JNI boundary.
+			// Trace.write(..., Trace.messageType.error) logs without invoking the throwing error handler.
 			Trace.write(`${fragment}.onCreateView: this.frame is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;

--- a/packages/core/ui/frame/frame-helper-for-android.ts
+++ b/packages/core/ui/frame/frame-helper-for-android.ts
@@ -115,9 +115,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 			// Recoverable race: a stale fragment is being driven to onCreateView by the
 			// FragmentManager after its entry was cleared.
 			// Using Trace.error (routes to an error handler, which throws) would be fatal as the error handler rethrows across the JNI boundary.
-			if (Trace.isEnabled()) {
-				Trace.write(`${fragment}.onCreateView: entry is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
-			}
+			Trace.write(`${fragment}.onCreateView: entry is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;
 		}
@@ -125,9 +123,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 		const page = entry.resolvedPage;
 		if (!page) {
 			// Logging via Trace.error (routes to an error handler, which throws) here is fatal because the registered error handler rethrows across the JNI boundary.
-			if (Trace.isEnabled()) {
-				Trace.write(`${fragment}.onCreateView: entry has no resolvedPage`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
-			}
+			Trace.write(`${fragment}.onCreateView: entry has no resolvedPage`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;
 		}
@@ -136,9 +132,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 		if (!frame) {
 			// Recoverable race: the owning frame was already torn down. Returning null discards
 			// this fragment; using Trace.error (routes to an error handler, which throws) would be fatal as the error handler rethrows across the JNI boundary.
-			if (Trace.isEnabled()) {
-				Trace.write(`${fragment}.onCreateView: this.frame is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
-			}
+			Trace.write(`${fragment}.onCreateView: this.frame is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;
 		}


### PR DESCRIPTION
onCreateView already returns null when its entry, resolvedPage, or frame is missing, but it first called Trace.error, which rethrows through the registered error handler across the JNI boundary and turns the recoverable case into a fatal "Calling js method onCreateView failed" crash.

These nulls happen when the FragmentManager drives a stale fragment to CREATE_VIEW after NativeScript has already torn down the corresponding backstack entry (process death / activity recreation after rotation or theme change, clearHistory, or rapid navigate+goBack). The fragment should just be discarded, not crash the app.

Replace those three Trace.error calls with Trace.write using Trace.messageType.error, and remove the Trace.isEnabled guards around those writes so the logs are always emitted while the existing return-null recovery path is still reached (consistent with existing onDestroy handling of the same race).

Fixes production crashlytics reports:

```text
Fatal Exception: com.tns.NativeScriptException: Calling js method onCreateView failed
Error: fragment0[0]<null>.onCreateView: entry has no resolvedPage
       at com.tns.Runtime.callJSMethodNative(Runtime.java)
       at com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1441)
       at com.tns.Runtime.callJSMethodImpl(Runtime.java:1327)
       at com.tns.Runtime.callJSMethod(Runtime.java:1314)
       at com.tns.Runtime.callJSMethod(Runtime.java:1291)
       at com.tns.Runtime.callJSMethod(Runtime.java:1287)
       at com.tns.FragmentClass.onCreateView(FragmentClass.java:55)
       at androidx.fragment.app.Fragment.performCreateView(Fragment.java:3119)
       at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:577)
       at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
       at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2214)
       at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2109)
       at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2052)
       at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:703)
       at android.os.Handler.handleCallback(Handler.java:883)
       at android.os.Handler.dispatchMessage(Handler.java:100)
       at android.os.Looper.loop(Looper.java:214)
       at android.app.ActivityThread.main(ActivityThread.java:7631)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:964)
```