### PR TITLE
feat(core): corner-shape css property for continuous corners on iOS

### DIFF
--- a/packages/core/core-types/index.ts
+++ b/packages/core/core-types/index.ts
@@ -272,6 +272,14 @@ export namespace CoreTypes {
 		export const parse = makeParser<BackgroundRepeatType>(isValid);
 	}
 
+	export type CornerShapeType = 'round' | 'squircle';
+	export namespace CornerShape {
+		export const round: CornerShapeType = 'round';
+		export const squircle: CornerShapeType = 'squircle';
+		export const isValid = makeValidator<CornerShapeType>(round, squircle);
+		export const parse = makeParser<CornerShapeType>(isValid);
+	}
+
 	export namespace AnimationCurve {
 		export const ease = 'ease';
 		export const easeIn = 'easeIn';

--- a/packages/core/ui/styling/background-common.ts
+++ b/packages/core/ui/styling/background-common.ts
@@ -39,6 +39,7 @@ export class Background {
 	public borderTopRightRadius = 0;
 	public borderBottomLeftRadius = 0;
 	public borderBottomRightRadius = 0;
+	public cornerShape: CoreTypes.CornerShapeType = CoreTypes.CornerShape.round;
 	public clipPath: string | ClipPathFunction;
 	public boxShadows: BoxShadow[];
 	public clearFlags: number = BackgroundClearFlags.NONE;
@@ -63,6 +64,7 @@ export class Background {
 		clone.borderTopRightRadius = this.borderTopRightRadius;
 		clone.borderBottomRightRadius = this.borderBottomRightRadius;
 		clone.borderBottomLeftRadius = this.borderBottomLeftRadius;
+		clone.cornerShape = this.cornerShape;
 		clone.clipPath = this.clipPath;
 		clone.boxShadows = this.boxShadows;
 		clone.clearFlags = this.clearFlags;
@@ -192,6 +194,13 @@ export class Background {
 		return clone;
 	}
 
+	public withCornerShape(value: CoreTypes.CornerShapeType): Background {
+		const clone = this.clone();
+		clone.cornerShape = value;
+
+		return clone;
+	}
+
 	public withClipPath(value: string | ClipPathFunction): Background {
 		const clone = this.clone();
 		clone.clipPath = value;
@@ -256,6 +265,7 @@ export class Background {
 			value1.borderTopRightRadius === value2.borderTopRightRadius &&
 			value1.borderBottomRightRadius === value2.borderBottomRightRadius &&
 			value1.borderBottomLeftRadius === value2.borderBottomLeftRadius &&
+			value1.cornerShape === value2.cornerShape &&
 			isClipPathEqual
 			// && value1.clearFlags === value2.clearFlags
 		);

--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -12,6 +12,7 @@ import { parse as cssParse } from '../../css-value/reworkcss-value';
 import { BoxShadow } from './box-shadow';
 import { BackgroundClearFlags } from './background-common';
 import { ClipPathFunction } from './clip-path-function';
+import { CoreTypes } from '../../core-types';
 
 export * from './background-common';
 
@@ -93,6 +94,7 @@ export namespace ios {
 			layer.borderColor = borderColor?.ios?.CGColor;
 			layer.borderWidth = layout.toDeviceIndependentPixels(background.getUniformBorderWidth());
 			layer.cornerRadius = getUniformBorderRadius(view, layer.bounds);
+			layer.cornerCurve = background.cornerShape === CoreTypes.CornerShape.squircle ? kCACornerCurveContinuous : kCACornerCurveCircular;
 		} else {
 			drawNonUniformBorders(nativeView, background);
 			needsLayerAdjustmentOnScroll = true;

--- a/packages/core/ui/styling/style-properties.spec.ts
+++ b/packages/core/ui/styling/style-properties.spec.ts
@@ -35,3 +35,29 @@ describe('border-color shorthand', () => {
 		expect(label.style.borderLeftColor).toEqual(new Color('blue'));
 	});
 });
+
+describe('corner-shape', () => {
+	it('defaults to round', () => {
+		const label = new Label();
+
+		expect(label.style.cornerShape).toBe('round');
+		expect(label.style.backgroundInternal.cornerShape).toBe('round');
+	});
+
+	it('accepts squircle and reaches the background', () => {
+		const label = new Label();
+		label.style.cornerShape = 'squircle';
+
+		expect(label.style.backgroundInternal.cornerShape).toBe('squircle');
+
+		label.style.cornerShape = 'round';
+
+		expect(label.style.backgroundInternal.cornerShape).toBe('round');
+	});
+
+	it('rejects unknown keywords', () => {
+		const label = new Label();
+
+		expect(() => (label.style.cornerShape = 'bevel' as any)).toThrow();
+	});
+});

--- a/packages/core/ui/styling/style-properties.ts
+++ b/packages/core/ui/styling/style-properties.ts
@@ -1053,6 +1053,17 @@ export const borderBottomLeftRadiusProperty = new CssProperty<Style, CoreTypes.L
 });
 borderBottomLeftRadiusProperty.register(Style);
 
+export const cornerShapeProperty = new CssProperty<Style, CoreTypes.CornerShapeType>({
+	name: 'cornerShape',
+	cssName: 'corner-shape',
+	defaultValue: CoreTypes.CornerShape.round,
+	valueConverter: CoreTypes.CornerShape.parse,
+	valueChanged: (target, oldValue, newValue) => {
+		target.backgroundInternal = target.backgroundInternal.withCornerShape(newValue);
+	},
+});
+cornerShapeProperty.register(Style);
+
 const boxShadowProperty = new CssProperty<Style, ShadowCSSValues[]>({
 	name: 'boxShadow',
 	cssName: 'box-shadow',

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -152,6 +152,13 @@ export class Style extends Observable {
 	public borderBottomRightRadius: CoreTypes.LengthType;
 	public borderBottomLeftRadius: CoreTypes.LengthType;
 
+	/**
+	 * The curve used to round the corners: 'round' (circular arcs, the default)
+	 * or 'squircle' (Apple's continuous corner curve). iOS only; Android always
+	 * renders circular corners.
+	 */
+	public cornerShape: CoreTypes.CornerShapeType;
+
 	public boxShadow: string | ShadowCSSValues[];
 
 	public direction: CoreTypes.LayoutDirectionType;


### PR DESCRIPTION
> **Stacked on #11364** — only the last commit (`feat(core): corner-shape css property for continuous corners on iOS`) is new here; the first two belong to the base PR.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Corners always render as circular arcs — `CALayer.cornerCurve` is never set, so layers use the `kCACornerCurveCircular` default. Apps that want Apple's smooth "continuous" corners (the squircle look used across iOS system UI: app icons, alerts, cards) have to patch `@nativescript/core` dist output or poke `view.ios.layer.cornerCurve` manually.

## What is the new behavior?

A new `corner-shape` CSS property — the [CSS Borders Level 4 property](https://drafts.csswg.org/css-borders-4/#corner-shaping) recently shipped on the web (Chrome 139; proposed by Safari) — with the `round | squircle` keyword subset:

```css
.card {
	border-radius: 16;
	corner-shape: squircle; /* Apple's continuous corner curve */
}
```

- `squircle` maps to `kCACornerCurveContinuous` on iOS; `round` (the default) keeps `kCACornerCurveCircular`, so **existing apps are visually unchanged**.
- Follows the standard `Background` flow: `Style.cornerShape` → `backgroundInternal.withCornerShape()` → applied in `background.ios.ts` on the uniform-border fast path where corners render via `layer.cornerRadius`.
- Android is a no-op (always `round`) — there is no native equivalent.

**Known limitation** (documented in the commit): the path-drawn branches — non-uniform borders, box-shadow outlines, clip masks — build circular-arc `UIBezierPath`s and are unaffected, so a squircle view falls back to circular corners in those combinations. Teaching those generators to emit the continuous curve (a superellipse approximation) can land as a follow-up.

3 new unit tests (default, squircle round-trip to `Background`, unknown-keyword rejection); full suite passing (403).
