### PR TITLE
fix(ios): update swipe back gesture from Page property

### DIFF
--- a/apps/automated/src/ui/page/page-tests.ios.ts
+++ b/apps/automated/src/ui/page/page-tests.ios.ts
@@ -5,6 +5,23 @@ import { addLabelToPage } from './page-tests-common';
 
 export * from './page-tests-common';
 
+export function test_enableSwipeBackNavigation_updates_the_native_gesture() {
+	const page = new Page();
+	addLabelToPage(page);
+	helper.navigateWithHistory(() => page);
+
+	const gesture = page.ios.navigationController.interactivePopGestureRecognizer;
+	TKUnit.assertTrue(gesture.enabled, 'Swipe-back gesture should initially be enabled.');
+
+	page.enableSwipeBackNavigation = false;
+	TKUnit.assertFalse(gesture.enabled, 'Swipe-back gesture should be disabled after updating the Page property.');
+
+	page.enableSwipeBackNavigation = true;
+	TKUnit.assertTrue(gesture.enabled, 'Swipe-back gesture should be re-enabled after updating the Page property.');
+
+	helper.goBack();
+}
+
 export function test_NavigateToNewPage_InnerControl() {
 	var testPage: Page;
 	var pageFactory = function (): Page {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -2,7 +2,7 @@ import { isAccessibilityServiceEnabled } from '../../application';
 import type { Frame } from '../frame';
 import { BackstackEntry, NavigationType } from '../frame/frame-interfaces';
 import { View, IOSHelper } from '../core/view';
-import { PageBase, actionBarHiddenProperty } from './page-common';
+import { PageBase, actionBarHiddenProperty, enableSwipeBackNavigationProperty } from './page-common';
 
 import { profile } from '../../profiling';
 import { layout } from '../../utils/layout-helper';
@@ -575,8 +575,6 @@ export class Page extends PageBase {
 	}
 
 	[actionBarHiddenProperty.setNative](value: boolean) {
-		this._updateEnableSwipeBackNavigation(value);
-
 		// Invalidate all inner controller.
 		invalidateTopmostController(this.viewController);
 
@@ -585,6 +583,10 @@ export class Page extends PageBase {
 			// Update nav-bar visibility with disabled animations
 			frame._updateActionBar(this, true);
 		}
+	}
+
+	[enableSwipeBackNavigationProperty.setNative](value: boolean) {
+		this._updateEnableSwipeBackNavigation(value);
 	}
 
 	public accessibilityScreenChanged(refocus = false): void {


### PR DESCRIPTION
## What changed

- bind `enableSwipeBackNavigationProperty` to the native gesture update hook
- stop `actionBarHidden` changes from overwriting swipe-back state
- add an iOS regression test that toggles the Page property and checks the native recognizer

The handler was lost during the property-system migration: `enableSwipeBackNavigation` remained public and was read during page presentation, but changing it on a visible page did not update either iOS gesture recognizer.

## Validation

- `nx run core:build`
- `nx run core:lint` (passes with existing warnings)
- iOS 26.5 simulator XCUITest: disabling the property prevents an interactive edge pop; re-enabling it restores the native transition