### PR TITLE
fix(core): iOS double free of V8-owned buffers; getRandomValues view handling

### DIFF
--- a/packages/core/file-system/file-system-access.ios.spec.ts
+++ b/packages/core/file-system/file-system-access.ios.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { FileSystemAccess } from './file-system-access.ios';
+
+function getBuffer(buffer: any) {
+	return FileSystemAccess.getBuffer(buffer) as unknown as { selector: string; args: any[] };
+}
+
+// Views reach the runtime's pointer marshalling as backingStore->Data() + byteOffset, so the
+// view can be handed straight to a copying selector. Wrapping their bytes no-copy would hand
+// Foundation memory V8 owns, and at a non-zero offset a pointer that is not a chunk start.
+const views: [string, () => ArrayBufferView][] = [
+	['Uint8Array', () => new Uint8Array(new ArrayBuffer(16))],
+	['offset Uint8Array', () => new Uint8Array(new ArrayBuffer(32), 4, 10)],
+	['offset Uint8ClampedArray', () => new Uint8ClampedArray(new ArrayBuffer(32), 4, 10)],
+	['offset DataView', () => new DataView(new ArrayBuffer(32), 4, 10)],
+];
+
+describe('FileSystemAccess.getBuffer (iOS)', () => {
+	it('copies a whole ArrayBuffer', () => {
+		const buffer = new ArrayBuffer(8);
+		const data = getBuffer(buffer);
+
+		expect(data.selector).toBe('dataWithData');
+		expect(data.args[0]).toBe(buffer);
+	});
+
+	it.each(views)('passes an %s itself and copies only its window', (_name, makeView) => {
+		const view = makeView();
+		const data = getBuffer(view);
+
+		expect(data.selector).toBe('dataWithBytesLength');
+		expect(data.args[0]).toBe(view);
+		expect(data.args[1]).toBe(view.byteLength);
+	});
+});

--- a/packages/core/file-system/file-system-access.ios.ts
+++ b/packages/core/file-system/file-system-access.ios.ts
@@ -439,9 +439,9 @@ export class FileSystemAccess {
 		if (buffer instanceof ArrayBuffer) {
 			return NSData.dataWithData(buffer as any);
 		} else {
-			const buf = NSData.dataWithData(buffer?.buffer as any);
-			const len = buffer.byteLength;
-			return NSData.dataWithBytesNoCopyLength((buf.bytes as interop.Pointer).add(buffer?.byteOffset ?? 0), len);
+			// The view marshals to backingStore->Data() + byteOffset, so this copies exactly its window.
+			// The bytes are V8-owned; a no-copy wrapper would donate them to Foundation to free.
+			return NSData.dataWithBytesLength(buffer as any, buffer.byteLength);
 		}
 	}
 

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -33,6 +33,32 @@ global.NSObject = class NSObject {
 	}
 };
 global.NSNumber = {};
