### PR TITLE
fix(vite): fold an exports-map plugin's root entry onto its bare package id

### DIFF
--- a/packages/vite/hmr/server/websocket-module-specifiers.spec.ts
+++ b/packages/vite/hmr/server/websocket-module-specifiers.spec.ts
@@ -1,0 +1,60 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveInternalRuntimePluginBareSpecifier } from './websocket-module-specifiers.js';
+
+const CORE_PEER = { peerDependencies: { '@nativescript/core': '>=9.0.0' } };
+
+function writePackage(root: string, name: string, pkg: Record<string, unknown>): void {
+	const dir = join(root, 'node_modules', ...name.split('/'));
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, version: '1.0.0', ...pkg }));
+}
+
+// Package names are unique per case: the exports reverse map is cached by name alone.
+describe('resolveInternalRuntimePluginBareSpecifier', () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), 'ns-vite-plugin-specifier-'));
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it('folds the root export of an exports-map plugin onto its bare package id', () => {
+		writePackage(root, '@nativescript-community/exports-root-fixture', {
+			...CORE_PEER,
+			exports: {
+				'./package.json': './package.json',
+				'.': { types: './dist/index.d.ts', import: './dist/index.js', default: './dist/index.js' },
+				'./config': './dist/config.js',
+			},
+		});
+		expect(resolveInternalRuntimePluginBareSpecifier('/node_modules/@nativescript-community/exports-root-fixture/dist/index.js', root)).toBe('@nativescript-community/exports-root-fixture');
+	});
+
+	it('leaves a subpath export to the vendor resolver', () => {
+		writePackage(root, '@nativescript-community/exports-subpath-fixture', {
+			...CORE_PEER,
+			exports: { '.': './dist/index.js', './config': './dist/config.js' },
+		});
+		expect(resolveInternalRuntimePluginBareSpecifier('/node_modules/@nativescript-community/exports-subpath-fixture/dist/config.js', root)).toBeNull();
+	});
+
+	it('keeps a package-internal file of an exports-map plugin as the concrete specifier', () => {
+		writePackage(root, '@nativescript-community/exports-internal-fixture', {
+			...CORE_PEER,
+			exports: { '.': './dist/index.js' },
+		});
+		expect(resolveInternalRuntimePluginBareSpecifier('/node_modules/@nativescript-community/exports-internal-fixture/dist/driver.js', root)).toBe('@nativescript-community/exports-internal-fixture/dist/driver.js');
+	});
+
+	it('folds a main-field plugin entry resolved to a platform file onto its bare package id', () => {
+		writePackage(root, '@nativescript-community/main-field-fixture', { ...CORE_PEER, main: 'dist/index' });
+		expect(resolveInternalRuntimePluginBareSpecifier('/node_modules/@nativescript-community/main-field-fixture/dist/index.ios.js', root)).toBe('@nativescript-community/main-field-fixture');
+	});
+});

--- a/packages/vite/hmr/server/websocket-module-specifiers.ts
+++ b/packages/vite/hmr/server/websocket-module-specifiers.ts
@@ -742,7 +742,13 @@ export function resolveInternalRuntimePluginBareSpecifier(spec: string, projectR
 
 	const reverseMap = getExportsReverseMap(packageName, projectRoot);
 	const originalSpec = reverseMap.get(subpath);
-	if (originalSpec && originalSpec !== packageName) {
+	// The device vendor registry serves plugins by bare package id, so the file
+	// the root export resolves to must fold back onto that id whether the
+	// package declares it through `exports` or `main`.
+	if (originalSpec === packageName) {
+		return packageName;
+	}
+	if (originalSpec) {
 		return null;
 	}
 


### PR DESCRIPTION
`resolveInternalRuntimePluginBareSpecifier` decides which vendor id a NativeScript plugin import is served under on device. Vite resolves `import { x } from '@scope/plugin'` through the package's `exports` map to the concrete file (`/node_modules/@scope/plugin/dist/index.js`) before the rewriter sees it. For a plugin **with** an `exports` map the function then keeps that concrete subpath as the vendor id:

```ts
if (originalSpec && originalSpec !== packageName) return null;      // subpath export
if (!packageMainInfo.hasExports && subpathMatchesMainEntry(...)) return packageName;  // main-field packages only
return normalized;                                                    // -> '@scope/plugin/dist/index.js'
```

The device vendor registry is keyed on bare package ids, so `__nsVendorRequire('@scope/plugin/dist/index.js')` misses the deps bundle, falls to the runtime's base require and comes back as an empty placeholder module. Every named import is `undefined` and the app dies at the first call (`registerElement is not a function`). This is the same failure the `subpathMatchesMainEntry` comment describes for extensionless `main` fields, reached through the other package shape.

### Fix

Consult the exports reverse map first: when the resolved file is what the package's root export points to, return the bare package id. Subpath exports still return `null` (left to the vendor resolver), package-internal files still keep their concrete specifier, and `main`-field packages resolved to a platform file (`dist/index.ios.js`) still fold through `subpathMatchesMainEntry`.