### PR TITLE
fix(core): scene session discard no longer retires a live window

### DIFF
--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -541,6 +541,36 @@ export class ApplicationCommon {
 	}
 
 	/**
+	 * @internal - retire the windows behind discarded window-session ids.
+	 *
+	 * A session id can only stand in for a window whose native surface is already gone.
+	 * iOS reports sessions discarded while the app was not running on the next launch,
+	 * and such an id can name the session driving the app now, so an id match alone is
+	 * no evidence that the window is finished with. Retiring an attached window tears
+	 * down the UI in use - its root view unloads and nothing ever reloads it - so only
+	 * detached windows are retired. Ids matching no window are ignored: they routinely
+	 * belong to windows this JS context has never seen.
+	 */
+	_retireDiscardedWindows(ids: string[]): void {
+		for (const id of ids) {
+			const nativeWindow = id ? this.getWindowById(id) : undefined;
+
+			if (!nativeWindow) {
+				continue;
+			}
+
+			if (nativeWindow.state === 'attached') {
+				Trace.write(`Ignoring a discarded session for window '${id}': its surface is still attached.`, Trace.categories.NativeLifecycle, Trace.messageType.warn);
+
+				continue;
+			}
+
+			nativeWindow._notifyEvent(NativeWindowEvents.close);
+			this._unregisterWindow(nativeWindow);
+		}
+	}
+
+	/**
 	 * @internal - Unregister a NativeWindow when its native surface is gone for good.
 	 */
 	_unregisterWindow(nativeWindow: NativeWindow): void {

--- a/packages/core/application/application-common.ts
+++ b/packages/core/application/application-common.ts
@@ -574,6 +574,10 @@ export class ApplicationCommon {
 	 * @internal - Unregister a NativeWindow when its native surface is gone for good.
 	 */
 	_unregisterWindow(nativeWindow: NativeWindow): void {
+		if (!nativeWindow._surfaceGone) {
+			Trace.write(`Unregistering window '${nativeWindow.id}' while its native surface is still live. A window may only be retired once the platform has reported the surface gone.`, Trace.categories.NativeLifecycle, Trace.messageType.error);
+		}
+
 		const idx = this._windows.indexOf(nativeWindow);
 		if (idx >= 0) {
 			this._windows.splice(idx, 1);

--- a/packages/core/application/application-registry.spec.ts
+++ b/packages/core/application/application-registry.spec.ts
@@ -112,6 +112,15 @@ describe('ApplicationCommon window registry', () => {
 		setActiveWindow(undefined);
 	});
 
+	/**
+	 * Retires a window the way a platform does: the disconnect callback records that the
+	 * surface is gone, and only then is the window unregistered.
+	 */
+	function retire(window: WindowBase): void {
+		window._surfaceGone = true;
+		app._unregisterWindow(asWindow(window));
+	}
+
 	function record(...eventNames: string[]): Array<{ eventName: string; window: WindowBase }> {
 		const recorded: Array<{ eventName: string; window: WindowBase }> = [];
 		for (const eventName of eventNames) {
@@ -224,7 +233,7 @@ describe('ApplicationCommon window registry', () => {
 			app._registerWindow(window);
 			const recorded = record('windowClose');
 
-			app._unregisterWindow(window);
+			retire(window);
 
 			expect(recorded.map((entry) => entry.window)).toEqual([window]);
 			expect(app.getWindows()).toEqual([]);
@@ -244,7 +253,7 @@ describe('ApplicationCommon window registry', () => {
 			detached._detach();
 
 			const recorded = record('windowClose', 'primaryWindowChanged');
-			app._unregisterWindow(primary);
+			retire(primary);
 
 			expect(events).toEqual(['windowClose', 'primaryWindowChanged']);
 			expect(recorded[1].window).toBe(successor);
@@ -261,7 +270,7 @@ describe('ApplicationCommon window registry', () => {
 			detached._detach();
 
 			record('windowClose', 'primaryWindowChanged');
-			app._unregisterWindow(primary);
+			retire(primary);
 
 			expect(events).toEqual(['windowClose']);
 			expect(primary.isPrimary).toBe(false);
@@ -275,7 +284,7 @@ describe('ApplicationCommon window registry', () => {
 			app._registerWindow(secondary);
 
 			record('windowClose', 'primaryWindowChanged');
-			app._unregisterWindow(secondary);
+			retire(secondary);
 
 			expect(events).toEqual(['windowClose']);
 			expect(app.primaryWindow).toBe(primary);
@@ -308,7 +317,7 @@ describe('ApplicationCommon window registry', () => {
 		it('falls back to the primary window once the active one closes', () => {
 			secondary._notifyEvent(NativeWindowEvents.activate);
 
-			app._unregisterWindow(secondary);
+			retire(secondary);
 
 			expect(app.activeWindow).toBe(primary);
 		});

--- a/packages/core/application/application-registry.spec.ts
+++ b/packages/core/application/application-registry.spec.ts
@@ -320,4 +320,80 @@ describe('ApplicationCommon window registry', () => {
 			expect(app.activeWindow).toBe(primary);
 		});
 	});
+
+	describe('discarded window sessions', () => {
+		let attached: TestWindow;
+		let detached: TestWindow;
+
+		beforeEach(() => {
+			attached = new TestWindow('scene-live', true).withContent();
+			detached = new TestWindow('scene-gone').withContent();
+
+			app._registerWindow(attached);
+			app._registerWindow(detached);
+
+			detached._detach();
+		});
+
+		it('retires a window whose surface is already gone', () => {
+			record('windowClose');
+
+			// The window drops its listeners in `_destroy`, so a listener only sees `close`
+			// if it is raised before the window is unregistered.
+			let closed = false;
+			detached.on(NativeWindowEvents.close, () => {
+				closed = true;
+			});
+
+			app._retireDiscardedWindows(['scene-gone']);
+
+			expect(app.getWindowById('scene-gone')).toBeUndefined();
+			expect(closed).toBe(true);
+			expect(events).toEqual(['windowClose']);
+		});
+
+		/**
+		 * iOS reports sessions discarded in an earlier run on the next launch, and such an
+		 * id can name the session driving the app now. Retiring on the id alone would unload
+		 * the live root view and every frame under it, and nothing reloads a root view whose
+		 * window has left the registry - navigation then queues forever behind `Frame.isLoaded`.
+		 */
+		it('leaves an attached window alone when a discarded id names it', () => {
+			const rootView = attached.rootView as any;
+			let unloaded = false;
+
+			rootView.isLoaded = true;
+			rootView.callUnloaded = () => {
+				unloaded = true;
+			};
+
+			app._retireDiscardedWindows(['scene-live']);
+
+			expect(app.getWindowById('scene-live')).toBe(attached);
+			expect(attached.state).toBe('attached');
+			expect(unloaded).toBe(false);
+			expect(events).toEqual([]);
+		});
+
+		it('ignores ids that match no window', () => {
+			record('windowClose');
+
+			app._retireDiscardedWindows(['scene-never-seen']);
+
+			expect(app.getWindows()).toEqual([attached, detached]);
+			expect(events).toEqual([]);
+		});
+
+		it('retires every detached window named in one discard', () => {
+			const alsoDetached = new TestWindow('scene-gone-too').withContent();
+			app._registerWindow(alsoDetached);
+			alsoDetached._detach();
+
+			app._retireDiscardedWindows(['scene-gone', 'scene-live', 'scene-gone-too']);
+
+			expect(app.getWindowById('scene-gone')).toBeUndefined();
+			expect(app.getWindowById('scene-gone-too')).toBeUndefined();
+			expect(app.getWindowById('scene-live')).toBe(attached);
+		});
+	});
 });

--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -153,6 +153,8 @@ function initNativeScriptLifecycleCallbacks() {
 				// there and wedging the app as never-suspended.
 				Application.android._setWindowActive(nativeWindow, false, activity);
 
+				nativeWindow._surfaceGone = true;
+
 				// A destroyed activity only ends the window session when it is finishing —
 				// otherwise Android is recreating it and the same window is reused.
 				const isClosing = activity.isFinishing();

--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -469,6 +469,8 @@ class SceneDelegate extends UIResponder implements UIWindowSceneDelegate {
 		Application.ios._setWindowInForeground(nativeWindow, false, windowScene);
 
 		if (nativeWindow) {
+			nativeWindow._surfaceGone = true;
+
 			// A disconnect only ends the window session when the app asked for it —
 			// otherwise iOS may reconnect the same session later. A window with no session
 			// identity is the exception: a reconnect could never be matched back to it.

--- a/packages/core/application/application.ios.ts
+++ b/packages/core/application/application.ios.ts
@@ -1386,8 +1386,8 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 	// --- NativeWindow registry ---
 
 	/**
-	 * @internal - iOS reports discarded sessions for windows this JS context may never
-	 * have seen (they can arrive on a later launch), so unknown ids are ignored.
+	 * @internal - hands the discarded sessions' ids to the window registry, which decides
+	 * which of them name a window that is actually finished with.
 	 */
 	_onSceneSessionsDiscarded(sessions: NSSet<UISceneSession>): void {
 		const all = sessions?.allObjects;
@@ -1395,16 +1395,17 @@ export class iOSApplication extends ApplicationCommon implements IiOSApplication
 			return;
 		}
 
+		const ids: string[] = [];
+
 		for (let i = 0; i < all.count; i++) {
 			const persistentIdentifier = all.objectAtIndex(i)?.persistentIdentifier;
-			const nativeWindow = persistentIdentifier ? this.getWindowById(`${persistentIdentifier}`) : undefined;
-			if (!nativeWindow) {
-				continue;
-			}
 
-			nativeWindow._notifyEvent(NativeWindowEvents.close);
-			this._unregisterWindow(nativeWindow);
+			if (persistentIdentifier) {
+				ids.push(`${persistentIdentifier}`);
+			}
 		}
+
+		this._retireDiscardedWindows(ids);
 	}
 
 	/**

--- a/packages/core/native-window/native-window-common.ts
+++ b/packages/core/native-window/native-window-common.ts
@@ -415,6 +415,8 @@ export abstract class NativeWindow extends WindowBase {
 	 * this window for the same reason — it is still this window's content.
 	 */
 	_detach(): void {
+		this._surfaceGone = true;
+
 		// Take a final reading while the surface can still answer and the root view is
 		// still up: from here on these are what the window reports.
 		this.orientation();

--- a/packages/core/native-window/native-window.ios.spec.ts
+++ b/packages/core/native-window/native-window.ios.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { IOSNativeWindow } from './native-window.ios';
+
+function sceneWithSession(persistentIdentifier?: string): any {
+	return persistentIdentifier ? { session: { persistentIdentifier } } : { session: {} };
+}
+
+const uiWindow: any = {};
+
+/**
+ * The flag decides whether a disconnect detaches the window for a later reconnect or ends
+ * it outright, so it has to mean "this id came from the scene's session" and nothing looser.
+ */
+describe('IOSNativeWindow session identity', () => {
+	it('recognises an id taken from the scene session', () => {
+		const window = new IOSNativeWindow(sceneWithSession('ABC-123'), uiWindow, 'ABC-123');
+
+		expect(window._hasSessionIdentity).toBe(true);
+	});
+
+	it('rejects a hand-minted id even when the window has a scene', () => {
+		const window = new IOSNativeWindow(sceneWithSession('ABC-123'), uiWindow, 'embedded-main');
+
+		expect(window._hasSessionIdentity).toBe(false);
+	});
+
+	it('rejects a hand-minted id on a window with no scene', () => {
+		const window = new IOSNativeWindow(undefined, uiWindow, 'main');
+
+		expect(window._hasSessionIdentity).toBe(false);
+	});
+
+	it('rejects a scene whose session carries no persistent identifier', () => {
+		const window = new IOSNativeWindow(sceneWithSession(), uiWindow);
+
+		expect(window._hasSessionIdentity).toBe(false);
+		expect(window.id).toMatch(/^window-\d+$/);
+	});
+});

--- a/packages/core/native-window/native-window.ios.ts
+++ b/packages/core/native-window/native-window.ios.ts
@@ -29,7 +29,12 @@ export class IOSNativeWindow extends NativeWindow {
 
 	constructor(scene: UIWindowScene | undefined, window: UIWindow, id?: string, isPrimary = false, role: WindowRole = 'application') {
 		super(id, isPrimary, role);
-		this._hasSessionIdentity = !!id;
+
+		// Only an id taken from the scene's session can be matched back to that session.
+		// Hand-minted ids ('main', 'embedded-main') are ids all the same, so their mere
+		// presence says nothing.
+		const sessionId = scene?.session?.persistentIdentifier;
+		this._hasSessionIdentity = !!sessionId && id === `${sessionId}`;
 		this._scene = scene;
 		this._window = window;
 	}

--- a/packages/core/native-window/window-base.spec.ts
+++ b/packages/core/native-window/window-base.spec.ts
@@ -189,6 +189,17 @@ describe('WindowBase lifecycle', () => {
 		expect(events).toEqual(['attached', 'detached', 'attached', 'close', 'deactivate']);
 	});
 
+	it('records the surface as gone on detach and clears it on re-attach', () => {
+		const window = new TestWindow();
+		expect(window._surfaceGone).toBe(false);
+
+		window._detach();
+		expect(window._surfaceGone).toBe(true);
+
+		window._setState('attached');
+		expect(window._surfaceGone).toBe(false);
+	});
+
 	it('keeps listeners through a detach so a re-attached window still notifies them', () => {
 		const window = new TestWindow();
 		const events: string[] = [];

--- a/packages/core/native-window/window-base.ts
+++ b/packages/core/native-window/window-base.ts
@@ -35,6 +35,15 @@ export abstract class WindowBase extends Observable {
 	private _state: WindowState = 'attached';
 	private _isPrimary: boolean;
 
+	/**
+	 * @internal – whether the native surface behind this window is known to be gone.
+	 *
+	 * Only the platform's disconnect callback can establish this, and {@link state} cannot
+	 * stand in for it: a disconnect that ends the session unregisters the window while it is
+	 * still `attached`, so an attached window is not necessarily a live one.
+	 */
+	_surfaceGone = false;
+
 	constructor(id?: string, isPrimary = false, role: WindowRole = 'application') {
 		super();
 		this._id = id || `window-${++_windowIdCounter}`;
@@ -69,6 +78,12 @@ export abstract class WindowBase extends Observable {
 	 * @internal
 	 */
 	_setState(value: WindowState): void {
+		// A window only ever attaches to a surface that exists, so attaching is what clears
+		// the record of the previous one going away.
+		if (value === 'attached') {
+			this._surfaceGone = false;
+		}
+
 		this._state = value;
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. (Found while debugging an app on `9.1.1-next.0`; no issue filed.)
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing.
- [x] Tests for the changes are included.

## What is the current behavior?

`application:didDiscardSceneSessions:` matches discarded sessions to windows by `persistentIdentifier` alone:

```ts
const persistentIdentifier = all.objectAtIndex(i)?.persistentIdentifier;
const nativeWindow = persistentIdentifier ? this.getWindowById(`${persistentIdentifier}`) : undefined;
if (!nativeWindow) continue;

nativeWindow._notifyEvent(NativeWindowEvents.close);
this._unregisterWindow(nativeWindow);
```

UIKit delivers this callback shortly after launch for sessions the user closed while the app was not running. On such a launch the reported id can name the session that is driving the app right now, so the lookup returns the **live** window and the discard destroys it.

The consequences are silent and fatal to navigation:

- `_unregisterWindow()` ends in `_destroy()` → `_onDestroy()` → `rootView.callUnloaded()`. The root view unloads, cascading through `onUnloaded` → `eachChild` into every `Frame` beneath it.
- `Frame._processNextNavigationEntry()` early-returns on `!this.isLoaded`, so every subsequent `navigate()` sits in `_navigationQueue` forever. In an Angular app the router still reports `NavigationEnd` normally, so the app logs a successful route change while the screen never updates.
- There is no recovery. `sceneDidBecomeActive` reloads the root view via `nativeWindow?.rootView`, but the window has left `_windows`, so `_getWindowForScene()` returns `undefined` and neither `callLoaded()` nor `setActiveWindow()` ever runs again.

It presents as an intermittent hang on the first screen, since it depends on whether iOS has a stale discarded session to report at launch.

Captured on a real app — the stack that destroys the live window, moments after the frame had loaded and navigated normally:

```
SceneDelegate.sceneWillEnterForeground window=resolved
callUnloaded <RootLayout> was=true
    at IOSNativeWindow._onDestroy
    at IOSNativeWindow._destroy
    at iOSApplication._unregisterWindow
    at iOSApplication._onSceneSessionsDiscarded
```

and the resulting wedge, with nothing in flight to unblock it:

```
Frame.navigate                        loaded=false executing=none queue=0
Frame._processNextNavigationEntry     BLOCKED loaded=false executing=none queue=1
SceneDelegate.sceneDidBecomeActive    window=UNRESOLVED
```

## What UIKit documents

Both halves of the precondition are Apple's documented behavior, not inference — from [`application(_:didDiscardSceneSessions:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:diddiscardscenesessions:)):

> When the user removes a scene from the app switcher, UIKit calls this method before discarding the scene's associated session object altogether. […] **If your app isn't running, UIKit calls this method the next time your app launches.**

> UIKit calls this method **only when dismissing scenes permanently**. It doesn't call it when the system disconnects a scene to free up memory. Memory reclamation deletes the scene objects, but **preserves the sessions** associated with those scenes.

That second paragraph is the contract the fix keys on, and it maps exactly onto the split core already implements: memory reclamation disconnects a scene and preserves its session, which is `_detach()`; permanent dismissal discards it, which is a retire. A discard therefore always follows the surface going away, which is why `state !== 'attached'` is an invariant rather than a heuristic.

Worth noting what is *not* documented: [`persistentIdentifier`](https://developer.apple.com/documentation/uikit/uiscenesession/persistentidentifier) is specified only as "a unique identifier that persists **for the lifetime of the session**". Uniqueness is scoped to that lifetime, and nothing is said either way about reuse once a session is destroyed — so treating an id match alone as proof that a window is finished with was relying on a guarantee UIKit never gave.

## What is the new behavior?

A session id only ever stands in for a window whose native surface is already gone. That is exactly what `sceneDidDisconnect` guarantees: a window carrying a session identity is `_detach()`ed rather than unregistered, precisely so a later reconnect *or discard* can find it. Retiring an `attached` window was therefore never an intended outcome.

Id matching now lives in `ApplicationCommon._retireDiscardedWindows(ids)`, which retires detached windows only and traces when it declines an attached one. `_onSceneSessionsDiscarded` is reduced to extracting the identifiers, which also makes the rule unit-testable without UIKit — the iOS delegate itself cannot be loaded under vitest.

Both new assertions fail against the previous behavior and pass with the fix; the rest of `packages/core` (478 tests) is unaffected.

## Two further lifecycle fixes in this PR

Both came out of reviewing the above; each is a separate commit.

**`_hasSessionIdentity` must reflect where the id came from** (`native-window.ios.ts`). It was set from `!!id`, true for the hand-minted `'main'` and `'embedded-main'` ids as much as for a real `persistentIdentifier` - contradicting the field's own documentation ("whether the id comes from a scene session identity"). This is a live leak rather than a cosmetic one: `'embedded-main'` is constructed with the host's `windowScene`, so `_getWindowForScene()` can reach it; on disconnect `isClosing = _closeRequested || !_hasSessionIdentity` then evaluated false, and the window detached to await a reconnect that can never be matched back to an id no session will ever report. The window and its listeners leak for the life of the process. (`'main'` is built with `scene: undefined`, so the scene lookup cannot reach it - latent there, live for embedded.)

**A window may only be retired once its surface is gone.** The guard in the first commit protects one call site; the invariant it enforces is general - `_unregisterWindow()` will destroy a window whose surface is live for any caller, unload its root view, and leave nothing able to reload it. It cannot simply reject `attached` windows, because the closing branch of a disconnect legitimately unregisters one. So the fact is now recorded where the platform actually observes it - `sceneDidDisconnect` on iOS, activity destruction on Android, and `_detach()` for both - cleared on re-attach via `_setState('attached')`, and its absence at `_unregisterWindow()` traces an error. This subsumes the discard-before-disconnect ordering as well: such a discard would leave the window parked as `detached` forever, and the same fact is what a follow-up would key on.

Existing registry specs now retire windows through a small helper that models the platform close, so the new diagnostic fires nowhere in the suite - each of the three fixes is verified to fail without its change (5 assertions across the three).

Not addressed here, but adjacent and worth follow-ups:
- Root-view load state has no single owner: it is reconciled at three independent sites (`sceneDidBecomeActive` loads, `sceneDidEnterBackground` unloads, `_detach`/`_onDestroy` unload) with nothing answering "should this window's root view be loaded right now?". That absence is what made the original bug unrecoverable rather than merely wrong.
- `_detach()` resets the root view and leaves `_rootView` set, so a later `_onDestroy()` resets it a second time; the two are also asymmetric (`_detach` calls `_tearDownUI(true)`, `_onDestroy` does not).
- `setActiveWindow` only fires on `sceneDidBecomeActive` - well after first render - so `getActiveWindow()` is `undefined` for the whole early boot and every `Frame.topmost()` in that window silently takes the "belongs to no window" fallback.
- `Frame._processNextNavigationEntry()` returning early with a non-empty `_navigationQueue` is always worth tracing; it is the symptom anyone hitting this actually sees.
