### PR TITLE
fix(core): invalidate sibling combinator selector matches on child insert/remove

### DIFF
--- a/packages/core/ui/layouts/layout-base-common.spec.ts
+++ b/packages/core/ui/layouts/layout-base-common.spec.ts
@@ -1,0 +1,115 @@
+import { LayoutBaseCommon } from './layout-base-common';
+import { View } from '../core/view';
+
+describe('LayoutBaseCommon sibling CSS invalidation', () => {
+	function createLayout(scopeFlags: { hasAdjacentCombinatorSelectors: boolean; hasSiblingCombinatorSelectors: boolean } | null) {
+		const layout = new LayoutBaseCommon();
+		layout._styleScope = scopeFlags as any;
+
+		const a = new LayoutBaseCommon();
+		const b = new LayoutBaseCommon();
+		layout.addChild(a as unknown as View);
+		layout.addChild(b as unknown as View);
+
+		const spyA = vi.spyOn(a, '_onCssStateChange');
+		const spyB = vi.spyOn(b, '_onCssStateChange');
+
+		return { layout, a, b, spyA, spyB };
+	}
+
+	const adjacentOnly = { hasAdjacentCombinatorSelectors: true, hasSiblingCombinatorSelectors: false };
+	const generalSibling = { hasAdjacentCombinatorSelectors: false, hasSiblingCombinatorSelectors: true };
+	const noCombinators = { hasAdjacentCombinatorSelectors: false, hasSiblingCombinatorSelectors: false };
+
+	it('insert at 0 with adjacent selectors invalidates only the shifted view', () => {
+		const { layout, spyA, spyB } = createLayout(adjacentOnly);
+
+		layout.insertChild(new LayoutBaseCommon() as unknown as View, 0);
+
+		expect(spyA).toHaveBeenCalledTimes(1);
+		expect(spyB).not.toHaveBeenCalled();
+	});
+
+	it('insert in the middle with adjacent selectors invalidates only the next view', () => {
+		const { layout, spyA, spyB } = createLayout(adjacentOnly);
+
+		layout.insertChild(new LayoutBaseCommon() as unknown as View, 1);
+
+		expect(spyA).not.toHaveBeenCalled();
+		expect(spyB).toHaveBeenCalledTimes(1);
+	});
+
+	it('remove at 0 with adjacent selectors invalidates only the view taking its place', () => {
+		const { layout, a, spyB } = createLayout(adjacentOnly);
+
+		layout.removeChild(a as unknown as View);
+
+		expect(spyB).toHaveBeenCalledTimes(1);
+	});
+
+	it('insert at 0 with general sibling selectors invalidates all following views', () => {
+		const { layout, spyA, spyB } = createLayout(generalSibling);
+
+		layout.insertChild(new LayoutBaseCommon() as unknown as View, 0);
+
+		expect(spyA).toHaveBeenCalledTimes(1);
+		expect(spyB).toHaveBeenCalledTimes(1);
+	});
+
+	it('remove at 0 with general sibling selectors invalidates all following views', () => {
+		const { layout, a, spyB } = createLayout(generalSibling);
+
+		layout.removeChild(a as unknown as View);
+
+		expect(spyB).toHaveBeenCalledTimes(1);
+	});
+
+	it('fresh child is matched once through scope inheritance, not twice', () => {
+		const { layout } = createLayout(adjacentOnly);
+		const c = new LayoutBaseCommon();
+		const spyC = vi.spyOn(c, '_onCssStateChange');
+
+		layout.insertChild(c as unknown as View, 0);
+
+		expect(spyC).toHaveBeenCalledTimes(1);
+	});
+
+	it('re-inserting a child that kept its scope invalidates the child itself', () => {
+		const { layout, a, spyA, spyB } = createLayout(adjacentOnly);
+
+		layout.removeChild(a as unknown as View);
+		spyA.mockClear();
+		spyB.mockClear();
+
+		layout.insertChild(a as unknown as View, 1);
+
+		expect(spyA).toHaveBeenCalledTimes(1);
+		expect(spyB).not.toHaveBeenCalled();
+	});
+
+	it('append does not invalidate existing children', () => {
+		const { layout, spyA, spyB } = createLayout(generalSibling);
+
+		layout.addChild(new LayoutBaseCommon() as unknown as View);
+
+		expect(spyA).not.toHaveBeenCalled();
+		expect(spyB).not.toHaveBeenCalled();
+	});
+
+	it('stylesheet without sibling combinators does no invalidation work', () => {
+		const { layout, spyA, spyB } = createLayout(noCombinators);
+
+		layout.insertChild(new LayoutBaseCommon() as unknown as View, 0);
+		layout.removeChild(layout.getChildAt(0));
+
+		expect(spyA).not.toHaveBeenCalled();
+		expect(spyB).not.toHaveBeenCalled();
+	});
+
+	it('missing style scope does not throw', () => {
+		const { layout, spyA } = createLayout(null);
+
+		expect(() => layout.insertChild(new LayoutBaseCommon() as unknown as View, 0)).not.toThrow();
+		expect(spyA).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/ui/layouts/layout-base-common.ts
+++ b/packages/core/ui/layouts/layout-base-common.ts
@@ -51,9 +51,12 @@ export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefi
 
 	public insertChild(child: View, atIndex: number): boolean {
 		if (atIndex > -1) {
+			// A re-attached child keeps its scope, so inheriting it won't re-match its css state
+			const isReattached = child._styleScope === this._styleScope;
 			this._subViews.splice(atIndex, 0, child);
 			this._addView(child, atIndex);
 			this._registerLayoutChild(child);
+			this._invalidateSiblingCssState(isReattached ? atIndex : atIndex + 1, atIndex + 2);
 			return true;
 		}
 		return false;
@@ -67,6 +70,27 @@ export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefi
 		if (index > -1) {
 			this._subViews.splice(index, 1);
 			this._unregisterLayoutChild(child);
+			this._invalidateSiblingCssState(index, index + 1);
+		}
+	}
+
+	// Sibling combinator matches are cached and never re-queried on tree changes.
+	// Appending changes no predecessor, so addChild skips invalidation.
+	private _invalidateSiblingCssState(fromIndex: number, adjacentEndIndex: number): void {
+		const scope = this._styleScope;
+		if (!scope) {
+			return;
+		}
+
+		const general = scope.hasSiblingCombinatorSelectors;
+		if (!general && !scope.hasAdjacentCombinatorSelectors) {
+			return;
+		}
+
+		// '+' only affects views whose direct predecessor changed
+		const end = Math.min(general ? this._subViews.length : adjacentEndIndex, this._subViews.length);
+		for (let i = fromIndex; i < end; i++) {
+			this._subViews[i]._onCssStateChange();
 		}
 	}
 

--- a/packages/core/ui/styling/css-selector.spec.ts
+++ b/packages/core/ui/styling/css-selector.spec.ts
@@ -279,6 +279,62 @@ describe('css-selector', () => {
 		//expect(rule.selectors[0].specificity).toEqual(0);
 	});
 
+	describe('sibling combinator flags', () => {
+		it('adjacent combinator sets hasAdjacentCombinator', () => {
+			const sel = createSelector('.spaced > * + *');
+			expect(sel.hasAdjacentCombinator).toBe(true);
+			expect(sel.hasSiblingCombinator).toBe(false);
+		});
+
+		it('general sibling combinator sets hasSiblingCombinator', () => {
+			const sel = createSelector('.spaced > * ~ *');
+			expect(sel.hasSiblingCombinator).toBe(true);
+			expect(sel.hasAdjacentCombinator).toBe(false);
+		});
+
+		it('selector without sibling combinators sets neither flag', () => {
+			const sel = createSelector('.spaced > .child');
+			expect(sel.hasAdjacentCombinator).toBe(false);
+			expect(sel.hasSiblingCombinator).toBe(false);
+		});
+
+		it(':is() selector list propagates combinator flags', () => {
+			const sel = createSelector(':is(.a + .b)');
+			expect(sel.hasAdjacentCombinator).toBe(true);
+			expect(sel.hasSiblingCombinator).toBe(false);
+		});
+
+		it('compound selector propagates combinator flags of functional pseudo-class', () => {
+			const sel = createSelector('.list :is(.a ~ .b).c');
+			expect(sel.hasSiblingCombinator).toBe(true);
+		});
+
+		it('scope accumulates combinator flags from rulesets', () => {
+			const { selectorScope } = create(`
+				.a { color: red; }
+				.spaced > * + * { margin-top: 8; }
+			`);
+			expect(selectorScope.hasAdjacentCombinatorSelectors).toBe(true);
+			expect(selectorScope.hasSiblingCombinatorSelectors).toBe(false);
+		});
+
+		it('scope without sibling combinators keeps flags false', () => {
+			const { selectorScope } = create(`.a { color: red; }`);
+			expect(selectorScope.hasAdjacentCombinatorSelectors).toBe(false);
+			expect(selectorScope.hasSiblingCombinatorSelectors).toBe(false);
+		});
+
+		it('scope rolls up combinator flags from media query rules', () => {
+			const { selectorScope } = create(`
+				@media only screen and (max-width: 10000) {
+					.spaced > * ~ * { margin-top: 8; }
+				}
+			`);
+			expect(selectorScope.hasSiblingCombinatorSelectors).toBe(true);
+			expect(selectorScope.hasAdjacentCombinatorSelectors).toBe(false);
+		});
+	});
+
 	it('attribute selector with case-insensitive flag matches repeatedly', () => {
 		const rule = createOne(`button[testAttr='VaLuE' i] { color: red; }`);
 		const matching = { cssType: 'button', testAttr: 'vAlUe' };

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -149,6 +149,8 @@ function SelectorProperties(specificity: Specificity, rarity: Rarity, dynamic = 
 		cls.prototype.rarity = rarity;
 		cls.prototype.combinator = undefined;
 		cls.prototype.dynamic = dynamic;
+		cls.prototype.hasAdjacentCombinator = false;
+		cls.prototype.hasSiblingCombinator = false;
 
 		return cls;
 	};
@@ -160,6 +162,8 @@ function FunctionalPseudoClassProperties(specificity: Specificity, rarity: Rarit
 		cls.prototype.rarity = rarity;
 		cls.prototype.combinator = undefined;
 		cls.prototype.dynamic = false;
+		cls.prototype.hasAdjacentCombinator = false;
+		cls.prototype.hasSiblingCombinator = false;
 		cls.prototype.pseudoSelectorListType = pseudoSelectorListType;
 
 		return cls;
@@ -171,6 +175,14 @@ export abstract class SelectorBase {
 	 * Dynamic selectors depend on attributes and pseudo classes.
 	 */
 	public dynamic: boolean;
+	/**
+	 * Selector contains an adjacent sibling ('+') combinator, so its match depends on the direct previous sibling.
+	 */
+	public hasAdjacentCombinator: boolean;
+	/**
+	 * Selector contains a general sibling ('~') combinator, so its match depends on all previous siblings.
+	 */
+	public hasSiblingCombinator: boolean;
 	public abstract match(node: Node): boolean;
 	public abstract mayMatch(node: Node): boolean;
 	public abstract trackChanges(node: Node, map: ChangeAccumulator): void;
@@ -430,6 +442,8 @@ export abstract class FunctionalPseudoClassSelector extends PseudoClassSelector 
 		this.specificity = specificity;
 		// Functional pseudo-classes become dynamic based on selectors in selector list
 		this.dynamic = this.selectors.some((sel) => sel.dynamic);
+		this.hasAdjacentCombinator = this.selectors.some((sel) => sel.hasAdjacentCombinator);
+		this.hasSiblingCombinator = this.selectors.some((sel) => sel.hasSiblingCombinator);
 	}
 	public toString(): string {
 		return `:${this.cssPseudoClass}(${this.selectors.join(', ')})${wrap(this.combinator)}`;
@@ -492,6 +506,8 @@ export class SimpleSelectorSequence extends SimpleSelector {
 		this.specificity = selectors.reduce((sum, sel) => sel.specificity + sum, 0);
 		this.head = selectors.reduce((prev, curr) => (!prev || curr.rarity > prev.rarity ? curr : prev), null);
 		this.dynamic = selectors.some((sel) => sel.dynamic);
+		this.hasAdjacentCombinator = selectors.some((sel) => sel.hasAdjacentCombinator);
+		this.hasSiblingCombinator = selectors.some((sel) => sel.hasSiblingCombinator);
 	}
 	public toString(): string {
 		return `${this.selectors.join('')}${wrap(this.combinator)}`;
@@ -541,6 +557,8 @@ export class ComplexSelector extends SelectorCore {
 
 		this.specificity = 0;
 		this.dynamic = false;
+		this.hasAdjacentCombinator = false;
+		this.hasSiblingCombinator = false;
 
 		for (let i = selectors.length - 1; i >= 0; i--) {
 			const sel = selectors[i];
@@ -559,7 +577,10 @@ export class ComplexSelector extends SelectorCore {
 					currentGroup.push(siblingsToGroup);
 					break;
 				case Combinator.adjacent:
+					this.hasAdjacentCombinator = true;
+					break;
 				case Combinator.sibling:
+					this.hasSiblingCombinator = true;
 					break;
 				default:
 					throw new Error(`Unsupported combinator "${sel.combinator}" for selector ${sel}.`);
@@ -569,6 +590,14 @@ export class ComplexSelector extends SelectorCore {
 
 			if (sel.dynamic) {
 				this.dynamic = true;
+			}
+
+			if (sel.hasAdjacentCombinator) {
+				this.hasAdjacentCombinator = true;
+			}
+
+			if (sel.hasSiblingCombinator) {
+				this.hasSiblingCombinator = true;
 			}
 
 			siblingsToGroup.push(sel);
@@ -1053,6 +1082,15 @@ export abstract class SelectorScope<T extends Node> implements LookupSorter {
 
 	public position: number = 0;
 
+	/**
+	 * True when any selector in the scope contains an adjacent sibling ('+') combinator.
+	 */
+	public hasAdjacentCombinatorSelectors = false;
+	/**
+	 * True when any selector in the scope contains a general sibling ('~') combinator.
+	 */
+	public hasSiblingCombinatorSelectors = false;
+
 	getSelectorCandidates(node: T) {
 		const { cssClasses, id, cssType } = node;
 		const candidates: SelectorCore[] = [];
@@ -1090,6 +1128,14 @@ export abstract class SelectorScope<T extends Node> implements LookupSorter {
 	}
 
 	private makeDocSelector(sel: SelectorCore): SelectorCore {
+		if (sel.hasAdjacentCombinator) {
+			this.hasAdjacentCombinatorSelectors = true;
+		}
+
+		if (sel.hasSiblingCombinator) {
+			this.hasSiblingCombinatorSelectors = true;
+		}
+
 		sel.pos = this.position++;
 
 		return sel;
@@ -1160,6 +1206,19 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 		if (lastMediaSelectorScope) {
 			this.position = lastMediaSelectorScope.position;
 			lastMediaSelectorScope = null;
+		}
+
+		// Media query scopes are queried through this scope, so their combinator flags roll up
+		if (this.mediaQuerySelectorScopes) {
+			for (const selectorScope of this.mediaQuerySelectorScopes) {
+				if (selectorScope.hasAdjacentCombinatorSelectors) {
+					this.hasAdjacentCombinatorSelectors = true;
+				}
+
+				if (selectorScope.hasSiblingCombinatorSelectors) {
+					this.hasSiblingCombinatorSelectors = true;
+				}
+			}
 		}
 	}
 

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -944,6 +944,24 @@ export class StyleScope {
 	}
 
 	/**
+	 * True when any selector in the scope contains an adjacent sibling ('+') combinator.
+	 */
+	get hasAdjacentCombinatorSelectors(): boolean {
+		this.ensureSelectors();
+
+		return this._selectorScope ? this._selectorScope.hasAdjacentCombinatorSelectors : false;
+	}
+
+	/**
+	 * True when any selector in the scope contains a general sibling ('~') combinator.
+	 */
+	get hasSiblingCombinatorSelectors(): boolean {
+		this.ensureSelectors();
+
+		return this._selectorScope ? this._selectorScope.hasSiblingCombinatorSelectors : false;
+	}
+
+	/**
 	 * Increase the application CSS selector version.
 	 */
 	public _increaseApplicationCssSelectorVersion(): void {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

A selector with a sibling combinator (`+` or `~`) matched a view only once, when the view loaded. Nothing re-matched the affected siblings when a view entered or left the layout. The cached match then applied the wrong styles. Tailwind apps hit this through `space-*` and `divide-*` utilities, which compile to `> * + *`.

## What is the new behavior?
Styling is re-matched when siblings change
