### PR TITLE
fix(android): prevent memory leak from reused CustomTransition animator

### DIFF
--- a/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/CustomTransition.java
+++ b/packages/ui-mobile-base/android/widgets/src/main/java/org/nativescript/widgets/CustomTransition.java
@@ -58,24 +58,32 @@ public class CustomTransition extends Visibility {
 	}
 
 	private Animator setAnimatorsTarget(AnimatorSet animatorSet, final View view) {
-		ArrayList<Animator> animatorsList = animatorSet.getChildAnimations();
-		boolean resetOnTransitionEnd = this.resetOnTransitionEnd;
+		// IMPORTANT: run on a per-invocation clone instead of the shared this.animatorSet.
+		// androidx clones the transition for every run but shares this animatorSet field,
+		// and the framework adds its own end listeners (Visibility$OverlayListener, etc.) to
+		// the AnimatorSet we return. On a zero-duration ("none") transition those listeners
+		// are not always removed, so reusing a single shared AnimatorSet across navigations
+		// accumulates stale listeners - each one retaining the previous fragment and page,
+		// which leaks the whole navigation history. Cloning keeps the shared template clean
+		// and lets the throwaway run set (and its listeners) be collected after the transition.
+		AnimatorSet runSet = animatorSet.clone();
 
+		ArrayList<Animator> animatorsList = runSet.getChildAnimations();
 		for (int i = 0; i < animatorsList.size(); i++) {
 			animatorsList.get(i).setTarget(view);
 		}
 
 		// Reset animation to its initial state to prevent mirrorered effect
 		if (this.resetOnTransitionEnd) {
-			this.immediateAnimatorSet = this.animatorSet.clone();
+			this.immediateAnimatorSet = runSet.clone();
 		}
 
 		// Switching to hardware layer during transition to improve animation performance
 		CustomAnimatorListener listener = new CustomAnimatorListener(view);
-		animatorSet.addListener(listener);
+		runSet.addListener(listener);
 		this.addListener(new CustomTransitionListenerAdapter(this));
 
-		return this.animatorSet;
+		return runSet;
 	}
 
 	private class ReverseInterpolator implements Interpolator {
@@ -109,7 +117,7 @@ public class CustomTransition extends Visibility {
 
 	private static class CustomAnimatorListener extends AnimatorListenerAdapter {
 
-		private final View mView;
+		private View mView;
 		private boolean mLayerTypeChanged = false;
 
 		CustomAnimatorListener(View view) {
@@ -118,7 +126,8 @@ public class CustomTransition extends Visibility {
 
 		@Override
 		public void onAnimationStart(Animator animation) {
-			if (ViewCompat.hasOverlappingRendering(mView)
+			if (mView != null
+				&& ViewCompat.hasOverlappingRendering(mView)
 				&& mView.getLayerType() == View.LAYER_TYPE_NONE) {
 				mLayerTypeChanged = true;
 				mView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
@@ -127,9 +136,17 @@ public class CustomTransition extends Visibility {
 
 		@Override
 		public void onAnimationEnd(Animator animation) {
-			if (mLayerTypeChanged) {
+			if (mLayerTypeChanged && mView != null) {
 				mView.setLayerType(View.LAYER_TYPE_NONE, null);
 			}
+
+			// Release the strong reference to the animated view so the page/fragment
+			// can be garbage collected once navigation is done. The AnimatorSet (and in
+			// turn this listener) may be retained by the platform animation handler after
+			// the transition completes; without clearing mView that keeps the page's
+			// native view - and its linked JS object - alive forever.
+			animation.removeListener(this);
+			mView = null;
 		}
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

On Android, navigating forward/back with animations disabled leaks every visited page. `CustomTransition` exposes a single shared `AnimatorSet` (`this.animatorSet`) and returns it from `onAppear`/`onDisappear`. androidx clones the transition for each run but shares that field, and the framework attaches its own end listeners (`Visibility$OverlayListener`, etc.) to the returned `AnimatorSet`. For zero-duration ("none") navigation those listeners are not removed, so a reused `CustomTransition` accumulates one stale listener per navigation — each retaining the previous fragment and its page view. The leaked Java views in turn keep their linked JS objects alive, so the entire navigation history is held in memory forever (the chain roots through the live fragment's `Fragment$AnimationInfo` → `CustomTransition` → `AnimatorSet` → stale listeners → previous fragments).

With animations enabled the animator actually runs and ends, androidx removes those listeners, and nothing leaks — which is why the leak only reproduces with animations off.

## What is the new behavior?

`CustomTransition` now runs each transition on a per-invocation clone of the `AnimatorSet` instead of the shared instance, so the framework's end listeners land on a throwaway set and the shared template stays clean and collectable after the transition. It also releases the animated view reference (`mView`) when the animation ends. Pages and fragments are now garbage-collected after navigation regardless of whether animations are enabled.
