### PR TITLE
fix(ios): prevent duplicate Application suspend/resume events when using UIScenes

### DIFF
--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -282,8 +282,6 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 		super();
 
 		this.addNotificationObserver(UIApplicationDidFinishLaunchingNotification, this.didFinishLaunchingWithOptions.bind(this));
-		this.addNotificationObserver(UIApplicationDidBecomeActiveNotification, this.didBecomeActive.bind(this));
-		this.addNotificationObserver(UIApplicationDidEnterBackgroundNotification, this.didEnterBackground.bind(this));
 		this.addNotificationObserver(UIApplicationWillTerminateNotification, this.willTerminate.bind(this));
 		this.addNotificationObserver(UIApplicationDidReceiveMemoryWarningNotification, this.didReceiveMemoryWarning.bind(this));
 		this.addNotificationObserver(UIApplicationDidChangeStatusBarOrientationNotification, this.didChangeStatusBarOrientation.bind(this));
@@ -295,6 +293,10 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 			this.addNotificationObserver('UISceneWillEnterForegroundNotification', this.sceneWillEnterForeground.bind(this));
 			this.addNotificationObserver('UISceneDidEnterBackgroundNotification', this.sceneDidEnterBackground.bind(this));
 			this.addNotificationObserver('UISceneDidDisconnectNotification', this.sceneDidDisconnect.bind(this));
+		} else {
+			// For scene-based apps, the below are not needed as they are handled by the scene notifications
+			this.addNotificationObserver(UIApplicationDidBecomeActiveNotification, this.didBecomeActive.bind(this));
+			this.addNotificationObserver(UIApplicationDidEnterBackgroundNotification, this.didEnterBackground.bind(this));
 		}
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using Scenes as per #10786 the Application resume and suspend events are fired twice ( along with other logic ).

This is because the [UIApplicationDidBecomeActiveNotification](https://developer.apple.com/documentation/uikit/uiscenedelegate/scenedidbecomeactive(_:)?language=objc) & `UIApplicationDidEnterBackgroundNotification` notifications are fired in addition to the Scene notifications.

## What is the new behavior?
<!-- Describe the changes. -->

If scenes are supported, then the notifications `UIApplicationDidBecomeActiveNotification` & `UIApplicationDidEnterBackgroundNotification ` are not subscribed to.

The only code that is not duplicated in the scene events is the call to `notifyAppStarted` but this appears to the handled by the changes in #11149. The slight concern would be that the `UIApplicationDidBecomeActiveNotification`  was handling it in some scenarios.



closes https://github.com/NativeScript/NativeScript/issues/11268
