### PR TITLE
fix(core): iOS child index mapping skips the glass effect subview

### DIFF
--- a/packages/core/ui/core/view/index.ios.ts
+++ b/packages/core/ui/core/view/index.ios.ts
@@ -1003,6 +1003,19 @@ export class View extends ViewCommon {
 		IOSHelper.invalidateStatusBarAppearance(ownerController, `View.updateStatusBarStyle:${value}`);
 	}
 
+	public _childIndexToNativeChildIndex(index?: number): number {
+		if (typeof index !== 'number') {
+			return index;
+		}
+		// The glass effect view is a subview but not a child: it sits at subview
+		// 0, so every child's subview index is one past its child index.
+		const effectView = this._glassEffectView;
+		if (effectView && effectView.superview === this.nativeViewProtected) {
+			return index + 1;
+		}
+		return index;
+	}
+
 	[iosGlassEffectProperty.setNative](value: GlassEffectType) {
 		if (!this.nativeViewProtected || !supportsGlass()) {
 			return;

--- a/packages/core/ui/layouts/layout-base-common.ts
+++ b/packages/core/ui/layouts/layout-base-common.ts
@@ -147,7 +147,8 @@ export class LayoutBaseCommon extends CustomLayoutView implements LayoutBaseDefi
 			result += this._subViews[i]._getNativeViewsCount();
 		}
 
-		return result;
+		// The platform base accounts for native subviews that are not children.
+		return super._childIndexToNativeChildIndex(result);
 	}
 
 	public eachChildView(callback: (child: View) => boolean): void {


### PR DESCRIPTION
`iosGlassEffect` inserts a `UIVisualEffectView` at subview 0 of the view, so from then on every NativeScript child sits one subview past its child index. The index mapping used when a child is added (`_childIndexToNativeChildIndex`) still passed child indices through unchanged, so a child inserted at a given position landed one subview lower, beneath the sibling it should precede. Appends were unaffected, which is why it only shows for inserts in the middle: keyed list updates, prepends, conditional views mounting after their siblings.

There were two layers to it: `View` had no iOS-specific mapping at all, and `LayoutBaseCommon` overrides the mapping to count the native views of preceding children (for `ProxyViewContainer`) without deferring to the platform base, so a `View`-level fix alone never reached layouts.

### Fix

- `View` (iOS) maps a child index to `index + 1` while the glass effect view is attached to the view.
- `LayoutBaseCommon` keeps its proxy-aware count and hands the result to `super._childIndexToNativeChildIndex`, so the platform offset applies to layouts too.