### PR TITLE
fix(android): stop the FragmentManager driving fragments with a dead entry

### DIFF
--- a/packages/core/ui/frame/frame-helper-for-android.ts
+++ b/packages/core/ui/frame/frame-helper-for-android.ts
@@ -37,6 +37,10 @@ function findPageForFragment(fragment: androidx.fragment.app.Fragment, frame: Fr
 		entry = current;
 	} else if (executingContext && executingContext.entry && executingContext.entry.fragmentTag === fragmentTag) {
 		entry = executingContext.entry;
+	} else {
+		// Android also restores fragments that were only in the backstack or still queued, so
+		// widen the lookup before treating this fragment as an orphan.
+		entry = frame._findEntryForTag(fragmentTag);
 	}
 
 	let page: Page;
@@ -52,7 +56,41 @@ function findPageForFragment(fragment: androidx.fragment.app.Fragment, frame: Fr
 		entry.fragment = fragment;
 		_updateTransitions(entry);
 	} else {
-		throw new Error(`Could not find a page for ${fragmentTag}.`);
+		// Android restored a fragment no live entry owns anymore - the frame navigated on (or was
+		// reset) while the activity was being recreated. Throwing is fatal across the JNI boundary
+		// and this fragment can never produce a view, so discard it instead.
+		Trace.write(`Could not find a page for ${fragmentTag}. Discarding orphaned fragment.`, Trace.categories.NativeLifecycle, Trace.messageType.error);
+		removeFragmentIfAdded(fragment);
+	}
+}
+
+/**
+ * Drops a fragment the JS side no longer owns from its FragmentManager, so the manager stops
+ * driving it through the lifecycle. The removal is always deferred - callers may be inside a
+ * FragmentManager transaction, where commitNow throws "already executing transactions".
+ */
+export function removeFragmentIfAdded(fragment: androidx.fragment.app.Fragment): void {
+	if (!fragment.isAdded()) {
+		return;
+	}
+
+	const manager = fragment.getParentFragmentManager();
+	if (manager.isDestroyed()) {
+		return;
+	}
+
+	manager.beginTransaction().remove(fragment).commitAllowingStateLoss();
+}
+
+/**
+ * Breaks the fragment -> BackstackEntry link so a fragment the FragmentManager is still holding
+ * cannot bring a discarded entry (and its torn down page) back into the frame.
+ */
+export function detachFragmentCallbacks(fragment: androidx.fragment.app.Fragment): void {
+	const callbacks: FragmentCallbacksImplementation = fragment[CALLBACKS];
+	if (callbacks) {
+		callbacks.entry = null;
+		callbacks.frame = null;
 	}
 }
 
