### PR TITLE
fix(ios): guard interactiveContentPopGestureRecognizer for apps built with pre-26 SDKs

### DIFF
--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -189,13 +189,13 @@ class UIViewControllerImpl extends UIViewController {
 							// only consider when interactive transitions are not enabled
 							navigationController.interactivePopGestureRecognizer.delegate = navigationController;
 							navigationController.interactivePopGestureRecognizer.enabled = owner.enableSwipeBackNavigation;
-							if (SDK_VERSION >= 26) {
+							if (SDK_VERSION >= 26 && navigationController.interactiveContentPopGestureRecognizer) {
 								navigationController.interactiveContentPopGestureRecognizer.enabled = owner.enableSwipeBackNavigation;
 							}
 						}
 					} else {
 						navigationController.interactivePopGestureRecognizer.enabled = false;
-						if (SDK_VERSION >= 26) {
+						if (SDK_VERSION >= 26 && navigationController.interactiveContentPopGestureRecognizer) {
 							navigationController.interactiveContentPopGestureRecognizer.enabled = false;
 						}
 					}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

The iOS 26 support added for `UINavigationController.interactiveContentPopGestureRecognizer` gates the property access purely on the **runtime** OS version (`SDK_VERSION >= 26`):

```ts
if (SDK_VERSION >= 26) {
  navigationController.interactiveContentPopGestureRecognizer.enabled = owner.enableSwipeBackNavigation;
}
```

`interactiveContentPopGestureRecognizer` only exists in the iOS 26 SDK. When an app is **built with an older Xcode/SDK** (e.g. Xcode 16 / iOS 18 SDK) but **run on iOS 26+**, that property is absent from the NativeScript-generated ObjC metadata — metadata is derived from the *build* SDK's headers, not the runtime OS. So the property access returns `undefined`, and setting `.enabled` on it throws:

```
TypeError: Cannot set properties of undefined (setting 'enabled')
```

crashing the app on the first page navigation.

This was hit in real CI: an app built with **Xcode 16** running on the **iOS 26.2 simulator** (NativeScript/angular CI).

## What is the new behavior?

Guard the `interactiveContentPopGestureRecognizer` access with an existence check in addition to the runtime version check, so it is only touched when the property is actually present in the metadata:

```ts
if (SDK_VERSION >= 26 && navigationController.interactiveContentPopGestureRecognizer) {
  ...
}
```

This mirrors the guard already used in `_updateEnableSwipeBackNavigation`, making iOS 26 runtime safe for apps built with pre-26 SDKs. The legacy `interactivePopGestureRecognizer` lines are unchanged (that API exists on all supported versions).
