### PR TITLE
fix(vite): remove browser preload probe from native bundles

### DIFF
--- a/packages/vite/helpers/dynamic-import-plugin.spec.ts
+++ b/packages/vite/helpers/dynamic-import-plugin.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { transformDynamicImports } from './dynamic-import-plugin.js';
+
+const vitePreloadHelper = `const scriptRel = /* @__PURE__ */ (function detectScriptRel() {
+  const relList = typeof document !== "undefined" && document.createElement("link").relList;
+  return relList && relList.supports && relList.supports("modulepreload") ? "modulepreload" : "preload";
+})();const assetsURL = function(dep) { return "/"+dep };const seen = {};const __vitePreload = function preload(baseModule, deps, importerUrl) {
+  let promise = Promise.resolve();
+  if (deps && deps.length > 0) {
+    const link = document.createElement("link");
+    seen[assetsURL(deps[0], importerUrl)] = link;
+  }
+  return promise.then(() => baseModule());
+};`;
+
+describe('dynamic import plugin', () => {
+	it('removes the complete browser preload helper from development bundles', () => {
+		const result = transformDynamicImports(`${vitePreloadHelper}\nconst page = () => __vitePreload(() => import('./page.js'), []);`);
+
+		expect(result).not.toContain('scriptRel');
+		expect(result).not.toContain('assetsURL');
+		expect(result).not.toContain('const seen');
+		expect(result).not.toContain('document');
+		expect(result).toContain('const __vitePreload = function preload');
+		expect(result).toContain("import('~/page.js')");
+	});
+
+	it('does not remove unrelated declarations when the Vite preamble is absent', () => {
+		const source = `const scriptRel = "application-value";\nconst __vitePreload = function preload(baseModule) { return baseModule(); };`;
+		const result = transformDynamicImports(source);
+
+		expect(result).toContain('const scriptRel = "application-value";');
+		expect(result).toContain('const __vitePreload = function preload');
+	});
+
+	it('leaves chunks without dynamic imports or the Vite helper unchanged', () => {
+		const source = 'export const value = 42;';
+		expect(transformDynamicImports(source)).toBe(source);
+	});
+});

