### PR TITLE
test: fix safe-area expectations on iPadOS 18 and list-view type errors

### DIFF
--- a/apps/automated/src/ui/layouts/safe-area-tests.ts
+++ b/apps/automated/src/ui/layouts/safe-area-tests.ts
@@ -3,7 +3,7 @@ import * as view from '@nativescript/core/ui/core/view';
 import * as testModule from '../../ui-test';
 import * as platform from '@nativescript/core/platform';
 import * as helper from '../../ui-helper';
-import { Builder, Page, Label, GridLayout, Utils } from '@nativescript/core';
+import { Builder, Page, Label, GridLayout, TabView, Utils } from '@nativescript/core';
 import { dipToDp, left, top, right, bottom, height, width, equal, closeEnough, lessOrCloseEnough, greaterOrCloseEnough, isLeftAlignedWith, isRightAlignedWith, isTopAlignedWith, isBottomAlignedWith, isLeftWith, isAboveWith, isRightWith, isBelowWith } from './layout-tests-helper';
 
 export class SafeAreaTests extends testModule.UITest<any> {
@@ -69,15 +69,28 @@ export class SafeAreaTests extends testModule.UITest<any> {
 		};
 	}
 
-	private layout_insets_top_action_bar_test(layout: view.View) {
-		// const app = UIApplication.sharedApplication;
-		// const statusBarHeight = round(dipToDp(app.statusBarFrame.size.height));
-		// const actionBarHeight = round(dipToDp(layout.page.actionBar.nativeViewProtected.frame.size.height));
-		// const topInset = statusBarHeight + actionBarHeight;
+	// iPadOS 18+ renders the tab strip at the top of the screen and accounts for it
+	// in the safe area of the tab CONTENT controllers, not of the UITabBarController's
+	// own view - so read the inset UIKit computed for the selected content controller.
+	private tabContentTopInset(layout: view.View): number {
+		let parent = layout.parent;
+		while (parent) {
+			if (parent instanceof TabView) {
+				const controller = <UITabBarController>(<any>parent).viewController;
+				const contentView = controller?.selectedViewController?.view;
 
+				return contentView && contentView.window ? contentView.safeAreaInsets.top : 0;
+			}
+			parent = parent.parent;
+		}
+
+		return 0;
+	}
+
+	private layout_insets_top_action_bar_test(layout: view.View) {
 		const view = layout.page.actionBar.nativeViewProtected as unknown as UIView;
 		// use the action bar position and size instead of the status bar and action bar heights as those are unreliable on iOS 16+
-		const topInset = Math.round(dipToDp(view.frame.origin.y + view.frame.size.height));
+		const topInset = Math.round(dipToDp(Math.max(view.frame.origin.y + view.frame.size.height, this.tabContentTopInset(layout))));
 
 		const insets = layout.getSafeAreaInsets();
 		equal(insets.top, topInset, `${layout}.topInset - actual:${insets.top}; expected: ${topInset}`);
@@ -85,9 +98,9 @@ export class SafeAreaTests extends testModule.UITest<any> {
 
 	private layout_insets_top_action_bar_hidden_test(layout: view.View) {
 		const keyWindow = Utils.getWindow() as unknown as UIWindow;
-		// const statusBarHeight = round(dipToDp(app.statusBarFrame.size.height));
 		// use window inset instead of status bar frame as that's unreliable on iOS 16+
-		const topInset = Math.round(dipToDp(keyWindow ? keyWindow.safeAreaInsets.top : UIApplication.sharedApplication.keyWindow.safeAreaInsets.top));
+		const windowInset = keyWindow ? keyWindow.safeAreaInsets.top : UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+		const topInset = Math.round(dipToDp(Math.max(windowInset, this.tabContentTopInset(layout))));
 
 		const insets = layout.getSafeAreaInsets();
 		equal(insets.top, topInset, `${layout}.topInset - actual:${insets.top}; expected: ${topInset}`);

--- a/apps/automated/src/ui/list-view/list-view-tests.ts
+++ b/apps/automated/src/ui/list-view/list-view-tests.ts
@@ -29,6 +29,11 @@ for (var i = 0; i < 100; i++) {
 	MANY_ITEMS.push(i);
 }
 
+// Sectioned template resolution is internal, so the public typings do not declare it.
+type ListViewInternal = ListView & {
+	_getItemTemplateInSection(section: number, index: number): KeyedTemplate;
+};
+
 export class ListViewTest extends UITest<ListView> {
 	public create(): ListView {
 		return new ListView();
@@ -1099,7 +1104,7 @@ export class ListViewTest extends UITest<ListView> {
 	public test_SectionedListView_ItemTemplateSelector_CorrectTemplatePerSection() {
 		// Verifies that _getItemTemplateInSection resolves the template using the
 		// actual row data item (not the section wrapper object).
-		const listView = this.testView;
+		const listView = this.testView as ListViewInternal;
 		listView.sectioned = true;
 
 		// Section 0 items have age=0 (even → 'red'), section 1 items have age=1 (odd → 'green')
@@ -1129,7 +1134,7 @@ export class ListViewTest extends UITest<ListView> {
 
 	public test_SectionedListView_ItemTemplateSelector_DifferentTemplatesWithinSameSection() {
 		// Verifies mixed templates within a single section are resolved correctly.
-		const listView = this.testView;
+		const listView = this.testView as ListViewInternal;
 		listView.sectioned = true;
 
 		listView.items = [{ title: 'Mixed', items: [{ age: 0 }, { age: 1 }, { age: 2 }] }];
@@ -1144,7 +1149,7 @@ export class ListViewTest extends UITest<ListView> {
 	public test_SectionedListView_ItemTemplateSelector_UnknownKeyFallsBackToDefault() {
 		// Mirrors test_ItemTemplateSelector_WhenWrongTemplateKeyIsSpecified_TheDefaultTemplateIsUsed
 		// but for the sectioned path.
-		const listView = this.testView;
+		const listView = this.testView as ListViewInternal;
 		listView.sectioned = true;
 
 		listView.items = [{ title: 'Section A', items: [{ age: 0 }] }];


### PR DESCRIPTION
Fixes the tests with safe area on iPad.

don't merge until CI validates the iOS side (Github outage right now is preventing that from running)