### PR TITLE
fix(core): install global polyfills only when missing, without materializing lazy runtime globals

### DIFF
--- a/packages/core/globals/index.ts
+++ b/packages/core/globals/index.ts
@@ -272,7 +272,9 @@ global.loadModule = function loadModule(name: string): any {
 	return null;
 };
 function registerOnGlobalContext(moduleName: string, exportName: string): void {
-	if (global[exportName]) {
+	// Check presence with `in`, never by reading the property — reading forces
+	// runtime-provided lazy globals (e.g. TextDecoder) to materialize eagerly.
+	if (exportName in global) {
 		// already registered
 		return;
 	}
@@ -296,12 +298,19 @@ function registerOnGlobalContext(moduleName: string, exportName: string): void {
 }
 
 export function installPolyfills(moduleName: string, exportNames: string[]) {
+	// Install only what the runtime doesn't already provide, checking with `in`
+	// so runtime-provided lazy globals aren't materialized by the check itself.
+	const missingNames = exportNames.filter((exportName) => !(exportName in global));
+	if (!missingNames.length) {
+		return;
+	}
+
 	const shouldInstallEagerly = global.__snapshot || !__COMMONJS__;
 	if (shouldInstallEagerly) {
 		const loadedModule = global.loadModule(moduleName);
-		installPolyfillsFromModule(loadedModule, exportNames as any);
+		installPolyfillsFromModule(loadedModule, missingNames as any);
 	} else {
-		exportNames.forEach((exportName) => registerOnGlobalContext(moduleName, exportName));
+		missingNames.forEach((exportName) => registerOnGlobalContext(moduleName, exportName));
 	}
 }
 
@@ -336,7 +345,9 @@ if (!global.NativeScriptHasPolyfilled) {
 	global.registerModule('subtle', () => subtleCryptoImpl);
 	installPolyfills('subtle', ['SubtleCrypto']);
 
-	global.crypto = new cryptoImpl.Crypto() as any;
+	if (!('crypto' in (global as object))) {
+		global.crypto = new cryptoImpl.Crypto() as any;
+	}
 
 	// global.registerModule('abortcontroller', () => require('../abortcontroller'));
 	// installPolyfills('abortcontroller', ['AbortController', 'AbortSignal']);

--- a/packages/core/globals/polyfills/utils.ts
+++ b/packages/core/globals/polyfills/utils.ts
@@ -1,5 +1,7 @@
 export function installPolyfillsFromModule(module: Partial<Record<keyof typeof global, any>>, polyfills: (keyof typeof global)[]) {
 	for (const polyfill of polyfills) {
+		// `in` checks presence without reading the property — reading would force
+		// runtime-provided lazy globals (e.g. TextDecoder) to materialize eagerly.
 		if (!(polyfill in global)) {
 			global[polyfill as any] = module[polyfill];
 		}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

- `registerOnGlobalContext` (the lazy CJS install path) checks for an existing global with a property *read* (`if (global[exportName])`). On runtimes that expose lazy self-installing globals (e.g. `TextDecoder`), that read forces the native implementation to materialize eagerly, defeating the runtime's laziness. Truthiness also means a defined-but-falsy global would get shadowed.
- `installPolyfills` (eager ESM/snapshot path) loads the polyfill module even when the runtime already provides every requested export.
- `global.crypto` is overwritten unconditionally, clobbering a runtime-provided `crypto`.

## What is the new behavior?

Polyfills are installed only when the corresponding global is actually missing, and presence is always checked with the `in` operator, which does a HasProperty lookup without invoking getters or lazy-property callbacks — so checking for `TextDecoder` no longer evaluates it. (`Object.getOwnPropertyDescriptor` would not be safe here either: V8 resolves lazy data properties to produce the descriptor.)

- `installPolyfills` filters the export list down to names missing from `global` first, and skips loading the polyfill module entirely when the runtime provides everything.
- `registerOnGlobalContext` bails out via `exportName in global` instead of reading the property.
- `global.crypto` is only assigned when absent.
