### PR TITLE
chore(core): added string types for LengthType properties

### DIFF
--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -35,9 +35,9 @@ export namespace CoreTypes {
 	export type LengthPxUnit = { readonly unit: 'px'; readonly value: px };
 	export type LengthPercentUnit = { readonly unit: '%'; readonly value: percent };
 
-	export type FixedLengthType = dip | LengthDipUnit | LengthPxUnit | CSSWideKeywords;
+	export type FixedLengthType = dip | LengthDipUnit | LengthPxUnit | `${number}dip` | `${number}px` | CSSWideKeywords;
 	export type LengthType = 'auto' | FixedLengthType;
-	export type PercentLengthType = 'auto' | FixedLengthType | LengthPercentUnit;
+	export type PercentLengthType = 'auto' | FixedLengthType | LengthPercentUnit | `${number}%`;
 
 	export const zeroLength: LengthType = {
 		value: 0,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
TypeScript complains when we use string values like `100%` on height/width properties.

## What is the new behavior?
Core types will accept these values provided that they are numeric and end with a supported unit.