+// The NSData factories record which selector was used and with what arguments: ownership of the
+// bytes differs per selector, so that choice is the thing specs need to pin.
+function nsDataStub(selector: string, args: any[]) {
+	return { selector, args };
+}
+global.NSData = {
+	dataWithData(data: any) {
+		return nsDataStub('dataWithData', [data]);
+	},
+	dataWithBytesLength(bytes: any, length: number) {
+		return nsDataStub('dataWithBytesLength', [bytes, length]);
+	},
+	dataWithBytesNoCopyLength(bytes: any, length: number) {
+		return nsDataStub('dataWithBytesNoCopyLength', [bytes, length]);
+	},
+	dataWithBytesNoCopyLengthFreeWhenDone(bytes: any, length: number, freeWhenDone: boolean) {
+		return nsDataStub('dataWithBytesNoCopyLengthFreeWhenDone', [bytes, length, freeWhenDone]);
+	},
+};
+global.NSMutableData = { ...global.NSData };
+global.NSCCrypto = {
+	randomUUID() {
+		return 'native-uuid';
+	},
+	getRandomValues(data: any) {},
+};
 global.NSString = {
 	stringWithString() {
 		return {

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -59,6 +59,20 @@ global.NSCCrypto = {
 	},
 	getRandomValues(data: any) {},
 };
+// The Android crypto shim, so the platform branches of `wgc/crypto` can be exercised from the
+// same specs by flipping `__ANDROID__`.
+global.org = {
+	nativescript: {
+		winter_tc: {
+			Crypto: {
+				randomUUID() {
+					return 'native-uuid';
+				},
+				getRandomValues(bytes: any) {},
+			},
+		},
+	},
+};
 global.NSString = {
 	stringWithString() {
 		return {

--- a/packages/core/wgc/crypto/index.spec.ts
+++ b/packages/core/wgc/crypto/index.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Crypto } from './index';
+
+/** Runs `fn` and returns the NSMutableData stub that reached the native crypto shim. */
+function captureNativeData(fn: () => void) {
+	const spy = vi.spyOn((globalThis as any).NSCCrypto, 'getRandomValues');
+
+	try {
+		fn();
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		return spy.mock.calls[0][0] as unknown as { selector: string; args: any[] };
+	} finally {
+		spy.mockRestore();
+	}
+}
+
+describe('Crypto.getRandomValues (iOS)', () => {
+	const crypto = new Crypto();
+
+	// The bytes belong to V8's BackingStore. freeWhenDone:NO is what keeps Foundation from
+	// freeing an allocation that V8's ArrayBufferSweeper also frees.
+	it('wraps the buffer without donating ownership to Foundation', () => {
+		const bytes = new Uint8Array(16);
+		const data = captureNativeData(() => crypto.getRandomValues(bytes));
+
+		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
+		expect(data.args[0]).toBe(bytes);
+		expect(data.args[1]).toBe(16);
+		expect(data.args[2]).toBe(false);
+	});
+
+	it('wraps only the view window of an offset byte view', () => {
+		const view = new Uint8Array(new ArrayBuffer(32), 4, 10);
+		const data = captureNativeData(() => crypto.getRandomValues(view));
+
+		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
+		expect(data.args[0]).toBe(view);
+		expect(data.args[1]).toBe(10);
+		expect(data.args[2]).toBe(false);
+	});
+
+	it('wraps only the view window of a non-byte typed array', () => {
+		const buffer = new ArrayBuffer(32);
+		const data = captureNativeData(() => crypto.getRandomValues(new Uint32Array(buffer, 8, 2)));
+		const wrapped = data.args[0] as Uint8Array;
+
+		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
+		expect(wrapped.buffer).toBe(buffer);
+		expect(wrapped.byteOffset).toBe(8);
+		expect(wrapped.byteLength).toBe(8);
+		expect(data.args[1]).toBe(8);
+		expect(data.args[2]).toBe(false);
+	});
+});

--- a/packages/core/wgc/crypto/index.spec.ts
+++ b/packages/core/wgc/crypto/index.spec.ts
@@ -1,28 +1,40 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Crypto } from './index';
 
-/** Runs `fn` and returns the NSMutableData stub that reached the native crypto shim. */
-function captureNativeData(fn: () => void) {
-	const spy = vi.spyOn((globalThis as any).NSCCrypto, 'getRandomValues');
+/** Runs `fn` and returns the single argument that reached a platform's native crypto shim. */
+function captureNativeCall(shim: any, fn: () => void) {
+	const spy = vi.spyOn(shim, 'getRandomValues');
 
 	try {
 		fn();
 		expect(spy).toHaveBeenCalledTimes(1);
 
-		return spy.mock.calls[0][0] as unknown as { selector: string; args: any[] };
+		return spy.mock.calls[0][0] as any;
 	} finally {
 		spy.mockRestore();
 	}
 }
 
-describe('Crypto.getRandomValues (iOS)', () => {
-	const crypto = new Crypto();
+const crypto = new Crypto();
 
+describe('Crypto.getRandomValues', () => {
+	it.each([
+		['byte view', () => new Uint8Array(8)],
+		['non-byte typed array', () => new Uint32Array(4)],
+		['offset non-byte typed array', () => new Uint32Array(new ArrayBuffer(32), 8, 2)],
+	])('returns the very %s it was handed', (_name, makeArray) => {
+		const typedArray = makeArray();
+
+		expect(crypto.getRandomValues(typedArray)).toBe(typedArray);
+	});
+});
+
+describe('Crypto.getRandomValues (iOS)', () => {
 	// The bytes belong to V8's BackingStore. freeWhenDone:NO is what keeps Foundation from
 	// freeing an allocation that V8's ArrayBufferSweeper also frees.
 	it('wraps the buffer without donating ownership to Foundation', () => {
 		const bytes = new Uint8Array(16);
-		const data = captureNativeData(() => crypto.getRandomValues(bytes));
+		const data = captureNativeCall((globalThis as any).NSCCrypto, () => crypto.getRandomValues(bytes));
 
 		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
 		expect(data.args[0]).toBe(bytes);
@@ -32,7 +44,7 @@ describe('Crypto.getRandomValues (iOS)', () => {
 
 	it('wraps only the view window of an offset byte view', () => {
 		const view = new Uint8Array(new ArrayBuffer(32), 4, 10);
-		const data = captureNativeData(() => crypto.getRandomValues(view));
+		const data = captureNativeCall((globalThis as any).NSCCrypto, () => crypto.getRandomValues(view));
 
 		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
 		expect(data.args[0]).toBe(view);
@@ -42,7 +54,7 @@ describe('Crypto.getRandomValues (iOS)', () => {
 
 	it('wraps only the view window of a non-byte typed array', () => {
 		const buffer = new ArrayBuffer(32);
-		const data = captureNativeData(() => crypto.getRandomValues(new Uint32Array(buffer, 8, 2)));
+		const data = captureNativeCall((globalThis as any).NSCCrypto, () => crypto.getRandomValues(new Uint32Array(buffer, 8, 2)));
 		const wrapped = data.args[0] as Uint8Array;
 
 		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
@@ -51,5 +63,41 @@ describe('Crypto.getRandomValues (iOS)', () => {
 		expect(wrapped.byteLength).toBe(8);
 		expect(data.args[1]).toBe(8);
 		expect(data.args[2]).toBe(false);
+	});
+});
+
+describe('Crypto.getRandomValues (Android)', () => {
+	let previousAndroid: boolean;
+	let previousIOS: boolean;
+
+	beforeEach(() => {
+		previousAndroid = (globalThis as any).__ANDROID__;
+		previousIOS = (globalThis as any).__IOS__;
+		(globalThis as any).__ANDROID__ = true;
+		(globalThis as any).__IOS__ = false;
+	});
+
+	afterEach(() => {
+		(globalThis as any).__ANDROID__ = previousAndroid;
+		(globalThis as any).__IOS__ = previousIOS;
+	});
+
+	it('hands a byte view straight through', () => {
+		const view = new Uint8Array(new ArrayBuffer(32), 4, 10);
+		const bytes = captureNativeCall((globalThis as any).org.nativescript.winter_tc.Crypto, () => crypto.getRandomValues(view));
+
+		expect(bytes).toBe(view);
+	});
+
+	// The runtime maps the view to a direct ByteBuffer over backingStore->Data() + byteOffset with
+	// capacity byteLength, and the Java side fills the whole capacity — so a view any wider than
+	// the caller's window overwrites bytes past it.
+	it('reinterprets a non-byte typed array over its window only', () => {
+		const buffer = new ArrayBuffer(32);
+		const bytes = captureNativeCall((globalThis as any).org.nativescript.winter_tc.Crypto, () => crypto.getRandomValues(new Uint32Array(buffer, 8, 2)));
+
+		expect(bytes.buffer).toBe(buffer);
+		expect(bytes.byteOffset).toBe(8);
+		expect(bytes.byteLength).toBe(8);
 	});
 });

--- a/packages/core/wgc/crypto/index.ts
+++ b/packages/core/wgc/crypto/index.ts
@@ -27,7 +27,9 @@ export class Crypto {
 			if (typedArray.BYTES_PER_ELEMENT !== 1) {
 				typedArray = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
 			}
-			const data = NSMutableData.dataWithBytesNoCopyLength(typedArray as never, typedArray.byteLength);
+			// The pointer is V8-owned: freeWhenDone must stay NO, or Foundation and V8's
+			// ArrayBufferSweeper both free the same allocation.
+			const data = NSMutableData.dataWithBytesNoCopyLengthFreeWhenDone(typedArray as never, typedArray.byteLength, false);
 
 			NSCCrypto.getRandomValues(data);
 		}

--- a/packages/core/wgc/crypto/index.ts
+++ b/packages/core/wgc/crypto/index.ts
@@ -16,23 +16,23 @@ export class Crypto {
 		}
 	}
 
-	getRandomValues(typedArray: Exclude<TypedArray, Float32Array | Float64Array>) {
+	getRandomValues<T extends Exclude<TypedArray, Float32Array | Float64Array>>(typedArray: T): T {
+		// Both natives fill bytes, so a wider element type is reinterpreted over the very same
+		// window — never past it, and never in place of the caller's own view, which is what
+		// getRandomValues has to hand back.
+		const bytes = typedArray.BYTES_PER_ELEMENT === 1 ? typedArray : new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+
 		if (__ANDROID__) {
-			if (typedArray.BYTES_PER_ELEMENT !== 1) {
-				typedArray = new Uint8Array(typedArray.buffer, typedArray.byteOffset);
-			}
-			(<any>org).nativescript.winter_tc.Crypto.getRandomValues(typedArray);
+			(<any>org).nativescript.winter_tc.Crypto.getRandomValues(bytes);
 		}
 		if (__IOS__) {
-			if (typedArray.BYTES_PER_ELEMENT !== 1) {
-				typedArray = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
-			}
 			// The pointer is V8-owned: freeWhenDone must stay NO, or Foundation and V8's
 			// ArrayBufferSweeper both free the same allocation.
-			const data = NSMutableData.dataWithBytesNoCopyLengthFreeWhenDone(typedArray as never, typedArray.byteLength, false);
+			const data = NSMutableData.dataWithBytesNoCopyLengthFreeWhenDone(bytes as never, bytes.byteLength, false);
 
 			NSCCrypto.getRandomValues(data);
 		}
+
 		return typedArray;
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

### 1 & 2 — V8-owned buffers donated to Foundation (iOS)

Two iOS call sites hand a **V8-owned** pointer to `dataWithBytesNoCopy:length:`. The 2-arg selector is `freeWhenDone:YES` — Foundation takes ownership of the pointer and frees it. The same allocation is freed a second time by V8's `ArrayBufferSweeper` when the `ArrayBuffer` dies.

Because the second free is deferred, it lands on whatever recycled small-heap chunk occupies that address by then, so the victim — and therefore the symptom — rotates with allocation layout. In a production app this surfaced as `V8_Fatal` in the runtime's `kFinalizer` machinery, plus rotating `SIGSEGV` flavours (corrupted wrappers, zeroed `Persistent` slots, payload-overwritten vptrs) on worker threads ~30–70s into a session; some runs hung silently instead.

`malloc_history` on a parked process captured both stacks verbatim on a single chunk: the Foundation-side free under `-[NSConcreteMutableData initWithBytes:length:copy:deallocator:]`, and later `ArrayBufferSweeper::SweepingJob` → `shared_ptr<BackingStore*>::__on_zero_shared` → `~BackingStore` → `free`.

**1. `Crypto.getRandomValues` — `packages/core/wgc/crypto/index.ts`** (the production trigger)

```ts
const data = NSMutableData.dataWithBytesNoCopyLength(typedArray, typedArray.byteLength);
NSCCrypto.getRandomValues(data);
```

The donated pointer is the caller's typed array's V8 `BackingStore` buffer. For small payloads `NSConcreteMutableData` copies and `free()`s the donor immediately inside `initWithBytes:length:copy:deallocator:`; larger payloads free at `dealloc`. Either way Foundation frees memory V8 owns.

Every `crypto.getRandomValues()` call is one occurrence, and it backs UUID generation, so it fires constantly on UI paths. Since `wgc` (and `global.crypto`) is new in core 9.x, apps upgrading from 8.x hit this the moment anything calls `crypto.getRandomValues` / `crypto.randomUUID`.

**2. `FileSystemAccess.getBuffer` — `packages/core/file-system/file-system-access.ios.ts`** (write path)

```ts
const buf = NSData.dataWithData(buffer?.buffer);
const len = buffer.byteLength;
return NSData.dataWithBytesNoCopyLength(buf.bytes.add(buffer?.byteOffset ?? 0), len);
```

Same `freeWhenDone:YES`, but over an *interior* pointer of another `NSData`'s buffer:

- `free()` on a non-chunk-start pointer whenever `byteOffset > 0` — immediate heap corruption;
- a double free against `buf`'s own `dealloc` even at offset 0.

It also copies the entire underlying `ArrayBuffer` (`dataWithData(buffer.buffer)`) even when the view is a small window over it.

### 3 — `getRandomValues` overwrites past the caller's window (Android)

```ts
typedArray = new Uint8Array(typedArray.buffer, typedArray.byteOffset);
```

No length, so the reinterpreted view runs from the caller's offset to the **end of the `ArrayBuffer`**. The runtime maps a typed array to a direct `ByteBuffer` over `backingStore->Data() + array->ByteOffset()` with capacity `array->ByteLength()`, and `Crypto.java` fills the whole capacity after a `rewind()`:

```java
buffer.rewind();
int size = buffer.capacity();
byte[] tempBuf = new byte[size];
random.nextBytes(tempBuf);
buffer.put(tempBuf);
```

So for any non-byte typed array that is a *window* over a larger buffer, every byte from the view's offset to the end of that buffer is overwritten with randomness. `new Uint32Array(buffer32, 8, 2)` asks for 8 bytes and gets 24 clobbered.

### 4 — `getRandomValues` returns an object the caller never passed in

Both branches assign the coerced view over the `typedArray` **parameter** and then `return typedArray`, so for any non-byte typed array the caller gets back a `Uint8Array` rather than its own view. WebCrypto requires the same object back. #10658 added the missing `return`, but by then the parameter had already been reassigned. The randomness does land correctly (the buffer is shared), so this is a return-value defect only.

## What is the new behavior?

**1.** The 3-arg `freeWhenDone:NO` form:

```ts
const data = NSMutableData.dataWithBytesNoCopyLengthFreeWhenDone(bytes, bytes.byteLength, false);
```

Zero-copy behaviour is preserved — native randomness is still written directly into the JS buffer — with no ownership donation. The buffer is guaranteed alive for the duration of the synchronous call.

**2.** The whole `else` branch collapses to a single copying call:

```ts
return NSData.dataWithBytesLength(buffer, buffer.byteLength);
```

Passing the typed-array view itself as the `const void *bytes` parameter: the iOS runtime's pointer marshalling resolves it to `backingStore->Data() + byteOffset` (view-aware — audited against the runtime source), and `dataWithBytes:length:` copies exactly the view's window. Net result — one copy of only the window instead of a full-buffer copy plus an unsafe no-copy wrapper, no intermediate `NSData`, no ownership games.

**3 & 4.** The coercion is now a local bound to the caller's window, and the parameter is returned untouched:

```ts
getRandomValues<T extends Exclude<TypedArray, Float32Array | Float64Array>>(typedArray: T): T {
	const bytes = typedArray.BYTES_PER_ELEMENT === 1 ? typedArray : new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
	...
	return typedArray;
}
```

The generic signature preserves the caller's element type, matching the DOM's `getRandomValues<T>(array: T): T`.

### Validation

With the two iOS ownership changes patched into core (**unmodified** runtime), a previously 100%-reproducible ~60s crash survived 10+ minute soaks including document close/reopen cycles — on both a fixed runtime and the original unfixed runtime, making bug 1 the proven sole production trigger.

### Tests

New specs pin the selector and arguments each path picks, since ownership of the bytes is exactly what the selector choice decides, plus the window and identity guarantees:

- `packages/core/wgc/crypto/index.spec.ts` — iOS: `freeWhenDone` is `false`, the view itself is passed, and only the view's window is wrapped. Android: a byte view passes straight through, and a non-byte typed array is reinterpreted over its window only. Both: the object handed in is the object handed back.
- `packages/core/file-system/file-system-access.ios.spec.ts` — `ArrayBuffer` still copies whole; `Uint8Array`, offset `Uint8Array`, offset `Uint8ClampedArray` and offset `DataView` all pass the view itself to `dataWithBytes:length:` with the window's `byteLength`.

`packages/core/vitest.setup.ts` gains `NSData` / `NSMutableData` / `NSCCrypto` stubs that record the selector and arguments they were called with, plus the Android `org.nativescript.winter_tc.Crypto` shim so both platform branches are reachable from the specs.

10 of the 13 new assertions fail against `main` and pass here; the other 3 cover behaviour this PR deliberately leaves alone. The full `core` suite passes (442 tests), and lint/build are clean.

### Sweep

Any 2-arg `dataWithBytesNoCopy:length:` (or the `NSMutableData` equivalent) over a pointer derived from a typed array, `interop.handleof`, or another `NSData`'s `bytes` is this bug class. A repo-wide sweep found no other reachable JS-side occurrences. The one remaining native hit — `[NSData dataWithBytesNoCopy:exponent length:size]` in `packages/winter-tc/ios/NSCWinterTC/NSCWinterTC/NSCCrypto.m` (`generateKeyRsa`) — is currently unreachable: every core call site passes `null, 0` for the exponent (`// ignore publicExponent for now`). Worth tightening whenever that path is implemented.

### Cross-reference

The iOS runtime side is tracking a debug-build marshalling guard (warn when the 2-arg selector receives a pointer inside a live V8 `BackingStore`); NativeScript/ios#458 carries the full forensic narrative.
