### PR TITLE
fix(core): getRandomValues fills the caller's typed array on iOS

### DIFF
--- a/packages/core/references.d.ts
+++ b/packages/core/references.d.ts
@@ -2,6 +2,7 @@
 /// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!CFNetwork.d.ts" />
 /// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!CoreText.d.ts" />
 /// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!Darwin.d.ts" />
+/// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!Security.d.ts" />
 /// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!_DarwinFoundation1.d.ts" />
 /// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!_DarwinFoundation2.d.ts" />
 /// <reference path="../types-ios/src/lib/ios/objc-x86_64/objc!_DarwinFoundation3.d.ts" />

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -53,6 +53,14 @@ global.NSData = {
 	},
 };
 global.NSMutableData = { ...global.NSData };
+// Security's CSPRNG entry point, which the crypto shim feeds a typed array directly. The stub
+// fills it so specs can prove the bytes reach the caller's own view, and records the call.
+global.errSecSuccess = 0;
+global.kSecRandomDefault = { native: 'kSecRandomDefault' };
+global.SecRandomCopyBytes = (rnd: any, count: number, bytes: Uint8Array) => {
+	bytes.fill(0xab);
+	return 0;
+};
 global.NSCCrypto = {
 	randomUUID() {
 		return 'native-uuid';

--- a/packages/core/wgc/crypto/index.spec.ts
+++ b/packages/core/wgc/crypto/index.spec.ts
@@ -30,39 +30,82 @@ describe('Crypto.getRandomValues', () => {
 });
 
 describe('Crypto.getRandomValues (iOS)', () => {
-	// The bytes belong to V8's BackingStore. freeWhenDone:NO is what keeps Foundation from
-	// freeing an allocation that V8's ArrayBufferSweeper also frees.
-	it('wraps the buffer without donating ownership to Foundation', () => {
+	/** Runs `fn` and returns the arguments SecRandomCopyBytes received. */
+	function captureSecRandom(fn: () => void) {
+		const spy = vi.spyOn(globalThis as any, 'SecRandomCopyBytes');
+
+		try {
+			fn();
+			expect(spy).toHaveBeenCalledTimes(1);
+
+			return spy.mock.calls[0] as any[];
+		} finally {
+			spy.mockRestore();
+		}
+	}
+
+	// The view itself goes to Security: the runtime resolves it to V8's backing store at the
+	// view's byte offset, so the fill lands in the caller's array with nothing in between.
+	it('hands a byte view straight to SecRandomCopyBytes and the bytes land in it', () => {
 		const bytes = new Uint8Array(16);
-		const data = captureNativeCall((globalThis as any).NSCCrypto, () => crypto.getRandomValues(bytes));
+		const [rnd, count, target] = captureSecRandom(() => crypto.getRandomValues(bytes));
 
-		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
-		expect(data.args[0]).toBe(bytes);
-		expect(data.args[1]).toBe(16);
-		expect(data.args[2]).toBe(false);
+		expect(rnd).toBe((globalThis as any).kSecRandomDefault);
+		expect(count).toBe(16);
+		expect(target).toBe(bytes);
+		expect(Array.from(bytes)).toEqual(new Array(16).fill(0xab));
 	});
 
-	it('wraps only the view window of an offset byte view', () => {
-		const view = new Uint8Array(new ArrayBuffer(32), 4, 10);
-		const data = captureNativeCall((globalThis as any).NSCCrypto, () => crypto.getRandomValues(view));
-
-		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
-		expect(data.args[0]).toBe(view);
-		expect(data.args[1]).toBe(10);
-		expect(data.args[2]).toBe(false);
-	});
-
-	it('wraps only the view window of a non-byte typed array', () => {
+	it('fills only the window of an offset byte view', () => {
 		const buffer = new ArrayBuffer(32);
-		const data = captureNativeCall((globalThis as any).NSCCrypto, () => crypto.getRandomValues(new Uint32Array(buffer, 8, 2)));
-		const wrapped = data.args[0] as Uint8Array;
+		const view = new Uint8Array(buffer, 4, 10);
+		const [, count, target] = captureSecRandom(() => crypto.getRandomValues(view));
 
-		expect(data.selector).toBe('dataWithBytesNoCopyLengthFreeWhenDone');
-		expect(wrapped.buffer).toBe(buffer);
-		expect(wrapped.byteOffset).toBe(8);
-		expect(wrapped.byteLength).toBe(8);
-		expect(data.args[1]).toBe(8);
-		expect(data.args[2]).toBe(false);
+		expect(count).toBe(10);
+		expect(target).toBe(view);
+		const all = new Uint8Array(buffer);
+		expect(Array.from(all.subarray(0, 4))).toEqual([0, 0, 0, 0]);
+		expect(Array.from(all.subarray(4, 14))).toEqual(new Array(10).fill(0xab));
+		expect(Array.from(all.subarray(14))).toEqual(new Array(18).fill(0));
+	});
+
+	it('reinterprets a non-byte typed array over its window only', () => {
+		const buffer = new ArrayBuffer(32);
+		const words = new Uint32Array(buffer, 8, 2);
+		const [, count, target] = captureSecRandom(() => crypto.getRandomValues(words));
+
+		expect(count).toBe(8);
+		expect(target).toBeInstanceOf(Uint8Array);
+		expect(target.buffer).toBe(buffer);
+		expect(target.byteOffset).toBe(8);
+		expect(target.byteLength).toBe(8);
+		expect(Array.from(words)).toEqual([0xabababab, 0xabababab]);
+	});
+
+	it('throws when Security reports a failure', () => {
+		const spy = vi.spyOn(globalThis as any, 'SecRandomCopyBytes').mockReturnValue(-50);
+
+		try {
+			expect(() => crypto.getRandomValues(new Uint8Array(8))).toThrow(/SecRandomCopyBytes failed \(-50\)/);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	// NSMutableData copies bytes it does not own and frees ones it does, so no NSData wrapper
+	// can ever alias V8's memory: the shim must not route through the framework at all.
+	it('never wraps the bytes in NSData or calls the framework', () => {
+		const crypto_ = vi.spyOn((globalThis as any).NSCCrypto, 'getRandomValues');
+		const mutable = vi.spyOn((globalThis as any).NSMutableData, 'dataWithBytesNoCopyLengthFreeWhenDone');
+
+		try {
+			crypto.getRandomValues(new Uint8Array(8));
+			expect(crypto_).not.toHaveBeenCalled();
+			expect(mutable).not.toHaveBeenCalled();
+		} finally {
+			crypto_.mockRestore();
+			mutable.mockRestore();
+		}
 	});
 });
 

--- a/packages/core/wgc/crypto/index.ts
+++ b/packages/core/wgc/crypto/index.ts
@@ -26,11 +26,14 @@ export class Crypto {
 			(<any>org).nativescript.winter_tc.Crypto.getRandomValues(bytes);
 		}
 		if (__IOS__) {
-			// The pointer is V8-owned: freeWhenDone must stay NO, or Foundation and V8's
-			// ArrayBufferSweeper both free the same allocation.
-			const data = NSMutableData.dataWithBytesNoCopyLengthFreeWhenDone(bytes as never, bytes.byteLength, false);
-
-			NSCCrypto.getRandomValues(data);
+			// The view goes to Security directly: the runtime hands over V8's backing store at
+			// the view's byte offset, so the bytes land in the caller's array. No NSData may
+			// sit in between — NSMutableData copies bytes it does not own, so a no-copy wrapper
+			// fills a private copy, and one that owns them frees V8's allocation.
+			const status = SecRandomCopyBytes(kSecRandomDefault, bytes.byteLength, bytes);
+			if (status !== errSecSuccess) {
+				throw new Error(`getRandomValues: SecRandomCopyBytes failed (${status})`);
+			}
 		}
 
 		return typedArray;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

On iOS, `crypto.getRandomValues(typedArray)` returns the array unchanged: every byte stays zero. Any key, token, IV or nonce minted through it on the main thread or in a worker is all zeros.

The shim wraps V8's backing store in `NSMutableData.dataWithBytesNoCopy:length:freeWhenDone:` and lets `NSCCrypto.getRandomValues:` fill `mutableBytes`. `NSMutableData` does not adopt foreign bytes, regardless of the ownership flag (measured on macOS 15 and the iOS simulator; only the immutable `NSData` adopts them):

| Call | Adopts the caller's buffer? |
|---|---|
| `NSData dataWithBytesNoCopy:… freeWhenDone:NO` | yes |
| `NSMutableData dataWithBytesNoCopy:… freeWhenDone:NO` | no, copies on creation |
| `NSMutableData dataWithBytesNoCopy:… freeWhenDone:YES` | no, copies on creation and frees the original |

So `freeWhenDone:YES` (the previous code) filled a private copy and freed V8's allocation, which is the double-free that was fixed by switching to `NO`, and `NO` fills the same private copy and leaves the caller's array untouched. No `NSData`-based construction can make the native fill reach the typed array.

## What is the new behavior?

The iOS branch hands the typed array to `SecRandomCopyBytes` directly and checks the status. The runtime already passes an `ArrayBufferView` as its backing store pointer plus the view's byte offset (`tns::TryGetBufferFromArrayBuffer`), so the bytes land in the caller's own window with no intermediate object: zero copies and nothing for Foundation to own or free. A wider element type is still reinterpreted as a byte view over the same window.

`packages/core/references.d.ts` now references the Security framework typings. The Android branch is unchanged: the runtime maps the view to a direct `ByteBuffer` over the same window and the Java side fills it in place.

Specs assert that the very view reaches `SecRandomCopyBytes` with its byte length, that an offset view and a reinterpreted `Uint32Array` are filled within their window only and the bytes are visible through the caller's array, that a failure status throws, and that neither `NSMutableData` nor `NSCCrypto` is involved.

`NSCCrypto.getRandomValues:(NSMutableData *)` in NSCWinterTC is left as is; it is no longer used by core and its `NSMutableData` contract cannot alias caller memory, so it is a candidate for deprecation when the framework is next rebuilt.
