### PR TITLE
fix(core): guard undefined navigation queue entry in Frame

### DIFF
--- a/packages/core/ui/frame/frame-common.ts
+++ b/packages/core/ui/frame/frame-common.ts
@@ -351,9 +351,9 @@ export class FrameBase extends CustomLayoutView implements FrameDefinition {
 			return;
 		}
 
+		// Entry is undefined for a goBack() queued before performGoBack populates it.
 		const entry = this._navigationQueue[0].entry;
-		const currentNavigationPage = entry.resolvedPage;
-		if (page !== currentNavigationPage) {
+		if (entry && page !== entry.resolvedPage) {
 			// If the page is not the one that requested navigation - skip it.
 			return;
 		}


### PR DESCRIPTION
A goBack() queued while another navigation is still executing (e.g. an interactive dismiss that finished out-of-band) can leave the head of the navigation queue without an entry, since performGoBack hasn't populated it yet. Skip the head safely instead of crashing on reading `.resolvedPage`.

