### PR TITLE
feat(vite): framework registration API 

### DIFF
--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -158,7 +158,7 @@ A framework can ship its own flavor — config helper, server strategy and devic
 client strategy — as a package, using `@nativescript/vite/framework` and
 `@nativescript/vite/hmr/client/framework.js`. `init` and flavor detection pick it up from a
 `nativescript.vite` declaration in that package's `package.json`. The Octane flavor,
-[`@nativescript-community/vite-octane`](https://github.com/NativeScript/octane), is built this way:
+[`@nativescript-community/vite-octane`](https://github.com/nativescript-community/octane), is built this way:
 
 ```ts
 import { octaneConfig } from '@nativescript-community/vite-octane';

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -158,10 +158,10 @@ A framework can ship its own flavor — config helper, server strategy and devic
 client strategy — as a package, using `@nativescript/vite/framework` and
 `@nativescript/vite/hmr/client/framework.js`. `init` and flavor detection pick it up from a
 `nativescript.vite` declaration in that package's `package.json`. The Octane flavor,
-[`@nativescript/vite-octane`](https://github.com/NativeScript/octane), is built this way:
+[`@nativescript-community/vite-octane`](https://github.com/NativeScript/octane), is built this way:
 
 ```ts
-import { octaneConfig } from '@nativescript/vite-octane';
+import { octaneConfig } from '@nativescript-community/vite-octane';
 
 export default defineConfig(({ mode }) => octaneConfig({ mode }));
 ```

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -44,7 +44,7 @@ npx nativescript-vite init
 
 This will:
 
-- Generate a `vite.config.mts` using the detected project flavor (Angular, Vue, React, Solid, TypeScript, or JavaScript) and the corresponding helper subpath from `@nativescript/vite`.
+- Generate a `vite.config.mts` using the detected project flavor (Angular, Vue, React, Solid, TypeScript, or JavaScript — or a flavor a dependency declares, see below) and the corresponding helper subpath from `@nativescript/vite`.
 - Add the dependency `@valor/nativescript-websockets`.
 - Append `.ns-vite-build` to `.gitignore` if it is not already present.
 
@@ -151,6 +151,22 @@ import { reactConfig } from '@nativescript/vite/react';
 import { solidConfig } from '@nativescript/vite/solid';
 import { vueConfig } from '@nativescript/vite/vue';
 ```
+
+### Flavors from other packages
+
+A framework can ship its own flavor — config helper, server strategy and device-side
+client strategy — as a package, using `@nativescript/vite/framework` and
+`@nativescript/vite/hmr/client/framework.js`. `init` and flavor detection pick it up from a
+`nativescript.vite` declaration in that package's `package.json`. The Octane flavor,
+[`@nativescript/vite-octane`](https://github.com/NativeScript/octane), is built this way:
+
+```ts
+import { octaneConfig } from '@nativescript/vite-octane';
+
+export default defineConfig(({ mode }) => octaneConfig({ mode }));
+```
+
+See [docs/framework-flavors.md](./docs/framework-flavors.md) for the full walkthrough.
 
 2) Update `nativescript.config.ts`:
 

--- a/packages/vite/configuration/base.ts
+++ b/packages/vite/configuration/base.ts
@@ -120,7 +120,7 @@ export const baseConfig = ({ mode, flavor }: { mode: string; flavor?: string }):
 	}
 
 	// Filtered logger to suppress noisy warnings
-	const filteredLogger = createFilteredViteLogger();
+	const filteredLogger = createFilteredViteLogger({ hmrActive });
 
 	// Create TypeScript aliases with platform support
 	const tsConfig = getTsConfigData({ platform, verbose });

--- a/packages/vite/docs/framework-flavors.md
+++ b/packages/vite/docs/framework-flavors.md
@@ -7,7 +7,7 @@ description: How a JS framework ships NativeScript Vite HMR support as its own p
 
 `@nativescript/vite` has built-in flavors for Angular, Vue, React, Solid, TypeScript and JavaScript. A **flavor** is what turns a saved file into a change on the device: a config helper that declares it, a server strategy that runs in the Vite process, and a client strategy the device evaluates next to the shared HMR client.
 
-Flavors are not limited to the built-ins. A framework — or a renderer, a router, anything that holds live objects between saves — can register a flavor from its own package, under its own npm scope, with no change to `@nativescript/vite`. This page is how. The worked example throughout is [`@nativescript-community/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane), the Octane flavor: a community package built entirely on this API.
+Flavors are not limited to the built-ins. A framework — or a renderer, a router, anything that holds live objects between saves — can register a flavor from its own package, under its own npm scope, with no change to `@nativescript/vite`. This page is how. The worked example throughout is [`@nativescript-community/vite-octane`](https://github.com/nativescript-community/octane/tree/main/packages/vite-octane), the Octane flavor: a community package built entirely on this API.
 
 [[toc]]
 
@@ -238,4 +238,4 @@ On a device, five saves cover the matrix: a component, a plain dependency, a wor
 
 - `@nativescript/vite/framework` — `registerFrameworkFlavor`, `getFrameworkFlavor`, `baseConfig`, `getTypeCheckPlugins`, `typescriptServerStrategy`, `runHotUpdatePrologue`, `purgeTransformCachesForHotUpdate`, and the strategy types.
 - `@nativescript/vite/hmr/client/framework.js` — `getNsHotRegistry`, `graph`, `getGraphVersion`, `normalizeSpec`, `requestModuleFromServer`, `invalidateModulesByUrls`, `buildEvictionUrls`, `resolveHmrHttpOrigin`, `safeDynImport`, `getCore`, `ENV_VERBOSE`, `setUpdateStage`, `getOverlayApi`, `performResetRoot`, `getGlobalScope`, `readNsRuntimeDevHostApi`.
-- Worked example: [`@nativescript-community/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane).
+- Worked example: [`@nativescript-community/vite-octane`](https://github.com/nativescript-community/octane/tree/main/packages/vite-octane).

--- a/packages/vite/docs/framework-flavors.md
+++ b/packages/vite/docs/framework-flavors.md
@@ -1,0 +1,241 @@
+---
+title: Framework flavors — shipping HMR for your own framework
+description: How a JS framework ships NativeScript Vite HMR support as its own package with registerFrameworkFlavor, a server strategy and a device-side client strategy.
+---
+
+# Framework flavors
+
+`@nativescript/vite` has built-in flavors for Angular, Vue, React, Solid, TypeScript and JavaScript. A **flavor** is what turns a saved file into a change on the device: a config helper that declares it, a server strategy that runs in the Vite process, and a client strategy the device evaluates next to the shared HMR client.
+
+Flavors are not limited to the built-ins. A framework — or a renderer, a router, anything that holds live objects between saves — can register a flavor from its own package, with no change to `@nativescript/vite`. This page is how. The worked example throughout is [`@nativescript/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane), the Octane flavor, which is built entirely on this API.
+
+[[toc]]
+
+## What a flavor provides
+
+```ts
+import { registerFrameworkFlavor } from '@nativescript/vite/framework';
+
+registerFrameworkFlavor({
+  flavor: 'octane',                           // the name, everywhere
+  server: octaneServerStrategy,               // runs in the dev server
+  client: '@nativescript/vite-octane/client', // fetched and evaluated by the device
+});
+```
+
+| Part | Runs where | Responsibility |
+| --- | --- | --- |
+| **Config helper** | Vite process | Registers the flavor, wraps `baseConfig({ mode, flavor })`, adds the framework's Vite plugin(s). |
+| **Server strategy** | Vite process | Owns `handleHotUpdate` for the flavor's files: update the module graph, purge transform caches, broadcast the delta. |
+| **Client strategy** | Device | Decides what a freshly re-imported module *means* for the live app: fire accept callbacks, propagate to importers, reload the graph. |
+
+The shared pieces stay shared. `@nativescript/vite` serves the app over HTTP ESM, speaks the WebSocket protocol, evicts and re-imports modules through `ns:module`, drives the on-device overlay, and tracks workers. A strategy never re-implements those.
+
+## Package layout
+
+```
+@my-framework/nativescript-vite/
+├─ package.json        exports ".", "./client"; declares nativescript.vite
+├─ src/index.ts        config helper + registerFrameworkFlavor   (Node)
+├─ src/server/strategy.ts                                         (Node)
+└─ src/client/strategy.ts                                         (device)
+```
+
+Two rules shape the layout:
+
+- **The server half and the client half are different programs.** The server entry may import anything Node can load. The client entry is served to the device raw, so it must be plain ESM with explicit `.js` extensions on relative imports, and it must reach the shared client only through `@nativescript/vite/hmr/client/framework.js`. Keep the two in separate files; the config entry must not import the client file.
+- **Declare the flavor in `package.json`** so `nativescript-vite init` and flavor detection recognise the package:
+
+```json
+{
+  "name": "@nativescript/vite-octane",
+  "exports": {
+    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
+    "./client": { "import": "./dist/client/strategy.js", "types": "./dist/client/strategy.d.ts" }
+  },
+  "nativescript": {
+    "vite": {
+      "flavor": "octane",
+      "config": { "import": "octaneConfig", "from": "@nativescript/vite-octane" }
+    }
+  },
+  "peerDependencies": { "@nativescript/vite": ">=8.0.0", "vite": "^8.0.0" }
+}
+```
+
+With that in place, `npx nativescript-vite init` in an app that depends on the package generates:
+
+```ts
+import { defineConfig } from 'vite';
+import { octaneConfig } from '@nativescript/vite-octane';
+
+export default defineConfig(({ mode }) => octaneConfig({ mode }));
+```
+
+## 1. The config helper
+
+```ts
+// src/index.ts
+import { mergeConfig, type UserConfig } from 'vite';
+import { baseConfig, getTypeCheckPlugins, registerFrameworkFlavor, type TypeCheckControlOptions } from '@nativescript/vite/framework';
+import { octane, type OctanePluginOptions } from '@octanejs/vite-plugin';
+import { octaneServerStrategy } from './server/strategy.js';
+
+registerFrameworkFlavor({ flavor: 'octane', server: octaneServerStrategy, client: '@nativescript/vite-octane/client' });
+
+export interface OctaneConfigOptions extends TypeCheckControlOptions {
+  octane?: OctanePluginOptions;
+}
+
+export const octaneConfig = ({ mode }: { mode: string }, options: OctaneConfigOptions = {}): UserConfig =>
+  mergeConfig(baseConfig({ mode, flavor: 'octane' }), {
+    plugins: [...getTypeCheckPlugins('typescript', options.typeCheck), ...octane(options.octane)],
+  });
+```
+
+Register at module scope, before `baseConfig` can run. `baseConfig` installs the HMR plugins for the declared flavor and looks the server strategy up by name; it also seeds the device bundle with the client module's path (`__NS_CLIENT_STRATEGY_URL__`) so the on-device loader can fetch it without knowing your package.
+
+`getTypeCheckPlugins` takes the *kind* of type-check, not the flavor name: `'typescript'` for a `.ts`/`.tsx` project, `'vue'` for `vue-tsc`.
+
+## 2. The server strategy
+
+Most frameworks need nothing new on the server. `typescriptServerStrategy` is the generic device-module pipeline — it serves app files over `/ns/m`, primes the module graph, and emits deltas. Spread it, rename the flavor, and write the one thing that differs: the hot-update tail.
+
+```ts
+// src/server/strategy.ts
+import * as path from 'node:path';
+import { purgeTransformCachesForHotUpdate, runHotUpdatePrologue, typescriptServerStrategy, type FrameworkServerStrategy } from '@nativescript/vite/framework';
+
+const SCRIPT_FILE_RE = /\.(?:[mc]?[jt]sx?)$/i;
+
+export const octaneServerStrategy: FrameworkServerStrategy = {
+  ...typescriptServerStrategy,
+  flavor: 'octane',
+  deferDeltaBroadcast: true,
+  async handleHotUpdate(ctx, deps) {
+    const state = await runHotUpdatePrologue(ctx, deps);
+    if (!state) return;
+    const { root, metrics, emitSummary } = state;
+    const { moduleGraph, verbose, sharedTransformRequest } = deps;
+    const { file, server } = ctx;
+    if (!SCRIPT_FILE_RE.test(file)) return emitSummary();
+    metrics.tAfterFramework = Date.now();
+
+    const rel = '/' + path.posix.normalize(path.relative(root, file)).split(path.sep).join('/');
+    const id = moduleGraph.normalizeGraphId(rel);
+    if (!moduleGraph.get(id)) moduleGraph.upsert(rel, `/* hmr ${Date.now()} */`, [], { emitDeltaOnInsert: true });
+
+    // The device applies an edit by re-fetching the module. Purge BEFORE the
+    // delta goes out, or the re-fetch is served from the previous save.
+    purgeTransformCachesForHotUpdate({ file, server, sharedTransformRequest, verbose, label: 'octane' });
+    const fresh = await sharedTransformRequest(rel, 30000);
+    if (fresh?.code) {
+      const mod = server.moduleGraph.getModuleById(file);
+      const deps = mod ? Array.from(mod.importedModules).map((m) => (m.id || '').replace(/\?.*$/, '')).filter(Boolean) : moduleGraph.get(id)?.deps ?? [];
+      moduleGraph.upsert(id, fresh.code, deps as string[], { broadcastDelta: false });
+    }
+    const gm = moduleGraph.get(id);
+    if (gm) moduleGraph.emitDelta([gm], []);
+    emitSummary();
+  },
+};
+```
+
+`deferDeltaBroadcast: true` is the contract that makes the purge-then-broadcast order hold: the shared prologue records the change but leaves the broadcast to you. Read the module's dependency edges *after* the re-transform — import analysis runs inside it — so a newly added import reaches the client graph on the save that introduced it.
+
+Other optional members of `FrameworkServerStrategy` cover the less common needs: `transformNodeModule` (patch a vendor module before it is served), `rewriteServedModule`, `registerRoutes` (framework-owned dev endpoints), `importMapEntries`, `volatilePatterns`, `handleClientCustomEvent` (a `hot.send` from the device). The interface is documented inline in `hmr/server/framework-strategy.ts`.
+
+## 3. The client strategy
+
+This is where a framework's HMR semantics live. The shared queue does, for every delta: evict the changed modules from the runtime registry → re-import each one → call the strategy. Your strategy answers: what now?
+
+```ts
+// src/client/strategy.ts — served to the device as-is
+import type { FrameworkClientStrategy } from '@nativescript/vite/hmr/client/framework.js';
+import { getNsHotRegistry, graph, setUpdateStage } from '@nativescript/vite/hmr/client/framework.js';
+
+export const octaneClientStrategy: FrameworkClientStrategy = {
+  flavor: 'octane',
+  drivesQueueOverlayStages: true,
+  install() {},
+  beforeBatchEvict(drained) { /* snapshot accept callbacks, run dispose */ },
+  afterModuleReimport(id, namespace) { /* fire accept with the fresh namespace */ },
+  async refreshAfterBatch(drained, ctx) { /* propagate what nothing accepted; finish the overlay */ },
+};
+export default octaneClientStrategy;
+```
+
+Export it as `default`, `clientStrategy`, or `<flavor>ClientStrategy`.
+
+### Hooks, in the order they run
+
+| Hook | When | Typical use |
+| --- | --- | --- |
+| `install()` | once, when the client resolves the strategy | dev shims, event listeners |
+| `shouldQueueReimport(id)` | per changed id, before anything is fetched | return `false` for a module that must not evaluate in this realm (a worker script, a type-only module) or that nothing can accept |
+| `applyUnqueuedChanges(ids)` | once, for the ids declined above | fire dependency acceptors; request a graph reload |
+| `beforeBatchEvict(drained)` | once, before eviction | the last moment the outgoing module instances are reachable: read their `hot.accept` callbacks, drain `hot.dispose` |
+| `afterModuleReimport(id, namespace)` | per re-imported module | invoke the captured accept callbacks with the fresh namespace |
+| `refreshAfterBatch(drained, ctx)` | once, after the drain | walk the reverse graph for modules nothing accepted; `ctx.setUpdateOverlayStage('complete', …)` |
+| `handleGraphResync(changedIds)` | a full graph with drifted hashes (dev-server restart) | return `true` after requesting one ordered reload instead of the piecemeal default |
+| `handleHotUpdateMessage(msg, ctx)` | any protocol message the shared dispatcher did not consume | framework-specific messages a server strategy broadcasts |
+
+`ctx.graph` (and the `graph` export) is the live mirror of the server's module graph: `Map<id, { deps, hash }>`. It is what makes "who imports the changed module" answerable on the device.
+
+### The hot registry
+
+`getNsHotRegistry()` is the process-wide `import.meta.hot` implementation — every served app module gets a context from it, keyed by canonical id (`/src/app`, extensionless). The members a strategy uses:
+
+| Member | Purpose |
+| --- | --- |
+| `getAcceptCallbacks(key)` | the self-accept callbacks registered by the key's **current** evaluation (a copy); non-empty = self-accepting boundary |
+| `getDepAcceptors(depKey)` / `acceptsDep(owner, dep)` | the dependency form — `hot.accept('./worker', cb)` — resolved relative to the owner; lets an update reach a module that never imported the changed file |
+| `runDispose(keys)` / `runPrune(keys)` | drain `hot.dispose` / `hot.prune` |
+| `hasDeclined(keys)` | any `hot.decline()` |
+| `createHotContext(id).data` | persists across re-evaluations of the same key |
+| `dispatchHotEvent(event, payload)` / `createHotContext(id).on(event, cb)` | custom events; the shared client emits `vite:beforeFullReload`, `ns:full-reload-complete`, `ns:full-reload-failed` |
+| `requestFullReload(reason)` | the in-process graph reload: drains dispose, evicts every app-owned module (never `@nativescript/core` or vendor), re-imports the entry |
+
+One subtlety worth knowing before you write `afterModuleReimport`: the registry holds the callbacks of the **latest** evaluation (Vite's semantics). If your framework's accept callback closes over a module-local binding — as Octane's does — the callback that can reach the live instances is the **first** evaluation's, and you must keep firing that one. If it consults a global registry keyed by component id (Vue, React Refresh, solid-refresh), the latest is equivalent. The Octane strategy's `anchors` map is the reference for the former.
+
+### The runtime
+
+`readNsRuntimeDevHostApi()` returns the `ns:module` builtin: `getLoadedModuleUrls()` is the authoritative answer to "has this realm evaluated that module" (worker scripts and type-only files have not), and `invalidateModules(urls)` is the eviction primitive the shared `invalidateModulesByUrls` wraps. Both are `{}`-safe off-device, so strategies unit-test under Node.
+
+### What the device must be able to load
+
+The client module is served at `/ns/m/node_modules/<package>/<file>` — the registry resolves your `client` specifier from the app root and expresses it relative to the package, so a linked workspace package works the same as an installed one. The package is classified as dev tooling, like `@nativescript/vite`: served per-module, never vendor-bundled, never wrapped as a plugin. That is why relative imports inside it (`./boundary-propagation.js`) and its imports of the shared surface resolve to the same canonical URLs the running client uses — and why importing any other client-internal path is unsupported.
+
+## 4. Testing a strategy without a device
+
+Keep the decision logic pure. Octane's reverse-graph walk is a function `(changedIds, graph, { acceptsSelf, acceptsDep }) → { boundaries, evict, dead }` with a dozen cases that run in milliseconds. The strategy itself is testable against the real hot registry:
+
+```ts
+import { getNsHotRegistry } from '@nativescript/vite/hmr/client/framework.js';
+import { octaneClientStrategy } from './strategy.js';
+
+const hot = getNsHotRegistry().createHotContext('/src/app.tsx');
+hot.accept(gen1);
+octaneClientStrategy.beforeBatchEvict!(['/src/app.tsx']);
+getNsHotRegistry().createHotContext('/src/app.tsx').accept(gen2);   // the fresh evaluation
+octaneClientStrategy.afterModuleReimport!('/src/app.tsx', { App: 'v2' });
+expect(gen1).toHaveBeenCalledWith({ App: 'v2' });
+```
+
+On a device, five saves cover the matrix: a component, a plain dependency, a worker script, a registry-style module that accepts itself, and the entry.
+
+## Checklist
+
+- [ ] `registerFrameworkFlavor` runs before `baseConfig({ flavor })`.
+- [ ] Server strategy spreads `typescriptServerStrategy`, sets `flavor` and `deferDeltaBroadcast: true`, purges before it broadcasts.
+- [ ] Client module: plain ESM, `.js` extensions, imports only from `@nativescript/vite/hmr/client/framework.js`, exports `default`.
+- [ ] `package.json` exports `./client` and declares `nativescript.vite.flavor` (+ `config` for `init`).
+- [ ] `shouldQueueReimport` declines modules the main realm never loaded.
+- [ ] Every path ends the overlay: `setUpdateStage('complete', …)`.
+- [ ] A failed re-import leaves the app on the previous revision and the next good save applies in place.
+
+## Reference
+
+- `@nativescript/vite/framework` — `registerFrameworkFlavor`, `getFrameworkFlavor`, `baseConfig`, `getTypeCheckPlugins`, `typescriptServerStrategy`, `runHotUpdatePrologue`, `purgeTransformCachesForHotUpdate`, and the strategy types.
+- `@nativescript/vite/hmr/client/framework.js` — `getNsHotRegistry`, `graph`, `getGraphVersion`, `normalizeSpec`, `requestModuleFromServer`, `invalidateModulesByUrls`, `buildEvictionUrls`, `resolveHmrHttpOrigin`, `safeDynImport`, `getCore`, `ENV_VERBOSE`, `setUpdateStage`, `getOverlayApi`, `performResetRoot`, `getGlobalScope`, `readNsRuntimeDevHostApi`.
+- Worked example: [`@nativescript/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane).

--- a/packages/vite/docs/framework-flavors.md
+++ b/packages/vite/docs/framework-flavors.md
@@ -7,7 +7,7 @@ description: How a JS framework ships NativeScript Vite HMR support as its own p
 
 `@nativescript/vite` has built-in flavors for Angular, Vue, React, Solid, TypeScript and JavaScript. A **flavor** is what turns a saved file into a change on the device: a config helper that declares it, a server strategy that runs in the Vite process, and a client strategy the device evaluates next to the shared HMR client.
 
-Flavors are not limited to the built-ins. A framework — or a renderer, a router, anything that holds live objects between saves — can register a flavor from its own package, with no change to `@nativescript/vite`. This page is how. The worked example throughout is [`@nativescript/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane), the Octane flavor, which is built entirely on this API.
+Flavors are not limited to the built-ins. A framework — or a renderer, a router, anything that holds live objects between saves — can register a flavor from its own package, under its own npm scope, with no change to `@nativescript/vite`. This page is how. The worked example throughout is [`@nativescript-community/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane), the Octane flavor: a community package built entirely on this API.
 
 [[toc]]
 
@@ -19,7 +19,7 @@ import { registerFrameworkFlavor } from '@nativescript/vite/framework';
 registerFrameworkFlavor({
   flavor: 'octane',                           // the name, everywhere
   server: octaneServerStrategy,               // runs in the dev server
-  client: '@nativescript/vite-octane/client', // fetched and evaluated by the device
+  client: '@nativescript-community/vite-octane/client', // fetched and evaluated by the device
 });
 ```
 
@@ -48,7 +48,7 @@ Two rules shape the layout:
 
 ```json
 {
-  "name": "@nativescript/vite-octane",
+  "name": "@nativescript-community/vite-octane",
   "exports": {
     ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
     "./client": { "import": "./dist/client/strategy.js", "types": "./dist/client/strategy.d.ts" }
@@ -56,7 +56,7 @@ Two rules shape the layout:
   "nativescript": {
     "vite": {
       "flavor": "octane",
-      "config": { "import": "octaneConfig", "from": "@nativescript/vite-octane" }
+      "config": { "import": "octaneConfig", "from": "@nativescript-community/vite-octane" }
     }
   },
   "peerDependencies": { "@nativescript/vite": ">=8.0.0", "vite": "^8.0.0" }
@@ -67,7 +67,7 @@ With that in place, `npx nativescript-vite init` in an app that depends on the p
 
 ```ts
 import { defineConfig } from 'vite';
-import { octaneConfig } from '@nativescript/vite-octane';
+import { octaneConfig } from '@nativescript-community/vite-octane';
 
 export default defineConfig(({ mode }) => octaneConfig({ mode }));
 ```
@@ -81,7 +81,7 @@ import { baseConfig, getTypeCheckPlugins, registerFrameworkFlavor, type TypeChec
 import { octane, type OctanePluginOptions } from '@octanejs/vite-plugin';
 import { octaneServerStrategy } from './server/strategy.js';
 
-registerFrameworkFlavor({ flavor: 'octane', server: octaneServerStrategy, client: '@nativescript/vite-octane/client' });
+registerFrameworkFlavor({ flavor: 'octane', server: octaneServerStrategy, client: '@nativescript-community/vite-octane/client' });
 
 export interface OctaneConfigOptions extends TypeCheckControlOptions {
   octane?: OctanePluginOptions;
@@ -238,4 +238,4 @@ On a device, five saves cover the matrix: a component, a plain dependency, a wor
 
 - `@nativescript/vite/framework` — `registerFrameworkFlavor`, `getFrameworkFlavor`, `baseConfig`, `getTypeCheckPlugins`, `typescriptServerStrategy`, `runHotUpdatePrologue`, `purgeTransformCachesForHotUpdate`, and the strategy types.
 - `@nativescript/vite/hmr/client/framework.js` — `getNsHotRegistry`, `graph`, `getGraphVersion`, `normalizeSpec`, `requestModuleFromServer`, `invalidateModulesByUrls`, `buildEvictionUrls`, `resolveHmrHttpOrigin`, `safeDynImport`, `getCore`, `ENV_VERBOSE`, `setUpdateStage`, `getOverlayApi`, `performResetRoot`, `getGlobalScope`, `readNsRuntimeDevHostApi`.
-- Worked example: [`@nativescript/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane).
+- Worked example: [`@nativescript-community/vite-octane`](https://github.com/NativeScript/octane/tree/main/packages/vite-octane).

--- a/packages/vite/framework.ts
+++ b/packages/vite/framework.ts
@@ -1,0 +1,25 @@
+/**
+ * `@nativescript/vite/framework` — the surface a framework package uses to
+ * ship its own NativeScript HMR flavor (dev-server side, Node).
+ *
+ * A flavor is a name, a server strategy, and a client strategy module. The
+ * server strategy runs in the Vite process; the client strategy is fetched by
+ * the device next to the shared HMR client and is authored against
+ * `@nativescript/vite/hmr/client/framework.js`.
+ */
+export { registerFrameworkFlavor, getFrameworkFlavor, getClientStrategyDevicePath, isBuiltInFlavor } from './hmr/framework-flavors.js';
+export type { FrameworkFlavorDefinition } from './hmr/framework-flavors.js';
+
+export type { FrameworkServerStrategy, FrameworkProcessFileContext, FrameworkRegistryContext, FrameworkServedModuleContext, FrameworkModuleRequestContext, FrameworkRouteContext } from './hmr/server/framework-strategy.js';
+export type { FrameworkClientStrategy, FrameworkClientBatchContext, FrameworkClientMessageContext, FrameworkClientMountContext, ClientGraphModule } from './hmr/client/framework-client-strategy.js';
+
+/** The generic device-module pipeline; the usual base for a new server strategy. */
+export { typescriptServerStrategy } from './hmr/frameworks/typescript/server/strategy.js';
+/** Shared hot-update prologue every server strategy's `handleHotUpdate` starts with. */
+export { runHotUpdatePrologue } from './hmr/server/websocket-hot-update.js';
+export type { NsHotUpdateContext, HotUpdatePrologueState, HmrUpdateMetrics } from './hmr/server/websocket-hot-update.js';
+export { purgeTransformCachesForHotUpdate } from './hmr/server/transform-cache-invalidation.js';
+
+export { baseConfig } from './configuration/base.js';
+export { getTypeCheckPlugins } from './helpers/typescript-check.js';
+export type { TypeCheckControlOptions, TypeCheckSetting, TypeCheckFlavor } from './helpers/typescript-check.js';

--- a/packages/vite/helpers/flavor.ts
+++ b/packages/vite/helpers/flavor.ts
@@ -1,5 +1,48 @@
-// import { defaultConfigs } from '..';
+import { existsSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
 import { getAllDependencies } from './utils.js';
+import { findMonorepoWorkspaceRoot, getProjectRootPath } from './project.js';
+
+/**
+ * A flavor declared by a framework package in its own package.json:
+ *
+ *   "nativescript": { "vite": { "flavor": "octane", "config": { "import": "octaneConfig", "from": "@nativescript/vite-octane" } } }
+ *
+ * The dependency that carries it identifies the flavor for detection, and
+ * `config` tells `nativescript-vite init` which helper to scaffold.
+ */
+export interface DeclaredViteFlavor {
+	flavor: string;
+	package: string;
+	config?: { import: string; from: string };
+}
+
+function readDeclaredViteFlavor(dependency: string): DeclaredViteFlavor | null {
+	const projectRoot = getProjectRootPath();
+	const roots = [projectRoot, findMonorepoWorkspaceRoot(projectRoot)].filter((root): root is string => !!root);
+	for (const root of roots) {
+		const manifest = path.join(root, 'node_modules', dependency, 'package.json');
+		if (!existsSync(manifest)) continue;
+		try {
+			const vite = JSON.parse(readFileSync(manifest, 'utf8'))?.nativescript?.vite;
+			if (vite && typeof vite.flavor === 'string' && vite.flavor) {
+				const config = vite.config && typeof vite.config.import === 'string' && typeof vite.config.from === 'string' ? { import: vite.config.import, from: vite.config.from } : undefined;
+				return { flavor: vite.flavor, package: dependency, config };
+			}
+		} catch {}
+		return null;
+	}
+	return null;
+}
+
+/** The first installed dependency that declares a Vite flavor, if any. */
+export function findDeclaredViteFlavor(): DeclaredViteFlavor | null {
+	for (const dependency of getAllDependencies()) {
+		const declared = readDeclaredViteFlavor(dependency);
+		if (declared) return declared;
+	}
+	return null;
+}
 
 let targetFlavor: string;
 
@@ -57,6 +100,11 @@ export function determineProjectFlavor(): string | false {
 
 	if (dependencies.includes('svelte-native') || dependencies.includes('@nativescript-community/svelte-native')) {
 		return 'svelte';
+	}
+
+	const declared = findDeclaredViteFlavor();
+	if (declared) {
+		return declared.flavor;
 	}
 
 	// the order is important - angular, react, and svelte also include these deps

--- a/packages/vite/helpers/flavor.ts
+++ b/packages/vite/helpers/flavor.ts
@@ -6,7 +6,7 @@ import { findMonorepoWorkspaceRoot, getProjectRootPath } from './project.js';
 /**
  * A flavor declared by a framework package in its own package.json:
  *
- *   "nativescript": { "vite": { "flavor": "octane", "config": { "import": "octaneConfig", "from": "@nativescript/vite-octane" } } }
+ *   "nativescript": { "vite": { "flavor": "octane", "config": { "import": "octaneConfig", "from": "@nativescript-community/vite-octane" } } }
  *
  * The dependency that carries it identifies the flavor for detection, and
  * `config` tells `nativescript-vite init` which helper to scaffold.

--- a/packages/vite/helpers/global-defines.ts
+++ b/packages/vite/helpers/global-defines.ts
@@ -1,4 +1,5 @@
 import { getProjectAppPath, getProjectAppVirtualPath } from './utils.js';
+import { getClientStrategyDevicePath } from '../hmr/framework-flavors.js';
 
 const APP_ROOT_DIR = getProjectAppPath();
 const APP_ROOT_VIRTUAL = getProjectAppVirtualPath();
@@ -93,6 +94,9 @@ export function getRuntimeSeedValues(opts: { platform?: string; isDevMode: boole
 		isIOS: values.__APPLE__,
 		// Runtime flavor for the raw-served HMR client's TARGET_FLAVOR resolution.
 		__NS_TARGET_FLAVOR__: opts.flavor,
+		// Device path of a registered (non built-in) flavor's client strategy;
+		// '' for built-ins, which the client resolves from its own package.
+		__NS_CLIENT_STRATEGY_URL__: getClientStrategyDevicePath(opts.flavor),
 		// App-root virtual path — every served-id → moduleName mapping (frame
 		// navigation targets, modal re-present matching) depends on this.
 		__NS_APP_ROOT_DIR__: APP_ROOT_DIR,
@@ -247,6 +251,7 @@ export function getGlobalDefines(opts: { platform: string; targetMode: string; v
 		__non_webpack_require__: 'globalThis.require',
 		__NS_ENV_VERBOSE__: JSON.stringify(values.__NS_ENV_VERBOSE__),
 		__NS_TARGET_FLAVOR__: JSON.stringify(opts.flavor),
+		__NS_CLIENT_STRATEGY_URL__: JSON.stringify(getClientStrategyDevicePath(opts.flavor)),
 		// whether to show the HMR in-progress overlay.
 		__NS_HMR_PROGRESS_OVERLAY_ENABLED__: JSON.stringify(isHmrProgressOverlayEnabled()),
 		__CSS_PARSER__: JSON.stringify(values.__CSS_PARSER__),

--- a/packages/vite/helpers/init.ts
+++ b/packages/vite/helpers/init.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'node:module';
-import { determineProjectFlavor } from './flavor.js';
+import { determineProjectFlavor, findDeclaredViteFlavor } from './flavor.js';
 import { getProjectFilePath, getProjectRootPath } from './project.js';
 
 const require = createRequire(import.meta.url);
@@ -90,12 +90,25 @@ function getFlavorImportAndConfig(flavor: string): { importLine: string; configE
 				configExpr: 'typescriptConfig({ mode })',
 			};
 		case 'javascript':
-		default:
-			return {
-				importLine: "import { javascriptConfig } from '@nativescript/vite/javascript';",
-				configExpr: 'javascriptConfig({ mode })',
-			};
+			return javascriptImportAndConfig();
+		default: {
+			const declared = findDeclaredViteFlavor();
+			if (declared?.flavor === flavor && declared.config) {
+				return {
+					importLine: `import { ${declared.config.import} } from '${declared.config.from}';`,
+					configExpr: `${declared.config.import}({ mode })`,
+				};
+			}
+			return javascriptImportAndConfig();
+		}
 	}
+}
+
+function javascriptImportAndConfig(): { importLine: string; configExpr: string } {
+	return {
+		importLine: "import { javascriptConfig } from '@nativescript/vite/javascript';",
+		configExpr: 'javascriptConfig({ mode })',
+	};
 }
 
 function ensureViteConfig() {

--- a/packages/vite/helpers/logging.spec.ts
+++ b/packages/vite/helpers/logging.spec.ts
@@ -162,3 +162,13 @@ describe('shouldSuppressViteWarning', () => {
 		});
 	});
 });
+
+describe('shouldSuppressViteInfo', () => {
+	it('drops the stock web-client HMR verdicts, which never apply to a device session', async () => {
+		const { shouldSuppressViteInfo } = await import('./logging.js');
+		expect(shouldSuppressViteInfo('page reload src/octane/driver.ts')).toBe(true);
+		expect(shouldSuppressViteInfo('hmr update /src/app.tsx')).toBe(true);
+		expect(shouldSuppressViteInfo('  VITE v8.2.2  ready in 1007 ms')).toBe(false);
+		expect(shouldSuppressViteInfo('server restarted.')).toBe(false);
+	});
+});

--- a/packages/vite/helpers/logging.ts
+++ b/packages/vite/helpers/logging.ts
@@ -104,10 +104,14 @@ export function clearVerboseCache(): void {
 // All matching uses `.includes()` (never `.startsWith()`) because Vite wraps
 // some warnings in picocolors ANSI escape sequences before handing them to
 // the logger, which would defeat `startsWith`-style probes on TTY output.
-export function createFilteredViteLogger(): Logger {
+export function createFilteredViteLogger(options: { hmrActive?: boolean } = {}): Logger {
 	const baseLogger = createLogger(undefined, { allowClearScreen: true });
 	return {
 		...baseLogger,
+		info(message: any, opts?: any) {
+			if (options.hmrActive && shouldSuppressViteInfo(String(message || ''))) return;
+			return baseLogger.info(message, opts);
+		},
 		warn(message: any, options?: any) {
 			const msg = String(message || '');
 			if (shouldSuppressViteWarning(msg)) return;
@@ -119,6 +123,17 @@ export function createFilteredViteLogger(): Logger {
 			return baseLogger.warnOnce(message);
 		},
 	};
+}
+
+/**
+ * Vite's stock HMR client never connects under device HMR — the device talks
+ * to `/ns-hmr` — so Vite's own verdicts about that client are noise, and one
+ * of them misleads: `page reload <file>` is what Vite decides for any module
+ * it cannot hot-accept on the web, printed while the device is applying the
+ * same save in place through a framework strategy.
+ */
+export function shouldSuppressViteInfo(msg: string): boolean {
+	return /\bpage reload\b/.test(msg) || /\bhmr update\b/.test(msg);
 }
 
 // Exported for unit tests. Keep this function pure so the test suite can

--- a/packages/vite/helpers/typescript-check.ts
+++ b/packages/vite/helpers/typescript-check.ts
@@ -10,7 +10,7 @@ import type { Platform } from './platform-types.js';
 const require = createRequire(import.meta.url);
 
 export type PlatformType = Platform;
-type TypeCheckFlavor = 'typescript' | 'react' | 'solid' | 'vue' | 'angular' | 'javascript';
+export type TypeCheckFlavor = 'typescript' | 'react' | 'solid' | 'vue' | 'angular' | 'javascript';
 
 export type TypeCheckMode = 'off' | 'warn' | 'error';
 

--- a/packages/vite/hmr/client/framework-client-strategy.ts
+++ b/packages/vite/hmr/client/framework-client-strategy.ts
@@ -85,6 +85,40 @@ export interface FrameworkClientStrategy {
 	recordPayloadChanges?(changed: any[], graphVersion: number): void;
 
 	/**
+	 * Decide whether a changed module goes through the shared evict + re-import
+	 * queue in this realm. Return `false` for a module whose fresh body must
+	 * not evaluate here — a worker script only a worker isolate ever loaded,
+	 * a type-only module nothing imports. Declined ids are handed to
+	 * {@link applyUnqueuedChanges} instead. Defaults to `true`.
+	 */
+	shouldQueueReimport?(id: string): boolean;
+
+	/**
+	 * Apply the changed modules {@link shouldQueueReimport} declined, in the
+	 * same delta. Runs only after boot, for real edits, and only when at least
+	 * one id was declined.
+	 */
+	applyUnqueuedChanges?(ids: string[]): void | Promise<void>;
+
+	/**
+	 * A full graph arrived after boot with hashes that differ from the client's
+	 * mirror — a reconnect after a dev-server restart, or version drift. The
+	 * shared fallback re-imports every changed module piecemeal, outside any
+	 * accept/dispose sequencing. Return `true` to take over (Octane requests
+	 * one ordered graph reload instead); `changedIds` is the inferred set.
+	 */
+	handleGraphResync?(changedIds: string[]): boolean | Promise<boolean>;
+
+	/**
+	 * Runs once per queue drain, BEFORE the changed modules are evicted from
+	 * the runtime registry. The only point at which a framework can still reach
+	 * the module instances about to be replaced — their `hot.accept` callbacks
+	 * and `hot.dispose` registrations are reset when the fresh bodies evaluate
+	 * (Octane: Vite-parity accept/dispose sequencing).
+	 */
+	beforeBatchEvict?(drained: string[]): void;
+
+	/**
 	 * Post-process one freshly re-imported module during the queue drain
 	 * (TypeScript/React: refresh the bundled module registry so Builder /
 	 * `loadModule` resolves the NEW code-behind instead of the boot-bundle copy).

--- a/packages/vite/hmr/client/framework.ts
+++ b/packages/vite/hmr/client/framework.ts
@@ -1,0 +1,36 @@
+/**
+ * `@nativescript/vite/hmr/client/framework.js` — the device-side surface a
+ * framework's client strategy is written against.
+ *
+ * A registered flavor's client module is served to the device through
+ * `/ns/m` and evaluates in the same realm as the shared HMR client. It must
+ * reach the client's singletons — the module graph mirror, the hot registry,
+ * the overlay — through this one module, so that both resolve to the same
+ * canonical URLs and therefore the same instances. Importing the client's
+ * internal files by path is not supported.
+ */
+export type { FrameworkClientStrategy, FrameworkClientBatchContext, FrameworkClientMessageContext, FrameworkClientMountContext, ClientGraphModule } from './framework-client-strategy.js';
+export type { NsHotRegistry, NsHotContext } from './hot-context.js';
+
+/** The process-wide `import.meta.hot` registry: accept/dispose callbacks, dependency acceptors, `hot.data`, events, full reload. */
+export { getNsHotRegistry } from './hot-context.js';
+
+/** Live mirror of the server's module graph (id → { deps, hash }). */
+export { graph, getGraphVersion } from './utils.js';
+/** Canonical-URL helpers and the evict + re-import primitives the shared queue uses. */
+export { normalizeSpec, requestModuleFromServer, invalidateModulesByUrls, buildEvictionUrls, resolveHmrHttpOrigin, safeDynImport } from './utils.js';
+/** `@nativescript/core` export lookup that resolves against the live core realm. */
+export { getCore } from './utils.js';
+export { ENV_VERBOSE } from './utils.js';
+
+/** Drive the on-device "HMR update" overlay: 'received' | 'evicting' | 'reimporting' | 'rebooting' | 'complete'. */
+export { setUpdateStage, getOverlayApi } from './overlay-driver.js';
+export type { HmrUpdateOverlayStage } from './overlay-driver.js';
+
+/** Swap the live root view for a freshly loaded component (the reset path). */
+export { performResetRoot } from './root-reset.js';
+
+export { getGlobalScope } from '../shared/runtime/global-scope.js';
+/** The `ns:module` builtin as the runtime exposes it (`invalidateModules`, `getLoadedModuleUrls`, …); `{}` off-device. */
+export { readNsRuntimeDevHostApi } from '../shared/runtime/browser-runtime-contract.js';
+export type { NsRuntimeDevHostApi } from '../shared/runtime/browser-runtime-contract.js';

--- a/packages/vite/hmr/client/hot-context.spec.ts
+++ b/packages/vite/hmr/client/hot-context.spec.ts
@@ -67,3 +67,71 @@ describe('hot-context custom-event listener lifecycle', () => {
 		expect(cb).not.toHaveBeenCalled();
 	});
 });
+
+describe('hot-context accept callbacks', () => {
+	it('exposes the current evaluation’s accept callbacks (a bare accept() counts)', () => {
+		const registry = getNsHotRegistry();
+		const hot = registry.createHotContext('/src/accept-one.tsx');
+		const cb = vi.fn();
+		hot.accept(cb);
+		hot.accept();
+
+		const callbacks = registry.getAcceptCallbacks('/src/accept-one');
+		expect(callbacks).toHaveLength(2);
+		callbacks[0]({ fresh: true });
+		expect(cb).toHaveBeenCalledWith({ fresh: true });
+	});
+
+	it('returns a copy keyed canonically, and a fresh evaluation resets the list', () => {
+		const registry = getNsHotRegistry();
+		registry.createHotContext('/src/accept-two.tsx').accept(() => {});
+		const snapshot = registry.getAcceptCallbacks('http://localhost:5173/ns/m/src/accept-two?t=1');
+		expect(snapshot).toHaveLength(1);
+
+		// The re-evaluated body has not called accept yet → nothing registered,
+		// while the snapshot taken before eviction is unaffected.
+		registry.createHotContext('/src/accept-two.tsx');
+		expect(registry.getAcceptCallbacks('/src/accept-two')).toEqual([]);
+		expect(snapshot).toHaveLength(1);
+	});
+
+	it('returns an empty list for a module that never evaluated', () => {
+		expect(getNsHotRegistry().getAcceptCallbacks('/src/never-seen')).toEqual([]);
+	});
+});
+
+describe('hot-context dependency accepts', () => {
+	it('resolves relative dependency paths against the owner and indexes the acceptor', () => {
+		const registry = getNsHotRegistry();
+		const cb = vi.fn();
+		registry.createHotContext('/src/features/flame.ts').accept('./flame.worker', cb);
+		registry.createHotContext('/src/features/other.ts').accept(['../util/shared.ts'], () => {});
+
+		expect(registry.acceptsDep('/src/features/flame', '/src/features/flame.worker')).toBe(true);
+		expect(registry.acceptsDep('/src/features/other', '/src/util/shared')).toBe(true);
+		expect(registry.acceptsDep('/src/features/flame', '/src/util/shared')).toBe(false);
+
+		const acceptors = registry.getDepAcceptors('http://localhost:5173/ns/m/src/features/flame.worker?t=1');
+		expect(acceptors.map((a) => a.owner)).toEqual(['/src/features/flame']);
+		acceptors[0].callback([undefined]);
+		expect(cb).toHaveBeenCalledWith([undefined]);
+	});
+
+	it('does not treat a dependency accept as a self accept, and drops it on re-evaluation', () => {
+		const registry = getNsHotRegistry();
+		registry.createHotContext('/src/spawner.ts').accept('./spawner.worker', () => {});
+		expect(registry.getAcceptCallbacks('/src/spawner')).toEqual([]);
+		expect(registry.getDepAcceptors('/src/spawner.worker')).toHaveLength(1);
+
+		registry.createHotContext('/src/spawner.ts');
+		expect(registry.getDepAcceptors('/src/spawner.worker')).toEqual([]);
+		expect(registry.acceptsDep('/src/spawner', '/src/spawner.worker')).toBe(false);
+	});
+
+	it('ignores bare specifiers in the dependency form', () => {
+		const registry = getNsHotRegistry();
+		registry.createHotContext('/src/bare.ts').accept('octane', () => {});
+		expect(registry.getAcceptCallbacks('/src/bare')).toEqual([]);
+		expect(registry.getDepAcceptors('octane')).toEqual([]);
+	});
+});

--- a/packages/vite/hmr/client/hot-context.ts
+++ b/packages/vite/hmr/client/hot-context.ts
@@ -27,6 +27,15 @@ type HotCallback = (...args: unknown[]) => unknown;
 interface HotModuleEntry {
 	data: Record<string, unknown>;
 	acceptCallbacks: HotCallback[];
+	/**
+	 * `hot.accept(dep | deps, cb)` registrations by the CURRENT evaluation,
+	 * keyed by the dependency's canonical hot key. Mirrored into the
+	 * registry-wide `depAcceptors` index so an update to the dependency can
+	 * find its acceptors without an import edge — the spawner of a Worker
+	 * accepts the worker script this way, and the graph carries no edge
+	 * between them.
+	 */
+	acceptDeps: Map<string, HotCallback>;
 	disposeCallbacks: HotCallback[];
 	pruneCallbacks: HotCallback[];
 	declined: boolean;
@@ -53,6 +62,25 @@ export interface NsHotRegistry {
 	runPrune(keys?: readonly string[]): number;
 	/** True when any module (or any module in the key subset) called `hot.decline()`. */
 	hasDeclined(keys?: readonly string[]): boolean;
+	/**
+	 * Accept callbacks registered by `key`'s CURRENT evaluation (a copy; an
+	 * argument-less `hot.accept()` contributes a no-op). They belong to the
+	 * module instance being replaced, so a framework strategy must read them
+	 * BEFORE eviction — `createHotContext` resets them the moment the fresh body
+	 * evaluates — and invoke them with the fresh namespace afterwards (Vite's
+	 * accept contract). A non-empty result is what makes a module a
+	 * self-accepting HMR boundary.
+	 */
+	getAcceptCallbacks(key: string): HotCallback[];
+	/**
+	 * Modules whose CURRENT evaluation accepts updates to `depKey` through the
+	 * dependency form of `hot.accept`. Each callback takes the array Vite
+	 * passes (`[freshNamespace]`, `[undefined]` when the dependency does not
+	 * evaluate in this realm). Same lifetime rule as `getAcceptCallbacks`.
+	 */
+	getDepAcceptors(depKey: string): Array<{ owner: string; callback: HotCallback }>;
+	/** True when `ownerKey`'s current evaluation accepts `depKey` via the dependency form. */
+	acceptsDep(ownerKey: string, depKey: string): boolean;
 	/** Fire `hot.on(event, cb)` listeners. Returns the number of listeners invoked. */
 	dispatchHotEvent(event: string, payload?: unknown): number;
 	listHotEventListeners(): Record<string, number>;
@@ -105,6 +133,27 @@ function canonicalHotKey(id: string): string {
 	return key;
 }
 
+/**
+ * Canonical hot key of a dependency specifier as written in `hot.accept` —
+ * relative to the owner module's key (`./embers`, `../util/x`) or already
+ * root-absolute (`/src/x`). Bare specifiers are not hot-acceptable (they are
+ * vendor modules) and yield ''.
+ */
+function resolveDepHotKey(ownerKey: string, specifier: string): string {
+	if (typeof specifier !== 'string' || !specifier) return '';
+	const spec = specifier.trim();
+	if (/^https?:\/\//i.test(spec) || spec.startsWith('/')) return canonicalHotKey(spec);
+	if (!spec.startsWith('.')) return '';
+	const base = ownerKey.slice(0, ownerKey.lastIndexOf('/') + 1) || '/';
+	const segments: string[] = base.split('/').filter(Boolean);
+	for (const part of spec.split('/')) {
+		if (part === '' || part === '.') continue;
+		if (part === '..') segments.pop();
+		else segments.push(part);
+	}
+	return canonicalHotKey('/' + segments.join('/'));
+}
+
 const VERBOSE: boolean = (() => {
 	try {
 		return globalThis.__NS_ENV_VERBOSE__ === true;
@@ -116,13 +165,15 @@ const VERBOSE: boolean = (() => {
 function createRegistry(): NsHotRegistry {
 	const modules = new Map<string, HotModuleEntry>();
 	const eventListeners = new Map<string, Set<HotCallback>>();
+	// depKey → owner keys whose current evaluation accepts it.
+	const depAcceptors = new Map<string, Set<string>>();
 	let sendToServer: ((event: string, data?: unknown) => void) | null = null;
 	let fullReloadHandler: ((message?: string) => void) | null = null;
 
 	const entryFor = (key: string): HotModuleEntry => {
 		let entry = modules.get(key);
 		if (!entry) {
-			entry = { data: {}, acceptCallbacks: [], disposeCallbacks: [], pruneCallbacks: [], declined: false };
+			entry = { data: {}, acceptCallbacks: [], acceptDeps: new Map(), disposeCallbacks: [], pruneCallbacks: [], declined: false };
 			modules.set(key, entry);
 		}
 		return entry;
@@ -153,14 +204,34 @@ function createRegistry(): NsHotRegistry {
 		return executed;
 	};
 
+	// A graph reload replaces what the app owns and nothing else. `@nativescript/core`
+	// (`/ns/core*`), the vendor bundle and per-file vendor modules (`/ns/m/node_modules/*`)
+	// evaluate once per process: core re-evaluated in place would mint a second
+	// `View` hierarchy the still-live native views fail `instanceof` against, and
+	// vendor re-evaluation would split every singleton a plugin keeps. The
+	// running dev client keeps its identity for the same reason.
+	const isAppOwnedModuleUrl = (url: string, origin: string): boolean => {
+		if (!url.startsWith(origin)) return false;
+		const path = url.slice(origin.length).replace(/[?#].*$/, '');
+		if (path.startsWith('/ns/m/')) return !path.startsWith('/ns/m/node_modules/');
+		return path.startsWith('/ns/sfc') || path.startsWith('/ns/asm');
+	};
+
 	const jsFullReload = (message?: string): void => {
 		const g: any = globalThis;
 		const entryUrl = typeof g.__NS_DEV_ENTRY_URL__ === 'string' ? g.__NS_DEV_ENTRY_URL__ : '';
 		if (!entryUrl) {
 			console.warn('[ns-hot] full reload requested but no dev entry URL is known', message || '');
+			registry.dispatchHotEvent('ns:full-reload-failed', { message: 'no dev entry URL is known' });
 			return;
 		}
 		registry.dispatchHotEvent('vite:beforeFullReload', { message: message || '' });
+		// Every app module is about to be replaced, so its `hot.dispose`
+		// registrations are due now — the in-process analogue of the page
+		// teardown a browser reload implies (an entry module uses this to
+		// unmount the root it created before the re-evaluated entry mounts a
+		// new one).
+		registry.runDispose();
 		try {
 			// Evict every same-origin module EXCEPT the dev-client modules (the
 			// running HMR client must keep its singleton identity) so the entry
@@ -180,7 +251,7 @@ function createRegistry(): NsHotRegistry {
 			const getUrls = dev?.getLoadedModuleUrls;
 			const invalidate = dev?.invalidateModules;
 			const list = typeof getUrls === 'function' ? getUrls() : [];
-			const evict = (Array.isArray(list) ? list : []).filter((u: unknown): u is string => typeof u === 'string' && u.startsWith(origin) && !u.includes('/__ns_dev__/') && !u.includes('/node_modules/@nativescript/vite/'));
+			const evict = (Array.isArray(list) ? list : []).filter((u: unknown): u is string => typeof u === 'string' && isAppOwnedModuleUrl(u, origin));
 			if (evict.length && typeof invalidate === 'function') {
 				invalidate(evict);
 			}
@@ -190,10 +261,16 @@ function createRegistry(): NsHotRegistry {
 		} catch (err) {
 			console.warn('[ns-hot] full reload eviction failed:', (err as any)?.message ?? err);
 		}
-		// Fire and forget — module re-evaluation drives the app reset.
-		void import(/* @vite-ignore */ entryUrl).catch((err) => {
-			console.warn('[ns-hot] full reload entry re-import failed:', (err as any)?.message ?? err);
-		});
+		// Module re-evaluation drives the app reset; the settled import is the
+		// only signal that the reloaded graph has finished evaluating.
+		void import(/* @vite-ignore */ entryUrl)
+			.then(() => {
+				registry.dispatchHotEvent('ns:full-reload-complete', { message: message || '' });
+			})
+			.catch((err) => {
+				console.warn('[ns-hot] full reload entry re-import failed:', (err as any)?.message ?? err);
+				registry.dispatchHotEvent('ns:full-reload-failed', { message: String((err as any)?.message ?? err) });
+			});
 	};
 
 	const registry: NsHotRegistry = {
@@ -204,6 +281,12 @@ function createRegistry(): NsHotRegistry {
 			// Fresh evaluation of the module: previous accept/dispose/prune
 			// registrations belong to the replaced instance. `data` persists.
 			entry.acceptCallbacks = [];
+			for (const depKey of entry.acceptDeps.keys()) {
+				const owners = depAcceptors.get(depKey);
+				owners?.delete(key);
+				if (owners && owners.size === 0) depAcceptors.delete(depKey);
+			}
+			entry.acceptDeps = new Map();
 			entry.disposeCallbacks = [];
 			entry.pruneCallbacks = [];
 			entry.declined = false;
@@ -230,7 +313,22 @@ function createRegistry(): NsHotRegistry {
 				},
 				accept(...args: unknown[]) {
 					const cb = args.find((a) => typeof a === 'function') as HotCallback | undefined;
-					entry.acceptCallbacks.push(cb || (() => {}));
+					const deps = typeof args[0] === 'string' ? [args[0]] : Array.isArray(args[0]) ? args[0] : null;
+					if (deps === null) {
+						entry.acceptCallbacks.push(cb || (() => {}));
+						return;
+					}
+					for (const dep of deps) {
+						const depKey = resolveDepHotKey(key, String(dep));
+						if (!depKey) continue;
+						entry.acceptDeps.set(depKey, cb || (() => {}));
+						let owners = depAcceptors.get(depKey);
+						if (!owners) {
+							owners = new Set();
+							depAcceptors.set(depKey, owners);
+						}
+						owners.add(key);
+					}
 				},
 				acceptExports(_exportNames: string[], cb?: HotCallback) {
 					entry.acceptCallbacks.push(cb || (() => {}));
@@ -290,6 +388,23 @@ function createRegistry(): NsHotRegistry {
 				if (modules.get(key)?.declined) return true;
 			}
 			return false;
+		},
+		getAcceptCallbacks(key: string): HotCallback[] {
+			const entry = modules.get(canonicalHotKey(String(key)));
+			return entry ? entry.acceptCallbacks.slice() : [];
+		},
+		getDepAcceptors(depKey: string) {
+			const owners = depAcceptors.get(canonicalHotKey(String(depKey)));
+			if (!owners) return [];
+			const out: Array<{ owner: string; callback: HotCallback }> = [];
+			for (const owner of owners) {
+				const callback = modules.get(owner)?.acceptDeps.get(canonicalHotKey(String(depKey)));
+				if (callback) out.push({ owner, callback });
+			}
+			return out;
+		},
+		acceptsDep(ownerKey: string, depKey: string): boolean {
+			return modules.get(canonicalHotKey(String(ownerKey)))?.acceptDeps.has(canonicalHotKey(String(depKey))) === true;
 		},
 		dispatchHotEvent(event: string, payload?: unknown): number {
 			const listeners = eventListeners.get(event);

--- a/packages/vite/hmr/client/strategy-loader.ts
+++ b/packages/vite/hmr/client/strategy-loader.ts
@@ -15,7 +15,7 @@
  */
 
 import { getGlobalScope } from '../shared/runtime/global-scope.js';
-import { ENV_VERBOSE } from './utils.js';
+import { ENV_VERBOSE, resolveHmrHttpOrigin } from './utils.js';
 import type { FrameworkClientStrategy } from './framework-client-strategy.js';
 
 const VERBOSE = ENV_VERBOSE;
@@ -71,6 +71,30 @@ export const APP_MAIN_ENTRY_SPEC = `${APP_VIRTUAL_WITH_SLASH}app.ts`;
 const CLIENT_STRATEGY_FLAVORS = new Set(['vue', 'angular', 'solid', 'typescript', 'react']);
 let CLIENT_STRATEGY: FrameworkClientStrategy | undefined;
 
+// A flavor registered from outside the package (`registerFrameworkFlavor`)
+// ships its client strategy in its own package; the dev server seeds that
+// module's device path so the loader never has to know the package.
+function resolveRegisteredClientStrategyUrl(): string | undefined {
+	let devicePath: unknown;
+	try {
+		devicePath = typeof __NS_CLIENT_STRATEGY_URL__ === 'string' ? __NS_CLIENT_STRATEGY_URL__ : undefined;
+	} catch {}
+	if (!devicePath) {
+		try {
+			devicePath = getGlobalScope().__NS_CLIENT_STRATEGY_URL__;
+		} catch {}
+	}
+	if (typeof devicePath !== 'string' || !devicePath) return undefined;
+	if (/^https?:\/\//.test(devicePath)) return devicePath;
+	const origin = resolveHmrHttpOrigin();
+	return origin ? origin + devicePath : devicePath;
+}
+
+function pickClientStrategyExport(mod: any, flavor: string): FrameworkClientStrategy | undefined {
+	const candidates = [mod?.default, mod?.clientStrategy, mod?.[`${flavor}ClientStrategy`]];
+	return candidates.find((candidate) => candidate && typeof candidate.install === 'function');
+}
+
 // The strategy module's URL, absolute and dot-segment free. The runtime keys
 // its module registry by the specifier it is handed, so a `../` specifier from
 // a dev-served module would register the strategy under a non-canonical URL
@@ -88,13 +112,24 @@ function resolveClientStrategyUrl(flavor: string): string {
 	return relative;
 }
 
+function clientStrategyModuleUrl(flavor: string): string | undefined {
+	if (CLIENT_STRATEGY_FLAVORS.has(flavor)) return resolveClientStrategyUrl(flavor);
+	return resolveRegisteredClientStrategyUrl();
+}
+
+const CLIENT_STRATEGY_URL = TARGET_FLAVOR ? clientStrategyModuleUrl(TARGET_FLAVOR) : undefined;
+
 export const CLIENT_STRATEGY_READY: Promise<void> =
-	TARGET_FLAVOR && CLIENT_STRATEGY_FLAVORS.has(TARGET_FLAVOR)
-		? import(/* @vite-ignore */ resolveClientStrategyUrl(TARGET_FLAVOR))
+	TARGET_FLAVOR && CLIENT_STRATEGY_URL
+		? import(/* @vite-ignore */ CLIENT_STRATEGY_URL)
 				.then((mod: any) => {
-					CLIENT_STRATEGY = mod && mod[`${TARGET_FLAVOR}ClientStrategy`];
+					CLIENT_STRATEGY = pickClientStrategyExport(mod, TARGET_FLAVOR);
+					if (!CLIENT_STRATEGY) {
+						console.warn(`[hmr-client] ${CLIENT_STRATEGY_URL} exports no client strategy for flavor "${TARGET_FLAVOR}" (expected default, clientStrategy or ${TARGET_FLAVOR}ClientStrategy)`);
+						return;
+					}
 					if (VERBOSE) console.log('[hmr-client] client strategy loaded for flavor:', TARGET_FLAVOR);
-					CLIENT_STRATEGY?.install();
+					CLIENT_STRATEGY.install();
 				})
 				.catch((err) => {
 					console.warn('[hmr-client] failed to load client strategy for', TARGET_FLAVOR, err);

--- a/packages/vite/hmr/client/update-pipeline.ts
+++ b/packages/vite/hmr/client/update-pipeline.ts
@@ -217,6 +217,8 @@ export function applyDelta(payload: any) {
 			if (VERBOSE) console.warn('[hmr][prefetch] failed', e);
 		}
 		const isAppMainEntryId = (value: string) => value.endsWith(APP_MAIN_ENTRY_SPEC);
+		const strategy = getClientStrategy();
+		const unqueued: string[] = [];
 		for (const id of realIds) {
 			// SFC registry update events trigger root resets for .vue files directly
 			if (/\.vue$/i.test(id)) {
@@ -236,7 +238,18 @@ export function applyDelta(payload: any) {
 					/* ignore */
 				}
 			}
+			if (strategy?.shouldQueueReimport?.(id) === false) {
+				unqueued.push(id);
+				continue;
+			}
 			changedQueue.push(id);
+		}
+		if (unqueued.length) {
+			try {
+				void strategy?.applyUnqueuedChanges?.(unqueued);
+			} catch (e) {
+				console.warn('[hmr][delta] applyUnqueuedChanges threw', (e as any)?.message ?? e);
+			}
 		}
 		if (changedQueue.length) processQueue();
 	}
@@ -294,6 +307,11 @@ export async function processQueue(): Promise<void> {
 				setUpdateOverlayStage('evicting', {
 					detail: drained.length === 1 ? `Invalidating ${drained[0]}` : `Invalidating ${drained.length} modules`,
 				});
+			}
+			try {
+				strategy?.beforeBatchEvict?.(drained);
+			} catch (e) {
+				console.warn('[hmr][queue] beforeBatchEvict threw', (e as any)?.message ?? e);
 			}
 			const evictUrls = buildEvictionUrls(drained);
 			const evicted = invalidateModulesByUrls(evictUrls);
@@ -383,6 +401,10 @@ export async function reimportInferredFullGraphChanges(prevGraph: Map<string, { 
 			if (id.endsWith(APP_MAIN_ENTRY_SPEC)) return false;
 			return true;
 		});
+		if (toReimport.length && (await getClientStrategy()?.handleGraphResync?.(toReimport))) {
+			if (VERBOSE) console.log('[hmr][full-graph] resync handled by the client strategy', toReimport.length);
+			return;
+		}
 		if (toReimport.length && VERBOSE) console.log('[hmr][full-graph] inferred changed modules; re-importing', toReimport);
 		// Evict the inferred changed set before re-importing.
 		// See `processQueue` for the architectural rationale; the

--- a/packages/vite/hmr/framework-flavors.spec.ts
+++ b/packages/vite/hmr/framework-flavors.spec.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getClientStrategyDevicePath, getFrameworkFlavor, registerFrameworkFlavor } from './framework-flavors.js';
+import { typescriptServerStrategy } from './frameworks/typescript/server/strategy.js';
+
+function fakeProject(): { root: string } {
+	const root = mkdtempSync(path.join(tmpdir(), 'ns-vite-flavor-'));
+	writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'app', dependencies: { '@acme/vite-fw': '*' } }));
+	const pkg = path.join(root, 'node_modules', '@acme', 'vite-fw');
+	mkdirSync(path.join(pkg, 'client'), { recursive: true });
+	writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({ name: '@acme/vite-fw', type: 'module', exports: { './client': './client/strategy.js' } }));
+	writeFileSync(path.join(pkg, 'client', 'strategy.js'), 'export default { flavor: "fw", install() {} };');
+	return { root };
+}
+
+const server = { ...typescriptServerStrategy, flavor: 'fw' };
+
+describe('registerFrameworkFlavor', () => {
+	it('rejects a built-in name, a mismatched server flavor, and a missing client', () => {
+		expect(() => registerFrameworkFlavor({ flavor: 'vue', server: { ...server, flavor: 'vue' }, client: 'x' })).toThrow(/built-in/);
+		expect(() => registerFrameworkFlavor({ flavor: 'fw', server: typescriptServerStrategy, client: 'x' })).toThrow(/declares flavor "typescript"/);
+		expect(() => registerFrameworkFlavor({ flavor: 'fw', server, client: '' })).toThrow(/module specifier/);
+	});
+
+	it('registers and looks up a flavor', () => {
+		registerFrameworkFlavor({ flavor: 'fw', server, client: '@acme/vite-fw/client' });
+		expect(getFrameworkFlavor('fw')?.server).toBe(server);
+		expect(getFrameworkFlavor('nope')).toBeUndefined();
+	});
+});
+
+describe('getClientStrategyDevicePath', () => {
+	it('is empty for a built-in or unknown flavor', () => {
+		expect(getClientStrategyDevicePath('vue', '/nowhere')).toBe('');
+		expect(getClientStrategyDevicePath('unknown', '/nowhere')).toBe('');
+	});
+
+	it('resolves a package subpath through the app root to its /ns/m/node_modules path', () => {
+		const { root } = fakeProject();
+		registerFrameworkFlavor({ flavor: 'fw', server, client: '@acme/vite-fw/client' });
+		expect(getClientStrategyDevicePath('fw', root)).toBe('/ns/m/node_modules/@acme/vite-fw/client/strategy.js');
+	});
+
+	it('expresses a linked (symlinked) package relative to the package, not the real path', () => {
+		const { root } = fakeProject();
+		const real = mkdtempSync(path.join(tmpdir(), 'ns-vite-linked-'));
+		mkdirSync(path.join(real, 'client'), { recursive: true });
+		writeFileSync(path.join(real, 'package.json'), JSON.stringify({ name: '@acme/linked-fw', type: 'module', exports: { './client': './client/index.js' } }));
+		writeFileSync(path.join(real, 'client', 'index.js'), 'export default { flavor: "linked", install() {} };');
+		symlinkSync(real, path.join(root, 'node_modules', '@acme', 'linked-fw'), 'dir');
+		registerFrameworkFlavor({ flavor: 'linked', server: { ...server, flavor: 'linked' }, client: '@acme/linked-fw/client' });
+		expect(getClientStrategyDevicePath('linked', root)).toBe('/ns/m/node_modules/@acme/linked-fw/client/index.js');
+	});
+});

--- a/packages/vite/hmr/framework-flavors.ts
+++ b/packages/vite/hmr/framework-flavors.ts
@@ -1,0 +1,141 @@
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import type { FrameworkServerStrategy } from './server/framework-strategy.js';
+import { getProjectRootPath } from '../helpers/project.js';
+
+/**
+ * A framework flavor contributed from outside this package.
+ *
+ * The built-in flavors (`angular`, `vue`, `react`, `solid`, `typescript`,
+ * `javascript`) are wired by name inside `@nativescript/vite`. Everything a
+ * flavor needs beyond a name is expressed here, so a framework can ship its
+ * own HMR support as a package: the server half runs in the dev server
+ * process; the client half is a module the device fetches and evaluates next
+ * to the shared HMR client.
+ */
+export interface FrameworkFlavorDefinition {
+	/**
+	 * The flavor name. It is what the config helper declares through
+	 * `baseConfig({ flavor })`, what the device receives as `__NS_TARGET_FLAVOR__`,
+	 * and what selects both strategies. Must not collide with a built-in name.
+	 */
+	flavor: string;
+	/**
+	 * The dev-server half. Most frameworks start from `typescriptServerStrategy`
+	 * (the generic device-module pipeline) and override `handleHotUpdate`.
+	 */
+	server: FrameworkServerStrategy;
+	/**
+	 * The device half: a module specifier resolvable from the app's root —
+	 * usually a package subpath such as `@my-framework/nativescript-vite/client`.
+	 * The module is served to the device as-is through `/ns/m`, so it must be
+	 * plain ESM with explicit `.js` import extensions, importing shared client
+	 * helpers only from `@nativescript/vite/hmr/client/framework.js`. It exports
+	 * the strategy as `default`, `clientStrategy`, or `<flavor>ClientStrategy`.
+	 */
+	client: string;
+}
+
+const BUILT_IN_FLAVORS = new Set(['angular', 'vue', 'react', 'solid', 'typescript', 'javascript']);
+const flavors = new Map<string, FrameworkFlavorDefinition>();
+
+/**
+ * Register a flavor. Call it before `baseConfig({ flavor })` runs — from the
+ * top of the framework's config helper is the natural place — so the HMR
+ * plugins the base config installs can find the server strategy, and the
+ * device bundle is seeded with the client strategy's URL. Registering the
+ * same flavor again replaces the previous definition.
+ */
+export function registerFrameworkFlavor(definition: FrameworkFlavorDefinition): void {
+	const flavor = String(definition?.flavor || '').trim();
+	if (!flavor) throw new TypeError('[@nativescript/vite] registerFrameworkFlavor: `flavor` is required.');
+	if (BUILT_IN_FLAVORS.has(flavor)) {
+		throw new Error(`[@nativescript/vite] registerFrameworkFlavor: "${flavor}" is a built-in flavor and cannot be replaced.`);
+	}
+	if (!definition.server || typeof definition.server.matchesFile !== 'function' || typeof definition.server.processFile !== 'function' || typeof definition.server.buildRegistry !== 'function') {
+		throw new TypeError(`[@nativescript/vite] registerFrameworkFlavor("${flavor}"): \`server\` must be a FrameworkServerStrategy.`);
+	}
+	if (typeof definition.client !== 'string' || !definition.client.trim()) {
+		throw new TypeError(`[@nativescript/vite] registerFrameworkFlavor("${flavor}"): \`client\` must be a module specifier.`);
+	}
+	if (definition.server.flavor !== flavor) {
+		throw new Error(`[@nativescript/vite] registerFrameworkFlavor("${flavor}"): the server strategy declares flavor "${definition.server.flavor}".`);
+	}
+	flavors.set(flavor, { ...definition, flavor });
+}
+
+export function getFrameworkFlavor(flavor: string): FrameworkFlavorDefinition | undefined {
+	return flavors.get(flavor);
+}
+
+/**
+ * Package names that ship a registered flavor's client strategy. The device
+ * pipeline treats them like `@nativescript/vite` itself: served per-module
+ * through `/ns/m`, never through the vendor bundle or the plugin registry
+ * shim, so the module's own relative imports and its imports of the shared
+ * client surface resolve to the live client's canonical URLs.
+ */
+export function getFlavorClientPackages(): ReadonlySet<string> {
+	const names = new Set<string>();
+	for (const definition of flavors.values()) {
+		const name = packageNameOfSpecifier(definition.client);
+		if (name) names.add(name);
+	}
+	return names;
+}
+
+function packageNameOfSpecifier(specifier: string): string | null {
+	if (!specifier || specifier.startsWith('.') || path.isAbsolute(specifier)) return null;
+	const parts = specifier.split('/');
+	return specifier.startsWith('@') ? (parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null) : parts[0];
+}
+
+export function isBuiltInFlavor(flavor: string): boolean {
+	return BUILT_IN_FLAVORS.has(flavor);
+}
+
+/**
+ * The device-side URL path of a registered flavor's client strategy module —
+ * `/ns/m/node_modules/<package>/<file>` — or `''` for a built-in / unknown
+ * flavor. The specifier is resolved from the app root like any import, then
+ * expressed relative to its package so the path holds whether the package is
+ * installed or linked from a workspace.
+ */
+export function getClientStrategyDevicePath(flavor: string, projectRoot: string = getProjectRootPath()): string {
+	const definition = flavors.get(flavor);
+	if (!definition) return '';
+	const resolved = resolveFromProject(definition.client, projectRoot);
+	const pkg = findPackageRoot(resolved);
+	if (!pkg) {
+		throw new Error(`[@nativescript/vite] flavor "${flavor}": client module ${definition.client} resolved to ${resolved}, which is not inside a package.`);
+	}
+	const inside = path.relative(pkg.dir, resolved).split(path.sep).join('/');
+	return `/ns/m/node_modules/${pkg.name}/${inside}`;
+}
+
+function resolveFromProject(specifier: string, projectRoot: string): string {
+	if (path.isAbsolute(specifier)) return specifier;
+	const require = createRequire(path.join(projectRoot, 'package.json'));
+	try {
+		return require.resolve(specifier);
+	} catch (error) {
+		throw new Error(`[@nativescript/vite] cannot resolve client strategy module ${JSON.stringify(specifier)} from ${projectRoot}: ${(error as Error).message}`);
+	}
+}
+
+function findPackageRoot(file: string): { dir: string; name: string } | null {
+	let dir = path.dirname(file);
+	for (;;) {
+		const manifest = path.join(dir, 'package.json');
+		if (existsSync(manifest)) {
+			try {
+				const name = JSON.parse(readFileSync(manifest, 'utf8')).name;
+				if (typeof name === 'string' && name) return { dir, name };
+			} catch {}
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}

--- a/packages/vite/hmr/server/clean-code-worker-realm.spec.ts
+++ b/packages/vite/hmr/server/clean-code-worker-realm.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { cleanCode } from './process-code-for-device.js';
+import { typescriptServerStrategy } from '../frameworks/typescript/server/strategy.js';
+
+const GLOBALS_IMPORT = `import "/node_modules/@nativescript/core/globals/index.js?v=abc";`;
+const BODY = `${GLOBALS_IMPORT}\nexport const tick = () => setInterval(() => {}, 33);\n`;
+
+describe('cleanCode — @nativescript/core/globals side-effect import', () => {
+	it('strips it for a main-realm serve (the entry installs globals once)', () => {
+		const out = cleanCode(BODY, typescriptServerStrategy);
+		expect(out).not.toContain('core/globals');
+		expect(out).toContain('export const tick');
+	});
+
+	it('keeps it for a worker-realm serve (the worker script is that realm’s only entry)', () => {
+		const out = cleanCode(BODY, typescriptServerStrategy, { workerRealm: true });
+		expect(out).toContain(GLOBALS_IMPORT);
+	});
+});
+
+describe('ensureWorkerEntryGlobalsImport', () => {
+	it('adds the globals import to a worker entry that lacks it', async () => {
+		const { ensureWorkerEntryGlobalsImport } = await import('./websocket-served-module-helpers.js');
+		const out = ensureWorkerEntryGlobalsImport(`globalThis.onmessage = () => {};\n`);
+		expect(out.startsWith(`import '@nativescript/core/globals';\n`)).toBe(true);
+	});
+
+	it('leaves a worker entry that already imports globals (in any resolved form) alone', async () => {
+		const { ensureWorkerEntryGlobalsImport } = await import('./websocket-served-module-helpers.js');
+		for (const line of [`import '@nativescript/core/globals';`, `import "/node_modules/@nativescript/core/globals/index.js?v=abc";`, `import "http://h:5173/ns/core/globals";`]) {
+			const code = `${line}\nexport {};\n`;
+			expect(ensureWorkerEntryGlobalsImport(code)).toBe(code);
+		}
+	});
+});

--- a/packages/vite/hmr/server/deps-bundle.ts
+++ b/packages/vite/hmr/server/deps-bundle.ts
@@ -70,7 +70,7 @@ import { getVendorManifest, setVendorRuntimeModuleProvider } from '../shared/ven
 import { collectVendorModules } from '../shared/vendor/manifest-collect.js';
 import { generatePlatformPolyfills } from '../shared/runtime/platform-polyfills.js';
 import { getAngularLinkerFactory, runAngularLinker } from '../frameworks/angular/build/shared-linker.js';
-import { getBlockedDeviceNodeModulesReason, resolveCandidateFilePath } from './websocket-module-specifiers.js';
+import { getBlockedDeviceNodeModulesReason, isFlavorClientPackageSpecifier, resolveCandidateFilePath } from './websocket-module-specifiers.js';
 import { extractDirectExportedNames, JS_IDENTIFIER_RE, parseExportSpecList } from './websocket-core-bridge.js';
 import { hasExistingDefaultExport } from './ns-core-cjs-shape.js';
 import { loadPersistedBootRecording } from './boot-recording.js';
@@ -382,7 +382,7 @@ function createDepsImportRoutingPlugin(projectRoot: string, workspaceRoot: strin
 				if (/^@nativescript\/core(?:\/|$)/.test(spec)) {
 					return { path: spec, external: true };
 				}
-				if (/^@nativescript\/vite(?:\/|$)/.test(spec)) {
+				if (/^@nativescript\/vite(?:\/|$)/.test(spec) || isFlavorClientPackageSpecifier(spec)) {
 					return { path: `/ns/m/node_modules/${spec.replace(SCRIPT_EXT_RE, '')}`, external: true };
 				}
 				if (flavor === 'solid' && spec === 'solid-js') {

--- a/packages/vite/hmr/server/process-code-for-device.ts
+++ b/packages/vite/hmr/server/process-code-for-device.ts
@@ -224,7 +224,18 @@ function collectImportDependencies(code: string, importerPath: string): Set<stri
 /**
  * Clean code: remove Vite/Vue noise, rewrite to vendor
  */
-function cleanCode(code: string, strategy: FrameworkServerStrategy): string {
+export interface CleanCodeOptions {
+	/**
+	 * The module evaluates in a worker realm. The main realm installs
+	 * `@nativescript/core/globals` once from the entry, so a served module's
+	 * own globals import is redundant there and is stripped; a worker realm
+	 * has no entry but the worker script itself, and that import is its only
+	 * source of timers, `console` and the other runtime globals.
+	 */
+	workerRealm?: boolean;
+}
+
+function cleanCode(code: string, strategy: FrameworkServerStrategy, options?: CleanCodeOptions): string {
 	let result = code;
 
 	// Remove Vite client and hot module noise ('$1' keeps the preceding
@@ -272,7 +283,7 @@ function cleanCode(code: string, strategy: FrameworkServerStrategy): string {
 
 	// Clean up HMR noise
 	result = strategy.postClean?.(result) ?? result;
-	result = stripCoreGlobalsImports(result);
+	if (!options?.workerRealm) result = stripCoreGlobalsImports(result);
 
 	return result;
 }

--- a/packages/vite/hmr/server/websocket-hot-update.ts
+++ b/packages/vite/hmr/server/websocket-hot-update.ts
@@ -216,11 +216,15 @@ export async function runHotUpdatePrologue(ctx: HmrContext, deps: NsHotUpdateCon
 			for (const mod of graphTargets) {
 				if (!mod?.id) continue;
 				try {
+					const transformed = await server.transformRequest(mod.id);
+					const code = transformed?.code || '';
+					// Import analysis runs inside the transform, so the module's edges
+					// are current only after it — read before, a newly added import is
+					// missing from the graph until the NEXT save, and a client walking
+					// the reverse graph to find accepting importers never sees it.
 					const deps = Array.from(mod.importedModules || [])
 						.map((m) => (m.id || '').replace(/\?.*$/, ''))
 						.filter(Boolean);
-					const transformed = await server.transformRequest(mod.id);
-					const code = transformed?.code || '';
 					moduleGraph.upsert((mod.id || '').replace(/\?.*$/, ''), code, deps, {
 						emitDeltaOnInsert: true,
 						// Defer the delta broadcast until AFTER the framework

--- a/packages/vite/hmr/server/websocket-module-specifiers.ts
+++ b/packages/vite/hmr/server/websocket-module-specifiers.ts
@@ -6,6 +6,7 @@ import type { VendorManifest } from '../shared/vendor/manifest.js';
 import { getVendorManifest, resolveVendorSpecifier } from '../shared/vendor/registry.js';
 import { getProjectRootPath } from '../../helpers/project.js';
 import { extractRootPackageName, getPackageRuntimeInfo } from '../shared/package-classifier.js';
+import { getFlavorClientPackages } from '../framework-flavors.js';
 
 const ESM_FRAMEWORK_PACKAGE_ROOTS = new Set(['@nativescript/angular', 'nativescript-angular']);
 
@@ -110,7 +111,16 @@ export function isNativeScriptPluginModule(spec: string): boolean {
 function isBuildTimeOnlyPackageRoot(root: string): boolean {
 	if (!root) return false;
 	if (BUILD_TIME_ONLY_PACKAGE_ROOTS.has(root)) return true;
+	if (getFlavorClientPackages().has(root)) return true;
 	return BUILD_TIME_ONLY_PACKAGE_PREFIXES.some((prefix) => root.startsWith(prefix));
+}
+
+/** A registered flavor's client package is dev tooling the device loads per-module, like `@nativescript/vite`. */
+export function isFlavorClientPackageSpecifier(spec: string): boolean {
+	const cleaned = spec.replace(PAT.QUERY_PATTERN, '');
+	const normalized = normalizeNodeModulesSpecifier(cleaned) || cleaned.replace(/^\/+/, '');
+	const root = extractRootPackageName(normalized) || normalized;
+	return getFlavorClientPackages().has(root);
 }
 
 function isAllowedNativeScriptViteDeviceSubpath(spec: string): boolean {
@@ -146,6 +156,10 @@ export function getBlockedDeviceNodeModulesReason(spec: string): string | null {
 
 		const subpath = normalized.slice(pkgName.length).replace(/^\/+/, '');
 		return subpath ? `build-time NativeScript Vite module is not device-loadable: ${pkgName}/${subpath}` : 'build-time NativeScript Vite package root is not device-loadable';
+	}
+
+	if (getFlavorClientPackages().has(pkgName)) {
+		return null;
 	}
 
 	if (isBuildTimeOnlyPackageRoot(pkgName)) {

--- a/packages/vite/hmr/server/websocket-ns-m.ts
+++ b/packages/vite/hmr/server/websocket-ns-m.ts
@@ -11,7 +11,7 @@ import { collapseLegacyNsMTags } from './websocket-ns-m-paths.js';
 import { createNsMRequestContext, resolveNsMTransformedModule } from './websocket-ns-m-request.js';
 import { setDeviceModuleHeaders } from './route-helpers.js';
 import { CSS_MODULE_RE, buildCssRegisterSnippetFromVar, normalizeCssForDevice } from './css-device-module.js';
-import { assertNoOptimizedArtifacts, buildBootProgressSnippet, canonicalizeRtImports, classifyServedModule, dedupeRtNamedImportsAgainstDestructures, deduplicateLinkerImports, ensureDestructureCoreImports, ensureGuardPlainDynamicImports, ensureVariableDynamicImportHelper, expandStarExports, hoistTopLevelStaticImports, MODULE_IMPORT_ANALYSIS_PLUGINS, wrapCommonJsModuleForDevice } from './websocket-served-module-helpers.js';
+import { assertNoOptimizedArtifacts, buildBootProgressSnippet, canonicalizeRtImports, classifyServedModule, dedupeRtNamedImportsAgainstDestructures, deduplicateLinkerImports, ensureDestructureCoreImports, ensureGuardPlainDynamicImports, ensureVariableDynamicImportHelper, expandStarExports, hoistTopLevelStaticImports, MODULE_IMPORT_ANALYSIS_PLUGINS, wrapCommonJsModuleForDevice, ensureWorkerEntryGlobalsImport } from './websocket-served-module-helpers.js';
 import { cleanCode, collectImportDependencies, isWorkerEntryModuleId, processCodeForDevice, rewriteImports } from './websocket-device-transform.js';
 import { REQUIRE_GUARD_SNIPPET } from './require-guard.js';
 import { getServerOrigin } from './server-origin.js';
@@ -352,9 +352,10 @@ export function registerNsModuleServerRoute(server: ViteDevServer, options: Regi
 				}
 			}
 			let code = transformed.code;
+			if (isWorkerEntryModuleId(spec)) code = ensureWorkerEntryGlobalsImport(code);
 			// Prepend guard to capture any URL-based require attempts
 			code = REQUIRE_GUARD_SNIPPET + code;
-			code = cleanCode(code, strategy);
+			code = cleanCode(code, strategy, isWorkerRealmRequest ? { workerRealm: true } : undefined);
 			// Library code (node_modules, monorepo core source, dist vite package)
 			// must skip the app-source passes inside processCodeForDevice (AST
 			// normalization, /ns/rt helper-alias injection). One classification

--- a/packages/vite/hmr/server/websocket-served-module-helpers.ts
+++ b/packages/vite/hmr/server/websocket-served-module-helpers.ts
@@ -193,6 +193,19 @@ export function buildBootProgressSnippet(bootModuleLabel: string): string {
 	return [`const __nsBootGlobal=globalThis;`, `try{if(!__nsBootGlobal.__NS_HMR_BOOT_COMPLETE__){__nsBootGlobal.__NS_HMR_BOOT_MODULE_COUNT__=Number(__nsBootGlobal.__NS_HMR_BOOT_MODULE_COUNT__||0)+1;__nsBootGlobal.__NS_HMR_BOOT_LAST_MODULE__=${normalizedLabel};}}catch(__nsBootErr){}`, ''].join('\n');
 }
 
+/**
+ * A worker entry served under HMR evaluates in a fresh isolate where nothing
+ * has installed the runtime globals — `setTimeout`, `console` formatting,
+ * `fetch` — that the main realm's entry installs once from
+ * `@nativescript/core/globals`. The production worker build bundles that
+ * module in; the dev serve adds the import when the script does not carry it
+ * itself, so a worker behaves the same way on both paths.
+ */
+export function ensureWorkerEntryGlobalsImport(code: string): string {
+	if (/^\s*import\s+(?:[^'"\n]*from\s+)?["'][^"']*(?:@nativescript(?:[/_-])core(?:[/_-])globals|\/ns\/core\/globals)[^"']*["']/m.test(code)) return code;
+	return `import '@nativescript/core/globals';\n${code}`;
+}
+
 export function stripCoreGlobalsImports(code: string): string {
 	const pattern = /^\s*(?:import\s+(?:[^'"\n]*from\s+)?|export\s+\*\s+from\s+)["'][^"']*(?:@nativescript(?:[/_-])core(?:[\/_-])globals|@nativescript_core_globals)[^"']*["'];?\s*$/gm;
 	return code.replace(pattern, '');

--- a/packages/vite/hmr/server/websocket.ts
+++ b/packages/vite/hmr/server/websocket.ts
@@ -13,6 +13,7 @@ import { angularServerStrategy } from '../frameworks/angular/server/strategy.js'
 import { solidServerStrategy } from '../frameworks/solid/server/strategy.js';
 import { typescriptServerStrategy } from '../frameworks/typescript/server/strategy.js';
 import { reactServerStrategy } from '../frameworks/react/server/strategy.js';
+import { getFrameworkFlavor } from '../framework-flavors.js';
 import { getProjectAppPath, getProjectAppRelativePath, getProjectAppVirtualPath } from '../../helpers/utils.js';
 import { getVitePackageVersion } from '../../helpers/vite-package-version.js';
 import { shouldIncludeRuntimeGraphFile, shouldSkipRuntimeGraphDirectoryName } from './runtime-graph-filter.js';
@@ -836,12 +837,11 @@ function createHmrWebSocketPlugin(opts: { verbose?: boolean }, strategy: Framewo
 
 /**
  * Build the server-side HMR WebSocket plugin for `flavor`, or `undefined` when
- * the flavor has no registered server strategy (e.g. `react`, which ships only
- * the client plugin today). Driven off `STRATEGY_REGISTRY`, so adding a flavor
- * is a one-line registry change — no per-flavor wrapper and no `getHMRPlugins`
- * switch arm.
+ * the flavor has no server strategy. Built-in flavors come from
+ * `STRATEGY_REGISTRY`; a framework shipped outside this package contributes
+ * its strategy through `registerFrameworkFlavor` (see `framework-flavors.ts`).
  */
 export function hmrWebSocketPluginForFlavor(flavor: string, opts: { verbose?: boolean }): Plugin | undefined {
-	const strategy = STRATEGY_REGISTRY.get(flavor);
+	const strategy = STRATEGY_REGISTRY.get(flavor) ?? getFrameworkFlavor(flavor)?.server;
 	return strategy ? createHmrWebSocketPlugin(opts, strategy) : undefined;
 }

--- a/packages/vite/hmr/shared/ns-globals.ts
+++ b/packages/vite/hmr/shared/ns-globals.ts
@@ -66,6 +66,7 @@ declare global {
 	var __NS_HMR_REALM__: string | undefined;
 	var __NS_RT_REALM__: string | undefined;
 	var __NS_HMR_BROWSER_RUNTIME_TARGET_FLAVOR__: string | undefined;
+	var __NS_CLIENT_STRATEGY_URL__: string | undefined;
 	var __NS_HMR_GRAPH_VERSION__: number | undefined;
 	var __NS_HMR_IMPORT_NONCE__: number | undefined;
 

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -59,6 +59,13 @@
 			"import": "./configuration/base.js",
 			"default": "./configuration/base.js"
 		},
+		"./framework": {
+			"types": "./framework.d.ts",
+			"import": "./framework.js",
+			"default": "./framework.js"
+		},
+		"./hmr/client/framework": "./hmr/client/framework.js",
+		"./hmr/client/framework.js": "./hmr/client/framework.js",
 		"./hmr/client/index.js": "./hmr/client/index.js",
 		"./hmr/client/hot-context": "./hmr/client/hot-context.js",
 		"./hmr/client/hot-context.js": "./hmr/client/hot-context.js",


### PR DESCRIPTION
Support for third-party frameworks to define and register their own NativeScript Vite HMR "flavors," enabling any framework to provide custom HMR strategies through their own packages. 

**Framework Flavor Extensibility**

* Added `@nativescript/vite/framework` API, exposing functions and types for registering and using custom framework flavors, including server and client strategy types and helpers like `registerFrameworkFlavor`, `getFrameworkFlavor`, and `typescriptServerStrategy`. (`packages/vite/framework.ts`)
* Introduced logic to detect and use flavors declared by dependencies in their `package.json` (via `nativescript.vite.flavor`), enabling automatic flavor selection and configuration scaffolding for third-party frameworks. 

**Configuration and Runtime Integration**

* Updated the Vite configuration and runtime seed values to include the client strategy module path for custom flavors, allowing the device to load the correct HMR client strategy. 
* Modified the logger instantiation in `baseConfig` to accept an `hmrActive` parameter, supporting improved logging for HMR scenarios. 