### PR TITLE
fix(vite): lazy-load Vue SFC compiler

### DIFF
--- a/packages/vite/hmr/frameworks/vue/server/strategy.spec.ts
+++ b/packages/vite/hmr/frameworks/vue/server/strategy.spec.ts
@@ -211,12 +211,12 @@ const lazy = import("http://localhost:5173/ns/sfc/42/components/Other.vue");
 	});
 
 	// ── Vue's dev HTTP surface + device config ────────────────────────────
-	it('registerRoutes mounts the three Vue SFC endpoints', () => {
+	it('registerRoutes mounts the three Vue SFC endpoints', async () => {
 		const handlers: Array<(...a: any[]) => unknown> = [];
 		const server = { middlewares: { use: (fn: any) => handlers.push(fn) } } as unknown as FrameworkRouteContext['server'];
 
 		expect(typeof vueServerStrategy.registerRoutes).toBe('function');
-		vueServerStrategy.registerRoutes!({
+		await vueServerStrategy.registerRoutes!({
 			server,
 			wss: null,
 			verbose: false,

--- a/packages/vite/hmr/frameworks/vue/server/strategy.ts
+++ b/packages/vite/hmr/frameworks/vue/server/strategy.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import * as PAT from '../../../server/constants.js';
 import { rewriteVendorVueSpec } from '../../../helpers/vendor-rewrite.js';
 import type { FrameworkProcessFileContext, FrameworkRegistryContext, FrameworkRouteContext, FrameworkServerStrategy } from '../../../server/framework-strategy.js';
-import { registerSfcHandlers } from './websocket-sfc.js';
 import { getProjectAppPath } from '../../../../helpers/utils.js';
 import { runHotUpdatePrologue } from '../../../server/websocket-hot-update.js';
 import { cleanCode, collectImportDependencies, processCodeForDevice, rewriteImports } from '../../../server/websocket-device-transform.js';
@@ -573,7 +572,8 @@ if (typeof __VUE_HMR_RUNTIME__ === 'undefined') {
 	// The SFC dev endpoints are inherently Vue-only, so Vue owns registering
 	// them (and contributing its import-map + volatile-pattern entries) rather
 	// than the shared server modules branching on flavor.
-	registerRoutes(ctx: FrameworkRouteContext) {
+	async registerRoutes(ctx: FrameworkRouteContext) {
+		const { registerSfcHandlers } = await import('./websocket-sfc.js');
 		registerSfcHandlers(ctx.server, {
 			verbose: ctx.verbose,
 			appVirtualWithSlash: ctx.appVirtualWithSlash,

--- a/packages/vite/hmr/server/framework-strategy.ts
+++ b/packages/vite/hmr/server/framework-strategy.ts
@@ -233,7 +233,7 @@ export interface FrameworkServerStrategy {
 	 * Register framework-owned dev HTTP endpoints (Vue: `/ns/sfc*`). Defaults to
 	 * no-op for frameworks without extra routes.
 	 */
-	registerRoutes?(ctx: FrameworkRouteContext): void;
+	registerRoutes?(ctx: FrameworkRouteContext): void | Promise<void>;
 
 	/**
 	 * Extra import-map entries for this framework (e.g. Vue → `vue` /

--- a/packages/vite/hmr/server/websocket-framework-isolation.spec.ts
+++ b/packages/vite/hmr/server/websocket-framework-isolation.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@vue/compiler-sfc', () => {
+	throw new Error('Vue compiler loaded for a non-Vue flavor');
+});
+
+describe('framework dependency isolation', () => {
+	it('does not load the Vue compiler for Angular', async () => {
+		const { hmrWebSocketPluginForFlavor } = await import('./websocket.js');
+
+		expect(hmrWebSocketPluginForFlavor('angular', {})).toBeDefined();
+	});
+});

--- a/packages/vite/hmr/server/websocket.ts
+++ b/packages/vite/hmr/server/websocket.ts
@@ -710,7 +710,7 @@ function createHmrWebSocketPlugin(opts: { verbose?: boolean }, strategy: Framewo
 			// Only the strategy that owns routes (Vue) registers them via
 			// `registerRoutes`; SFC/assembler endpoints are inherently Vue-only
 			// (see websocket-sfc.ts).
-			strategy.registerRoutes?.({
+			await strategy.registerRoutes?.({
 				server,
 				wss,
 				verbose,


### PR DESCRIPTION
Avoids dependency warning on non-related integrations.