### PR TITLE
fix(vite): settings-only pnpm-workspace.yaml is not a monorepo root marker

### DIFF
--- a/.github/workflows/secure_nx_release.yml
+++ b/.github/workflows/secure_nx_release.yml
@@ -295,74 +295,6 @@ jobs:
         if: ${{ steps.ctx.outputs.mode == 'dispatch' && !inputs.dry-run }}
         run: git push --atomic --follow-tags origin HEAD
 
-      # Nx only writes CHANGELOG.md files (nx.json release.changelog has no createRelease),
-      # so GitHub releases are posted here. This must stay after the push above: creating a
-      # release for a tag GitHub doesn't have yet would auto-create that tag from the wrong
-      # commit and make the push non-fast-forward.
-      - name: Create GitHub releases (dispatch)
-        if: ${{ steps.ctx.outputs.mode == 'dispatch' && !inputs.dry-run }}
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          tags=$(git tag --points-at HEAD)
-          if [[ -z "$tags" ]]; then
-            echo "No release tags on HEAD; skipping GitHub release creation."
-            exit 0
-          fi
-
-          projects=$(npx nx show projects --projects "packages/*" --type lib --exclude "ui-mobile-base,types-minimal,winter-tc,types,types-ios,types-android" --sep ' ')
-
-          for tag in $tags; do
-            # Tag format is {version}-{projectName} (nx.json releaseTag.pattern); take the
-            # longest project suffix so project names containing '-' resolve correctly.
-            best_match=""
-            best_len=0
-            for p in $projects; do
-              suffix="-${p}"
-              if [[ "$tag" == *"$suffix" ]] && (( ${#p} > best_len )); then
-                best_match="$p"
-                best_len=${#p}
-              fi
-            done
-            if [[ -z "$best_match" ]]; then
-              echo "Skipping tag '$tag' (no matching release project)."
-              continue
-            fi
-
-            version="${tag%-$best_match}"
-            root=$(npx nx show project "$best_match" --json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).root))')
-            pkg=$(node -e "console.log(require('./${root}/package.json').name)")
-
-            if gh release view "$tag" --json id --jq .id >/dev/null 2>&1; then
-              echo "Release for '$tag' already exists; skipping."
-              continue
-            fi
-
-            notes_file="$(mktemp)"
-            awk -v h="## ${version} (" 'index($0, h) == 1 {found=1; next} /^## / {if (found) exit} found' "${root}/CHANGELOG.md" > "$notes_file"
-
-            flags=(--verify-tag --title "${pkg}@${version}")
-            if [[ "$version" == *-* ]]; then
-              flags+=(--prerelease)
-            elif [[ "$best_match" == "core" ]]; then
-              # The repo's Latest badge stays on stable core releases; other packages
-              # must not claim it just by being published later.
-              flags+=(--latest)
-            else
-              flags+=(--latest=false)
-            fi
-            if [[ -s "$notes_file" ]]; then
-              flags+=(--notes-file "$notes_file")
-            else
-              flags+=(--generate-notes)
-            fi
-
-            gh release create "$tag" "${flags[@]}"
-          done
-
       - name: nx release version + changelog (dispatch, dry-run)
         if: ${{ steps.ctx.outputs.mode == 'dispatch' && inputs.dry-run }}
         shell: bash
@@ -552,6 +484,103 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           npx nx release publish --projects "${{ steps.taginfo.outputs.project }}" --tag "${{ steps.taginfo.outputs.dist_tag }}" --access public --verbose
+
+      # Nx only writes CHANGELOG.md files (nx.json release.changelog has no createRelease),
+      # so GitHub releases are posted here. This must run after the tag push (creating a
+      # release for a tag GitHub doesn't have yet would auto-create it from the wrong
+      # commit) and after npm publish (so a GitHub API failure cannot block publishing —
+      # a red run here means only the release/docs steps need manual recovery).
+      - name: Create GitHub releases (dispatch)
+        if: ${{ steps.ctx.outputs.mode == 'dispatch' && !inputs.dry-run }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          tags=$(git tag --points-at HEAD)
+          if [[ -z "$tags" ]]; then
+            echo "No release tags on HEAD; skipping GitHub release creation."
+            exit 0
+          fi
+
+          projects=$(npx nx show projects --projects "packages/*" --type lib --exclude "ui-mobile-base,types-minimal,winter-tc,types,types-ios,types-android" --sep ' ')
+
+          for tag in $tags; do
+            # Tag format is {version}-{projectName} (nx.json releaseTag.pattern); take the
+            # longest project suffix so project names containing '-' resolve correctly.
+            best_match=""
+            best_len=0
+            for p in $projects; do
+              suffix="-${p}"
+              if [[ "$tag" == *"$suffix" ]] && (( ${#p} > best_len )); then
+                best_match="$p"
+                best_len=${#p}
+              fi
+            done
+            if [[ -z "$best_match" ]]; then
+              echo "Skipping tag '$tag' (no matching release project)."
+              continue
+            fi
+
+            version="${tag%-$best_match}"
+            root=$(npx nx show project "$best_match" --json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).root))')
+            pkg=$(node -e "console.log(require('./${root}/package.json').name)")
+
+            if gh release view "$tag" --json id --jq .id >/dev/null 2>&1; then
+              echo "Release for '$tag' already exists; skipping."
+              continue
+            fi
+
+            notes_file="$(mktemp)"
+            awk -v h="## ${version} (" 'index($0, h) == 1 {found=1; next} /^## / {if (found) exit} found' "${root}/CHANGELOG.md" > "$notes_file"
+
+            flags=(--verify-tag --title "${pkg}@${version}")
+            if [[ "$version" == *-* ]]; then
+              flags+=(--prerelease)
+            elif [[ "$best_match" == "core" ]]; then
+              # The repo's Latest badge stays on stable core releases; other packages
+              # must not claim it just by being published later.
+              flags+=(--latest)
+            else
+              flags+=(--latest=false)
+            fi
+            if [[ -s "$notes_file" ]]; then
+              flags+=(--notes-file "$notes_file")
+            else
+              flags+=(--generate-notes)
+            fi
+
+            gh release create "$tag" "${flags[@]}"
+          done
+
+      # notify_docs_core_release.yml never fires for tags pushed by this workflow (GitHub
+      # suppresses workflow runs for pushes made with the default GITHUB_TOKEN), so the
+      # docs dispatch happens here. GITHUB_TOKEN cannot dispatch cross-repo:
+      # DOCS_DISPATCH_TOKEN must be a PAT with contents read/write on NativeScript/docs.
+      - name: Notify docs of stable core release (dispatch)
+        if: ${{ steps.ctx.outputs.mode == 'dispatch' && !inputs.dry-run }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          for tag in $(git tag --points-at HEAD); do
+            if [[ "$tag" == *-core ]]; then
+              version="${tag%-core}"
+              if [[ "$version" != *-* ]]; then
+                if [[ -z "${GH_TOKEN:-}" ]]; then
+                  echo "::error::DOCS_DISPATCH_TOKEN is not set; NativeScript/docs was NOT notified. Run the update-api-docs workflow there manually with version=${version}."
+                  exit 1
+                fi
+                echo "Dispatching core-release (${version}) to NativeScript/docs..."
+                gh api repos/NativeScript/docs/dispatches \
+                  -f event_type=core-release \
+                  -f "client_payload[version]=${version}"
+              fi
+            fi
+          done
 
       - name: Summary
         if: always()

--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 8.0.1-dev.0 (2026-08-31)
+
+### 🩹 Fixes
+
+- **vite:** settings-only pnpm-workspace.yaml is not a monorepo root marker ([25a16ea39](https://github.com/NativeScript/NativeScript/commit/25a16ea39))
+
+### ❤️ Thank You
+
+- Nathan Walker
+
 # 8.0.0 (2026-08-27)
 
 ### 🚀 Features

--- a/packages/vite/helpers/project.spec.ts
+++ b/packages/vite/helpers/project.spec.ts
@@ -73,6 +73,32 @@ describe('findMonorepoWorkspaceRoot', () => {
 		}
 	});
 
+	it('walks past a settings-only pnpm-workspace.yaml (no packages key) to the real root', () => {
+		const { root, cleanup } = createTempTree();
+		try {
+			const appDir = join(root, 'apps', 'a');
+			mkdirSync(appDir, { recursive: true });
+			writeFileSync(join(root, 'nx.json'), '{}');
+			// pnpm >= 10 settings file pinning install behavior for the app only.
+			writeFileSync(join(appDir, 'pnpm-workspace.yaml'), 'nodeLinker: hoisted\nignoreScripts: true\n');
+			expect(findMonorepoWorkspaceRoot(appDir)).toBe(root);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('does not treat a settings-only pnpm-workspace.yaml as a workspace root by itself', () => {
+		const { root, cleanup } = createTempTree();
+		try {
+			const appDir = join(root, 'apps', 'a');
+			mkdirSync(appDir, { recursive: true });
+			writeFileSync(join(root, 'pnpm-workspace.yaml'), 'nodeLinker: hoisted\n');
+			expect(findMonorepoWorkspaceRoot(appDir)).toBe(null);
+		} finally {
+			cleanup();
+		}
+	});
+
 	it('detects npm/yarn workspace via package.json#workspaces', () => {
 		const { root, cleanup } = createTempTree();
 		try {

--- a/packages/vite/helpers/project.ts
+++ b/packages/vite/helpers/project.ts
@@ -76,13 +76,31 @@ function denoConfigHasWorkspace(dir: string): boolean {
  *  - `turbo.json`     (Turborepo)
  *  - `deno.json` / `deno.jsonc` containing a `workspace` field
  *  - `package.json` containing a `workspaces` field (npm/yarn workspaces)
+ *
+ * `pnpm-workspace.yaml` counts only when it declares a top-level `packages:`
+ * list. pnpm >= 10 uses the file as its general settings file, so a nested
+ * project can legitimately carry a settings-only one (e.g. to pin its own
+ * install behavior inside a hoisted monorepo) without being a workspace root.
  */
+function pnpmWorkspaceDeclaresPackages(filePath: string): boolean {
+	if (!existsSync(filePath)) return false;
+	try {
+		return /^packages\s*:/m.test(readFileSync(filePath, 'utf-8'));
+	} catch {
+		return false;
+	}
+}
+
 export function findMonorepoWorkspaceRoot(start: string = getProjectRootPath()): string | null {
 	let current = resolve(start);
 	while (true) {
 		for (const marker of MONOREPO_WORKSPACE_MARKERS) {
 			if (marker.startsWith('deno.')) {
 				if (denoConfigHasWorkspace(current)) return current;
+				continue;
+			}
+			if (marker.startsWith('pnpm-workspace.')) {
+				if (pnpmWorkspaceDeclaresPackages(join(current, marker))) return current;
 				continue;
 			}
 			if (existsSync(join(current, marker))) return current;

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nativescript/vite",
-	"version": "8.0.0",
+	"version": "8.0.1-dev.0",
 	"description": "Vite for NativeScript",
 	"main": "./index.js",
 	"module": "./index.js",


### PR DESCRIPTION
npm >= 10 uses pnpm-workspace.yaml as its general settings file, so a nested app can carry one that only pins install behavior (nodeLinker, ignoreScripts, ...) inside a hoisted monorepo. Treating any pnpm-workspace.yaml as a workspace root made findMonorepoWorkspaceRoot stop at such an app dir: the vendor collector skipped its workspace-root dependency merge (hoisted deps never made the vendor manifest) and /ns/m/ hoisted-module serving 404'd on packages living in the real root's node_modules, failing device boot. Only a file declaring a top-level `packages:` list counts as a root marker now; settings-only files are walked past.
