### PR TITLE
fix(core): css lost to a local value or a late attribute assignment

### DIFF
--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -775,6 +775,8 @@ export class CssProperty<T extends Style, U> {
 				return;
 			}
 
+			this._localValueVersion++;
+
 			const reset = isResetValue(newValue) || newValue === '';
 			let value: U;
 
@@ -1227,12 +1229,18 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 			}
 		};
 
-		const setFunc = (valueSource: ValueSource) =>
-			function (this: T, boxedValue: any): void {
+		const setFunc = (valueSource: ValueSource) => {
+			const isLocalWrite = valueSource === ValueSource.Local;
+
+			return function (this: T, boxedValue: any): void {
 				const view = this.viewRef.get();
 				if (!view) {
 					Trace.write(`${boxedValue} not set to view's property because ".viewRef" is cleared`, Trace.categories.Style, Trace.messageType.warn);
 					return;
+				}
+
+				if (isLocalWrite) {
+					this._localValueVersion++;
 				}
 
 				const reset = isResetValue(boxedValue) || boxedValue === '';
@@ -1336,6 +1344,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 					});
 				}
 			};
+		};
 
 		const setDefaultFunc = setFunc(ValueSource.Default);
 		const setInheritedFunc = setFunc(ValueSource.Inherited);

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -35,6 +35,26 @@ const enum ValueSource {
 	Keyframe = 4,
 }
 