@@ -214,7 +252,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 			const hasRemovingParent = fragment.getRemovingParentFragment();
 
 			if (hasRemovingParent) {
-				const nativeFrameView = this.frame.nativeViewProtected;
+				const nativeFrameView = this.frame?.nativeViewProtected;
 				if (nativeFrameView) {
 					const bitmapDrawable = new android.graphics.drawable.BitmapDrawable(getNativeApp<android.app.Application>().getApplicationContext().getResources(), this.backgroundBitmap);
 					this.frame._originalBackground = this.frame.backgroundColor || new Color('White');
@@ -237,7 +275,10 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 
 		const entry = this.entry;
 		if (!entry) {
-			Trace.error(`${fragment}.onDestroy: entry is null or undefined`);
+			// A fragment that was never bound to an entry, or whose entry has already been
+			// discarded, is still destroyed by the FragmentManager. Trace.error routes to the error
+			// handler, which rethrows and turns this teardown into a fatal exception.
+			Trace.write(`${fragment}.onDestroy: entry is null or undefined`, Trace.categories.NativeLifecycle, Trace.messageType.error);
 
 			return null;
 		}
@@ -270,7 +311,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 			const hasRemovingParent = fragment.getRemovingParentFragment();
 
 			if (hasRemovingParent) {
-				this.backgroundBitmap = this.loadBitmapFromView(this.frame.nativeViewProtected);
+				this.backgroundBitmap = this.loadBitmapFromView(this.frame?.nativeViewProtected);
 			}
 		} finally {
 			superFunc.call(fragment);
@@ -279,7 +320,16 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 
 	@profile
 	public onResume(fragment: org.nativescript.widgets.FragmentBase, superFunc: Function): void {
-		const frame = this.entry.resolvedPage.frame;
+		const frame = this.entry?.resolvedPage?.frame;
+		if (!frame) {
+			// Stale fragment the FragmentManager is still driving after its entry (or page) was
+			// discarded: there is no navigation left to complete, and dereferencing the missing page
+			// would throw across the JNI boundary.
+			superFunc.call(fragment);
+
+			return;
+		}
+
 		// on some cases during the first navigation on nested frames the animation doesn't trigger
 		// we depend on the animation (even None animation) to set the entry as the current entry
 		// animation should start between start and resume, so if we have an executing navigation here it probably means the animation was skipped
@@ -288,7 +338,7 @@ export class FragmentCallbacksImplementation implements AndroidFragmentCallbacks
 		const weakRef = new WeakRef(this);
 		setTimeout(() => {
 			const owner = weakRef.get();
-			if (!owner) {
+			if (!owner || !owner.entry) {
 				return;
 			}
 			if (!owner.entry.isAnimationRunning) {

--- a/packages/core/ui/frame/index.android.ts
+++ b/packages/core/ui/frame/index.android.ts
@@ -16,7 +16,7 @@ import { getAppMainEntry } from '../../application/helpers-common';
 import { AndroidActivityBackPressedEventData, AndroidActivityNewIntentEventData, AndroidActivityRequestPermissionsEventData, AndroidActivityResultEventData } from '../../application/application-interfaces';
 import { Application } from '../../application/application';
 import { isEmbedded, setEmbeddedView } from '../embedding';
-import { CALLBACKS, FRAMEID, framesCache, setFragmentCallbacks } from './frame-helper-for-android';
+import { CALLBACKS, detachFragmentCallbacks, FRAMEID, framesCache, removeFragmentIfAdded, setFragmentCallbacks } from './frame-helper-for-android';
 import { SDK_VERSION } from '../../utils';
 
 export * from './frame-common';
@@ -459,8 +459,18 @@ export class Frame extends FrameBase {
 	public _removeEntry(removed: BackstackEntry): void {
 		super._removeEntry(removed);
 
-		if (removed.fragment) {
+		const fragment = removed.fragment;
+		if (fragment) {
 			_clearEntry(removed);
+
+			// The entry is gone now - its page was torn down and resolvedPage cleared - but the
+			// fragment can still be sitting in the FragmentManager: navigation only evicts fragments
+			// sharing the frame's current container, so anything left over from an activity
+			// recreation or a frame reset survives. Cut it loose here, or the FragmentManager keeps
+			// driving it through the lifecycle against a dead entry.
+			detachFragmentCallbacks(fragment);
+			removeFragmentIfAdded(fragment);
+
 			removed.fragment = null;
 		}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing.
- [ ] Tests for the changes are included.

## What is the current behavior?

A `FragmentClass` can outlive the `BackstackEntry` it is bound to, and the FragmentManager then drives it through the lifecycle against that dead entry. The reported symptom is a fatal:

```
com.tns.NativeScriptException: Calling js method onCreateView failed
Error: fragment0[0]<null>.onCreateView: entry has no resolvedPage
	at com.tns.FragmentClass.onCreateView(FragmentClass.java:55)
	at androidx.fragment.app.Fragment.performCreateView(Fragment.java:3119)
	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:577)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2211)
	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2106)
	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2049)
```

Note `<null>` in the fragment's `toString`: the fragment's `entry` is intact, only `resolvedPage` is gone.

**How the fragment gets stranded.** Navigation only evicts fragments via `transaction.replace(this.containerViewId, ...)`, which removes added fragments *in that container*. `Frame._removeEntry` then clears `resolvedPage` (`FrameBase._removeEntry`) and drops `entry.fragment`, but never tells the FragmentManager anything — it assumes the `replace` already did. That assumption breaks for any fragment whose container is no longer the frame's current container: leftovers from an activity recreation, a frame/root-view reset, or a navigation that was interrupted mid-flight. Such a fragment stays `mAdded`, so `moveToExpectedState()` keeps promoting it, and it gets `onCreateView` again after its entry has been discarded.

**Why it is fatal rather than a no-op.** Every callback on that path either reported the condition through `Trace.error` — which routes to `DefaultErrorHandler`, rethrows, and surfaces as an uncaught exception across the JNI boundary — or dereferenced the missing page directly:

- `onCreateView` — fixed in #11264, but that only moved the crash one step later, since the fragment continues to…
- `onResume` — `this.entry.resolvedPage.frame` throws a `TypeError` on the very same stale fragment
- `onDestroy` — `Trace.error` on a missing entry, which is exactly what a discarded fragment hits on teardown
- `onPause` / `onDestroyView` — `this.frame.nativeViewProtected` with no frame
- `findPageForFragment` — `throw new Error('Could not find a page for <tag>')` for a restored fragment no live entry claims

This correlates strongly with memory pressure: the tighter memory gets, the more the OS destroys and recreates activities, which is what strands the fragments in the first place. It was reported from production with 300+ occurrences on low-RAM (4 GB) devices, mostly on resume after the app had been idle.

## What is the new behavior?

The stale fragment is discarded instead of taking the app down, and it stops being stale in the first place:

- **`Frame._removeEntry`** — when the discarded entry still has a fragment, detach the fragment's callbacks (`entry`/`frame`) and remove it from its FragmentManager if it is still added. This is the actual leak fix: the guard only fires for fragments that are *still* added while their entry is being discarded, i.e. exactly the orphans. In normal forward/back/`clearHistory`/`backstackVisible: false` navigation the outgoing fragment has already been evicted by the `replace` before `setCurrent` runs, so `isAdded()` is false and nothing changes.
- **`findPageForFragment`** — widen the entry lookup through the (previously unused) `_findEntryForTag`, which also searches the backstack and the navigation queue, so fragments Android restored from those are matched rather than declared orphans. When there genuinely is no entry, log and remove the fragment instead of throwing.
- **`onDestroy` / `onResume` / `onPause` / `onDestroyView`** — treat a missing entry, page or frame as the recoverable state it is. `onResume` in particular had to be guarded, or the `onCreateView` fix from #11264 just relocates the crash.

Removals are always committed with `commitAllowingStateLoss()`: callers can be inside a FragmentManager transaction (`findPageForFragment` runs from `onCreate`, `_removeEntry` from a transition listener), where `commitNow` throws *"FragmentManager is already executing transactions"*.

Also considered and left out: extending the restored-fragment cleanup in `ActivityCallbacksImplementation.onCreate` (which deliberately skips `fragment*` tags) to drop unclaimed NativeScript fragments. Having each orphan remove itself in its own `onCreate` is ordering-independent and also covers child FragmentManagers, which that cleanup does not walk.

No unit tests: `packages/core` specs cover parser/pure-logic modules only and nothing platform-specific, and these are FragmentManager lifecycle paths. Verification is on device — activity destroy/recreate (Don't keep activities) with a navigation in flight, plus tabs/bottom-navigation nested frames on resume.
