### PR TITLE
fix(core): insert iOS child views relative to their sibling, not by raw index

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -1270,11 +1270,7 @@ export class CustomLayoutView extends ContainerView {
 		const childNativeView: NativeScriptUIView = <NativeScriptUIView>child.nativeViewProtected;
 
 		if (parentNativeView && childNativeView) {
-			if (typeof atIndex !== 'number' || atIndex >= parentNativeView.subviews.count) {
-				parentNativeView.addSubview(childNativeView);
-			} else {
-				parentNativeView.insertSubviewAtIndex(childNativeView, atIndex);
-			}
+			IOSHelper.insertSubview(parentNativeView, childNativeView, atIndex);
 
 			// Add outer shadow layer manually as it belongs to parent layer tree (this is needed for reusable views)
 			if (childNativeView.outerShadowContainerLayer && !childNativeView.outerShadowContainerLayer.superlayer) {

--- a/packages/core/ui/core/view/view-helper/index.d.ts
+++ b/packages/core/ui/core/view/view-helper/index.d.ts
@@ -66,6 +66,11 @@ export namespace IOSHelper {
 	export function invalidateStatusBarAppearance(controller?: any /* UIViewController */, reason?: string): void;
 	export function updateAutoAdjustScrollInsets(controller: any /* UIViewController */, owner: View): void;
 	export function updateConstraints(controller: any /* UIViewController */, owner: View): void;
+	/**
+	 * Add `childNativeView` to `parentNativeView` at subview index `atIndex`, or append it when the index is absent or past the end.
+	 * Uses `insertSubview:belowSubview:` — `insertSubview:atIndex:` resolves the index against the layer's sublayers, which also hold non-view layers (gradient backgrounds, shadow layers).
+	 */
+	export function insertSubview(parentNativeView: any /* UIView */, childNativeView: any /* UIView */, atIndex?: number): void;
 	export function layoutView(controller: any /* UIViewController */, owner: View): void;
 	export function getPositionFromFrame(frame: any /* CGRect */): Position;
 	export function getFrameFromPosition(position: Position, insets?: Position): any; /* CGRect */

--- a/packages/core/ui/core/view/view-helper/index.ios.ts
+++ b/packages/core/ui/core/view/view-helper/index.ios.ts
@@ -312,6 +312,23 @@ export class IOSHelper {
 		return rootView.safeAreaLayoutGuide;
 	}
 
+	/**
+	 * Add `childNativeView` to `parentNativeView` at subview index `atIndex`, or
+	 * append it when the index is absent or past the end. Never done with
+	 * `insertSubview:atIndex:`: UIKit resolves that index against the layer's
+	 * sublayers, which also hold the non-view layers core installs (a gradient
+	 * background at sublayer 0, an outer shadow layer per shadowed child), so the
+	 * view lands below the sibling it should precede.
+	 */
+	static insertSubview(parentNativeView: UIView, childNativeView: UIView, atIndex?: number): void {
+		const subviews = parentNativeView.subviews;
+		if (typeof atIndex !== 'number' || atIndex >= subviews.count) {
+			parentNativeView.addSubview(childNativeView);
+		} else {
+			parentNativeView.insertSubviewBelowSubview(childNativeView, subviews.objectAtIndex(atIndex));
+		}
+	}
+
 	static layoutView(controller: UIViewController, owner: View): void {
 		let layoutGuide = controller.view.safeAreaLayoutGuide;
 		if (!layoutGuide) {

--- a/packages/core/ui/layouts/liquid-glass-container/index.ios.ts
+++ b/packages/core/ui/layouts/liquid-glass-container/index.ios.ts
@@ -1,6 +1,6 @@
 import type { NativeScriptUIView } from '../../utils';
 import { supportsGlass } from '../../../utils/constants';
-import { GlassEffectType, iosGlassEffectProperty, View } from '../../core/view';
+import { GlassEffectType, iosGlassEffectProperty, IOSHelper, View } from '../../core/view';
 import { LiquidGlassContainerCommon } from './liquid-glass-container-common';
 import { toUIGlassStyle } from '../liquid-glass';
 
@@ -39,11 +39,7 @@ export class LiquidGlassContainer extends LiquidGlassContainerCommon {
 		const childNativeView: NativeScriptUIView = <NativeScriptUIView>child.nativeViewProtected;
 
 		if (parentNativeView && childNativeView) {
-			if (typeof atIndex !== 'number' || atIndex >= parentNativeView.subviews.count) {
-				parentNativeView.addSubview(childNativeView);
-			} else {
-				parentNativeView.insertSubviewAtIndex(childNativeView, atIndex);
-			}
+			IOSHelper.insertSubview(parentNativeView, childNativeView, atIndex);
 
 			// Add outer shadow layer manually as it belongs to parent layer tree (this is needed for reusable views)
 			if (childNativeView.outerShadowContainerLayer && !childNativeView.outerShadowContainerLayer.superlayer) {

--- a/packages/core/ui/layouts/liquid-glass/index.ios.ts
+++ b/packages/core/ui/layouts/liquid-glass/index.ios.ts
@@ -1,6 +1,6 @@
 import type { NativeScriptUIView } from '../../utils';
 import { supportsGlass } from '../../../utils/constants';
-import { type GlassEffectType, type GlassEffectVariant, iosGlassEffectProperty, View } from '../../core/view';
+import { type GlassEffectType, type GlassEffectVariant, iosGlassEffectProperty, IOSHelper, View } from '../../core/view';
 import { LiquidGlassCommon } from './liquid-glass-common';
 
 export class LiquidGlass extends LiquidGlassCommon {
@@ -35,11 +35,7 @@ export class LiquidGlass extends LiquidGlassCommon {
 		const childNativeView: NativeScriptUIView = <NativeScriptUIView>child.nativeViewProtected;
 
 		if (parentNativeView && childNativeView) {
-			if (typeof atIndex !== 'number' || atIndex >= parentNativeView.subviews.count) {
-				parentNativeView.addSubview(childNativeView);
-			} else {
-				parentNativeView.insertSubviewAtIndex(childNativeView, atIndex);
-			}
+			IOSHelper.insertSubview(parentNativeView, childNativeView, atIndex);
 
 			// If the child has an outer shadow layer, ensure it is attached under the child's layer
 			if (childNativeView.outerShadowContainerLayer && !childNativeView.outerShadowContainerLayer.superlayer) {

--- a/packages/core/ui/page/index.ios.ts
+++ b/packages/core/ui/page/index.ios.ts
@@ -548,11 +548,7 @@ export class Page extends PageBase {
 		}
 
 		if (nativeParent && nativeChild) {
-			if (typeof atIndex !== 'number' || atIndex >= nativeParent.subviews.count) {
-				nativeParent.addSubview(nativeChild);
-			} else {
-				nativeParent.insertSubviewAtIndex(nativeChild, atIndex);
-			}
+			IOSHelper.insertSubview(nativeParent, nativeChild, atIndex);
 
 			return true;
 		}


### PR DESCRIPTION
On iOS, `insertChild(view, index)` can place the child's native view one position lower than asked, beneath the sibling it should sit above. A view inserted after a `ScrollView` ends up underneath it and stops receiving touches while remaining fully visible; a view inserted before an opaque sibling disappears behind it.

Root cause: every iOS `_addViewToNativeVisualTree` implementation used `insertSubview:atIndex:`. UIKit resolves that index against the layer's **sublayers**, not the `subviews` array, and core installs non-view sublayers of its own:

- a CSS `linear-gradient` background is a `CAGradientLayer` at sublayer 0 (`background.ios.ts`, also `RootLayout`)
- each child with `box-shadow` gets an outer shadow layer inserted below its own layer

With any of those ahead of the insertion point, the raw index is off by the number of such layers. Appending (`addChild`) is unaffected, which is why this only shows up when a child is inserted in the middle: keyed list updates, `@for`/`v-for` prepends, conditional views that mount after their siblings, framework HMR remounts.

### Fix

New `IOSHelper.insertSubview(parentNativeView, childNativeView, atIndex?)` appends when the index is absent or past the end and otherwise inserts with `insertSubview:belowSubview:` against the subview currently at that index, which is independent of extra sublayers. All four raw-index sites use it:

- `View._addViewToNativeVisualTree`
- `Page._addViewToNativeVisualTree`
- `LiquidGlass._addViewToNativeVisualTree`
- `LiquidGlassContainer._addViewToNativeVisualTree`

The `atIndex` contract is unchanged (a subview index, as `ProxyViewContainer` and `_childIndexToNativeChildIndex` already assume), so callers are untouched.