### PR TITLE
fix(ios): guard safe-area helpers against detached NS subtrees

### DIFF
--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -386,6 +386,15 @@ export class IOSHelper {
 
 	static expandBeyondSafeArea(view: View, frame: CGRect): CGRect {
 		const availableSpace = IOSHelper.getAvailableSpaceFromParent(view, frame);
+		// When the view is in a detached NS subtree (e.g. a view passed to TabView's
+		// `iosBottomAccessory`, which is attached to UIKit but has no NS parent), there is
+		// no viewController/scrollView ancestor to derive safe-area bounds from. In that
+		// case `safeArea` and `fullscreen` are null and `getPositionFromFrame(null)` would
+		// throw `Cannot read properties of null (reading 'origin')`. Return the frame as-is
+		// since "expand beyond safe area" is meaningless without a reference rect.
+		if (!availableSpace || !availableSpace.safeArea || !availableSpace.fullscreen) {
+			return frame;
+		}
 		const safeArea = availableSpace.safeArea;
 		const fullscreen = availableSpace.fullscreen;
 		const inWindow = availableSpace.inWindow;
@@ -438,10 +447,17 @@ export class IOSHelper {
 				parent = parent.parent as View;
 			}
 
-			if (parent.nativeViewProtected instanceof UIScrollView) {
-				scrollView = parent.nativeViewProtected;
-			} else if (parent.viewController) {
-				viewControllerView = parent.viewController.view;
+			// `parent` may be null here when `view` is part of a detached NS subtree (e.g. a
+			// view passed to TabView's `iosBottomAccessory`, which is attached to UIKit's
+			// `UITabAccessory.contentView` but never added to an NS parent). Without this
+			// guard, the next line throws "Cannot read properties of undefined (reading
+			// 'nativeViewProtected')" and the entire layout pass aborts.
+			if (parent) {
+				if (parent.nativeViewProtected instanceof UIScrollView) {
+					scrollView = parent.nativeViewProtected;
+				} else if (parent.viewController) {
+					viewControllerView = parent.viewController.view;
+				}
 			}
 		}
 

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -386,12 +386,8 @@ export class IOSHelper {
 
 	static expandBeyondSafeArea(view: View, frame: CGRect): CGRect {
 		const availableSpace = IOSHelper.getAvailableSpaceFromParent(view, frame);
-		// When the view is in a detached NS subtree (e.g. a view passed to TabView's
-		// `iosBottomAccessory`, which is attached to UIKit but has no NS parent), there is
-		// no viewController/scrollView ancestor to derive safe-area bounds from. In that
-		// case `safeArea` and `fullscreen` are null and `getPositionFromFrame(null)` would
-		// throw `Cannot read properties of null (reading 'origin')`. Return the frame as-is
-		// since "expand beyond safe area" is meaningless without a reference rect.
+		// Detached NS subtrees (e.g. TabView's `iosBottomAccessory`) have no safe-area
+		// reference rects to expand against; leave the frame as-is.
 		if (!availableSpace || !availableSpace.safeArea || !availableSpace.fullscreen) {
 			return frame;
 		}
@@ -447,11 +443,8 @@ export class IOSHelper {
 				parent = parent.parent as View;
 			}
 
-			// `parent` may be null here when `view` is part of a detached NS subtree (e.g. a
-			// view passed to TabView's `iosBottomAccessory`, which is attached to UIKit's
-			// `UITabAccessory.contentView` but never added to an NS parent). Without this
-			// guard, the next line throws "Cannot read properties of undefined (reading
-			// 'nativeViewProtected')" and the entire layout pass aborts.
+			// `parent` is null when `view` is attached to UIKit but has no NS parent
+			// (e.g. TabView's `iosBottomAccessory` hosted in UITabAccessory.contentView).
 			if (parent) {
 				if (parent.nativeViewProtected instanceof UIScrollView) {
 					scrollView = parent.nativeViewProtected;


### PR DESCRIPTION
Views attached to UIKit but without an NS parent (e.g. a view passed to TabView's `iosBottomAccessory`, hosted in UITabAccessory.contentView) have no viewController/scrollView ancestor to derive safe-area bounds from. Guard IOSHelper.getAvailableSpaceFromParent against a null parent and have expandBeyondSafeArea return the frame as-is when no reference rect exists, instead of crashing the layout pass.
