### PR TITLE
fix(ios): ensure notification event is passed to app start when not delaying launch event

### DIFF
--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -702,7 +702,7 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 
 			this.launchEventCalled = false;
 			if (!this.shouldDelayLaunchEvent) {
-				this.notifyAppStarted();
+				this.notifyAppStarted(notification);
 			}
 		} else {
 			// Scene-based app - window creation will happen in scene delegate


### PR DESCRIPTION
regressed in: https://github.com/NativeScript/NativeScript/pull/9906/changes