### PR TITLE
fix(core): remove once listeners by identity, not stale index

### DIFF
--- a/packages/core/data/observable/index.spec.ts
+++ b/packages/core/data/observable/index.spec.ts
@@ -55,5 +55,48 @@ describe('Observable', () => {
 			expect(callCount1).toBe(1);
 			expect(callCount2).toBe(1);
 		});
+
+		it('fires just once when registered after a listener that removes itself', () => {
+			const observable = new Observable();
+			let selfRemovingCallCount = 0;
+			let onceCallCount = 0;
+			let regularCallCount = 0;
+			const selfRemovingHandler = function () {
+				selfRemovingCallCount++;
+				observable.off('test', selfRemovingHandler);
+			};
+			const onceHandler = function () {
+				onceCallCount++;
+			};
+			const regularHandler = function () {
+				regularCallCount++;
+			};
+			observable.on('test', selfRemovingHandler);
+			observable.once('test', onceHandler);
+			observable.on('test', regularHandler);
+			observable.notify({ eventName: 'test', object: observable });
+			observable.notify({ eventName: 'test', object: observable });
+			expect(selfRemovingCallCount).toBe(1);
+			expect(onceCallCount).toBe(1);
+			expect(regularCallCount).toBe(2);
+		});
+
+		it('fires each of two once listeners just once', () => {
+			const observable = new Observable();
+			let callCount1 = 0;
+			let callCount2 = 0;
+			observable.once('test', function () {
+				callCount1++;
+			});
+			observable.once('test', function () {
+				callCount2++;
+			});
+			observable.notify({ eventName: 'test', object: observable });
+			expect(callCount1).toBe(1);
+			expect(callCount2).toBe(1);
+			observable.notify({ eventName: 'test', object: observable });
+			expect(callCount1).toBe(1);
+			expect(callCount2).toBe(1);
+		});
 	});
 });

--- a/packages/core/data/observable/index.ts
+++ b/packages/core/data/observable/index.ts
@@ -430,26 +430,29 @@ export class Observable {
 		}
 
 		if (length === 1) {
-			const index = 0;
-			this._handleListenerEntry<T>(observers[index], index, observers, data);
+			this._handleListenerEntry<T>(observers[0], observers, data);
 		} else {
 			// This keeps a copy of observers list to ensure concurrency
 			const observersCp = observers.slice();
 
 			for (let i = 0; i < length; i++) {
 				const entry = observersCp[i];
-				this._handleListenerEntry<T>(entry, i, observers, data);
+				this._handleListenerEntry<T>(entry, observers, data);
 			}
 		}
 	}
 
-	private static _handleListenerEntry<T extends EventData>(entry: ListenerEntry, index: number, observers: Array<ListenerEntry>, data: T): void {
+	private static _handleListenerEntry<T extends EventData>(entry: ListenerEntry, observers: Array<ListenerEntry>, data: T): void {
 		if (!entry || entry._isRemoved) {
 			return;
 		}
 
 		if (entry.once) {
-			observers.splice(index, 1);
+			entry._isRemoved = true;
+			const index = observers.indexOf(entry);
+			if (index !== -1) {
+				observers.splice(index, 1);
+			}
 		}
 
 		const returnValue = entry.thisArg ? entry.callback.apply(entry.thisArg, [data]) : entry.callback(data);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Regression introduced in 1e55f0c (#10946), first released in core 9.0.0.

`Observable._fireEvent` iterates a copy of the observers array but passes the copy's loop index to `_handleListenerEntry`, which splices the live array at that position. If any listener at a lower index is removed during the same notify pass (a handler calling `off()` on itself, or a preceding `once` entry being consumed), the live array shifts left and the splice for a later `once` entry removes the wrong element or nothing at all. Consequences:

1. The `once` listener stays subscribed and fires on every subsequent notify.
2. An unrelated listener sitting after it can be silently unsubscribed.

The `launch` event is affected deterministically in every app: `NativeScriptGlobalState` registers `_setLaunched` as the first launch listener and it removes itself inside its handler, so every `Application.once('launch', ...)` remains permanently armed. On Android this crashes apps that bootstrap from a launch listener and keep their process alive with a foreground service: recreating the activity (e.g. back-button exit, then relaunch) fires `launch` again, the armed `once` runs the bootstrap a second time and `Application.run()` throws `Error: Application is already started.` inside `NativeScriptActivity.onCreate`.

Minimal repro:

```ts
const obj = new Observable();
obj.on('foo', function handler() {
	obj.off('foo', handler);
});
obj.once('foo', () => console.log('once'));

obj.notify({ eventName: 'foo', object: obj }); // logs "once"
obj.notify({ eventName: 'foo', object: obj }); // logs "once" again