### PR TITLE
feat(vite): align the dev boot with 9.1 runtime contract

### DIFF
--- a/packages/vite/configuration/base.ts
+++ b/packages/vite/configuration/base.ts
@@ -444,6 +444,12 @@ export const baseConfig = ({ mode, flavor }: { mode: string; flavor?: string }):
 				postcssImport,
 			}),
 		},
+		// The dev server serves ES modules to the device, never HTML. Vite's
+		// default 'spa' app type answers unknown paths with index.html when one
+		// exists, and the runtime's module loader now rejects any non-JavaScript
+		// MIME outright — 'custom' drops those HTML middlewares so a bad module
+		// path fails as a plain 404 that names the URL.
+		...(isDevMode ? { appType: 'custom' as const } : {}),
 		// Development server configuration for HMR
 		server: isDevMode
 			? {

--- a/packages/vite/helpers/main-entry.ts
+++ b/packages/vite/helpers/main-entry.ts
@@ -259,6 +259,19 @@ export function mainEntryPlugin(opts: { platform: 'ios' | 'android' | 'visionos'
 			// builds, we keep bare specifiers so production bundlers inline core
 			// the normal way.
 			//
+			// Pre-configure invariant. bundle.mjs is a local ES module entry, so
+			// its static import graph is fetched and keyed by the runtime BEFORE
+			// its body runs `configureLoader` (session-bootstrap). Unconfigured,
+			// the runtime keys an HTTP module by its URL verbatim (fragment
+			// stripped, nothing else). Every URL reachable from this entry's
+			// static graph must therefore be canonical on its own — absolute,
+			// query-free, resolvable without the import map — or the same module
+			// requested after configuration lands under a second registry key
+			// and evaluates twice. The /ns/core bridge URLs satisfy this
+			// (`buildCoreUrl` emits no query, and the bridge shims import only
+			// `/ns/core-bundle.mjs`); anything served through /ns/m must be
+			// reached from the dev session, after configuration.
+			//
 			// Routes through `resolveDeviceReachableOrigin` so the URL baked
 			// into the bundle is something the DEVICE can reach: wildcard
 			// binds (`0.0.0.0`) and Android loopback get remapped to a real

--- a/packages/vite/hmr/client/strategy-loader.ts
+++ b/packages/vite/hmr/client/strategy-loader.ts
@@ -71,9 +71,26 @@ export const APP_MAIN_ENTRY_SPEC = `${APP_VIRTUAL_WITH_SLASH}app.ts`;
 const CLIENT_STRATEGY_FLAVORS = new Set(['vue', 'angular', 'solid', 'typescript', 'react']);
 let CLIENT_STRATEGY: FrameworkClientStrategy | undefined;
 
+// The strategy module's URL, absolute and dot-segment free. The runtime keys
+// its module registry by the specifier it is handed, so a `../` specifier from
+// a dev-served module would register the strategy under a non-canonical URL
+// (`…/hmr/client/../frameworks/…`) — a second identity next to the canonical
+// one, fetched outside the async graph walk. Resolving against
+// `import.meta.url` here hands the loader the canonical URL up front.
+function resolveClientStrategyUrl(flavor: string): string {
+	const relative = `../frameworks/${flavor}/client/strategy.js`;
+	try {
+		const base = import.meta.url;
+		if (typeof base === 'string' && /^https?:\/\//.test(base)) {
+			return new URL(relative, base).href;
+		}
+	} catch {}
+	return relative;
+}
+
 export const CLIENT_STRATEGY_READY: Promise<void> =
 	TARGET_FLAVOR && CLIENT_STRATEGY_FLAVORS.has(TARGET_FLAVOR)
-		? import(`../frameworks/${TARGET_FLAVOR}/client/strategy.js`)
+		? import(/* @vite-ignore */ resolveClientStrategyUrl(TARGET_FLAVOR))
 				.then((mod: any) => {
 					CLIENT_STRATEGY = mod && mod[`${TARGET_FLAVOR}ClientStrategy`];
 					if (VERBOSE) console.log('[hmr-client] client strategy loaded for flavor:', TARGET_FLAVOR);

--- a/packages/vite/hmr/server/import-map.ts
+++ b/packages/vite/hmr/server/import-map.ts
@@ -14,10 +14,12 @@
  *   Trailing-slash prefix entries cover subpath imports
  *     (e.g. @nativescript/tanstack-router/solid) for every package.
  *
- * The runtime's NormalizeViteSpecifier() extracts bare package names from
- * Vite-rewritten paths (e.g. /node_modules/.vite/deps/solid-js.js → solid-js),
- * then looks them up in this map. This ensures ALL imports — regardless of
- * how Vite rewrites them — resolve through a single deterministic path.
+ * The runtime matches map keys literally: it reverse-engineers none of Vite's
+ * rewrites (`/node_modules/.vite/deps/solid-js.js?v=…`, `/@id/…`, `/@fs/…`).
+ * Every specifier form that reaches the device must therefore either be a key
+ * in this map or be rewritten by the server before it is served — the /ns/m
+ * pipeline (`processCodeForDevice`) turns prebundled-dep paths back into bare
+ * ids and resolves package-internal paths to full `/ns/m/node_modules/…` URLs.
  */
 
 import type { VendorManifest } from '../shared/vendor/manifest.js';

--- a/packages/vite/hmr/server/websocket-ns-entry.ts
+++ b/packages/vite/hmr/server/websocket-ns-entry.ts
@@ -118,10 +118,9 @@ export function registerNsEntryRoutes(server: ViteDevServer, options: RegisterNs
 				}
 			} catch {}
 			const verSeg = urlObj.pathname.replace(/^\/ns\/entry\/?/, '');
-			// Resolve app main entry to an absolute path-like key used by /ns/m
-			res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
-			res.setHeader('Pragma', 'no-cache');
-			res.setHeader('Expires', '0');
+			// A JavaScript MIME is required: the runtime refuses to evaluate a
+			// module response that carries none.
+			setDeviceModuleHeaders(res);
 			const ver = /^[0-9]+$/.test(verSeg) ? verSeg : String(getGraphVersion() || 0);
 			const origin = getServerOrigin(server) || `${urlObj.protocol}//${urlObj.host}`;
 			// Resolve app main entry to an absolute path-like key used by /ns/m

--- a/packages/vite/hmr/shared/runtime/browser-runtime-contract.ts
+++ b/packages/vite/hmr/shared/runtime/browser-runtime-contract.ts
@@ -81,7 +81,15 @@ export interface NsRuntimeDevHostApi {
 	invalidateModules?: (urls: string[]) => void;
 	/** `getLoadedModuleUrls` — registry introspection for JS-driven full reload. */
 	getLoadedModuleUrls?: () => string[];
-	/** `setDevBootComplete` — flips the native cold-boot gate + `__NS_HMR_BOOT_COMPLETE__`. */
+	/** `createRequire` — a CommonJS `require` resolving against a local file path or `file:` URL. */
+	createRequire?: (filenameOrURL: string | URL) => (specifier: string) => unknown;
+	/** `createPumpingRequire` — like `createRequire`, but settles top-level-await graphs by pumping V8 tasks; boot-only options. */
+	createPumpingRequire?: (filenameOrURL: string | URL, options?: { deadlineSeconds?: number; onTimeout?: 'throw' | 'return-pending'; pumpRunLoop?: boolean }) => (specifier: string) => unknown;
+	/**
+	 * `setDevBootComplete` — flips the native cold-boot gate. Only runtimes that
+	 * let the client arm that gate expose it; current runtimes scope the gate
+	 * to entry evaluation natively and omit the member.
+	 */
 	setDevBootComplete?: (value?: boolean) => void;
 }
 

--- a/packages/vite/hmr/shared/runtime/session-bootstrap.ts
+++ b/packages/vite/hmr/shared/runtime/session-bootstrap.ts
@@ -252,9 +252,9 @@ export async function startBrowserRuntimeSession(defaultSessionUrl: string, verb
 			trace.importMap = { ok: true, ms: Date.now() - tImap };
 		}
 
-		// Session globals + arm the cold-boot gate (runloop pump between
-		// synchronous fetches). `setDevBootComplete(false)` is a no-op on
-		// a fresh realm but matters for re-bootstrapped sessions.
+		// Session globals. `setDevBootComplete` only exists on runtimes that
+		// still let the client arm their cold-boot gate; current runtimes derive
+		// that window natively and expose no such member.
 		applyDevSessionGlobals(session);
 		try {
 			runtimeApi.setDevBootComplete?.(false);


### PR DESCRIPTION
Support 9.1 runtime contract.
- import-map keys are matched literally, module responses must carry a JavaScript MIME, unresolvable specifiers fail loudly, and the client owns every URL shape it hands the loader. The dev boot already fits that contract - bundle.mjs is a local ES module whose static graph is only the query-free /ns/core bridge URLs, so the pre-configure window is harmless - and this makes the remaining edges explicit:
  - Serve the dev server with appType 'custom' so Vite's SPA fallback can never answer a module request with index.html; a bad module path now fails as a plain 404 that names the URL instead of a MIME rejection.
  - Set the module headers on /ns/entry, the one module route that sent no Content-Type.
  - Load the framework client strategy through an absolute URL resolved from import.meta.url. A `../` specifier from a dev-served module made the runtime register the strategy under a non-canonical `.../hmr/client/../frameworks/...` key and fetch its closure through blocking synchronous requests outside the async graph walk.
  - Type createRequire/createPumpingRequire on the ns:module surface and document the pre-configure invariant in the entry emitter