+/** `sourceKey` of every registered `CssProperty`, by css name. */
+const cssValueSourceKeys: Record<string, symbol> = Object.create(null);
+
+/**
+ * Whether the style still carries what the cascade last wrote for the property.
+ * A `CssProperty` keeps one value: a local value both suppresses the css write and
+ * takes the slot, so clearing it leaves the property at its default with the css
+ * value gone. The cascade has to write it again rather than skip it as unchanged.
+ */
+export function _isCssValueStillApplied(style: unknown, cssLocalName: string, value: unknown): boolean {
+	const sourceKey = cssValueSourceKeys[cssLocalName];
+	if (sourceKey === undefined) {
+		// Applied through the view rather than the style; nothing to verify.
+		return true;
+	}
+
+	// A reset leaves no source behind, so it is in effect precisely when nothing else claimed the property.
+	return style[sourceKey] === (isResetValue(value) ? undefined : ValueSource.Css);
+}
+
 function print(map) {
 	const symbols = Object.getOwnPropertySymbols(map);
 	for (const symbol of symbols) {
@@ -939,6 +959,8 @@ export class CssProperty<T extends Style, U> {
 		if (this.cssLocalName !== this.cssName) {
 			Object.defineProperty(cls.prototype, this.cssLocalName, this.localValueDescriptor);
 		}
+
+		cssValueSourceKeys[this.cssLocalName] = this.sourceKey;
 	}
 
 	public isSet(instance: T): boolean {

--- a/packages/core/ui/styling/css-attribute-match.spec.ts
+++ b/packages/core/ui/styling/css-attribute-match.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { StyleScope } from './style-scope';
+import { StackLayout } from '../layouts/stack-layout';
+import { Label } from '../label';
+
+function scoped(css: string) {
+	const scope = new StyleScope();
+	scope.css = css;
+
+	const root: any = new StackLayout();
+	root._styleScope = scope;
+
+	return { scope, root };
+}
+
+describe('css matches an attribute assigned after the view was inserted', () => {
+	function insertedIntoLoadedTree(css: string) {
+		const { scope, root } = scoped(css);
+		root._isLoaded = true;
+
+		const view: any = new Label();
+		root.addChild(view);
+		view._styleScope = scope;
+
+		return { root, view };
+	}
+
+	it('applies once the attribute lands on the view', () => {
+		const { view } = insertedIntoLoadedTree('label[ngcontent] { color: red; }');
+
+		view.ngcontent = '';
+		view._cssState.onLoaded();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('applies once the attribute lands on an ancestor', () => {
+		const { root, view } = insertedIntoLoadedTree('stacklayout[ngcontent] label { color: red; }');
+
+		root.ngcontent = '';
+		view._cssState.onLoaded();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('applies on a later dynamic update', () => {
+		const { view } = insertedIntoLoadedTree('label[ngcontent] { color: red; }');
+
+		view.ngcontent = '';
+		view._cssState.updateDynamicState();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it('leaves a view without the attribute alone', () => {
+		const { view } = insertedIntoLoadedTree('label[ngcontent] { color: red; }');
+
+		view._cssState.onLoaded();
+
+		expect(view.style.color).toBeUndefined();
+	});
+});

--- a/packages/core/ui/styling/css-selector.spec.ts
+++ b/packages/core/ui/styling/css-selector.spec.ts
@@ -364,7 +364,20 @@ describe('css-selector', () => {
 			const rule = createOne(`.title[_ngcontent-c7] { color: red; }`);
 			const node = { cssType: 'label', cssClasses: new Set(['title']), '_ngcontent-c3': '' };
 
-			expect(rule.selectors[0].accumulateChanges(<any>node, undefined)).toBe(false);
+			expect(rule.selectors[0].match(<any>node)).toBe(false);
+		});
+
+		it('stays a candidate so it can match once the attribute is assigned', () => {
+			// Assigning a plain instance value raises no change event, so a selector
+			// dropped from the match would never be reconsidered.
+			const rule = createOne(`.title[_ngcontent-c7] { color: red; }`);
+			const node: any = { cssType: 'label', cssClasses: new Set(['title']) };
+
+			expect(rule.selectors[0].accumulateChanges(node, undefined)).toBe(true);
+
+			node['_ngcontent-c7'] = '';
+
+			expect(rule.selectors[0].match(node)).toBe(true);
 		});
 
 		it('matches a node carrying the attribute', () => {

--- a/packages/core/ui/styling/css-selector.ts
+++ b/packages/core/ui/styling/css-selector.ts
@@ -428,10 +428,11 @@ export class AttributeSelector extends SimpleSelector {
 		return false;
 	}
 	public mayMatch(node: Node): boolean {
-		// Registered properties live on the prototype and anything already assigned is
-		// an own value; an attribute on neither can never start matching without the
-		// css state being invalidated anyway.
-		return this.attribute in node;
+		// An attribute the node does not carry yet cannot be ruled out: assigning a
+		// plain instance value (Angular's `_ngcontent-*` markers, `[attr.x]` bindings)
+		// neither raises a change event nor invalidates the match, so a selector
+		// dropped here would never be reconsidered.
+		return true;
 	}
 	public trackChanges(node: Node, map: ChangeAccumulator): void {
 		if (attributeNotifiesChanges(node, this.attribute)) {

--- a/packages/core/ui/styling/css-state-recovery.spec.ts
+++ b/packages/core/ui/styling/css-state-recovery.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+
+import { StyleScope, applyInlineStyle } from './style-scope';
+import { StackLayout } from '../layouts/stack-layout';
+import { Label } from '../label';
+import { unsetValue } from '../core/properties';
+
+function scoped(css: string) {
+	const scope = new StyleScope();
+	scope.css = css;
+
+	const root: any = new StackLayout();
+	root._styleScope = scope;
+
+	return { scope, root };
+}
+
+function loaded(css: string) {
+	const { scope, root } = scoped(css);
+
+	const view: any = new Label();
+	root.addChild(view);
+	view._styleScope = scope;
+	view._cssState.onLoaded();
+
+	return view;
+}
+
+function restyle(view: any): void {
+	view._cssState.onChange();
+	view._cssState.onLoaded();
+}
+
+/** Counts css writes per `<view>.<property>`, reporting only the ones that happened. */
+function countWrites(targets: Array<[view: any, cssProperty: string]>): () => Record<string, number> {
+	const counts: Record<string, number> = {};
+
+	for (const [view, cssProperty] of targets) {
+		const style = view.style;
+		const key = `${view.cssType}.${cssProperty}`;
+		const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(style), `css:${cssProperty}`);
+
+		Object.defineProperty(style, `css:${cssProperty}`, {
+			configurable: true,
+			get: descriptor.get,
+			set(value: unknown) {
+				counts[key] = (counts[key] ?? 0) + 1;
+				descriptor.set.call(this, value);
+			},
+		});
+	}
+
+	return () => counts;
+}
+
+describe('css survives a local value that shadows it', () => {
+	it('restores a longhand after a local value is released', () => {
+		const view = loaded('label { color: red; }');
+		expect(view.style.color.toString()).toBe('#FF0000');
+
+		view.style.color = 'blue';
+		view.style.color = unsetValue;
+		view._cssState.updateDynamicState();
+
+		expect(view.style.color.toString()).toBe('#FF0000');
+	});
+
+	it.each([
+		['a shorthand', 'label { margin: 4; }'],
+		['a longhand', 'label { margin-top: 4; }'],
+	])('restores margin from %s after a local value is released', (_name, css) => {
+		const view = loaded(css);
+		expect(view.style.marginTop).toBe(4);
+
+		view.style.marginTop = 20;
+		view.style.marginTop = unsetValue;
+		view._cssState.updateDynamicState();
+
+		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('restores padding after a local value is released', () => {
+		const view = loaded('label { padding: 4; }');
+
+		view.style.paddingTop = 20;
+		view.style.paddingTop = unsetValue;
+		view._cssState.updateDynamicState();
+
+		expect(view.style.paddingTop).toBe(4);
+		expect(view.style.paddingInternal).toBe('4 4 4 4');
+	});
+
+	it('restores a value a local one shadowed before css ever ran', () => {
+		const { scope, root } = scoped('label { margin: 4; }');
+
+		const view: any = new Label();
+		view.style.marginTop = 20;
+		root.addChild(view);
+		view._styleScope = scope;
+		view._cssState.onLoaded();
+		expect(view.style.marginTop).toBe(20);
+
+		view.style.marginTop = unsetValue;
+		view._cssState.updateDynamicState();
+
+		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('restores a value an inline style shadowed', () => {
+		const view = loaded('label { margin: 4; }');
+
+		applyInlineStyle(view, 'margin-top: 20');
+		expect(view.style.marginTop).toBe(20);
+
+		view.style.marginTop = unsetValue;
+		view._cssState.updateDynamicState();
+
+		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('restores a value on the next full re-match', () => {
+		const view = loaded('label { margin: 4; } .a { color: red; }');
+
+		view.style.marginTop = 20;
+		view.style.marginTop = unsetValue;
+
+		view.className = 'a';
+		restyle(view);
+
+		expect(view.style.marginTop).toBe(4);
+	});
+
+	it('still skips every value nothing disturbed', () => {
+		// Verifying the write took effect must not cost a re-application: inherited
+		// values, expanded longhands and the ones a shorthand left unset included.
+		const { scope, root } = scoped('stacklayout { color: red; font-size: 12; } label { margin: 4; background: blue; }');
+
+		const view: any = new Label();
+		root.addChild(view);
+		view._styleScope = scope;
+		root._cssState.onLoaded();
+		view._cssState.onLoaded();
+
+		const writes = countWrites([
+			[root, 'color'],
+			[root, 'font-size'],
+			[view, 'color'],
+			[view, 'margin-top'],
+			[view, 'background-color'],
+			[view, 'background-image'],
+		]);
+
+		for (let i = 0; i < 3; i++) {
+			root._cssState.updateDynamicState();
+			view._cssState.updateDynamicState();
+		}
+
+		expect(writes()).toEqual({});
+	});
+});

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -1,7 +1,7 @@
 import { getNativeScriptGlobals } from '../../globals/global-utils';
 import { ViewBase } from '../core/view-base';
 import { View } from '../core/view';
-import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, _expandCssShorthand, _isCssPendingSubstitution, CssPendingSubstitution, isCssVariable, isCssVariableExpression, isCssCalcExpression } from '../core/properties';
+import { _evaluateCssVariableExpression, _evaluateCssCalcExpression, _expandCssShorthand, _isCssPendingSubstitution, _isCssValueStillApplied, CssPendingSubstitution, isCssVariable, isCssVariableExpression, isCssCalcExpression } from '../core/properties';
 import { unsetValue } from '../core/properties/property-shared';
 import * as ReworkCSS from '../../css';
 
@@ -898,7 +898,7 @@ export class CssState {
 
 			// Whatever is left in oldProperties after these loops was removed and gets unset.
 			const hadOldValue = property in oldProperties;
-			const unchanged = hadOldValue && oldProperties[property] === value;
+			const unchanged = hadOldValue && oldProperties[property] === value && _isCssValueStillApplied(view.style, property, value);
 			if (hadOldValue) {
 				delete oldProperties[property];
 			}
@@ -942,7 +942,7 @@ export class CssState {
 				newPropertyValues[property] = value;
 			}
 
-			if (hadOldValue && oldValue === value) {
+			if (hadOldValue && oldValue === value && _isCssValueStillApplied(view.style, property, value)) {
 				continue;
 			}
 
@@ -980,7 +980,7 @@ export class CssState {
 				newPropertyValues[property] = value;
 			}
 
-			if (hadOldValue && oldValue === value) {
+			if (hadOldValue && oldValue === value && _isCssValueStillApplied(view.style, property, value)) {
 				continue;
 			}
 

--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -688,6 +688,7 @@ export class CssState {
 	_onDynamicStateChangeHandler: () => void;
 	_appliedChangeMap: Readonly<ChangeMap<ViewBase>>;
 	private _appliedPropertyValues: Record<string, unknown> = CssState.emptyPropertyBag;
+	private _appliedLocalValueVersion = -1;
 	_appliedAnimations: ReadonlyArray<KeyframeAnimation>;
 	_appliedSelectorsVersion: number;
 
@@ -865,6 +866,11 @@ export class CssState {
 		matchingSelectors.forEach((selector) => selector.ruleset.declarations.forEach((declaration) => (newPropertyValues[declaration.property] = declaration.value)));
 
 		const oldProperties = this._appliedPropertyValues;
+		// A local write is the only thing that can drop a value the cascade already
+		// applied, so the recorded values only have to be verified after one.
+		const localValueVersion = view.style._localValueVersion;
+		const verifyApplied = localValueVersion !== this._appliedLocalValueVersion;
+
 		// Update values for the scope's css-variables
 		view.style.resetScopedCssVariables();
 
@@ -898,7 +904,7 @@ export class CssState {
 
 			// Whatever is left in oldProperties after these loops was removed and gets unset.
 			const hadOldValue = property in oldProperties;
-			const unchanged = hadOldValue && oldProperties[property] === value && _isCssValueStillApplied(view.style, property, value);
+			const unchanged = hadOldValue && oldProperties[property] === value && (!verifyApplied || _isCssValueStillApplied(view.style, property, value));
 			if (hadOldValue) {
 				delete oldProperties[property];
 			}
@@ -942,7 +948,7 @@ export class CssState {
 				newPropertyValues[property] = value;
 			}
 
-			if (hadOldValue && oldValue === value && _isCssValueStillApplied(view.style, property, value)) {
+			if (hadOldValue && oldValue === value && (!verifyApplied || _isCssValueStillApplied(view.style, property, value))) {
 				continue;
 			}
 
@@ -980,7 +986,7 @@ export class CssState {
 				newPropertyValues[property] = value;
 			}
 
-			if (hadOldValue && oldValue === value && _isCssValueStillApplied(view.style, property, value)) {
+			if (hadOldValue && oldValue === value && (!verifyApplied || _isCssValueStillApplied(view.style, property, value))) {
 				continue;
 			}
 
@@ -1016,6 +1022,7 @@ export class CssState {
 		}
 
 		this._appliedPropertyValues = newPropertyValues;
+		this._appliedLocalValueVersion = view.style._localValueVersion;
 	}
 
 	private subscribeForDynamicUpdates(): void {

--- a/packages/core/ui/styling/style/index.ts
+++ b/packages/core/ui/styling/style/index.ts
@@ -267,6 +267,12 @@ export class Style extends Observable {
 
 	public viewRef: WeakRef<ViewBase>;
 
+	/**
+	 * Bumped on every local write. A local value takes the slot of the css value it
+	 * shadows, so this is what tells the css state its recorded values may be stale.
+	 */
+	public _localValueVersion: number;
+
 	public get view(): ViewBase {
 		if (this.viewRef) {
 			return this.viewRef.get();
@@ -278,3 +284,4 @@ export class Style extends Observable {
 Style.prototype.PropertyBag = class {
 	[property: string]: string;
 };
+Style.prototype._localValueVersion = 0;

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -23,6 +23,12 @@ export default defineConfig({
 		watch: false,
 		globals: true,
 		environment: 'node',
+		// VITEST_NO_OPT=1 runs the worker interpreter-only, which is how iOS executes
+		// (V8 jitless) and reads very differently in benchmarks. `--max-opt=0` is what
+		// `--jitless` does to javascript, without also disabling the WebAssembly vite
+		// needs; plain `--no-opt` only drops turbofan and measures almost nothing.
+		pool: 'forks',
+		execArgv: process.env['VITEST_NO_OPT'] ? ['--max-opt=0'] : [],
 		setupFiles: ['vitest.setup.ts'],
 		include: ['**/*.{test,spec}.{ts,mts}'],
 		reporters: ['default'],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

Two regressions from #11361, both of which leave the wrong css applied in a real app. Each was confirmed by running the same scenario against the commit before that PR.

### 1. An attribute selector stops matching when the attribute is assigned after the view is inserted

`AttributeSelector.mayMatch` was narrowed to `this.attribute in node`, dropping the selector from the candidate set for a node that does not carry the attribute yet. Assigning a plain instance value raises no `<attribute>Change` event and does not invalidate the match, so the selector is never reconsidered and the rule never applies.

```css
label[ngcontent] { color: red; }
```
```js
const view = new Label();
root.addChild(view); // parent is loaded -> the css state is computed here
view.ngcontent = ''; // marker assigned after insertion
```

| | before #11361 | on main |
|---|---|---|
| after `onLoaded()` | `#FF0000` | `undefined` |
| after `updateDynamicState()` | `#FF0000` | `undefined` |

This is the shape Angular's emulated view encapsulation produces (`.foo[_ngcontent-ng-c123]`), so it can take out a component's styles wholesale. It also reproduces with the attribute on an ancestor (`stacklayout[foo] label`) and combined with a class (`label.mid[foo]`).

### 2. A local value permanently destroys the css value it shadows

`CssProperty` keeps a single value, so a local write both suppresses the css write *and* takes the slot: clearing it leaves the property at its default with the cascaded value gone. `CssState` recorded the value as applied either way, and the unchanged-value diff then skipped it for good — a full re-match included.

```js
// label { margin: 4 }
view.style.marginTop = 20;         // local value wins, as designed
view.style.marginTop = unsetValue; // released
// -> marginTop is 0, and stays 0
```

| | before #11361 | on main |
|---|---|---|
| final `style.marginTop` | `4` | `0` |

Before #11361 the diff never fired (the `delete` ran ahead of the comparison), so css was re-asserted on every update and this was invisible. Verified for `color`, `margin` and `padding` (via the shorthand and via the longhand), for inherited properties, for a local value set before css ever ran, and for `applyInlineStyle`. Real triggers are Angular `[style.x]` / `ngStyle` bindings going null (the renderer calls `removeStyle`, which sets `unsetValue`), a `style="..."` attribute later cleared, and any code doing `view.style.X = …` then resetting it.

## What is the new behavior?

**1.** `AttributeSelector.mayMatch` returns `true` again. The selector stays a candidate and `match()` decides at apply time, as it already does for pseudo classes.

The pruning is not salvageable: `this.attribute in node` is false *only* when the attribute is neither a prototype accessor nor an own value, which is exactly the ad-hoc, non-notifying attribute that can silently start matching later. It was only ever active in the case where it is wrong.

**2.** A value is recorded as applied only while the style still carries it. `_isCssValueStillApplied` reads the property's `sourceKey` — collected per `CssProperty` at registration — so the cascade writes the value again on the next update instead of skipping it. Values nothing disturbed are still skipped.

**3.** That check is gated on a local-write counter, so it costs nothing on the hot path. A local write is the only thing that can drop a value the cascade applied, so `Style` counts them and `CssState` records the count it applied against; the check runs only when the two differ, which for a view nothing writes to locally is never.

## Performance

The `css-state` benchmarks, run on node 24 under `--max-opt=0` — interpreter only, which is how iOS executes — against `9228826b4`, the commit before #11361. Higher is better:

| benchmark | before #11361 | this PR | |
|---|---|---|---|
| re-apply 200 views, nothing changed | 544.25 hz | 1581.79 hz | **2.91x** |
| toggle a class on 200 loaded views | 12.04 hz | 27.40 hz | **2.28x** |
| toggle a pseudo class on 200 views | 194.59 hz | 420.14 hz | **2.16x** |
| add 30 stylesheets + restyle 200 views | 4.25 hz | 6.63 hz | **1.56x** |
| load 30 components | 22.07 hz | 27.29 hz | **1.24x** |
| style 400 views (angular attribute css) | 25.10 hz | 27.55 hz | **1.10x** |
| style 400 views (plain css) | 41.38 hz | 40.56 hz | 0.98x |
| build a style scope | 345.06 hz | 318.71 hz | 0.92x |

So #11361's win survives the fixes: every figure lands within noise of what that PR measured, and no path ends up slower than it was before it — the attribute-scoped one included, despite `mayMatch` no longer pruning.

Against `main` the two fixes cost very little, but only because the check is gated. Ungated it took back a third of the re-apply win:

| | check ungated | gated, as shipped |
|---|---|---|
| re-apply 200 views, nothing changed | -30% | **-4%** |
| toggle a class on 200 views | -24% | **-6%** |
| toggle a pseudo class on 200 views | -23% | **-1%** |

Restoring `mayMatch` is what the attribute-scoped paths pay for (about 20% against `main` under the same conditions, nothing measurable with the optimizing compilers on). That is the price of those rules applying at all, and as the first table shows it still leaves them ahead of where they started.

This PR also adds `VITEST_NO_OPT=1`, which runs the vitest worker with `--max-opt=0`. That is what `--jitless` does to javascript without also disabling the WebAssembly vite needs; plain `--no-opt` only drops turbofan and measures almost nothing on current node.

## Tests

`css-attribute-match.spec.ts` and `css-state-recovery.spec.ts`, 12 tests — 10 of them fail without these changes. They cover the attribute landing on the view, on an ancestor, and arriving before a dynamic update; and the local-value release for a longhand, for both shorthand and longhand `margin`/`padding`, for a local value set before css ran, for `applyInlineStyle`, and across a full re-match. One test pins that idle updates still write nothing, inherited values and shorthand-unset longhands included.

`css-selector.spec.ts` keeps its assertion that a node without the attribute is not styled, now against `match()` rather than the removed candidate pruning.

455 core unit tests pass and `nx run core:build` is clean.
