### PR TITLE
fix(webpack): restore source map files and always respect env.sourceMap

### DIFF
--- a/packages/webpack5/src/configuration/base.ts
+++ b/packages/webpack5/src/configuration/base.ts
@@ -48,9 +48,12 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 	// by App Transport Security. A `data:` URL inlined in the bundle
 	// sidesteps all three since DevTools handles it without any network
 	// request. Production builds keep their configured devtool unchanged.
+
+	let defaultSourceMap: Config.DevTool = 'inline-source-map';
+
 	function useSourceMapFiles() {
 		if (mode === 'development') {
-			env.sourceMap = 'inline-source-map';
+			defaultSourceMap = 'source-map';
 		}
 	}
 	// determine target output by @nativescript/* runtime version
@@ -160,8 +163,6 @@ export default function (config: Config, env: IWebpackEnv = _env): Config {
 		.resolve.set('fullySpecified', false);
 
 	const getSourceMapType = (map: string | boolean): Config.DevTool => {
-		const defaultSourceMap = 'inline-source-map';
-
 		if (typeof map === 'undefined') {
 			// source-maps disabled in production by default
 			// enabled with --env.sourceMap=<type>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

For v9+ (ESM) dev builds, the webpack config called `useSourceMapFiles()`, which **overwrote** `env.sourceMap` with `'inline-source-map'`. This had two problems:

1. **`env.sourceMap` was silently ignored.** Since NativeScript 9, passing `--env.sourceMap=<type>` (e.g. `source-map`) on a dev build had no effect — the user's value was clobbered before `getSourceMapType()` ever saw it, so builds always emitted inline source maps regardless of what was requested.
2. **File (external) source maps were effectively lost.** Everything was forced inline, even though the Android and iOS runtimes are capable of loading `.map` files.

## What is the new behavior?

The clobbering of `env.sourceMap` is removed. Instead, the v9+ dev-build path only adjusts a local `defaultSourceMap` fallback (now `'source-map'`), which is used solely when the user hasn't specified `env.sourceMap`:

- **`env.sourceMap` is always respected again.** A user-provided `--env.sourceMap=<type>` (or `=true`/`=false`) now flows through `getSourceMapType()` unchanged, on both dev and production builds.
- **File source maps are restored** as the default for v9+ dev builds, so the Android/iOS runtimes once again handle external `.map` files properly instead of everything being inlined.
