### PR TITLE
perf(core): overhaul css matching, cascade, and application

### DIFF
--- a/packages/core/__tests__/benchmarks/css-state.bench.ts
+++ b/packages/core/__tests__/benchmarks/css-state.bench.ts
@@ -124,6 +124,23 @@ describe('css state - dynamic updates', () => {
 		}
 	});
 
+	const classTree = buildTree(200);
+	attachScope(classTree.root, classTree.views, scope);
+	for (const view of classTree.views) {
+		// The class-change path only runs for loaded views.
+		(view as any)._isLoaded = true;
+	}
+	styleTree(classTree.views);
+
+	bench('toggle a class on 200 loaded views', () => {
+		for (const view of classTree.views) {
+			view.className = `${view.className} accent`;
+		}
+		for (const view of classTree.views) {
+			view.className = view.className.replace(' accent', '');
+		}
+	});
+
 	bench('toggle a pseudo class on 200 views', () => {
 		for (const view of views) {
 			view.addPseudoClass('highlighted');

--- a/packages/core/__tests__/benchmarks/css-state.bench.ts
+++ b/packages/core/__tests__/benchmarks/css-state.bench.ts
@@ -1,0 +1,189 @@
+import { bench, describe } from 'vitest';
+
+import { StyleScope, addTaggedAdditionalCSS, removeTaggedAdditionalCSS } from '../../ui/styling/style-scope';
+import { StackLayout } from '../../ui/layouts/stack-layout';
+import { Label } from '../../ui/label';
+import type { ViewBase } from '../../ui/core/view-base';
+
+/**
+ * A stylesheet shaped like a themed app (the kind `@nativescript/theme` ships).
+ */
+function themeCss(): string {
+	const parts: string[] = ['* { font-family: sans-serif; }'];
+	const types = ['label', 'button', 'stacklayout', 'image', 'textfield'];
+
+	for (const type of types) {
+		parts.push(`${type} { color: #222222; font-size: 14; }`);
+		parts.push(`${type}.accent { color: #0088cc; }`);
+		parts.push(`${type}:highlighted { background-color: #eeeeee; }`);
+	}
+
+	for (let i = 0; i < 80; i++) {
+		parts.push(`.cls-${i} { margin: ${i % 20}; padding: ${i % 10}; }`);
+		parts.push(`.cls-${i} .child-${i} { color: #333333; }`);
+	}
+
+	return parts.join('\n');
+}
+
+/**
+ * Component-level CSS the way Angular's emulated encapsulation emits it:
+ * every rule carries a `[_ngcontent-cN]` attribute selector.
+ */
+function componentCss(componentIndex: number): string {
+	const attr = `_ngcontent-c${componentIndex}`;
+
+	return [`.title[${attr}] { color: #111111; font-size: 18; }`, `.body[${attr}] { color: #444444; font-size: 13; }`, `label[${attr}] { margin: 2; }`].join('\n');
+}
+
+const COMPONENT_COUNT = 30;
+
+function buildTree(viewCount: number, ngComponentIndex?: number): { root: StackLayout; views: ViewBase[] } {
+	const root = new StackLayout();
+	const views: ViewBase[] = [];
+
+	let current: StackLayout = root;
+	for (let i = 0; i < viewCount; i++) {
+		if (i % 8 === 0) {
+			const layout = new StackLayout();
+			current.addChild(layout);
+			current = layout;
+			views.push(layout);
+			continue;
+		}
+
+		const view = new Label();
+		view.className = `cls-${i % 80} ${i % 5 === 0 ? 'accent' : 'title'}`;
+		current.addChild(view);
+		views.push(view);
+	}
+
+	if (ngComponentIndex !== undefined) {
+		// Angular's EmulatedRenderer sets a content attribute on every element it creates.
+		const attr = `_ngcontent-c${ngComponentIndex}`;
+		for (const view of views) {
+			view[attr] = '';
+		}
+	}
+
+	return { root, views };
+}
+
+function attachScope(root: StackLayout, views: ViewBase[], scope: StyleScope): void {
+	root._styleScope = scope;
+	for (const view of views) {
+		view._styleScope = scope;
+	}
+}
+
+function styleTree(views: ViewBase[]): void {
+	for (const view of views) {
+		// The load path: match selectors, subscribe for dynamic updates, apply values.
+		view._cssState.onLoaded();
+	}
+}
+
+function restyleTree(views: ViewBase[]): void {
+	for (const view of views) {
+		view._cssState.onChange();
+		view._cssState.onLoaded();
+	}
+}
+
+describe('css state - initial styling', () => {
+	const scope = new StyleScope();
+	scope.css = themeCss();
+
+	bench('style a 400 view tree (plain css)', () => {
+		const { root, views } = buildTree(400);
+		attachScope(root, views, scope);
+		styleTree(views);
+	});
+
+	const ngScope = new StyleScope();
+	ngScope.css = themeCss() + '\n' + Array.from({ length: COMPONENT_COUNT }, (_, i) => componentCss(i)).join('\n');
+
+	bench('style a 400 view tree (angular attribute-scoped css)', () => {
+		const { root, views } = buildTree(400, 3);
+		attachScope(root, views, ngScope);
+		styleTree(views);
+	});
+});
+
+describe('css state - dynamic updates', () => {
+	const scope = new StyleScope();
+	scope.css = themeCss();
+
+	const { root, views } = buildTree(200);
+	attachScope(root, views, scope);
+	styleTree(views);
+
+	bench('re-apply matched properties for 200 views (no actual change)', () => {
+		for (const view of views) {
+			(view._cssState as any).updateDynamicState();
+		}
+	});
+
+	bench('toggle a pseudo class on 200 views', () => {
+		for (const view of views) {
+			view.addPseudoClass('highlighted');
+		}
+		for (const view of views) {
+			view.deletePseudoClass('highlighted');
+		}
+	});
+});
+
+describe('css state - adding css at runtime (angular component styles)', () => {
+	bench('add 30 component stylesheets and restyle a 200 view tree', () => {
+		const scope = new StyleScope();
+		scope.css = themeCss();
+
+		const { root, views } = buildTree(200, 3);
+		attachScope(root, views, scope);
+		styleTree(views);
+
+		for (let i = 0; i < COMPONENT_COUNT; i++) {
+			addTaggedAdditionalCSS(componentCss(i), `bench-component-${i}`);
+			// Angular creates the component's views right after registering its styles,
+			// which forces the scope to rebuild and every view to re-match.
+			restyleTree(views);
+		}
+
+		for (let i = 0; i < COMPONENT_COUNT; i++) {
+			removeTaggedAdditionalCSS(`bench-component-${i}`);
+		}
+	});
+});
+
+describe('css state - angular component loading', () => {
+	// What actually happens when an Angular app navigates: each component registers
+	// its (attribute scoped) styles the first time it is used, then immediately
+	// creates and styles its own views.
+	bench('load 30 components (register styles + style 20 views each)', () => {
+		const scope = new StyleScope();
+		scope.css = themeCss();
+
+		for (let i = 0; i < COMPONENT_COUNT; i++) {
+			addTaggedAdditionalCSS(componentCss(i), `bench-ng-${i}`);
+
+			const { root, views } = buildTree(20, i);
+			attachScope(root, views, scope);
+			styleTree(views);
+		}
+
+		for (let i = 0; i < COMPONENT_COUNT; i++) {
+			removeTaggedAdditionalCSS(`bench-ng-${i}`);
+		}
+	});
+});
+
+describe('css state - selector scope construction', () => {
+	const css = themeCss();
+
+	bench('build a StyleScope from a themed stylesheet', () => {
+		const scope = new StyleScope();
+		scope.css = css;
+		scope.ensureSelectors();
+	});
+});

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -12,8 +12,8 @@ import { calc } from '@csstools/css-calc';
 export { unsetValue } from './property-shared';
 
 const cssPropertyNames: string[] = [];
-const cssShorthandPropertyNames = new Set<string>();
 const cssShorthandConverters = new Map<string, (value: string) => [any, any][]>();
+const cssShorthandLonghands = new Map<string, string[]>();
 const HAS_OWN = Object.prototype.hasOwnProperty;
 const symbolPropertyMap = {};
 const cssSymbolPropertyMap = {};
@@ -59,12 +59,87 @@ export function _getStyleProperties(): CssProperty<any, any>[] {
 }
 
 /**
- * A shorthand writes several longhand properties, so unsetting one of the two
- * can silently clear the other. Callers that diff css values need to know which
- * names can overlap.
+ * Stands in for the longhands of a shorthand whose value still has to be resolved.
+ *
+ * A single `var()` can substitute the value of several longhands at once, so such a
+ * shorthand cannot be split while parsing. CSS fills its longhands with a
+ * pending-substitution value instead, cascades that like any other value, and parses
+ * the shorthand once substitution has happened - which is what this carries.
+ *
+ * @see https://drafts.csswg.org/css-variables/#variables-in-shorthands
  */
-export function isCssShorthandProperty(cssName: string): boolean {
-	return cssShorthandPropertyNames.has(cssName);
+export class CssPendingSubstitution {
+	constructor(
+		public readonly shorthand: string,
+		public readonly value: string,
+	) {}
+
+	toString(): string {
+		return this.value;
+	}
+}
+
+export function _isCssPendingSubstitution(value: unknown): value is CssPendingSubstitution {
+	return value instanceof CssPendingSubstitution;
+}
+
+/**
+ * The longhands a shorthand expands into, discovered by asking its converter.
+ *
+ * Every converter answers an unset value with its full set of longhands, and the
+ * probe is deferred to first use because the longhand properties a converter closes
+ * over are not initialized yet while the shorthand itself is being registered.
+ */
+function getCssShorthandLonghands(cssName: string): string[] | undefined {
+	const known = cssShorthandLonghands.get(cssName);
+	if (known) {
+		return known;
+	}
+
+	const converter = cssShorthandConverters.get(cssName);
+	if (!converter) {
+		return undefined;
+	}
+
+	try {
+		const probed = converter(unsetValue);
+		if (!probed?.length) {
+			return undefined;
+		}
+
+		const longhands: string[] = [];
+		for (let i = 0, length = probed.length; i < length; i++) {
+			longhands.push(probed[i][0].cssLocalName);
+		}
+
+		cssShorthandLonghands.set(cssName, longhands);
+
+		return longhands;
+	} catch (e) {
+		Trace.write(`Could not determine the longhands of shorthand [${cssName}]. ${e}`, Trace.categories.Style, Trace.messageType.warn);
+
+		return undefined;
+	}
+}
+
+/**
+ * Pending-substitution values for a shorthand that cannot be expanded yet, one per
+ * longhand. Returns `undefined` when the property is not a shorthand or its
+ * longhands cannot be determined, leaving the declaration as it was.
+ */
+export function _pendingCssShorthandSubstitution(cssName: string, value: string): [string, CssPendingSubstitution][] | undefined {
+	const longhands = getCssShorthandLonghands(cssName);
+	if (!longhands) {
+		return undefined;
+	}
+
+	const pending = new CssPendingSubstitution(cssName, value);
+	const declarations: [string, CssPendingSubstitution][] = [];
+	for (let i = 0, length = longhands.length; i < length; i++) {
+		declarations.push([longhands[i], pending]);
+	}
+
+	return declarations;
 }
 
 /**
@@ -1286,7 +1361,6 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 
 		this.cssName = `css:${options.cssName}`;
 		this.cssLocalName = `${options.cssName}`;
-		cssShorthandPropertyNames.add(options.cssName);
 		cssShorthandConverters.set(options.cssName, options.converter as (value: string) => [any, any][]);
 
 		const converter = options.converter;

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -59,13 +59,9 @@ export function _getStyleProperties(): CssProperty<any, any>[] {
 }
 
 /**
- * Stands in for the longhands of a shorthand whose value still has to be resolved.
- *
- * A single `var()` can substitute the value of several longhands at once, so such a
- * shorthand cannot be split while parsing. CSS fills its longhands with a
- * pending-substitution value instead, cascades that like any other value, and parses
- * the shorthand once substitution has happened - which is what this carries.
- *
+ * Placeholder cascaded for each longhand of a shorthand that cannot be split while
+ * parsing - a single `var()` may substitute several longhands at once, so the
+ * shorthand is only parsed once its expression is resolved per view.
  * @see https://drafts.csswg.org/css-variables/#variables-in-shorthands
  */
 export class CssPendingSubstitution {
@@ -84,11 +80,9 @@ export function _isCssPendingSubstitution(value: unknown): value is CssPendingSu
 }
 
 /**
- * The longhands a shorthand expands into, discovered by asking its converter.
- *
- * Every converter answers an unset value with its full set of longhands, and the
- * probe is deferred to first use because the longhand properties a converter closes
- * over are not initialized yet while the shorthand itself is being registered.
+ * The longhands a shorthand expands into, probed from its converter on first use -
+ * the longhand properties a converter closes over are not initialized yet while
+ * the shorthand itself is being registered.
  */
 function getCssShorthandLonghands(cssName: string): string[] | undefined {
 	const known = cssShorthandLonghands.get(cssName);
@@ -123,9 +117,8 @@ function getCssShorthandLonghands(cssName: string): string[] | undefined {
 }
 
 /**
- * Pending-substitution values for a shorthand that cannot be expanded yet, one per
- * longhand. Returns `undefined` when the property is not a shorthand or its
- * longhands cannot be determined, leaving the declaration as it was.
+ * One pending-substitution value per longhand of the shorthand, or `undefined`
+ * when the longhands cannot be determined.
  */
 export function _pendingCssShorthandSubstitution(cssName: string, value: string): [string, CssPendingSubstitution][] | undefined {
 	const longhands = getCssShorthandLonghands(cssName);
@@ -143,16 +136,9 @@ export function _pendingCssShorthandSubstitution(cssName: string, value: string)
 }
 
 /**
- * Expand a shorthand declaration into the longhand declarations it stands for.
- *
- * The cascade is defined on longhands - a shorthand declaration is equivalent to
- * declaring each of its longhands in its place - so doing this once while parsing
- * keeps source order meaningful and saves converting the same declaration again
- * for every view it applies to.
- *
- * Returns `undefined` when the property is not a shorthand, when the value still
- * has to be evaluated (`var()` / `calc()` are only resolvable per view), or when
- * the value does not parse - all of which leave the declaration as it was.
+ * Expand a shorthand declaration into its longhand declarations, or `undefined`
+ * when the property is not a shorthand, the value still has to be evaluated per
+ * view (`var()`/`calc()`), or it does not parse.
  */
 export function _expandCssShorthand(cssName: string, value: string): [string, any][] | undefined {
 	const converter = cssShorthandConverters.get(cssName);
@@ -1424,9 +1410,8 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 			Object.defineProperty(cls.prototype, this.cssLocalName, this.localValueDescriptor);
 		}
 
-		// Note: nothing is registered on `PropertyBag` here. Shorthands are expanded
-		// while parsing, and the only ones that reach the bag are `var()`/`calc()`
-		// values, which must not be converted until they have been evaluated.
+		// Nothing is defined on `PropertyBag`: shorthands are expanded while parsing,
+		// and the var()/calc() ones that do reach the bag must stay unconverted.
 	}
 }
 

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -12,6 +12,7 @@ import { calc } from '@csstools/css-calc';
 export { unsetValue } from './property-shared';
 
 const cssPropertyNames: string[] = [];
+const cssShorthandPropertyNames = new Set<string>();
 const HAS_OWN = Object.prototype.hasOwnProperty;
 const symbolPropertyMap = {};
 const cssSymbolPropertyMap = {};
@@ -54,6 +55,15 @@ export function _getProperties(): Property<any, any>[] {
 
 export function _getStyleProperties(): CssProperty<any, any>[] {
 	return getPropertiesFromMap(cssSymbolPropertyMap) as CssProperty<any, any>[];
+}
+
+/**
+ * A shorthand writes several longhand properties, so unsetting one of the two
+ * can silently clear the other. Callers that diff css values need to know which
+ * names can overlap.
+ */
+export function isCssShorthandProperty(cssName: string): boolean {
+	return cssShorthandPropertyNames.has(cssName);
 }
 
 export function isCssVariable(property: string) {
@@ -1239,6 +1249,7 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 
 		this.cssName = `css:${options.cssName}`;
 		this.cssLocalName = `${options.cssName}`;
+		cssShorthandPropertyNames.add(options.cssName);
 
 		const converter = options.converter;
 

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -13,6 +13,7 @@ export { unsetValue } from './property-shared';
 
 const cssPropertyNames: string[] = [];
 const cssShorthandPropertyNames = new Set<string>();
+const cssShorthandConverters = new Map<string, (value: string) => [any, any][]>();
 const HAS_OWN = Object.prototype.hasOwnProperty;
 const symbolPropertyMap = {};
 const cssSymbolPropertyMap = {};
@@ -64,6 +65,43 @@ export function _getStyleProperties(): CssProperty<any, any>[] {
  */
 export function isCssShorthandProperty(cssName: string): boolean {
 	return cssShorthandPropertyNames.has(cssName);
+}
+
+/**
+ * Expand a shorthand declaration into the longhand declarations it stands for.
+ *
+ * The cascade is defined on longhands - a shorthand declaration is equivalent to
+ * declaring each of its longhands in its place - so doing this once while parsing
+ * keeps source order meaningful and saves converting the same declaration again
+ * for every view it applies to.
+ *
+ * Returns `undefined` when the property is not a shorthand, when the value still
+ * has to be evaluated (`var()` / `calc()` are only resolvable per view), or when
+ * the value does not parse - all of which leave the declaration as it was.
+ */
+export function _expandCssShorthand(cssName: string, value: string): [string, any][] | undefined {
+	const converter = cssShorthandConverters.get(cssName);
+	if (!converter) {
+		return undefined;
+	}
+
+	if (typeof value === 'string' && (isCssVariableExpression(value) || isCssCalcExpression(value))) {
+		return undefined;
+	}
+
+	try {
+		const converted = converter(value);
+		const expanded: [string, any][] = [];
+		for (let i = 0, length = converted.length; i < length; i++) {
+			expanded.push([converted[i][0].cssLocalName, converted[i][1]]);
+		}
+
+		return expanded;
+	} catch (e) {
+		Trace.write(`Failed to expand shorthand [${cssName}] with value [${value}]. ${e}`, Trace.categories.Style, Trace.messageType.warn);
+
+		return undefined;
+	}
 }
 
 export function isCssVariable(property: string) {
@@ -1237,7 +1275,6 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 
 	protected readonly cssValueDescriptor: PropertyDescriptor;
 	protected readonly localValueDescriptor: PropertyDescriptor;
-	protected readonly propertyBagDescriptor: PropertyDescriptor;
 
 	public readonly sourceKey: symbol;
 
@@ -1250,6 +1287,7 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 		this.cssName = `css:${options.cssName}`;
 		this.cssLocalName = `${options.cssName}`;
 		cssShorthandPropertyNames.add(options.cssName);
+		cssShorthandConverters.set(options.cssName, options.converter as (value: string) => [any, any][]);
 
 		const converter = options.converter;
 
@@ -1297,16 +1335,6 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 			set: setLocalValue,
 		};
 
-		this.propertyBagDescriptor = {
-			enumerable: false,
-			configurable: true,
-			set(value: string) {
-				converter(value).forEach(([property, value]) => {
-					this[property.cssLocalName] = value;
-				});
-			},
-		};
-
 		cssSymbolPropertyMap[key] = this;
 	}
 
@@ -1322,7 +1350,9 @@ export class ShorthandProperty<T extends Style, P> implements ShorthandProperty<
 			Object.defineProperty(cls.prototype, this.cssLocalName, this.localValueDescriptor);
 		}
 
-		Object.defineProperty(cls.prototype.PropertyBag, this.cssLocalName, this.propertyBagDescriptor);
+		// Note: nothing is registered on `PropertyBag` here. Shorthands are expanded
+		// while parsing, and the only ones that reach the bag are `var()`/`calc()`
+		// values, which must not be converted until they have been evaluated.
 	}
 }
 

--- a/packages/core/ui/styling/css-selector.spec.ts
+++ b/packages/core/ui/styling/css-selector.spec.ts
@@ -347,6 +347,80 @@ describe('css-selector', () => {
 		}
 	});
 
+	describe('attribute selectors', () => {
+		class Widget {
+			public cssType = 'widget';
+			public cssClasses = new Set<string>();
+			private _text: string;
+			get text(): string {
+				return this._text;
+			}
+			set text(value: string) {
+				this._text = value;
+			}
+		}
+
+		it('does not match a node that does not know the attribute', () => {
+			const rule = createOne(`.title[_ngcontent-c7] { color: red; }`);
+			const node = { cssType: 'label', cssClasses: new Set(['title']), '_ngcontent-c3': '' };
+
+			expect(rule.selectors[0].accumulateChanges(<any>node, undefined)).toBe(false);
+		});
+
+		it('matches a node carrying the attribute', () => {
+			const rule = createOne(`.title[_ngcontent-c3] { color: red; }`);
+			const node = { cssType: 'label', cssClasses: new Set(['title']), '_ngcontent-c3': '' };
+
+			expect(rule.selectors[0].accumulateChanges(<any>node, undefined)).toBe(true);
+		});
+
+		it('does not subscribe for attributes that cannot raise change events', () => {
+			const rule = createOne(`[_ngcontent-c3] { color: red; }`);
+			const node = { cssType: 'label', '_ngcontent-c3': '' };
+			const changes: Array<string> = [];
+
+			rule.selectors[0].accumulateChanges(
+				<any>node,
+				<any>{
+					addAttribute: (_n, attribute: string) => changes.push(attribute),
+					addPseudoClass: () => {},
+				},
+			);
+
+			expect(changes).toEqual([]);
+		});
+
+		it('subscribes for attributes backed by a property', () => {
+			const rule = createOne(`widget[text] { color: red; }`);
+			const node = new Widget();
+			node.text = 'hello';
+			const changes: Array<string> = [];
+
+			rule.selectors[0].accumulateChanges(
+				<any>node,
+				<any>{
+					addAttribute: (_n, attribute: string) => changes.push(attribute),
+					addPseudoClass: () => {},
+				},
+			);
+
+			expect(changes).toEqual(['text']);
+		});
+
+		it('matches a property backed attribute even when it is unset', () => {
+			const rule = createOne(`widget[text] { color: red; }`);
+
+			// The value can still be assigned later, and assigning it raises `textChange`.
+			const accumulator = <any>{ addAttribute: () => {}, addPseudoClass: () => {} };
+			expect(rule.selectors[0].accumulateChanges(<any>new Widget(), accumulator)).toBe(true);
+		});
+	});
+
+	it('strips the unsupported !important flag while parsing', () => {
+		const rule = createOne(`button { color: red !important; }`);
+		expect(rule.declarations).toEqual([{ property: 'color', value: 'red' }]);
+	});
+
 	it('query returns selectors sorted by specificity then position', () => {
 		const { selectorScope } = create(`
 	        button { color: red; }

--- a/packages/core/ui/styling/css-selector.spec.ts
+++ b/packages/core/ui/styling/css-selector.spec.ts
@@ -1,6 +1,6 @@
 import { parse } from '../../css/reworkcss.js';
 import { Screen } from '../../platform';
-import { createSelector, RuleSet, StyleSheetSelectorScope, fromAstNode, Node, Changes } from './css-selector';
+import { createSelector, RuleSet, StyleSheetSelectorScope, SelectorTier, fromAstNode, Node, Changes, matchSelectorCandidates } from './css-selector';
 import { _populateRules } from './style-scope';
 
 describe('css-selector', () => {
@@ -419,6 +419,43 @@ describe('css-selector', () => {
 	it('strips the unsupported !important flag while parsing', () => {
 		const rule = createOne(`button { color: red !important; }`);
 		expect(rule.declarations).toEqual([{ property: 'color', value: 'red' }]);
+	});
+
+	describe('candidate resolution across scopes', () => {
+		it('breaks a specificity tie on the scope tier before the position', () => {
+			const application = create(`label { color: red; }`).selectorScope;
+			const local = new StyleSheetSelectorScope(create(`label { color: blue; }`).rulesets, SelectorTier.Local);
+
+			const node = { cssType: 'label', cssClasses: new Set<string>() };
+			const candidates = local.collectCandidates(<any>node, application.collectCandidates(<any>node));
+			const { selectors } = matchSelectorCandidates(<any>node, candidates);
+
+			// Local styles are a later "stylesheet", so they win the tie regardless of
+			// the position each selector got inside its own scope.
+			expect(selectors.length).toBe(2);
+			expect(selectors[1].ruleset.declarations[0].value).toBe('blue');
+		});
+
+		it('drops rules scoped to a stylesheet the caller did not load', () => {
+			const { rulesets, selectorScope } = create(`label { color: red; } label { color: blue; }`);
+			rulesets[1].scopedTag = 'other.css';
+
+			const node = { cssType: 'label', cssClasses: new Set<string>() };
+			const { selectors } = matchSelectorCandidates(<any>node, selectorScope.collectCandidates(<any>node), new Set(['mine.css']));
+
+			expect(selectors.length).toBe(1);
+			expect(selectors[0].ruleset.declarations[0].value).toBe('red');
+		});
+
+		it('keeps rules scoped to a stylesheet the caller did load', () => {
+			const { rulesets, selectorScope } = create(`label { color: red; } label { color: blue; }`);
+			rulesets[1].scopedTag = 'mine.css';
+
+			const node = { cssType: 'label', cssClasses: new Set<string>() };
+			const { selectors } = matchSelectorCandidates(<any>node, selectorScope.collectCandidates(<any>node), new Set(['mine.css']));
+
+			expect(selectors.length).toBe(2);
+		});
 	});
 
 	it('query returns selectors sorted by specificity then position', () => {

--- a/packages/core/ui/styling/css-selector.spec.ts
+++ b/packages/core/ui/styling/css-selector.spec.ts
@@ -416,6 +416,24 @@ describe('css-selector', () => {
 		});
 	});
 
+	it('expands a shorthand into its longhands while parsing', () => {
+		const rule = createOne(`button { margin: 4; }`);
+
+		expect(rule.declarations.map((d) => d.property)).toEqual(['margin-top', 'margin-right', 'margin-bottom', 'margin-left']);
+	});
+
+	it('gives a shorthand holding a variable one pending-substitution value per longhand', () => {
+		// A single var() can substitute several longhands at once, so the shorthand can
+		// only be parsed once substitution has happened - but the declaration is still
+		// keyed by longhands, as the cascade requires.
+		const rule = createOne(`button { margin: var(--m); }`);
+
+		expect(rule.declarations.map((d) => d.property)).toEqual(['margin-top', 'margin-right', 'margin-bottom', 'margin-left']);
+		expect(rule.declarations.map((d) => String(d.value))).toEqual(['var(--m)', 'var(--m)', 'var(--m)', 'var(--m)']);
+		// One placeholder shared by every longhand, so it is only resolved once.
+		expect(new Set(rule.declarations.map((d) => d.value)).size).toBe(1);
+	});
+
 	it('strips the unsupported !important flag while parsing', () => {
 		const rule = createOne(`button { color: red !important; }`);
 		expect(rule.declarations).toEqual([{ property: 'color', value: 'red' }]);

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -27,10 +27,7 @@ export interface Node {
 
 export interface Declaration {
 	property: string;
-	/**
-	 * Usually the raw text from the stylesheet, but a shorthand is expanded while
-	 * parsing and its longhands carry the already-converted value.
-	 */
+	/** Raw stylesheet text, except expanded shorthand longhands, which carry the converted value. */
 	value: any;
 }
 
@@ -107,14 +104,9 @@ interface LookupSorter {
 }
 
 /**
- * Which set of stylesheets a selector came from.
- *
- * The cascade breaks a specificity tie on source order, and source order across
- * stylesheets is really (stylesheet, position within it) - so a selector needs to
- * know its stylesheet's rank, not just its own index. Application styles are
- * consulted for every view and are indexed once; a scope's own styles come after
- * them and are indexed per scope, so their positions are only comparable within a
- * tier.
+ * Rank of the stylesheet set a selector was indexed in. Specificity ties break on
+ * (tier, pos): the application and local indexes are built separately, so positions
+ * are only comparable within a tier.
  */
 export const enum SelectorTier {
 	Application = 0,
@@ -164,13 +156,9 @@ function getNodePreviousDirectSibling(node: Node): null | Node {
 }
 
 /**
- * Cache of "does this view type notify for that attribute", keyed by prototype.
- *
- * `<attribute>Change` events are only raised by registered properties, which are
- * defined as accessors on a prototype. An attribute that is a plain value on the
- * instance - Angular's `_ngcontent-*` markers, anything a renderer assigns
- * directly - can never notify, so subscribing to its change event is pure
- * overhead on every view the selector may match.
+ * `<attribute>Change` is only raised by properties defined as prototype accessors;
+ * a plain instance value (e.g. Angular's `_ngcontent-*` markers) never notifies,
+ * so subscribing to its change event would be pure overhead.
  */
 const notifyingAttributes = new WeakMap<object, Map<string, boolean>>();
 
@@ -440,17 +428,12 @@ export class AttributeSelector extends SimpleSelector {
 		return false;
 	}
 	public mayMatch(node: Node): boolean {
-		// The attribute may still be assigned later, but only if the view knows about it:
-		// registered properties live on the prototype and anything a framework has already
-		// set is an own value. An attribute that is on neither can never start matching
-		// without the css state being invalidated anyway, and treating it as a permanent
-		// "maybe" keeps the selector - and a change subscription for it - on every view it
-		// will never match. Angular's per component `[_ngcontent-cN]` scoping makes that
-		// cost grow with the number of components in the app.
+		// Registered properties live on the prototype and anything already assigned is
+		// an own value; an attribute on neither can never start matching without the
+		// css state being invalidated anyway.
 		return this.attribute in node;
 	}
 	public trackChanges(node: Node, map: ChangeAccumulator): void {
-		// Only subscribe when the attribute can actually raise `<attribute>Change`.
 		if (attributeNotifiesChanges(node, this.attribute)) {
 			map.addAttribute(node, this.attribute);
 		}
@@ -970,13 +953,10 @@ export function fromAstNode(astRule: ReworkCSS.Rule): RuleSet {
 
 function appendDeclaration(declarations: Declaration[], decl: ReworkCSS.Declaration): void {
 	const property = isCssVariable(decl.property) ? decl.property : decl.property.toLowerCase();
-	// Strip the (unsupported) `!important` flag once, here, instead of scanning
-	// every declaration again for every view the rule is applied to.
 	const value = cleanupImportantFlags(decl.value, decl.property);
 
-	// A shorthand declaration is defined as declaring each of its longhands in its
-	// place, so expanding here keeps source order - and therefore the cascade -
-	// correct, and converts the value once instead of once per view per update.
+	// The cascade is defined on longhands: a shorthand declares each of its
+	// longhands in its place, so it is expanded here to keep source order meaningful.
 	const expanded = _expandCssShorthand(property, value);
 	if (expanded) {
 		for (let i = 0, length = expanded.length; i < length; i++) {
@@ -986,8 +966,8 @@ function appendDeclaration(declarations: Declaration[], decl: ReworkCSS.Declarat
 		return;
 	}
 
-	// A shorthand whose value still has to be resolved gets one pending-substitution
-	// value per longhand, so a declaration is only ever keyed by a longhand.
+	// A var()/calc() shorthand cannot be expanded yet - cascade one
+	// pending-substitution value per longhand instead.
 	const pending = _pendingCssShorthandSubstitution(property, value);
 	if (pending) {
 		for (let i = 0, length = pending.length; i < length; i++) {
@@ -1289,11 +1269,8 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 	}
 
 	/**
-	 * Index rulesets that were added after this scope was built.
-	 *
-	 * Application stylesheets are only ever appended to outside of a livesync or an
-	 * explicit removal, so the rules already indexed keep their positions and only
-	 * the tail has to be sorted into the lookup maps.
+	 * Index rulesets added after this scope was built; the rules already indexed
+	 * keep their positions.
 	 */
 	public appendRulesets(rulesets: RuleSet[], from: number): void {
 		this.lookupRulesets(rulesets, from);
@@ -1357,9 +1334,8 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 	}
 
 	/**
-	 * Append every selector that could match the node, this scope's matching media
-	 * query scopes included. Several scopes feed one match, so the candidates are
-	 * collected into a shared array and resolved once by `matchSelectorCandidates`.
+	 * Append every selector that could match the node, matching media query scopes
+	 * included, for `matchSelectorCandidates` to resolve.
 	 */
 	public collectCandidates(node: T, candidates: SelectorCore[] = []): SelectorCore[] {
 		this.getSelectorCandidates(node, candidates);
@@ -1387,27 +1363,19 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 	}
 }
 
-/**
- * Order matching selectors the way the cascade does: by specificity, then by
- * source order - which across stylesheets means the stylesheet's rank first and
- * the position within it second.
- */
+/** Cascade order: specificity, then source order - (tier, position) across stylesheets. */
 function compareSelectors(a: SelectorCore, b: SelectorCore): number {
 	return a.specificity - b.specificity || a.tier - b.tier || a.pos - b.pos;
 }
 
 /**
- * Resolve collected candidates against a node.
- *
- * `scopedTags` filters out rules that were registered on behalf of a stylesheet
- * this scope never loaded; pass it only when such rules exist, since it costs a
- * lookup per candidate.
+ * Resolve collected candidates against a node, compacting the array in place.
+ * `scopedTags` filters out rules registered on behalf of a stylesheet this scope
+ * never loaded; pass it only when such rules exist - it costs a lookup per candidate.
  */
 export function matchSelectorCandidates<T extends Node>(node: T, candidates: SelectorCore[], scopedTags?: Set<string>): SelectorsMatch<T> {
 	const selectorsMatch = new SelectorsMatch<T>();
 
-	// Compact the candidates in place - a query runs for every view, so the
-	// intermediate array a filter() would allocate is worth avoiding.
 	let matched = 0;
 	for (let i = 0, length = candidates.length; i < length; i++) {
 		const selector = candidates[i];
@@ -1435,10 +1403,7 @@ interface ChangeAccumulator {
 	addPseudoClass(node: Node, pseudoClass: string): void;
 }
 
-/**
- * Most views match no dynamic selector at all, so the change map is only
- * materialized once something actually has to be tracked.
- */
+/** Shared by matches that track nothing; a real map is materialized on first write. */
 const emptyChangeMap: ChangeMap<any> = new Map();
 
 export class SelectorsMatch<T extends Node> implements ChangeAccumulator {

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -1,6 +1,6 @@
 import { parse as convertToCSSWhatSelector, Selector as CSSWhatSelector, DataType as CSSWhatDataType } from 'css-what';
 import '../../globals';
-import { isCssVariable } from '../core/properties';
+import { _expandCssShorthand, isCssVariable } from '../core/properties';
 import { isNullOrUndefined } from '../../utils/types';
 import { cleanupImportantFlags } from './css-utils';
 
@@ -27,7 +27,11 @@ export interface Node {
 
 export interface Declaration {
 	property: string;
-	value: string;
+	/**
+	 * Usually the raw text from the stylesheet, but a shorthand is expanded while
+	 * parsing and its longhands carry the already-converted value.
+	 */
+	value: any;
 }
 
 export type ChangeMap<T extends Node> = Map<T, Changes>;
@@ -932,19 +936,40 @@ export class RuleSet {
 }
 
 export function fromAstNode(astRule: ReworkCSS.Rule): RuleSet {
-	const declarations = astRule.declarations.filter(isDeclaration).map(createDeclaration);
+	const declarations: Declaration[] = [];
+	const nodes = astRule.declarations;
+
+	for (let i = 0, length = nodes.length; i < length; i++) {
+		const node = nodes[i];
+		if (isDeclaration(node)) {
+			appendDeclaration(declarations, node);
+		}
+	}
+
 	const selectors = astRule.selectors.map(createSelector);
 
 	return new RuleSet(selectors, declarations);
 }
 
-function createDeclaration(decl: ReworkCSS.Declaration): any {
-	return {
-		property: isCssVariable(decl.property) ? decl.property : decl.property.toLowerCase(),
-		// Strip the (unsupported) `!important` flag once, here, instead of scanning
-		// every declaration again for every view the rule is applied to.
-		value: cleanupImportantFlags(decl.value, decl.property),
-	};
+function appendDeclaration(declarations: Declaration[], decl: ReworkCSS.Declaration): void {
+	const property = isCssVariable(decl.property) ? decl.property : decl.property.toLowerCase();
+	// Strip the (unsupported) `!important` flag once, here, instead of scanning
+	// every declaration again for every view the rule is applied to.
+	const value = cleanupImportantFlags(decl.value, decl.property);
+
+	// A shorthand declaration is defined as declaring each of its longhands in its
+	// place, so expanding here keeps source order - and therefore the cascade -
+	// correct, and converts the value once instead of once per view per update.
+	const expanded = _expandCssShorthand(property, value);
+	if (expanded) {
+		for (let i = 0, length = expanded.length; i < length; i++) {
+			declarations.push({ property: expanded[i][0], value: expanded[i][1] });
+		}
+
+		return;
+	}
+
+	declarations.push({ property, value });
 }
 
 function createSimpleSelectorFromAst(ast: CSSWhatSelector): SimpleSelector {

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -106,6 +106,21 @@ interface LookupSorter {
 	sortAsUniversal(sel: SelectorCore);
 }
 
+/**
+ * Which set of stylesheets a selector came from.
+ *
+ * The cascade breaks a specificity tie on source order, and source order across
+ * stylesheets is really (stylesheet, position within it) - so a selector needs to
+ * know its stylesheet's rank, not just its own index. Application styles are
+ * consulted for every view and are indexed once; a scope's own styles come after
+ * them and are indexed per scope, so their positions are only comparable within a
+ * tier.
+ */
+export const enum SelectorTier {
+	Application = 0,
+	Local = 1,
+}
+
 namespace Match {
 	/**
 	 * Depends on attributes or pseudoclasses state;
@@ -198,6 +213,7 @@ function SelectorProperties(specificity: Specificity, rarity: Rarity, dynamic = 
 		cls.prototype.dynamic = dynamic;
 		cls.prototype.hasAdjacentCombinator = false;
 		cls.prototype.hasSiblingCombinator = false;
+		cls.prototype.tier = SelectorTier.Application;
 
 		return cls;
 	};
@@ -238,6 +254,7 @@ export abstract class SelectorBase {
 @SelectorProperties(Specificity.Universal, Rarity.Universal, Match.Static)
 export abstract class SelectorCore extends SelectorBase {
 	public pos: number;
+	public tier: SelectorTier;
 	public specificity: number;
 	public rarity: Rarity;
 	public combinator: Combinator;
@@ -1164,6 +1181,7 @@ export abstract class SelectorScope<T extends Node> implements LookupSorter {
 	private universal: SelectorCore[] = [];
 
 	public position: number = 0;
+	public tier: SelectorTier = SelectorTier.Application;
 
 	/**
 	 * True when any selector in the scope contains an adjacent sibling ('+') combinator.
@@ -1228,6 +1246,7 @@ export abstract class SelectorScope<T extends Node> implements LookupSorter {
 		}
 
 		sel.pos = this.position++;
+		sel.tier = this.tier;
 
 		return sel;
 	}
@@ -1236,10 +1255,11 @@ export abstract class SelectorScope<T extends Node> implements LookupSorter {
 export class MediaQuerySelectorScope<T extends Node> extends SelectorScope<T> {
 	private _mediaQueryString: string | string[];
 
-	constructor(mediaQueryString: string | string[]) {
+	constructor(mediaQueryString: string | string[], tier: SelectorTier) {
 		super();
 
 		this._mediaQueryString = mediaQueryString;
+		this.tier = tier;
 	}
 
 	get mediaQueryString(): string | string[] {
@@ -1250,14 +1270,26 @@ export class MediaQuerySelectorScope<T extends Node> extends SelectorScope<T> {
 export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 	private mediaQuerySelectorScopes: MediaQuerySelectorScope<T>[];
 
-	constructor(rulesets: RuleSet[]) {
+	constructor(rulesets: RuleSet[], tier: SelectorTier = SelectorTier.Application) {
 		super();
 
+		this.tier = tier;
 		this.lookupRulesets(rulesets);
 	}
 
+	/**
+	 * Index rulesets that were added after this scope was built.
+	 *
+	 * Application stylesheets are only ever appended to outside of a livesync or an
+	 * explicit removal, so the rules already indexed keep their positions and only
+	 * the tail has to be sorted into the lookup maps.
+	 */
+	public appendRulesets(rulesets: RuleSet[], from: number): void {
+		this.lookupRulesets(rulesets, from);
+	}
+
 	private createMediaQuerySelectorScope(mediaQueryString: string | string[]): MediaQuerySelectorScope<T> {
-		const selectorScope = new MediaQuerySelectorScope(mediaQueryString);
+		const selectorScope = new MediaQuerySelectorScope(mediaQueryString, this.tier);
 		selectorScope.position = this.position;
 
 		if (this.mediaQuerySelectorScopes) {
@@ -1269,10 +1301,10 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 		return selectorScope;
 	}
 
-	private lookupRulesets(rulesets: RuleSet[]) {
+	private lookupRulesets(rulesets: RuleSet[], from = 0) {
 		let lastMediaSelectorScope: MediaQuerySelectorScope<T>;
 
-		for (let i = 0, length = rulesets.length; i < length; i++) {
+		for (let i = from, length = rulesets.length; i < length; i++) {
 			const ruleset = rulesets[i];
 
 			if (lastMediaSelectorScope && lastMediaSelectorScope.mediaQueryString !== ruleset.mediaQueryString) {
@@ -1313,9 +1345,13 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 		}
 	}
 
-	query(node: T): SelectorsMatch<T> {
-		const selectorsMatch = new SelectorsMatch<T>();
-		const selectors = this.getSelectorCandidates(node);
+	/**
+	 * Append every selector that could match the node, this scope's matching media
+	 * query scopes included. Several scopes feed one match, so the candidates are
+	 * collected into a shared array and resolved once by `matchSelectorCandidates`.
+	 */
+	public collectCandidates(node: T, candidates: SelectorCore[] = []): SelectorCore[] {
+		this.getSelectorCandidates(node, candidates);
 
 		// Validate media queries and include their selectors if needed
 		if (this.mediaQuerySelectorScopes) {
@@ -1327,26 +1363,60 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 				const isMatchingAllQueries = matchMediaQueryString(selectorScope.mediaQueryString, validatedMediaQueries);
 
 				if (isMatchingAllQueries) {
-					selectorScope.getSelectorCandidates(node, selectors);
+					selectorScope.getSelectorCandidates(node, candidates);
 				}
 			}
 		}
 
-		// Compact the candidates in place - a query runs for every view, so the
-		// intermediate array a filter() would allocate is worth avoiding.
-		let matched = 0;
-		for (let i = 0, length = selectors.length; i < length; i++) {
-			const selector = selectors[i];
-			if (selector.accumulateChanges(node, selectorsMatch)) {
-				selectors[matched++] = selector;
+		return candidates;
+	}
+
+	query(node: T): SelectorsMatch<T> {
+		return matchSelectorCandidates(node, this.collectCandidates(node));
+	}
+}
+
+/**
+ * Order matching selectors the way the cascade does: by specificity, then by
+ * source order - which across stylesheets means the stylesheet's rank first and
+ * the position within it second.
+ */
+function compareSelectors(a: SelectorCore, b: SelectorCore): number {
+	return a.specificity - b.specificity || a.tier - b.tier || a.pos - b.pos;
+}
+
+/**
+ * Resolve collected candidates against a node.
+ *
+ * `scopedTags` filters out rules that were registered on behalf of a stylesheet
+ * this scope never loaded; pass it only when such rules exist, since it costs a
+ * lookup per candidate.
+ */
+export function matchSelectorCandidates<T extends Node>(node: T, candidates: SelectorCore[], scopedTags?: Set<string>): SelectorsMatch<T> {
+	const selectorsMatch = new SelectorsMatch<T>();
+
+	// Compact the candidates in place - a query runs for every view, so the
+	// intermediate array a filter() would allocate is worth avoiding.
+	let matched = 0;
+	for (let i = 0, length = candidates.length; i < length; i++) {
+		const selector = candidates[i];
+
+		if (scopedTags) {
+			const scopedTag = selector.ruleset?.scopedTag;
+			if (scopedTag && !scopedTags.has(scopedTag)) {
+				continue;
 			}
 		}
-		selectors.length = matched;
 
-		selectorsMatch.selectors = selectors.sort((a, b) => a.specificity - b.specificity || a.pos - b.pos);
-
-		return selectorsMatch;
+		if (selector.accumulateChanges(node, selectorsMatch)) {
+			candidates[matched++] = selector;
+		}
 	}
+	candidates.length = matched;
+
+	selectorsMatch.selectors = candidates.sort(compareSelectors);
+
+	return selectorsMatch;
 }
 
 interface ChangeAccumulator {
@@ -1413,4 +1483,5 @@ export const CSSHelper = {
 	StyleSheetSelectorScope,
 	fromAstNode,
 	SelectorsMatch,
+	matchSelectorCandidates,
 };

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -2,6 +2,7 @@ import { parse as convertToCSSWhatSelector, Selector as CSSWhatSelector, DataTyp
 import '../../globals';
 import { isCssVariable } from '../core/properties';
 import { isNullOrUndefined } from '../../utils/types';
+import { cleanupImportantFlags } from './css-utils';
 
 import * as ReworkCSS from '../../css';
 import { checkIfMediaQueryMatches } from '../../media-query-list';
@@ -72,13 +73,13 @@ const enum PseudoClassSelectorList {
 }
 
 enum Combinator {
-	'descendant' = ' ',
-	'child' = '>',
-	'adjacent' = '+',
-	'sibling' = '~',
+	descendant = ' ',
+	child = '>',
+	adjacent = '+',
+	sibling = '~',
 
 	// Not supported
-	'parent' = '<',
+	parent = '<',
 	'column-combinator' = '||',
 }
 
@@ -141,6 +142,48 @@ function getNodePreviousDirectSibling(node: Node): null | Node {
 	}
 
 	return node.parent.getChildAt(nodeIndex - 1);
+}
+
+/**
+ * Cache of "does this view type notify for that attribute", keyed by prototype.
+ *
+ * `<attribute>Change` events are only raised by registered properties, which are
+ * defined as accessors on a prototype. An attribute that is a plain value on the
+ * instance - Angular's `_ngcontent-*` markers, anything a renderer assigns
+ * directly - can never notify, so subscribing to its change event is pure
+ * overhead on every view the selector may match.
+ */
+const notifyingAttributes = new WeakMap<object, Map<string, boolean>>();
+
+function attributeNotifiesChanges(node: Node, attribute: string): boolean {
+	const prototype = Object.getPrototypeOf(node);
+	if (!prototype) {
+		return false;
+	}
+
+	let cache = notifyingAttributes.get(prototype);
+	if (cache) {
+		const cached = cache.get(attribute);
+		if (cached !== undefined) {
+			return cached;
+		}
+	} else {
+		cache = new Map<string, boolean>();
+		notifyingAttributes.set(prototype, cache);
+	}
+
+	let notifies = false;
+	for (let current = prototype; current; current = Object.getPrototypeOf(current)) {
+		const descriptor = Object.getOwnPropertyDescriptor(current, attribute);
+		if (descriptor) {
+			notifies = !!descriptor.set;
+			break;
+		}
+	}
+
+	cache.set(attribute, notifies);
+
+	return notifies;
 }
 
 function SelectorProperties(specificity: Specificity, rarity: Rarity, dynamic = false): ClassDecorator {
@@ -376,10 +419,20 @@ export class AttributeSelector extends SimpleSelector {
 		return false;
 	}
 	public mayMatch(node: Node): boolean {
-		return true;
+		// The attribute may still be assigned later, but only if the view knows about it:
+		// registered properties live on the prototype and anything a framework has already
+		// set is an own value. An attribute that is on neither can never start matching
+		// without the css state being invalidated anyway, and treating it as a permanent
+		// "maybe" keeps the selector - and a change subscription for it - on every view it
+		// will never match. Angular's per component `[_ngcontent-cN]` scoping makes that
+		// cost grow with the number of components in the app.
+		return this.attribute in node;
 	}
 	public trackChanges(node: Node, map: ChangeAccumulator): void {
-		map.addAttribute(node, this.attribute);
+		// Only subscribe when the attribute can actually raise `<attribute>Change`.
+		if (attributeNotifiesChanges(node, this.attribute)) {
+			map.addAttribute(node, this.attribute);
+		}
 	}
 }
 
@@ -886,7 +939,12 @@ export function fromAstNode(astRule: ReworkCSS.Rule): RuleSet {
 }
 
 function createDeclaration(decl: ReworkCSS.Declaration): any {
-	return { property: isCssVariable(decl.property) ? decl.property : decl.property.toLowerCase(), value: decl.value };
+	return {
+		property: isCssVariable(decl.property) ? decl.property : decl.property.toLowerCase(),
+		// Strip the (unsupported) `!important` flag once, here, instead of scanning
+		// every declaration again for every view the rule is applied to.
+		value: cleanupImportantFlags(decl.value, decl.property),
+	};
 }
 
 function createSimpleSelectorFromAst(ast: CSSWhatSelector): SimpleSelector {
@@ -1091,16 +1149,24 @@ export abstract class SelectorScope<T extends Node> implements LookupSorter {
 	 */
 	public hasSiblingCombinatorSelectors = false;
 
-	getSelectorCandidates(node: T) {
+	getSelectorCandidates(node: T, candidates: SelectorCore[] = []): SelectorCore[] {
 		const { cssClasses, id, cssType } = node;
-		const candidates: SelectorCore[] = [];
 
 		appendSelectorCandidates(candidates, this.universal);
-		appendSelectorCandidates(candidates, this.id[id]);
-		appendSelectorCandidates(candidates, this.type[cssType]);
+
+		if (id) {
+			appendSelectorCandidates(candidates, this.id[id]);
+		}
+
+		if (cssType) {
+			appendSelectorCandidates(candidates, this.type[cssType]);
+		}
 
 		if (cssClasses && cssClasses.size) {
-			cssClasses.forEach((c) => appendSelectorCandidates(candidates, this.class[c]));
+			const classSelectors = this.class;
+			for (const cssClass of cssClasses) {
+				appendSelectorCandidates(candidates, classSelectors[cssClass]);
+			}
 		}
 
 		return candidates;
@@ -1236,13 +1302,23 @@ export class StyleSheetSelectorScope<T extends Node> extends SelectorScope<T> {
 				const isMatchingAllQueries = matchMediaQueryString(selectorScope.mediaQueryString, validatedMediaQueries);
 
 				if (isMatchingAllQueries) {
-					const mediaQuerySelectors = selectorScope.getSelectorCandidates(node);
-					selectors.push(...mediaQuerySelectors);
+					selectorScope.getSelectorCandidates(node, selectors);
 				}
 			}
 		}
 
-		selectorsMatch.selectors = selectors.filter((sel) => sel.accumulateChanges(node, selectorsMatch)).sort((a, b) => a.specificity - b.specificity || a.pos - b.pos);
+		// Compact the candidates in place - a query runs for every view, so the
+		// intermediate array a filter() would allocate is worth avoiding.
+		let matched = 0;
+		for (let i = 0, length = selectors.length; i < length; i++) {
+			const selector = selectors[i];
+			if (selector.accumulateChanges(node, selectorsMatch)) {
+				selectors[matched++] = selector;
+			}
+		}
+		selectors.length = matched;
+
+		selectorsMatch.selectors = selectors.sort((a, b) => a.specificity - b.specificity || a.pos - b.pos);
 
 		return selectorsMatch;
 	}
@@ -1253,8 +1329,14 @@ interface ChangeAccumulator {
 	addPseudoClass(node: Node, pseudoClass: string): void;
 }
 
+/**
+ * Most views match no dynamic selector at all, so the change map is only
+ * materialized once something actually has to be tracked.
+ */
+const emptyChangeMap: ChangeMap<any> = new Map();
+
 export class SelectorsMatch<T extends Node> implements ChangeAccumulator {
-	public changeMap: ChangeMap<T> = new Map<T, Changes>();
+	public changeMap: ChangeMap<T> = emptyChangeMap;
 	public selectors: SelectorCore[];
 
 	public addAttribute(node: T, attribute: string): void {
@@ -1274,9 +1356,14 @@ export class SelectorsMatch<T extends Node> implements ChangeAccumulator {
 	}
 
 	public properties(node: T): Changes {
-		let set = this.changeMap.get(node);
+		let changeMap = this.changeMap;
+		if (changeMap === emptyChangeMap) {
+			this.changeMap = changeMap = new Map<T, Changes>();
+		}
+
+		let set = changeMap.get(node);
 		if (!set) {
-			this.changeMap.set(node, (set = {}));
+			changeMap.set(node, (set = {}));
 		}
 
 		return set;

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -1,6 +1,6 @@
 import { parse as convertToCSSWhatSelector, Selector as CSSWhatSelector, DataType as CSSWhatDataType } from 'css-what';
 import '../../globals';
-import { _expandCssShorthand, isCssVariable } from '../core/properties';
+import { _expandCssShorthand, _pendingCssShorthandSubstitution, isCssVariable } from '../core/properties';
 import { isNullOrUndefined } from '../../utils/types';
 import { cleanupImportantFlags } from './css-utils';
 
@@ -981,6 +981,17 @@ function appendDeclaration(declarations: Declaration[], decl: ReworkCSS.Declarat
 	if (expanded) {
 		for (let i = 0, length = expanded.length; i < length; i++) {
 			declarations.push({ property: expanded[i][0], value: expanded[i][1] });
+		}
+
+		return;
+	}
+
+	// A shorthand whose value still has to be resolved gets one pending-substitution
+	// value per longhand, so a declaration is only ever keyed by a longhand.
+	const pending = _pendingCssShorthandSubstitution(property, value);
+	if (pending) {
+		for (let i = 0, length = pending.length; i < length; i++) {
+			declarations.push({ property: pending[i][0], value: pending[i][1] });
 		}
 
 		return;

--- a/packages/core/ui/styling/style-scope.spec.ts
+++ b/packages/core/ui/styling/style-scope.spec.ts
@@ -122,6 +122,20 @@ describe('CssState.setPropertyValues', () => {
 		expect(writes.count).toBe(0);
 	});
 
+	it('keeps a shorthand applied when an overlapping longhand stops matching', () => {
+		// Unsetting `margin-top` resets what `margin` had set, so the skip-unchanged
+		// path cannot be taken for values a removal can clear.
+		const { view } = styled('label { margin: 4; } label:highlighted { margin-top: 8; }');
+		view._cssState.onLoaded();
+		expect(view.style.marginTop).toBe(4);
+
+		view.addPseudoClass('highlighted');
+		expect(view.style.marginTop).toBe(8);
+
+		view.deletePseudoClass('highlighted');
+		expect(view.style.marginTop).toBe(4);
+	});
+
 	it('ignores the unsupported !important flag', () => {
 		const { view } = styled('label { color: red !important; }');
 		view._cssState.onLoaded();

--- a/packages/core/ui/styling/style-scope.spec.ts
+++ b/packages/core/ui/styling/style-scope.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 
-import { StyleScope, addTaggedAdditionalCSS, removeTaggedAdditionalCSS } from './style-scope';
+import { StyleScope, applyInlineStyle, addTaggedAdditionalCSS, removeTaggedAdditionalCSS } from './style-scope';
 import { StackLayout } from '../layouts/stack-layout';
 import { Label } from '../label';
 
@@ -122,19 +122,71 @@ describe('CssState.setPropertyValues', () => {
 		expect(writes.count).toBe(0);
 	});
 
-	it('keeps an unexpandable shorthand applied when an overlapping longhand stops matching', () => {
-		// A shorthand holding a css expression cannot be expanded while parsing, so it
-		// still shares style properties with its longhands. Unsetting `margin-top`
-		// resets what `margin` had set, and the skip-unchanged path cannot be taken.
+	it('lets a longhand override part of a shorthand holding a variable, and back', () => {
+		// The shorthand's longhands each hold a pending-substitution value, so
+		// `margin-top` overrides one of them and reverts to the resolved shorthand.
 		const { view } = styled('label { --m: 4; margin: var(--m); } label:highlighted { margin-top: 8; }');
+		view._cssState.onLoaded();
+		expect(view.style.marginTop).toBe(4);
+		expect(view.style.marginLeft).toBe(4);
+
+		view.addPseudoClass('highlighted');
+		expect(view.style.marginTop).toBe(8);
+		expect(view.style.marginLeft).toBe(4);
+
+		view.deletePseudoClass('highlighted');
+		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('re-resolves a shorthand when the variable it holds changes', () => {
+		const { view } = styled('label { --m: 4; margin: var(--m); } label:highlighted { --m: 9; }');
 		view._cssState.onLoaded();
 		expect(view.style.marginTop).toBe(4);
 
 		view.addPseudoClass('highlighted');
-		expect(view.style.marginTop).toBe(8);
+		expect(view.style.marginTop).toBe(9);
 
 		view.deletePseudoClass('highlighted');
 		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('does not re-apply a shorthand whose variable did not change', () => {
+		const { view } = styled('label { --m: 4; margin: var(--m); }');
+		view._cssState.onLoaded();
+
+		const writes = countCssWrites(view, 'margin-top');
+		view._cssState.updateDynamicState();
+
+		expect(writes.count).toBe(0);
+	});
+
+	it('unsets the longhands when a shorthand variable cannot be resolved', () => {
+		const { view } = styled('label { margin: 4; } label:highlighted { margin: var(--missing); }');
+		view._cssState.onLoaded();
+		expect(view.style.marginTop).toBe(4);
+
+		view.addPseudoClass('highlighted');
+		// Unresolvable leaves the longhands unset, i.e. back to the property default.
+		expect(view.style.marginTop).toEqual(styled('').view.style.marginTop);
+	});
+
+	it('applies an inline shorthand holding a variable', () => {
+		const { view } = styled('label { --m: 6; }');
+		view._cssState.onLoaded();
+
+		applyInlineStyle(view, 'margin: var(--m)');
+
+		expect(view.style.marginTop).toBe(6);
+		expect(view.style.marginLeft).toBe(6);
+	});
+
+	it('applies a literal inline shorthand', () => {
+		const { view } = styled('');
+		view._cssState.onLoaded();
+
+		applyInlineStyle(view, 'margin: 3');
+
+		expect(view.style.marginTop).toBe(3);
 	});
 
 	it('expands shorthands so a later, more specific rule wins', () => {

--- a/packages/core/ui/styling/style-scope.spec.ts
+++ b/packages/core/ui/styling/style-scope.spec.ts
@@ -122,10 +122,11 @@ describe('CssState.setPropertyValues', () => {
 		expect(writes.count).toBe(0);
 	});
 
-	it('keeps a shorthand applied when an overlapping longhand stops matching', () => {
-		// Unsetting `margin-top` resets what `margin` had set, so the skip-unchanged
-		// path cannot be taken for values a removal can clear.
-		const { view } = styled('label { margin: 4; } label:highlighted { margin-top: 8; }');
+	it('keeps an unexpandable shorthand applied when an overlapping longhand stops matching', () => {
+		// A shorthand holding a css expression cannot be expanded while parsing, so it
+		// still shares style properties with its longhands. Unsetting `margin-top`
+		// resets what `margin` had set, and the skip-unchanged path cannot be taken.
+		const { view } = styled('label { --m: 4; margin: var(--m); } label:highlighted { margin-top: 8; }');
 		view._cssState.onLoaded();
 		expect(view.style.marginTop).toBe(4);
 
@@ -134,6 +135,54 @@ describe('CssState.setPropertyValues', () => {
 
 		view.deletePseudoClass('highlighted');
 		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('expands shorthands so a later, more specific rule wins', () => {
+		const { view } = styled('label { margin: 1; } .a { margin-top: 8; } #x { margin: 4; }', 'a');
+		view.id = 'x';
+		view._cssState.onLoaded();
+
+		// #x is the most specific rule, so its shorthand overrides .a's longhand.
+		expect(view.style.marginTop).toBe(4);
+		expect(view.style.marginLeft).toBe(4);
+	});
+
+	it('lets a longhand override a shorthand from a less specific rule', () => {
+		const { view } = styled('#x { margin: 4; } label { margin-top: 1; } .a { margin-top: 8; }', 'a');
+		view.id = 'x';
+		view._cssState.onLoaded();
+
+		expect(view.style.marginTop).toBe(4);
+		expect(view.style.marginLeft).toBe(4);
+	});
+
+	it('does not re-apply an unchanged shorthand', () => {
+		const { view } = styled('label { margin: 4; }');
+		view._cssState.onLoaded();
+
+		// The expanded longhands are freshly parsed values, so the diff has to compare
+		// them with the property's own comparer rather than by identity.
+		const writes = countCssWrites(view, 'margin-top');
+		view._cssState.updateDynamicState();
+
+		expect(writes.count).toBe(0);
+	});
+
+	it('resolves a css variable inside a shorthand', () => {
+		// The value is only resolvable per view, so this shorthand cannot be expanded
+		// while parsing and has to survive as a shorthand declaration.
+		const { view } = styled('label { --m: 8; margin: var(--m); }');
+		view._cssState.onLoaded();
+
+		expect(view.style.marginTop).toBe(8);
+		expect(view.style.marginLeft).toBe(8);
+	});
+
+	it('resolves a css calc expression inside a shorthand', () => {
+		const { view } = styled('label { padding: calc(2 + 3); }');
+		view._cssState.onLoaded();
+
+		expect(view.style.paddingTop).toBe(5);
 	});
 
 	it('ignores the unsupported !important flag', () => {

--- a/packages/core/ui/styling/style-scope.spec.ts
+++ b/packages/core/ui/styling/style-scope.spec.ts
@@ -278,3 +278,66 @@ describe('application and local selector scopes', () => {
 		});
 	});
 });
+
+describe('CssState.onChange subscriptions', () => {
+	function trackListeners(view: any) {
+		const calls = { added: [] as string[], removed: [] as string[] };
+		const add = view.addEventListener.bind(view);
+		const remove = view.removeEventListener.bind(view);
+
+		view.addEventListener = (eventName: string, handler: any, thisArg?: any) => {
+			calls.added.push(eventName);
+
+			return add(eventName, handler, thisArg);
+		};
+		view.removeEventListener = (eventName: string, handler: any, thisArg?: any) => {
+			calls.removed.push(eventName);
+
+			return remove(eventName, handler, thisArg);
+		};
+
+		return calls;
+	}
+
+	function loadedView(css: string) {
+		const { view } = styled(css);
+		Object.defineProperty(view, 'isLoaded', { value: true, configurable: true });
+		view._cssState.onLoaded();
+
+		return view;
+	}
+
+	it('does not resubscribe when the matched dependencies are unchanged', () => {
+		const view = loadedView('label:highlighted { color: red; }');
+		const calls = trackListeners(view);
+
+		view._cssState.onChange();
+
+		expect(calls.added).toEqual([]);
+		expect(calls.removed).toEqual([]);
+	});
+
+	it('resubscribes when the matched dependencies change', () => {
+		const view = loadedView('label:highlighted { color: red; }');
+		const calls = trackListeners(view);
+
+		// A rule that depends on a different pseudo class changes what has to be watched.
+		view._styleScope.addCss('label:disabled { color: blue; }');
+		view._cssState.onChange();
+
+		expect(calls.added).toContain(':disabled');
+		expect(calls.removed).toContain(':highlighted');
+	});
+
+	it('still applies changed values when the subscriptions are left alone', () => {
+		const view = loadedView('label { color: red; } label:highlighted { color: blue; }');
+		view.addPseudoClass('highlighted');
+		expect(view.style.color.toString()).toBe('#0000FF');
+
+		const calls = trackListeners(view);
+		view._cssState.onChange();
+
+		expect(calls.added).toEqual([]);
+		expect(view.style.color.toString()).toBe('#0000FF');
+	});
+});

--- a/packages/core/ui/styling/style-scope.spec.ts
+++ b/packages/core/ui/styling/style-scope.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 
-import { StyleScope } from './style-scope';
+import { StyleScope, addTaggedAdditionalCSS, removeTaggedAdditionalCSS } from './style-scope';
 import { StackLayout } from '../layouts/stack-layout';
 import { Label } from '../label';
 
@@ -190,5 +190,91 @@ describe('CssState.setPropertyValues', () => {
 		view._cssState.onLoaded();
 
 		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+});
+
+describe('application and local selector scopes', () => {
+	function withApplicationCss(entries: Array<[string, string]>, run: () => void): void {
+		for (const [tag, css] of entries) {
+			addTaggedAdditionalCSS(css, tag);
+		}
+
+		try {
+			run();
+		} finally {
+			for (const [tag] of entries) {
+				removeTaggedAdditionalCSS(tag);
+			}
+		}
+	}
+
+	function loaded(css: string) {
+		const { view } = styled(css);
+		view._cssState.onLoaded();
+
+		return view;
+	}
+
+	function restyle(view: any): void {
+		view._cssState.onChange();
+		view._cssState.onLoaded();
+	}
+
+	it('applies application css to a scope with no css of its own', () => {
+		withApplicationCss([['scope-a', 'label { color: red; }']], () => {
+			expect(loaded('').style.color.toString()).toBe('#FF0000');
+		});
+	});
+
+	it('lets local css win over application css at equal specificity', () => {
+		withApplicationCss([['scope-b', 'label { color: red; }']], () => {
+			expect(loaded('label { color: blue; }').style.color.toString()).toBe('#0000FF');
+		});
+	});
+
+	it('keeps application css beaten by a more specific local rule and vice versa', () => {
+		withApplicationCss([['scope-c', '#x { color: red; }']], () => {
+			const { view } = styled('label { color: blue; }');
+			view.id = 'x';
+			view._cssState.onLoaded();
+
+			expect(view.style.color.toString()).toBe('#FF0000');
+		});
+	});
+
+	it('keeps registration order across separately registered application stylesheets', () => {
+		withApplicationCss(
+			[
+				['scope-d1', 'label { color: red; }'],
+				['scope-d2', 'label { color: blue; }'],
+			],
+			() => {
+				expect(loaded('').style.color.toString()).toBe('#0000FF');
+			},
+		);
+	});
+
+	it('picks up application css registered after the scope was built', () => {
+		const view = loaded('');
+		expect(view.style.color).toBeUndefined();
+
+		withApplicationCss([['scope-e', 'label { color: red; }']], () => {
+			restyle(view);
+			expect(view.style.color.toString()).toBe('#FF0000');
+		});
+
+		restyle(view);
+		expect(view.style.color).toBeUndefined();
+	});
+
+	it('serves several scopes from the same application index', () => {
+		withApplicationCss([['scope-f', 'label { color: red; } label.accent { color: blue; }']], () => {
+			const first = loaded('');
+			const { view: second } = styled('', 'accent');
+			second._cssState.onLoaded();
+
+			expect(first.style.color.toString()).toBe('#FF0000');
+			expect(second.style.color.toString()).toBe('#0000FF');
+		});
 	});
 });

--- a/packages/core/ui/styling/style-scope.spec.ts
+++ b/packages/core/ui/styling/style-scope.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { StyleScope } from './style-scope';
+import { StackLayout } from '../layouts/stack-layout';
+import { Label } from '../label';
+
+/**
+ * Counts how many times css applies a value to a style property, by wrapping the
+ * `css:<name>` accessor the css state writes through.
+ */
+function countCssWrites(view: any, cssProperty: string): { count: number; values: unknown[] } {
+	const style = view.style;
+	const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(style), `css:${cssProperty}`);
+	const result = { count: 0, values: [] as unknown[] };
+
+	Object.defineProperty(style, `css:${cssProperty}`, {
+		configurable: true,
+		get: descriptor.get,
+		set(value: unknown) {
+			result.count++;
+			result.values.push(value);
+			descriptor.set.call(this, value);
+		},
+	});
+
+	return result;
+}
+
+function styled(css: string, className?: string): { view: any; scope: StyleScope } {
+	const scope = new StyleScope();
+	scope.css = css;
+
+	const root = new StackLayout();
+	root._styleScope = scope;
+
+	const view = new Label();
+	root.addChild(view);
+	view._styleScope = scope;
+	if (className) {
+		view.className = className;
+	}
+
+	return { view, scope };
+}
+
+describe('CssState.setPropertyValues', () => {
+	it('applies matched declarations', () => {
+		const { view } = styled('label { color: red; }');
+		view._cssState.onLoaded();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('does not re-apply values that did not change', () => {
+		const { view } = styled('label { color: red; }');
+		view._cssState.onLoaded();
+
+		const writes = countCssWrites(view, 'color');
+		for (let i = 0; i < 5; i++) {
+			view._cssState.updateDynamicState();
+		}
+
+		expect(writes.count).toBe(0);
+	});
+
+	it('applies values that did change', () => {
+		const { view } = styled('label { color: red; } label:highlighted { color: blue; }');
+		view._cssState.onLoaded();
+
+		const writes = countCssWrites(view, 'color');
+		view.addPseudoClass('highlighted');
+
+		expect(writes.count).toBe(1);
+		expect(view.style.color.toString()).toBe('#0000FF');
+
+		view.deletePseudoClass('highlighted');
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('unsets declarations that stopped matching', () => {
+		const { view } = styled('label:highlighted { background-color: blue; }');
+		view._cssState.onLoaded();
+
+		view.addPseudoClass('highlighted');
+		expect(view.style.backgroundColor.toString()).toBe('#0000FF');
+
+		view.deletePseudoClass('highlighted');
+		expect(view.style.backgroundColor).toBeUndefined();
+	});
+
+	it('keeps scoped css variables registered across updates', () => {
+		const { view } = styled('label { --brand: red; color: var(--brand); }');
+		view._cssState.onLoaded();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+
+		// A second pass resets the scoped variables before re-applying, so the
+		// variable has to be registered again even though its value is unchanged.
+		view._cssState.updateDynamicState();
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('re-evaluates css expressions when the variable they depend on changes', () => {
+		const { view } = styled('label { --brand: red; color: var(--brand); } label:highlighted { --brand: blue; }');
+		view._cssState.onLoaded();
+		expect(view.style.color.toString()).toBe('#FF0000');
+
+		view.addPseudoClass('highlighted');
+		expect(view.style.color.toString()).toBe('#0000FF');
+
+		view.deletePseudoClass('highlighted');
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('does not re-apply an unchanged css expression', () => {
+		const { view } = styled('label { --brand: red; color: var(--brand); }');
+		view._cssState.onLoaded();
+
+		const writes = countCssWrites(view, 'color');
+		view._cssState.updateDynamicState();
+
+		expect(writes.count).toBe(0);
+	});
+
+	it('ignores the unsupported !important flag', () => {
+		const { view } = styled('label { color: red !important; }');
+		view._cssState.onLoaded();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+});

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -770,7 +770,9 @@ export class CssState {
 		for (const property in newPropertyValues) {
 			const value = newPropertyValues[property];
 
-			const isCssExp = isCssVariableExpression(value) || isCssCalcExpression(value);
+			// Expanded shorthands carry already-converted values, which can never be
+			// an expression.
+			const isCssExp = typeof value === 'string' && (isCssVariableExpression(value) || isCssCalcExpression(value));
 
 			if (isCssExp) {
 				// we handle css exp separately because css vars must be evaluated first

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -1,7 +1,7 @@
 import { getNativeScriptGlobals } from '../../globals/global-utils';
 import { ViewBase } from '../core/view-base';
 import { View } from '../core/view';
-import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, isCssVariable, isCssVariableExpression, isCssCalcExpression } from '../core/properties';
+import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, isCssVariable, isCssShorthandProperty, isCssVariableExpression, isCssCalcExpression } from '../core/properties';
 import { unsetValue } from '../core/properties/property-shared';
 import * as ReworkCSS from '../../css';
 
@@ -762,6 +762,11 @@ export class CssState {
 		let valuesToApply: Record<string, unknown>;
 		let cssExpsProperties: Record<string, string>;
 
+		// A shorthand and its longhands write the same style properties, so unsetting
+		// one of them can clear a value that is being skipped as unchanged. Remember
+		// whether any skipped value could be caught by that.
+		let skippedShorthand = false;
+
 		for (const property in newPropertyValues) {
 			const value = newPropertyValues[property];
 
@@ -793,6 +798,7 @@ export class CssState {
 
 			if (unchanged) {
 				// Skip unchanged values
+				skippedShorthand = skippedShorthand || isCssShorthandProperty(property);
 				continue;
 			}
 
@@ -827,6 +833,7 @@ export class CssState {
 
 			if (hadOldValue && oldValue === value) {
 				// Skip unchanged values
+				skippedShorthand = skippedShorthand || isCssShorthandProperty(property);
 				continue;
 			}
 
@@ -834,6 +841,26 @@ export class CssState {
 				valuesToApply = {};
 			}
 			valuesToApply[property] = value;
+		}
+
+		// Whatever is left in oldProperties stopped matching and has to be unset.
+		let hasRemovedValues = false;
+		let removedShorthand = false;
+		for (const property in oldProperties) {
+			hasRemovedValues = true;
+			if (isCssShorthandProperty(property)) {
+				removedShorthand = true;
+				break;
+			}
+		}
+
+		// Unsetting a shorthand clears its longhands (and the other way around), so a
+		// value that was skipped as unchanged has to be written again afterwards.
+		if (hasRemovedValues && (removedShorthand || skippedShorthand)) {
+			valuesToApply = {};
+			for (const property in newPropertyValues) {
+				valuesToApply[property] = newPropertyValues[property];
+			}
 		}
 
 		// Unset removed values

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -5,7 +5,7 @@ import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, isCssVariab
 import { unsetValue } from '../core/properties/property-shared';
 import * as ReworkCSS from '../../css';
 
-import { RuleSet, StyleSheetSelectorScope, SelectorCore, SelectorTier, SelectorsMatch, ChangeMap, fromAstNode, Node, matchMediaQueryString, matchSelectorCandidates } from './css-selector';
+import { RuleSet, StyleSheetSelectorScope, SelectorCore, SelectorTier, SelectorsMatch, ChangeMap, Changes, fromAstNode, Node, matchMediaQueryString, matchSelectorCandidates } from './css-selector';
 import { Trace } from './styling-shared';
 import { File, knownFolders, path } from '../../file-system';
 import { Application, CssChangedEventData, LoadAppCSSEventData } from '../../application';
@@ -619,6 +619,50 @@ if (Application.hasLaunched()) {
 	getNativeScriptGlobals().events.on('loadAppCss', loadAppCSS);
 }
 
+function trackedNamesEqual(a: Set<string> | undefined, b: Set<string> | undefined): boolean {
+	if (a === b) {
+		return true;
+	}
+
+	if (!a || !b || a.size !== b.size) {
+		return false;
+	}
+
+	for (const name of a) {
+		if (!b.has(name)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Whether two change maps subscribe to exactly the same things.
+ *
+ * Re-matching usually lands on the same dependencies - the same view, the same
+ * pseudo classes - so this decides whether the listeners have to be touched at
+ * all. Both empty maps count as equal even though they are different objects.
+ */
+function changeMapsEqual(applied: Readonly<ChangeMap<ViewBase>>, current: ChangeMap<ViewBase>): boolean {
+	if (applied === current) {
+		return true;
+	}
+
+	if (applied.size !== current.size) {
+		return false;
+	}
+
+	for (const [view, changes] of applied) {
+		const currentChanges: Changes = current.get(view);
+		if (!currentChanges || !trackedNamesEqual(changes.attributes, currentChanges.attributes) || !trackedNamesEqual(changes.pseudoClasses, currentChanges.pseudoClasses)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 export class CssState {
 	static emptyChangeMap: Readonly<ChangeMap<ViewBase>> = Object.freeze(new Map());
 	static emptyPropertyBag: Record<string, unknown> = {};
@@ -652,9 +696,18 @@ export class CssState {
 	public onChange(): void {
 		const view = this.viewRef.get();
 		if (view && view.isLoaded) {
-			this.unsubscribeFromDynamicUpdates();
+			// Matching does not read the subscriptions, so the new match can be computed
+			// first and its dependencies compared against the ones already subscribed to.
+			// They are usually identical, and tearing every listener down only to add the
+			// same ones back is pure churn - it also toggles the widget-level pseudo class
+			// handlers off and on for nothing.
 			this.updateMatch();
-			this.subscribeForDynamicUpdates();
+
+			if (!changeMapsEqual(this._appliedChangeMap, this._match.changeMap)) {
+				this.unsubscribeFromDynamicUpdates();
+				this.subscribeForDynamicUpdates();
+			}
+
 			this.updateDynamicState();
 		} else {
 			this._matchInvalid = true;

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -16,7 +16,6 @@ import { Keyframes, KeyframeAnimationInfo, KeyframeAnimation } from '../animatio
 import { CssAnimationParser } from './css-animation-parser';
 import { sanitizeModuleName } from '../../utils/common';
 import { resolveModuleName } from '../../module-name-resolver';
-import { cleanupImportantFlags } from './css-utils';
 import { cssTreeParse } from '../../css/css-tree-parser';
 import { CSS3Parser } from '../../css/CSS3Parser';
 import { CSSNativeScript } from '../../css/CSSNativeScript';
@@ -42,10 +41,12 @@ type KeyframesMap = Map<string, Keyframes[]>;
 let mergedApplicationCssSelectors: RuleSet[] = [];
 let applicationCssSelectors: RuleSet[] = [];
 const applicationAdditionalSelectors: RuleSet[] = [];
+let mergedApplicationCssSelectorsInvalid = false;
 
 let mergedApplicationCssKeyframes: Keyframes[] = [];
 let applicationCssKeyframes: Keyframes[] = [];
 const applicationAdditionalKeyframes: Keyframes[] = [];
+let mergedApplicationCssKeyframesInvalid = false;
 
 let applicationCssSelectorVersion = 0;
 
@@ -79,14 +80,54 @@ function evaluateCssExpressions(view: ViewBase, property: string, value: string)
 	return value;
 }
 
+/**
+ * Frameworks register component stylesheets one at a time, so merging eagerly on
+ * every call is O(stylesheets * rules). Mark the merged list dirty instead and
+ * rebuild it the next time a style scope actually reads it.
+ */
 export function mergeCssSelectors(): void {
-	mergedApplicationCssSelectors = applicationCssSelectors.slice();
-	mergedApplicationCssSelectors.push(...applicationAdditionalSelectors);
+	mergedApplicationCssSelectorsInvalid = true;
 }
 
 export function mergeCssKeyframes(): void {
-	mergedApplicationCssKeyframes = applicationCssKeyframes.slice();
-	mergedApplicationCssKeyframes.push(...applicationAdditionalKeyframes);
+	mergedApplicationCssKeyframesInvalid = true;
+}
+
+function getMergedApplicationCssSelectors(): RuleSet[] {
+	if (mergedApplicationCssSelectorsInvalid) {
+		mergedApplicationCssSelectorsInvalid = false;
+		mergedApplicationCssSelectors = concatRuleSets(applicationCssSelectors, applicationAdditionalSelectors);
+	}
+
+	return mergedApplicationCssSelectors;
+}
+
+function getMergedApplicationCssKeyframes(): Keyframes[] {
+	if (mergedApplicationCssKeyframesInvalid) {
+		mergedApplicationCssKeyframesInvalid = false;
+		mergedApplicationCssKeyframes = concatRuleSets(applicationCssKeyframes, applicationAdditionalKeyframes);
+	}
+
+	return mergedApplicationCssKeyframes;
+}
+
+/**
+ * `push(...arr)` passes every element as an argument, which allocates and blows
+ * the stack once a stylesheet grows past the engine's argument limit.
+ */
+function concatRuleSets<T>(base: T[], additional: T[]): T[] {
+	const baseLength = base.length;
+	const merged: T[] = new Array(baseLength + additional.length);
+
+	for (let i = 0; i < baseLength; i++) {
+		merged[i] = base[i];
+	}
+
+	for (let i = 0, length = additional.length; i < length; i++) {
+		merged[baseLength + i] = additional[i];
+	}
+
+	return merged;
 }
 
 class CSSSource {
@@ -239,7 +280,7 @@ class CSSSource {
 	}
 
 	@profile
-	private async parseCSSAst() {
+	private parseCSSAst(): void {
 		if (this._source) {
 			if (__CSS_PARSER__ === 'css-tree') {
 				this._ast = cssTreeParse(this._source, this._file);
@@ -716,47 +757,82 @@ export class CssState {
 		// Update values for the scope's css-variables
 		view.style.resetScopedCssVariables();
 
-		const valuesToApply = {};
-		const cssExpsProperties = {};
+		// Both bags stay empty in the common case (nothing changed, no css expressions),
+		// so they are only allocated once there is something to put in them.
+		let valuesToApply: Record<string, unknown>;
+		let cssExpsProperties: Record<string, string>;
 
 		for (const property in newPropertyValues) {
-			const value = cleanupImportantFlags(newPropertyValues[property], property);
+			const value = newPropertyValues[property];
 
 			const isCssExp = isCssVariableExpression(value) || isCssCalcExpression(value);
 
 			if (isCssExp) {
 				// we handle css exp separately because css vars must be evaluated first
+				if (!cssExpsProperties) {
+					cssExpsProperties = {};
+				}
 				cssExpsProperties[property] = value;
 				continue;
 			}
-			delete oldProperties[property];
-			if (property in oldProperties && oldProperties[property] === value) {
-				// Skip unchanged values
-				continue;
+
+			// Consume the entry - whatever is left in oldProperties once every new
+			// value has been visited was removed and has to be unset.
+			const hadOldValue = property in oldProperties;
+			const unchanged = hadOldValue && oldProperties[property] === value;
+			if (hadOldValue) {
+				delete oldProperties[property];
 			}
+
 			if (isCssVariable(property)) {
+				// The scoped css-variables were just reset, so they always have to be re-registered.
 				view.style.setScopedCssVariable(property, value);
 				delete newPropertyValues[property];
 				continue;
+			}
+
+			if (unchanged) {
+				// Skip unchanged values
+				continue;
+			}
+
+			if (!valuesToApply) {
+				valuesToApply = {};
 			}
 			valuesToApply[property] = value;
 		}
 		//we need to parse CSS vars first before evaluating css expressions
 		for (const property in cssExpsProperties) {
-			delete oldProperties[property];
+			const hadOldValue = property in oldProperties;
+			const oldValue = hadOldValue ? oldProperties[property] : undefined;
+			if (hadOldValue) {
+				delete oldProperties[property];
+			}
+
 			const value = evaluateCssExpressions(view, property, cssExpsProperties[property]);
-			if (property in oldProperties && oldProperties[property] === value) {
-				// Skip unchanged values
-				continue;
-			}
-			if (value === unsetValue) {
-				delete newPropertyValues[property];
-			}
+
 			if (isCssVariable(property)) {
 				view.style.setScopedCssVariable(property, value);
 				delete newPropertyValues[property];
+				continue;
 			}
 
+			if (value === unsetValue) {
+				delete newPropertyValues[property];
+			} else {
+				// Store the evaluated value so the next update can tell whether the
+				// expression still resolves to what is currently applied.
+				newPropertyValues[property] = value;
+			}
+
+			if (hadOldValue && oldValue === value) {
+				// Skip unchanged values
+				continue;
+			}
+
+			if (!valuesToApply) {
+				valuesToApply = {};
+			}
 			valuesToApply[property] = value;
 		}
 
@@ -856,7 +932,7 @@ export class StyleScope {
 
 	private _localCssSelectorsAppliedVersion = 0;
 	private _applicationCssSelectorsAppliedVersion = 0;
-	private _cssFiles: string[] = [];
+	private _cssFiles = new Set<string>();
 
 	get css(): string {
 		return this._css;
@@ -878,7 +954,7 @@ export class StyleScope {
 		if (!cssFileName) {
 			return;
 		}
-		this._cssFiles.push(cssFileName);
+		this._cssFiles.add(cssFileName);
 		currentScopeTag = cssFileName;
 
 		const cssFile = CSSSource.fromURI(cssFileName);
@@ -908,7 +984,7 @@ export class StyleScope {
 			return;
 		}
 		if (cssFileName) {
-			this._cssFiles.push(cssFileName);
+			this._cssFiles.add(cssFileName);
 			currentScopeTag = cssFileName;
 		}
 
@@ -980,13 +1056,36 @@ export class StyleScope {
 	private _createSelectors() {
 		const toMerge: RuleSet[] = [];
 		const toMergeKeyframes: Keyframes[] = [];
+		const cssFiles = this._cssFiles;
 
-		toMerge.push(...mergedApplicationCssSelectors.filter((v) => !v.scopedTag || this._cssFiles.indexOf(v.scopedTag) >= 0));
-		toMergeKeyframes.push(...mergedApplicationCssKeyframes.filter((v) => !v.scopedTag || this._cssFiles.indexOf(v.scopedTag) >= 0));
+		const applicationSelectors = getMergedApplicationCssSelectors();
+		for (let i = 0, length = applicationSelectors.length; i < length; i++) {
+			const ruleSet = applicationSelectors[i];
+			if (!ruleSet.scopedTag || cssFiles.has(ruleSet.scopedTag)) {
+				toMerge.push(ruleSet);
+			}
+		}
+
+		const applicationKeyframes = getMergedApplicationCssKeyframes();
+		for (let i = 0, length = applicationKeyframes.length; i < length; i++) {
+			const keyframe = applicationKeyframes[i];
+			if (!keyframe.scopedTag || cssFiles.has(keyframe.scopedTag)) {
+				toMergeKeyframes.push(keyframe);
+			}
+		}
+
 		this._applicationCssSelectorsAppliedVersion = applicationCssSelectorVersion;
 
-		toMerge.push(...this._localCssSelectors);
-		toMergeKeyframes.push(...this._localCssKeyframes);
+		const localSelectors = this._localCssSelectors;
+		for (let i = 0, length = localSelectors.length; i < length; i++) {
+			toMerge.push(localSelectors[i]);
+		}
+
+		const localKeyframes = this._localCssKeyframes;
+		for (let i = 0, length = localKeyframes.length; i < length; i++) {
+			toMergeKeyframes.push(localKeyframes[i]);
+		}
+
 		this._localCssSelectorsAppliedVersion = this._localCssSelectorVersion;
 
 		if (toMerge.length > 0) {

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -5,7 +5,7 @@ import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, isCssVariab
 import { unsetValue } from '../core/properties/property-shared';
 import * as ReworkCSS from '../../css';
 
-import { RuleSet, StyleSheetSelectorScope, SelectorCore, SelectorsMatch, ChangeMap, fromAstNode, Node, matchMediaQueryString } from './css-selector';
+import { RuleSet, StyleSheetSelectorScope, SelectorCore, SelectorTier, SelectorsMatch, ChangeMap, fromAstNode, Node, matchMediaQueryString, matchSelectorCandidates } from './css-selector';
 import { Trace } from './styling-shared';
 import { File, knownFolders, path } from '../../file-system';
 import { Application, CssChangedEventData, LoadAppCSSEventData } from '../../application';
@@ -49,6 +49,23 @@ const applicationAdditionalKeyframes: Keyframes[] = [];
 let mergedApplicationCssKeyframesInvalid = false;
 
 let applicationCssSelectorVersion = 0;
+
+/**
+ * The application stylesheets are the same for every style scope, so they are
+ * indexed once here instead of once per scope. Rules that were registered on
+ * behalf of a particular stylesheet stay in the index and are filtered out at
+ * match time for scopes that never loaded it - see `matchSelectorCandidates`.
+ */
+let applicationSelectorScope: StyleSheetSelectorScope<any> = null;
+let applicationSelectorScopeVersion = -1;
+let applicationSelectorScopeRuleCount = 0;
+let applicationSelectorsHaveScopedTags = false;
+/**
+ * Bumped whenever the application rules change in a way an append cannot express
+ * - a stylesheet reload, or a tagged stylesheet being removed.
+ */
+let applicationSelectorsResetVersion = 0;
+let applicationSelectorScopeResetVersion = -1;
 
 const tagToScopeTag: Map<string | number, string> = new Map();
 let currentScopeTag: string = null;
@@ -109,6 +126,36 @@ function getMergedApplicationCssKeyframes(): Keyframes[] {
 	}
 
 	return mergedApplicationCssKeyframes;
+}
+
+function getApplicationSelectorScope(): StyleSheetSelectorScope<any> {
+	if (applicationSelectorScopeVersion === applicationCssSelectorVersion) {
+		return applicationSelectorScope;
+	}
+
+	const rulesets = getMergedApplicationCssSelectors();
+	const canAppend = applicationSelectorScope && applicationSelectorScopeResetVersion === applicationSelectorsResetVersion && rulesets.length >= applicationSelectorScopeRuleCount;
+
+	if (canAppend) {
+		applicationSelectorScope.appendRulesets(rulesets, applicationSelectorScopeRuleCount);
+	} else {
+		applicationSelectorScope = rulesets.length > 0 ? new StyleSheetSelectorScope(rulesets, SelectorTier.Application) : null;
+		applicationSelectorsHaveScopedTags = false;
+		applicationSelectorScopeRuleCount = 0;
+	}
+
+	for (let i = applicationSelectorScopeRuleCount, length = rulesets.length; i < length; i++) {
+		if (rulesets[i].scopedTag) {
+			applicationSelectorsHaveScopedTags = true;
+			break;
+		}
+	}
+
+	applicationSelectorScopeRuleCount = rulesets.length;
+	applicationSelectorScopeVersion = applicationCssSelectorVersion;
+	applicationSelectorScopeResetVersion = applicationSelectorsResetVersion;
+
+	return applicationSelectorScope;
 }
 
 /**
@@ -415,6 +462,8 @@ export function removeTaggedAdditionalCSS(tag: string | number): boolean {
 	}
 
 	if (selectorsChanged) {
+		// Rules were dropped from the middle of the list, so the index has to be rebuilt.
+		applicationSelectorsResetVersion++;
 		mergeCssSelectors();
 		updated = true;
 	}
@@ -524,6 +573,8 @@ const loadCss = profile(`"style-scope".loadCss`, (cssModule: string): void => {
 
 	// Check for existing application css selectors too in case the app is undergoing a live-sync
 	if (selectors.length > 0 || applicationCssSelectors.length > 0) {
+		// The base stylesheet is replaced rather than appended to.
+		applicationSelectorsResetVersion++;
 		applicationCssSelectors = selectors;
 		mergeCssSelectors();
 		updated = true;
@@ -949,10 +1000,10 @@ CssState.prototype._appliedAnimations = CssState.emptyAnimationArray;
 CssState.prototype._matchInvalid = true;
 
 export class StyleScope {
-	private _selectorScope: StyleSheetSelectorScope<any>;
+	private _localSelectorScope: StyleSheetSelectorScope<any>;
 	private _css = '';
 
-	private _mergedCssSelectors: RuleSet[];
+	private _hasSelectors = false;
 	private _mergedCssKeyframes: Keyframes[];
 
 	private _localCssSelectors: RuleSet[] = [];
@@ -1041,7 +1092,7 @@ export class StyleScope {
 	}
 
 	public ensureSelectors(): number {
-		if (!this.isApplicationCssSelectorsLatestVersionApplied() || !this.isLocalCssSelectorsLatestVersionApplied() || !this._mergedCssSelectors) {
+		if (!this.isApplicationCssSelectorsLatestVersionApplied() || !this.isLocalCssSelectorsLatestVersionApplied()) {
 			this._createSelectors();
 		}
 
@@ -1054,7 +1105,7 @@ export class StyleScope {
 	get hasAdjacentCombinatorSelectors(): boolean {
 		this.ensureSelectors();
 
-		return this._selectorScope ? this._selectorScope.hasAdjacentCombinatorSelectors : false;
+		return !!applicationSelectorScope?.hasAdjacentCombinatorSelectors || !!this._localSelectorScope?.hasAdjacentCombinatorSelectors;
 	}
 
 	/**
@@ -1063,7 +1114,7 @@ export class StyleScope {
 	get hasSiblingCombinatorSelectors(): boolean {
 		this.ensureSelectors();
 
-		return this._selectorScope ? this._selectorScope.hasSiblingCombinatorSelectors : false;
+		return !!applicationSelectorScope?.hasSiblingCombinatorSelectors || !!this._localSelectorScope?.hasSiblingCombinatorSelectors;
 	}
 
 	/**
@@ -1083,18 +1134,18 @@ export class StyleScope {
 
 	@profile
 	private _createSelectors() {
-		const toMerge: RuleSet[] = [];
-		const toMergeKeyframes: Keyframes[] = [];
 		const cssFiles = this._cssFiles;
+		const applicationScope = getApplicationSelectorScope();
+		this._applicationCssSelectorsAppliedVersion = applicationCssSelectorVersion;
 
-		const applicationSelectors = getMergedApplicationCssSelectors();
-		for (let i = 0, length = applicationSelectors.length; i < length; i++) {
-			const ruleSet = applicationSelectors[i];
-			if (!ruleSet.scopedTag || cssFiles.has(ruleSet.scopedTag)) {
-				toMerge.push(ruleSet);
-			}
+		if (!this.isLocalCssSelectorsLatestVersionApplied() || (!this._localSelectorScope && this._localCssSelectors.length > 0)) {
+			this._localSelectorScope = this._localCssSelectors.length > 0 ? new StyleSheetSelectorScope(this._localCssSelectors, SelectorTier.Local) : null;
 		}
 
+		this._localCssSelectorsAppliedVersion = this._localCssSelectorVersion;
+		this._hasSelectors = !!applicationScope || !!this._localSelectorScope;
+
+		const toMergeKeyframes: Keyframes[] = [];
 		const applicationKeyframes = getMergedApplicationCssKeyframes();
 		for (let i = 0, length = applicationKeyframes.length; i < length; i++) {
 			const keyframe = applicationKeyframes[i];
@@ -1103,26 +1154,9 @@ export class StyleScope {
 			}
 		}
 
-		this._applicationCssSelectorsAppliedVersion = applicationCssSelectorVersion;
-
-		const localSelectors = this._localCssSelectors;
-		for (let i = 0, length = localSelectors.length; i < length; i++) {
-			toMerge.push(localSelectors[i]);
-		}
-
 		const localKeyframes = this._localCssKeyframes;
 		for (let i = 0, length = localKeyframes.length; i < length; i++) {
 			toMergeKeyframes.push(localKeyframes[i]);
-		}
-
-		this._localCssSelectorsAppliedVersion = this._localCssSelectorVersion;
-
-		if (toMerge.length > 0) {
-			this._mergedCssSelectors = toMerge;
-			this._selectorScope = new StyleSheetSelectorScope(this._mergedCssSelectors);
-		} else {
-			this._mergedCssSelectors = null;
-			this._selectorScope = null;
 		}
 
 		this._mergedCssKeyframes = toMergeKeyframes.length > 0 ? toMergeKeyframes : null;
@@ -1132,19 +1166,24 @@ export class StyleScope {
 	// HACK: because the function parameter type is evaluated with 'typeof'
 	@profile
 	public matchSelectors(view): SelectorsMatch<ViewBase> {
-		let match: SelectorsMatch<ViewBase>;
-
 		// should be (view: ViewBase): SelectorsMatch<ViewBase>
 		this.ensureSelectors();
 
-		if (this._selectorScope) {
-			match = this._selectorScope.query(view);
-
-			// Make sure to re-apply keyframes to matching selectors as a media query keyframe might be applicable at this point
-			this._applyKeyframesToSelectors(match.selectors);
-		} else {
-			match = null;
+		if (!this._hasSelectors) {
+			return null;
 		}
+
+		// The application and the scope's own stylesheets are indexed separately, so
+		// their candidates are gathered into one array and resolved together - the
+		// cascade needs to see them as a single ordered set.
+		const candidates: SelectorCore[] = [];
+		applicationSelectorScope?.collectCandidates(view, candidates);
+		this._localSelectorScope?.collectCandidates(view, candidates);
+
+		const match = matchSelectorCandidates<ViewBase>(view, candidates, applicationSelectorsHaveScopedTags ? this._cssFiles : undefined);
+
+		// Make sure to re-apply keyframes to matching selectors as a media query keyframe might be applicable at this point
+		this._applyKeyframesToSelectors(match.selectors);
 
 		return match;
 	}

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -1,7 +1,7 @@
 import { getNativeScriptGlobals } from '../../globals/global-utils';
 import { ViewBase } from '../core/view-base';
 import { View } from '../core/view';
-import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, isCssVariable, isCssShorthandProperty, isCssVariableExpression, isCssCalcExpression } from '../core/properties';
+import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, _expandCssShorthand, _isCssPendingSubstitution, CssPendingSubstitution, isCssVariable, isCssVariableExpression, isCssCalcExpression } from '../core/properties';
 import { unsetValue } from '../core/properties/property-shared';
 import * as ReworkCSS from '../../css';
 
@@ -74,6 +74,34 @@ const animationsSymbol = Symbol('animations');
 const kebabCasePattern = /-([a-z])/g;
 const kebabCaseReplacementFunc = (g: string) => g[1].toUpperCase();
 const pattern = /('|")(.*?)\1/;
+
+/**
+ * Resolve a pending-substitution value into the longhand values it stands for.
+ *
+ * The shorthand is only parsed here, once the expression it holds has been
+ * evaluated against the view - which is the point of the placeholder. A shorthand
+ * that does not survive evaluation leaves its longhands unset.
+ */
+function resolvePendingSubstitution(view: ViewBase, pending: CssPendingSubstitution): Record<string, unknown> {
+	const value = evaluateCssExpressions(view, pending.shorthand, pending.value);
+	if (value === unsetValue) {
+		return CssState.emptyPropertyBag;
+	}
+
+	const expanded = _expandCssShorthand(pending.shorthand, value);
+	if (!expanded) {
+		Trace.write(`Failed to expand shorthand [${pending.shorthand}] resolved to [${value}] for ${view}.`, Trace.categories.Style, Trace.messageType.warn);
+
+		return CssState.emptyPropertyBag;
+	}
+
+	const resolved: Record<string, unknown> = {};
+	for (let i = 0, length = expanded.length; i < length; i++) {
+		resolved[expanded[i][0]] = expanded[i][1];
+	}
+
+	return resolved;
+}
 
 /**
  * Evaluate css-variable and css-calc expressions
@@ -861,18 +889,24 @@ export class CssState {
 		// Update values for the scope's css-variables
 		view.style.resetScopedCssVariables();
 
-		// Both bags stay empty in the common case (nothing changed, no css expressions),
-		// so they are only allocated once there is something to put in them.
+		// These stay empty in the common case (nothing changed, no css expressions), so
+		// they are only allocated once there is something to put in them.
 		let valuesToApply: Record<string, unknown>;
 		let cssExpsProperties: Record<string, string>;
-
-		// A shorthand and its longhands write the same style properties, so unsetting
-		// one of them can clear a value that is being skipped as unchanged. Remember
-		// whether any skipped value could be caught by that.
-		let skippedShorthand = false;
+		let pendingProperties: Record<string, CssPendingSubstitution>;
 
 		for (const property in newPropertyValues) {
 			const value = newPropertyValues[property];
+
+			if (_isCssPendingSubstitution(value)) {
+				// The shorthand behind it can only be parsed once its expression has been
+				// evaluated, which needs the css variables below to be up to date first.
+				if (!pendingProperties) {
+					pendingProperties = {};
+				}
+				pendingProperties[property] = value;
+				continue;
+			}
 
 			// Expanded shorthands carry already-converted values, which can never be
 			// an expression.
@@ -904,7 +938,6 @@ export class CssState {
 
 			if (unchanged) {
 				// Skip unchanged values
-				skippedShorthand = skippedShorthand || isCssShorthandProperty(property);
 				continue;
 			}
 
@@ -939,7 +972,47 @@ export class CssState {
 
 			if (hadOldValue && oldValue === value) {
 				// Skip unchanged values
-				skippedShorthand = skippedShorthand || isCssShorthandProperty(property);
+				continue;
+			}
+
+			if (!valuesToApply) {
+				valuesToApply = {};
+			}
+			valuesToApply[property] = value;
+		}
+		// Each shorthand is resolved once, however many longhands point at it.
+		let resolvedShorthands: Map<CssPendingSubstitution, Record<string, unknown>>;
+		for (const property in pendingProperties) {
+			const pending = pendingProperties[property];
+
+			if (!resolvedShorthands) {
+				resolvedShorthands = new Map();
+			}
+
+			let resolved = resolvedShorthands.get(pending);
+			if (!resolved) {
+				resolved = resolvePendingSubstitution(view, pending);
+				resolvedShorthands.set(pending, resolved);
+			}
+
+			const value = property in resolved ? resolved[property] : unsetValue;
+
+			const hadOldValue = property in oldProperties;
+			const oldValue = hadOldValue ? oldProperties[property] : undefined;
+			if (hadOldValue) {
+				delete oldProperties[property];
+			}
+
+			if (value === unsetValue) {
+				delete newPropertyValues[property];
+			} else {
+				// Remember the resolved value so the next update can tell whether the
+				// shorthand still resolves to what is currently applied.
+				newPropertyValues[property] = value;
+			}
+
+			if (hadOldValue && oldValue === value) {
+				// Skip unchanged values
 				continue;
 			}
 
@@ -949,27 +1022,8 @@ export class CssState {
 			valuesToApply[property] = value;
 		}
 
-		// Whatever is left in oldProperties stopped matching and has to be unset.
-		let hasRemovedValues = false;
-		let removedShorthand = false;
-		for (const property in oldProperties) {
-			hasRemovedValues = true;
-			if (isCssShorthandProperty(property)) {
-				removedShorthand = true;
-				break;
-			}
-		}
-
-		// Unsetting a shorthand clears its longhands (and the other way around), so a
-		// value that was skipped as unchanged has to be written again afterwards.
-		if (hasRemovedValues && (removedShorthand || skippedShorthand)) {
-			valuesToApply = {};
-			for (const property in newPropertyValues) {
-				valuesToApply[property] = newPropertyValues[property];
-			}
-		}
-
-		// Unset removed values
+		// Unset removed values. The bag is keyed by longhands only, so no two entries
+		// write the same style property and unsetting one cannot clear another.
 		for (const property in oldProperties) {
 			if (property in view.style) {
 				view.style[`css:${property}`] = unsetValue;
@@ -1373,6 +1427,10 @@ export const applyInlineStyle = profile('applyInlineStyle', function applyInline
 		}
 	});
 
+	// A shorthand that could not be expanded while parsing left a pending-substitution
+	// value on each of its longhands; resolving it once serves all of them.
+	let resolvedShorthands: Map<CssPendingSubstitution, Record<string, unknown>>;
+
 	inlineRuleSet[0].declarations.forEach((d) => {
 		// Use the actual property name so that a local value is set.
 		const property = d.property;
@@ -1382,7 +1440,23 @@ export const applyInlineStyle = profile('applyInlineStyle', function applyInline
 				return;
 			}
 
-			const value = evaluateCssExpressions(view, property, d.value);
+			let value: unknown;
+			if (_isCssPendingSubstitution(d.value)) {
+				if (!resolvedShorthands) {
+					resolvedShorthands = new Map();
+				}
+
+				let resolved = resolvedShorthands.get(d.value);
+				if (!resolved) {
+					resolved = resolvePendingSubstitution(view, d.value);
+					resolvedShorthands.set(d.value, resolved);
+				}
+
+				value = property in resolved ? resolved[property] : unsetValue;
+			} else {
+				value = evaluateCssExpressions(view, property, d.value);
+			}
+
 			if (property in view.style) {
 				view.style[property] = value;
 			} else {

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -51,19 +51,14 @@ let mergedApplicationCssKeyframesInvalid = false;
 let applicationCssSelectorVersion = 0;
 
 /**
- * The application stylesheets are the same for every style scope, so they are
- * indexed once here instead of once per scope. Rules that were registered on
- * behalf of a particular stylesheet stay in the index and are filtered out at
- * match time for scopes that never loaded it - see `matchSelectorCandidates`.
+ * Shared index over the application stylesheets, built once for all style scopes.
+ * Tagged rules stay in it and are filtered out at match time - see `matchSelectorCandidates`.
  */
 let applicationSelectorScope: StyleSheetSelectorScope<any> = null;
 let applicationSelectorScopeVersion = -1;
 let applicationSelectorScopeRuleCount = 0;
 let applicationSelectorsHaveScopedTags = false;
-/**
- * Bumped whenever the application rules change in a way an append cannot express
- * - a stylesheet reload, or a tagged stylesheet being removed.
- */
+/** Bumped when the application rules change in a way an append cannot express. */
 let applicationSelectorsResetVersion = 0;
 let applicationSelectorScopeResetVersion = -1;
 
@@ -76,11 +71,8 @@ const kebabCaseReplacementFunc = (g: string) => g[1].toUpperCase();
 const pattern = /('|")(.*?)\1/;
 
 /**
- * Resolve a pending-substitution value into the longhand values it stands for.
- *
- * The shorthand is only parsed here, once the expression it holds has been
- * evaluated against the view - which is the point of the placeholder. A shorthand
- * that does not survive evaluation leaves its longhands unset.
+ * Parse a pending-substitution shorthand once its expression has been evaluated
+ * against the view; a value that does not survive evaluation leaves its longhands unset.
  */
 function resolvePendingSubstitution(view: ViewBase, pending: CssPendingSubstitution): Record<string, unknown> {
 	const value = evaluateCssExpressions(view, pending.shorthand, pending.value);
@@ -126,9 +118,8 @@ function evaluateCssExpressions(view: ViewBase, property: string, value: string)
 }
 
 /**
- * Frameworks register component stylesheets one at a time, so merging eagerly on
- * every call is O(stylesheets * rules). Mark the merged list dirty instead and
- * rebuild it the next time a style scope actually reads it.
+ * Only marks the merged list dirty - it is rebuilt on next read, since frameworks
+ * register stylesheets one call at a time.
  */
 export function mergeCssSelectors(): void {
 	mergedApplicationCssSelectorsInvalid = true;
@@ -186,10 +177,7 @@ function getApplicationSelectorScope(): StyleSheetSelectorScope<any> {
 	return applicationSelectorScope;
 }
 
-/**
- * `push(...arr)` passes every element as an argument, which allocates and blows
- * the stack once a stylesheet grows past the engine's argument limit.
- */
+/** Avoids `push(...arr)`, which blows the stack past the engine's argument limit. */
 function concatRuleSets<T>(base: T[], additional: T[]): T[] {
 	const baseLength = base.length;
 	const merged: T[] = new Array(baseLength + additional.length);
@@ -665,13 +653,7 @@ function trackedNamesEqual(a: Set<string> | undefined, b: Set<string> | undefine
 	return true;
 }
 
-/**
- * Whether two change maps subscribe to exactly the same things.
- *
- * Re-matching usually lands on the same dependencies - the same view, the same
- * pseudo classes - so this decides whether the listeners have to be touched at
- * all. Both empty maps count as equal even though they are different objects.
- */
+/** Two empty maps compare equal even when they are different objects. */
 function changeMapsEqual(applied: Readonly<ChangeMap<ViewBase>>, current: ChangeMap<ViewBase>): boolean {
 	if (applied === current) {
 		return true;
@@ -724,11 +706,8 @@ export class CssState {
 	public onChange(): void {
 		const view = this.viewRef.get();
 		if (view && view.isLoaded) {
-			// Matching does not read the subscriptions, so the new match can be computed
-			// first and its dependencies compared against the ones already subscribed to.
-			// They are usually identical, and tearing every listener down only to add the
-			// same ones back is pure churn - it also toggles the widget-level pseudo class
-			// handlers off and on for nothing.
+			// Matching does not read the subscriptions, so re-subscribe only when the
+			// dependencies actually changed - they are usually identical.
 			this.updateMatch();
 
 			if (!changeMapsEqual(this._appliedChangeMap, this._match.changeMap)) {
@@ -889,8 +868,6 @@ export class CssState {
 		// Update values for the scope's css-variables
 		view.style.resetScopedCssVariables();
 
-		// These stay empty in the common case (nothing changed, no css expressions), so
-		// they are only allocated once there is something to put in them.
 		let valuesToApply: Record<string, unknown>;
 		let cssExpsProperties: Record<string, string>;
 		let pendingProperties: Record<string, CssPendingSubstitution>;
@@ -899,8 +876,7 @@ export class CssState {
 			const value = newPropertyValues[property];
 
 			if (_isCssPendingSubstitution(value)) {
-				// The shorthand behind it can only be parsed once its expression has been
-				// evaluated, which needs the css variables below to be up to date first.
+				// Resolvable only after the css variables below are up to date.
 				if (!pendingProperties) {
 					pendingProperties = {};
 				}
@@ -908,8 +884,7 @@ export class CssState {
 				continue;
 			}
 
-			// Expanded shorthands carry already-converted values, which can never be
-			// an expression.
+			// Expanded shorthand values are already converted and may not be strings.
 			const isCssExp = typeof value === 'string' && (isCssVariableExpression(value) || isCssCalcExpression(value));
 
 			if (isCssExp) {
@@ -921,8 +896,7 @@ export class CssState {
 				continue;
 			}
 
-			// Consume the entry - whatever is left in oldProperties once every new
-			// value has been visited was removed and has to be unset.
+			// Whatever is left in oldProperties after these loops was removed and gets unset.
 			const hadOldValue = property in oldProperties;
 			const unchanged = hadOldValue && oldProperties[property] === value;
 			if (hadOldValue) {
@@ -937,7 +911,6 @@ export class CssState {
 			}
 
 			if (unchanged) {
-				// Skip unchanged values
 				continue;
 			}
 
@@ -965,13 +938,11 @@ export class CssState {
 			if (value === unsetValue) {
 				delete newPropertyValues[property];
 			} else {
-				// Store the evaluated value so the next update can tell whether the
-				// expression still resolves to what is currently applied.
+				// Record the evaluated value - the next diff compares against it.
 				newPropertyValues[property] = value;
 			}
 
 			if (hadOldValue && oldValue === value) {
-				// Skip unchanged values
 				continue;
 			}
 
@@ -1006,13 +977,10 @@ export class CssState {
 			if (value === unsetValue) {
 				delete newPropertyValues[property];
 			} else {
-				// Remember the resolved value so the next update can tell whether the
-				// shorthand still resolves to what is currently applied.
 				newPropertyValues[property] = value;
 			}
 
 			if (hadOldValue && oldValue === value) {
-				// Skip unchanged values
 				continue;
 			}
 
@@ -1022,8 +990,8 @@ export class CssState {
 			valuesToApply[property] = value;
 		}
 
-		// Unset removed values. The bag is keyed by longhands only, so no two entries
-		// write the same style property and unsetting one cannot clear another.
+		// Unset removed values - the bag is keyed by longhands only, so unsetting
+		// one entry cannot clear a value another one set.
 		for (const property in oldProperties) {
 			if (property in view.style) {
 				view.style[`css:${property}`] = unsetValue;
@@ -1280,9 +1248,7 @@ export class StyleScope {
 			return null;
 		}
 
-		// The application and the scope's own stylesheets are indexed separately, so
-		// their candidates are gathered into one array and resolved together - the
-		// cascade needs to see them as a single ordered set.
+		// The cascade has to see the application and local candidates as a single ordered set.
 		const candidates: SelectorCore[] = [];
 		applicationSelectorScope?.collectCandidates(view, candidates);
 		this._localSelectorScope?.collectCandidates(view, candidates);
@@ -1427,8 +1393,7 @@ export const applyInlineStyle = profile('applyInlineStyle', function applyInline
 		}
 	});
 
-	// A shorthand that could not be expanded while parsing left a pending-substitution
-	// value on each of its longhands; resolving it once serves all of them.
+	// Pending-substitution longhands share one placeholder - resolve it once.
 	let resolvedShorthands: Map<CssPendingSubstitution, Record<string, unknown>>;
 
 	inlineRuleSet[0].declarations.forEach((d) => {

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -14,6 +14,8 @@ global.__IOS__ = true;
 global.__VISIONOS__ = false;
 global.__APPLE__ = true;
 global.__COMMONJS__ = false;
+// Injected by the bundler in a real app; the css-tree parser is the default.
+global.__CSS_PARSER__ = 'css-tree';
 global.WeakRef.prototype.get = global.WeakRef.prototype.deref;
 global.NativeClass = function () {};
 global.NSBundle = {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

The CSS engine does a large amount of redundant work on every dynamic restyle, and has two correctness bugs in the cascade:

- **The "skip unchanged values" diff in `CssState.setPropertyValues` is dead code.** The previously applied entry is deleted *before* it is compared against, so every matching declaration is re-applied (colors and lengths re-parsed, converters re-run) on every dynamic update — tapping a button re-applies the view's entire computed style.
- **Attribute selectors always answer `mayMatch` with `true`** and unconditionally subscribe to `<attribute>Change`. With Angular's emulated encapsulation (`[_ngcontent-cN]` markers), every view keeps N−1 selectors it can never match and holds change subscriptions for events that are never raised — plain expando assignment does not notify. This is the main reason component-level CSS performs badly enough that it is currently discouraged.
- **Every `StyleScope` builds its own index over the merged application rule list**, so registering a stylesheet (as Angular does once per component at first use) re-sorts every application rule into fresh lookup maps for every scope in the app — O(components × rules × scopes) on navigation. Multiple scopes also write `pos` onto the same shared `RuleSet` selectors, and whichever built last wins.
- **Shorthand expansion never runs.** `ShorthandProperty.register` defines the expanding setter on `cls.prototype.PropertyBag` — the bag's constructor rather than its prototype — so shorthands reach the apply step unexpanded and the cascade breaks: `label { margin: 1 } .a { margin-top: 8 } #x { margin: 4 }` leaves `marginTop` at 8, ignoring the most specific rule.
- `CssState.onChange` tears down and rebuilds every dynamic-selector subscription on every re-match, even when the dependencies are identical.
- `CSSSource.parseCSSAst` is `async`, so parse failures escape the `try/catch` in `parse()` as unhandled rejections and leave the stylesheet silently empty.

## What is the new behavior?

Six commits, each self-contained, aligning the engine with how browsers and the CSS specs handle the same problems:

- The unchanged-value diff actually works: values are compared before the old entry is consumed, css expressions diff against their previously evaluated result, and `!important` stripping/scoped-tag lookups move out of the per-view hot path.
- `AttributeSelector.mayMatch` tests whether the view knows the attribute, and change subscriptions are only registered for attributes that can actually raise `<attribute>Change` (i.e. real properties with accessors). Angular's `[_ngcontent-*]` selectors no longer cost anything on views they can't match.
- Shorthands are expanded into their longhands at parse time, as the spec defines the cascade (a shorthand declaration is equivalent to declaring each longhand in its place). This fixes the specificity bug above, runs each converter once per declaration instead of once per view per update, and keeps values shared so the diff can compare by identity.
- `var()`/`calc()` shorthands, which cannot be expanded lexically, get **pending-substitution values** per the CSS Variables spec ([css-variables-1 §3.2](https://drafts.csswg.org/css-variables/#variables-in-shorthands)): each longhand cascades a shared placeholder, resolved once per view at apply time. Property bags are now longhand-only, so shorthand/longhand overlap is structurally impossible.
- The application stylesheets are indexed once, globally, instead of once per `StyleScope` — mirroring Blink's per-`TreeScope` `ScopedStyleResolver` + merged-collection architecture. Selectors sort by `(specificity, tier, position)` so application and scope-local rules cascade correctly from separate indexes, and component registration appends to the shared index instead of rebuilding it.
- `CssState.onChange` re-matches first and only rebuilds subscriptions when the change map actually differs.
- `parseCSSAst` is synchronous, so parse errors are reported through the existing error path again.

**Benchmarks** (included in `packages/core/__tests__/benchmarks/`; measured per-process against `main`, median, best of 3, node 22 — jitless approximates iOS JavaScriptCore):

| Scenario | JIT | jitless |
|---|---|---|
| re-apply 200 views, nothing changed | 2.90x | 3.00x |
| toggle a class on 200 loaded views | 2.12x | 2.74x |
| add 30 stylesheets + restyle 200 views | 1.84x | 2.28x |
| toggle a pseudo class on 200 views | 1.76x | 2.32x |
| style 400 views (angular attribute css) | 1.31x | 1.34x |
| load 30 components | 1.28x | 1.31x |
| style 400 views (plain css) | 1.00x | 1.00x |
| build a style scope | 0.89x | 0.87x |

The style-scope build is ~10% slower by design: `!important` stripping and shorthand expansion moved into parsing, paid once per stylesheet instead of once per view per update.

380 unit tests pass, including new suites for the cascade (`style-scope.spec.ts`, 28 tests) and selector behavior (`css-selector.spec.ts`). The `apps/automated` STYLE suite on a device is the remaining end-to-end check reviewers may want before merging, as it exercises the cascade against real native views.
