### PR TITLE
fix(ios): handle UIColor backgroundColor in Switch _onCheckedProperty…

### DIFF
--- a/packages/core/ui/switch/index.ios.ts
+++ b/packages/core/ui/switch/index.ios.ts
@@ -113,7 +113,8 @@ export class Switch extends SwitchBase {
 			super._onCheckedPropertyChanged(newValue);
 
 			if (this.offBackgroundColor) {
-				const nextColor = !newValue ? this.offBackgroundColor : this.backgroundColor instanceof Color ? this.backgroundColor : new Color(this.backgroundColor);
+				const bg = this.backgroundColor;
+				const nextColor = !newValue ? this.offBackgroundColor : bg instanceof Color ? bg : Color.fromIosColor(bg);
 
 				// On iOS 26+, coordinate with the system's switch animation:
 				// delay applying track color until the toggle animation finishes to avoid a janky mid-animation recolor.


### PR DESCRIPTION
## PR Checklist

* [x] The PR title follows the contribution guidelines.
* [x] There is an associated issue for this change.
* [x] The CLA has been signed.
* [ ] All existing tests are passing.
* [ ] Tests covering this change have been added.

## What is the current behavior?

Applying `color` or `backgroundColor` styles to a `Switch` on iOS can cause a crash when the switch is toggled to the checked (`on`) state.

The crash occurs in `_onCheckedPropertyChanged` when `backgroundColor` has been resolved to a native `UIColor` through the CSS styling system. The implementation assumes the value is either a NativeScript `Color` instance or a constructor-compatible value and attempts to create a new `Color` from the native object, resulting in an exception.

## What is the new behavior?

This change adds handling for native iOS color values when restoring the switch background color after toggling.

When `backgroundColor` is already a native color object, it is converted safely before being passed to `setNativeBackgroundColor`, preventing the runtime exception and allowing styled switches to function correctly.

Closes NativeScript/NativeScript#11266

### Breaking Changes

None.