### PR TITLE
fix(webpack): downlevel NativeClass classes in files updated by earlier transformers

### DIFF
--- a/packages/webpack5/__tests__/transformers/native-class.spec.ts
+++ b/packages/webpack5/__tests__/transformers/native-class.spec.ts
@@ -175,6 +175,48 @@ class X extends NSObject {}
 		});
 	});
 
+	describe('after a preceding transformer updates the source file', () => {
+		// Simulates transformers like Angular's Ivy transform, which rebuild the
+		// source file via factory.updateSourceFile() on files containing Angular
+		// decorators. The updated SourceFile node is flagged Synthesized; the
+		// NativeClass transformer must still process its original statements.
+		const updateSourceFileTransformer: ts.TransformerFactory<ts.SourceFile> =
+			(context) => (sourceFile) =>
+				context.factory.updateSourceFile(sourceFile, [
+					...sourceFile.statements,
+				]);
+
+		function transformAfterUpdate(input: string): string {
+			return ts.transpileModule(input, {
+				compilerOptions: {
+					module: ts.ModuleKind.ESNext,
+					target: ts.ScriptTarget.ES2022,
+					experimentalDecorators: true,
+					emitDecoratorMetadata: false,
+					useDefineForClassFields: false,
+				},
+				transformers: {
+					before: [
+						updateSourceFileTransformer,
+						nativeClassTransformer as ts.TransformerFactory<ts.SourceFile>,
+					],
+				},
+			}).outputText;
+		}
+
+		it('downlevels @NativeClass() on a synthesized (updated) source file', () => {
+			const output = transformAfterUpdate(`
+@NativeClass()
+class Foo extends NSObject {}
+`);
+
+			expect(output).toContain('var Foo =');
+			expect(output).toContain('__extends(Foo, _super)');
+			expect(output).not.toContain('NativeClass');
+			expect(countClassDeclarations(output)).toBe(0);
+		});
+	});
+
 	describe('nested scopes', () => {
 		it('downlevels @NativeClass() class declared inside a function body', () => {
 			const output = transform(`

--- a/packages/webpack5/src/transformers/NativeClass/index.ts
+++ b/packages/webpack5/src/transformers/NativeClass/index.ts
@@ -182,13 +182,19 @@ export default function (context: ts.TransformationContext, ...args) {
 		}
 
 		function visitNode(node: ts.Node): ts.Node {
-			// Do not traverse synthesized helper trees; leave them intact
-			if (((node as MutableNode).flags ?? 0) & ts.NodeFlags.Synthesized) {
-				return node;
-			}
+			// Handle the source file before the Synthesized bail-out below: a source
+			// file updated by an earlier transformer (e.g. Angular's Ivy transform on
+			// files containing Angular-decorated classes) is itself flagged
+			// Synthesized, but its original statements still need processing. The
+			// per-statement Synthesized check in transformStatements protects any
+			// generated statements.
 			if (ts.isSourceFile(node)) {
 				const [stmts, changed] = transformStatements(node.statements, true);
 				return changed ? factory.updateSourceFile(node, stmts) : node;
+			}
+			// Do not traverse synthesized helper trees; leave them intact
+			if (((node as MutableNode).flags ?? 0) & ts.NodeFlags.Synthesized) {
+				return node;
 			}
 			if (ts.isBlock(node)) {
 				const [stmts, changed] = transformStatements(node.statements, false);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

In Angular projects, any file that contains **both** an Angular-decorated class (`@Injectable`, `@Directive`, `@Component`, ...) and a `@NativeClass` class is silently skipped by the NativeClass transformer. The `@NativeClass` decorator survives into the emitted bundle as `__decorate([NativeClass()], ...)` and the app crashes at runtime with:

```
ReferenceError: NativeClass is not defined
```

Root cause: in the Angular webpack flavor the NativeClass transformer runs **after** Angular's Ivy transform. On files containing Angular-decorated classes, Ivy rebuilds the file via `factory.updateSourceFile()`, so the resulting `SourceFile` node itself carries `ts.NodeFlags.Synthesized`. The transformer's `visitNode` bails out on any `Synthesized` node **before** reaching its `isSourceFile` branch, so the whole file is returned untouched. Files without Angular decorators pass through Ivy unchanged (original `SourceFile`, no flag), which is why only this mixed-content case breaks.

## What is the new behavior?

`visitNode` handles the `SourceFile` before the `Synthesized` bail-out, so files rebuilt by earlier transformers are still processed. The per-statement `Synthesized` check in `transformStatements` continues to protect statements generated by earlier transformers (e.g. Ivy's added imports and rewritten Angular classes) as well as the transformer's own helper output.

Includes a regression test that runs the transformer after a preceding transformer which rebuilds the source file (simulating Ivy) — it fails without the fix and passes with it.
