### PR TITLE
fix(debugger): exclude internal props from devtools elements

### DIFF
--- a/packages/core/debugger/dom-types.ts
+++ b/packages/core/debugger/dom-types.ts
@@ -5,7 +5,37 @@ import { PercentLength } from '../ui/styling/length-shared';
 import { getSetProperties, getComputedCssValues } from '../ui/core/properties';
 const ELEMENT_NODE_TYPE = 1;
 const ROOT_NODE_TYPE = 9;
-const propertyBlacklist = ['effectivePaddingLeft', 'effectivePaddingBottom', 'effectivePaddingRight', 'effectivePaddingTop', 'effectiveBorderTopWidth', 'effectiveBorderRightWidth', 'effectiveBorderBottomWidth', 'effectiveBorderLeftWidth', 'effectiveMinWidth', 'effectiveMinHeight', 'effectiveWidth', 'effectiveHeight', 'effectiveMarginLeft', 'effectiveMarginTop', 'effectiveMarginRight', 'effectiveMarginBottom', 'effectiveRowGap', 'effectiveColumnGap', 'nodeName', 'nodeType', 'decodeWidth', 'decodeHeight', 'ng-reflect-items', 'domNode', 'touchListenerIsSet', 'bindingContext', 'nativeView'];
+const propertyBlacklist = [
+	'effectivePaddingLeft',
+	'effectivePaddingBottom',
+	'effectivePaddingRight',
+	'effectivePaddingTop',
+	'effectiveBorderTopWidth',
+	'effectiveBorderRightWidth',
+	'effectiveBorderBottomWidth',
+	'effectiveBorderLeftWidth',
+	'effectiveMinWidth',
+	'effectiveMinHeight',
+	'effectiveMaxWidth',
+	'effectiveMaxHeight',
+	'effectiveWidth',
+	'effectiveHeight',
+	'effectiveMarginLeft',
+	'effectiveMarginTop',
+	'effectiveMarginRight',
+	'effectiveMarginBottom',
+	'effectiveRowGap',
+	'effectiveColumnGap',
+	'nodeName',
+	'nodeType',
+	'decodeWidth',
+	'decodeHeight',
+	'ng-reflect-items',
+	'domNode',
+	'touchListenerIsSet',
+	'bindingContext',
+	'nativeView',
+];
 
 function lazy<T>(action: () => T): () => T {
 	let _value: T;

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -337,6 +337,14 @@ export abstract class ViewBase extends Observable {
 	private _style: Style;
 	private _isLoaded: boolean;
 
+	/**
+	 * if _setupAsRootView is called it means it is not supposed to be
+	 * added to a parent. However parent can be set before for the purpose
+	 * of CSS variables/classes. That variable ensures that _addViewToNativeVisualTree
+	 * is not called in _setupAsRootView
+	 */
+	private _isRootView = false;
+
 	private _effectivePaddingTop: number = null;
 	private _effectivePaddingRight: number = null;
 	private _effectivePaddingBottom: number = null;
@@ -1147,17 +1155,10 @@ export abstract class ViewBase extends Observable {
 		// }
 	}
 
-	/**
-	 * if _setupAsRootView is called it means it is not supposed to be
-	 * added to a parent. However parent can be set before for the purpose
-	 * of CSS variables/classes. That variable ensures that _addViewToNativeVisualTree
-	 * is not called in _setupAsRootView
-	 */
-	mIsRootView = false;
 	_setupAsRootView(context: any): void {
-		this.mIsRootView = true;
+		this._isRootView = true;
 		this._setupUI(context);
-		this.mIsRootView = false;
+		this._isRootView = false;
 	}
 
 	/**
@@ -1170,7 +1171,7 @@ export abstract class ViewBase extends Observable {
 			// this check is unnecessary as this function should never be called when this._context === context as it means the view was somehow detached,
 			// which is only possible by setting reusable = true. Adding it either way for feature flag safety
 			if (this.reusable) {
-				if (!this.mIsRootView && this.parent && !this._isAddedToNativeVisualTree) {
+				if (!this._isRootView && this.parent && !this._isAddedToNativeVisualTree) {
 					const nativeIndex = this.parent._childIndexToNativeChildIndex(atIndex);
 					this._isAddedToNativeVisualTree = this.parent._addViewToNativeVisualTree(this, nativeIndex);
 				}
@@ -1228,7 +1229,7 @@ export abstract class ViewBase extends Observable {
 
 		this.setNativeView(nativeView);
 
-		if (!this.mIsRootView && this.parent) {
+		if (!this._isRootView && this.parent) {
 			const nativeIndex = this.parent._childIndexToNativeChildIndex(atIndex);
 			this._isAddedToNativeVisualTree = this.parent._addViewToNativeVisualTree(this, nativeIndex);
 		}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
A couple of PRs, specifically #10554 and #11300, have added some new internal props that show up in devtools element tree:
<img width="681" height="178" alt="Screenshot 2026-07-31 at 7 18 12 PM" src="https://github.com/user-attachments/assets/39a012c4-3536-439e-b3c3-4ca64997b743" />

## What is the new behavior?
This PR adds the new effective props to the debugger black list and renames `mIsRootView` to honor the debugger underscore rule and core private props format at the same time.