--- a/packages/vite/helpers/dynamic-import-plugin.ts
+++ b/packages/vite/helpers/dynamic-import-plugin.ts
@@ -1,64 +1,70 @@
-// Fix NativeScript dynamic imports by transforming paths and simplifying __vitePreload
-// Vite auto adds __vitePreload which includes browser APIs we don't need.
-// Note: ideally build.modulePreload = false in build settings would fix this
-// by simply removing the existence of __vitePreload in the bundle.
-// However, this appears to be a known Vite issue: https://github.com/vitejs/vite/issues/13952
-// Keep issue in mind for future Vite updates as may be able to remove this eventually.
-export function dynamicImportPlugin() {
-	return {
-		name: 'nativescript-dynamic-import-fix',
-		generateBundle(options, bundle) {
-			for (const [fileName, chunk] of Object.entries(bundle) as any) {
-				if (chunk.type === 'chunk') {
-					let hasChanges = false;
-
-					// 1. Transform all relative import paths from ./ to ~/
-					if (chunk.code.includes("import('./")) {
-						chunk.code = chunk.code.replace(/import\(['"]\.\/([^'"]*)['"]\)/g, "import('~/$1')");
-						hasChanges = true;
-					}
-
-					// 2. Replace __vitePreload with simple implementation
-					if (chunk.code.includes('__vitePreload')) {
-						const vitePreloadStart = chunk.code.indexOf('const __vitePreload = function preload');
-						if (vitePreloadStart !== -1) {
-							// Find the matching closing brace by counting braces
-							let braceCount = 0;
-							let functionStart = chunk.code.indexOf('{', vitePreloadStart);
-							let i = functionStart;
-
-							while (i < chunk.code.length) {
-								if (chunk.code[i] === '{') braceCount++;
-								else if (chunk.code[i] === '}') {
-									braceCount--;
-									if (braceCount === 0) {
-										// Found the end of the function
-										const functionEnd = i + 1;
-										const before = chunk.code.substring(0, vitePreloadStart);
-										const after = chunk.code.substring(functionEnd);
-
-										// Simple implementation that just calls baseModule()
-										const replacement = `const __vitePreload = function preload(baseModule, deps, importerUrl) {
+const vitePreloadDeclaration = 'const __vitePreload = function preload';
+const vitePreloadPreamble = /^const scriptRel =[\s\S]*;\s*const assetsURL =[\s\S]*;\s*const seen = \{\};\s*$/;
+const nativePreloadImplementation = `const __vitePreload = function preload(baseModule, deps, importerUrl) {
       return baseModule().catch(err => {
         console.error("Dynamic import error:", err);
         throw err;
       });
     }`;
-										chunk.code = before + replacement + after;
-										hasChanges = true;
-										break;
-									}
-								}
-								i++;
-							}
-						}
-					}
 
-					//   if (hasChanges) {
-					//     console.log(
-					//       `Fixed NativeScript dynamic imports in: ${fileName}`,
-					//     );
-					//   }
+function findClosingBrace(code: string, declarationStart: number) {
+	const functionStart = code.indexOf('{', declarationStart);
+	if (functionStart === -1) {
+		return -1;
+	}
+
+	let braceCount = 0;
+	for (let i = functionStart; i < code.length; i++) {
+		if (code[i] === '{') {
+			braceCount++;
+		} else if (code[i] === '}') {
+			braceCount--;
+			if (braceCount === 0) {
+				return i;
+			}
+		}
+	}
+
+	return -1;
+}
+
+function simplifyVitePreload(code: string) {
+	const declarationStart = code.indexOf(vitePreloadDeclaration);
+	if (declarationStart === -1) {
+		return code;
+	}
+
+	const functionEnd = findClosingBrace(code, declarationStart);
+	if (functionEnd === -1) {
+		return code;
+	}
+
+	// Vite emits these browser-only declarations immediately before
+	// __vitePreload. Remove them with the function because scriptRel probes the DOM
+	// as soon as a development bundle is evaluated.
+	const codeBeforeDeclaration = code.slice(0, declarationStart);
+	const possiblePreambleStart = codeBeforeDeclaration.lastIndexOf('const scriptRel =');
+	const possiblePreamble = codeBeforeDeclaration.slice(possiblePreambleStart);
+	const replacementStart = possiblePreambleStart !== -1 && vitePreloadPreamble.test(possiblePreamble) ? possiblePreambleStart : declarationStart;
+
+	return code.slice(0, replacementStart) + nativePreloadImplementation + code.slice(functionEnd + 1);
+}
+
+export function transformDynamicImports(code: string) {
+	const withNativeImportPaths = code.replace(/import\(['"]\.\/([^'"]*)['"]\)/g, "import('~/$1')");
+	return simplifyVitePreload(withNativeImportPaths);
+}
+
+// Fix NativeScript dynamic imports by transforming paths and simplifying __vitePreload.
+// Vite still emits its browser preload helper when modulePreload is disabled:
+// https://github.com/vitejs/vite/issues/13952
+export function dynamicImportPlugin() {
+	return {
+		name: 'nativescript-dynamic-import-fix',
+		generateBundle(_options, bundle) {
+			for (const chunk of Object.values(bundle) as any) {
+				if (chunk.type === 'chunk') {
+					chunk.code = transformDynamicImports(chunk.code);
 				}
 			}
 		},


### PR DESCRIPTION
## Summary

- remove Vite's complete browser-only preload preamble when simplifying `__vitePreload`
- centralize the bundle transform so relative dynamic imports and preload cleanup are independently testable
- prevent `document.createElement("link")` from running in unminified NativeScript bundles

Vite still emits `scriptRel`, `assetsURL`, and `seen` alongside `__vitePreload` when `build.modulePreload` is disabled. The existing plugin replaced only the function body, so `scriptRel` probed the DOM at startup and produced `[UNDOM-NG] Element type 'link' is not registered.` in development builds.

## Validation

- `npx nx run vite:test --outputStyle=stream` (78 tests)
- `npx eslint --no-ignore packages/vite/helpers/dynamic-import-plugin.ts packages/vite/helpers/dynamic-import-plugin.spec.ts`
- `npx nx run vite:build --outputStyle=stream`
- real NativeScript Android API 35 build/install and end-to-end navigation against a TanStack Start application
- generated `.mjs` inspection and device logs confirm the browser preload probe and runtime warning are gone

The repository's `vite:lint` target currently exits because all configured paths are ignored; direct ESLint over both changed files passes.