### PR TITLE
ci: add preview releases in pkg.pr.new

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,46 @@
+name: Preview release
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  NX_BRANCH: ${{ github.event.number || github.ref_name }}
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Publish preview packages (pkg.pr.new)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npx nx run-many -t build -p core,webpack5,vite
+
+      - name: Publish preview packages
+        run: npx pkg-pr-new publish --compact ./dist/packages/core ./dist/packages/webpack5 ./dist/packages/vite


### PR DESCRIPTION
## What

Adds a `Preview release` workflow that publishes preview packages to [pkg.pr.new](https://pkg.pr.new) on every PR and on pushes to `main`, covering the publishable npm packages built in this repo:

- `@nativescript/core`
- `@nativescript/webpack`
- `@nativescript/vite`

This lets anyone install a PR's build directly (`npm i https://pkg.pr.new/@nativescript/core@<pr>`) without waiting for a `next` release.

## Notes

- Follows the repo's workflow conventions: step-security harden-runner, SHA-pinned actions, minimal permissions, and a concurrency group that cancels superseded runs.
- Publish paths match the `nx-release-publish` `packageRoot` (`dist/packages/<project>`).
- The types packages (`@nativescript/types*`) are intentionally excluded: their build regenerates typings from the native runtimes (needs macOS/Xcode for iOS), `types-android` is ~141MB unpacked, and PR diffs don't affect their content.
- Requires the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) to be installed on the repo — no secrets needed.