### PR TITLE
fix(core): iOS box-shadow alpha was applied twice

### DIFF
--- a/packages/core/ui/styling/background.ios.ts
+++ b/packages/core/ui/styling/background.ios.ts
@@ -1130,11 +1130,12 @@ function drawBoxShadow(view: View): void {
 			shadowLayer.allowsEdgeAntialiasing = true;
 			shadowLayer.contentsScale = Screen.mainScreen.scale;
 
-			// Shadow opacity is handled on the shadow's color instance
+			// The color's alpha is the shadow's opacity; the color itself must be
+			// passed opaque, or the alpha is applied twice (0.3 renders as 0.09).
 			shadowLayer.shadowOpacity = boxShadow.color?.a ? boxShadow.color.a / 255 : 1;
 			// Use this multiplier to imitate CSS shadow blur
 			shadowLayer.shadowRadius = shadowRadius * 0.5;
-			shadowLayer.shadowColor = boxShadow.color?.ios?.CGColor;
+			shadowLayer.shadowColor = boxShadow.color?.ios?.colorWithAlphaComponent(1)?.CGColor;
 			shadowLayer.shadowOffset = CGSizeMake(offsetX, offsetY);
 
 			// Apply spread radius by expanding shadow layer bounds (this has a nice glow with radii set to 0)


### PR DESCRIPTION
`drawBoxShadow` in `ui/styling/background.ios.ts` sets `shadowLayer.shadowOpacity` from the CSS color's alpha and then also assigns `shadowLayer.shadowColor` from the same `Color`, whose `CGColor` still carries that alpha. Core Animation multiplies the two, so the effective opacity is the alpha squared: `rgba(0, 0, 0, 0.3)` renders at 0.09, and the subtle values designs actually use (0.08 to 0.15) are effectively invisible.

### Fix

Pass the color opaque (`colorWithAlphaComponent(1)`) so the alpha lives in `shadowOpacity` alone. `shadowOpacity` still reflects the CSS alpha, so nothing that reads it changes.