### PR TITLE
fix(core): reset inherited children when an InheritedProperty is unset

### DIFF
--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -669,7 +669,7 @@ export class InheritedProperty<T extends ViewBase, U> extends Property<T, U> imp
 						const childValueSource = child[sourceKey] || ValueSource.Default;
 						if (reset) {
 							if (childValueSource === ValueSource.Inherited) {
-								setFunc.call(child, unsetValue);
+								setInheritedValue.call(child, unsetValue);
 							}
 						} else {
 							if (childValueSource <= ValueSource.Inherited) {

--- a/packages/core/ui/core/properties/inherited-property.spec.ts
+++ b/packages/core/ui/core/properties/inherited-property.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+
+import { InheritedProperty, unsetValue } from './index';
+import { StackLayout } from '../../layouts/stack-layout';
+import { Label } from '../../label';
+
+// Mirrors the private `ValueSource` enum in ./index.
+const ValueSource = {
+	Default: 0,
+	Inherited: 1,
+	Css: 2,
+	Local: 3,
+};
+
+class TestView extends StackLayout {
+	public testInherited: string;
+
+	public createNativeView(): Object {
+		return {};
+	}
+}
+
+const testInheritedProperty = new InheritedProperty<TestView, string>({
+	name: 'testInherited',
+	defaultValue: undefined,
+});
+testInheritedProperty.register(TestView);
+
+function valueSourceOf(view: any): number {
+	return view[testInheritedProperty.sourceKey] || ValueSource.Default;
+}
+
+function tree(): { root: TestView; child: TestView; grandChild: TestView } {
+	const root = new TestView();
+	const child = new TestView();
+	const grandChild = new TestView();
+
+	root.addChild(child);
+	child.addChild(grandChild);
+
+	return { root, child, grandChild };
+}
+
+function recordChanges(view: any, eventName: string): unknown[] {
+	const values: unknown[] = [];
+	view.on(eventName, (data: any) => values.push(data.value));
+
+	return values;
+}
+
+describe('InheritedProperty', () => {
+	it('propagates a value down the tree', () => {
+		const { root, child, grandChild } = tree();
+
+		root.testInherited = 'a';
+
+		expect(child.testInherited).toBe('a');
+		expect(grandChild.testInherited).toBe('a');
+		expect(valueSourceOf(root)).toBe(ValueSource.Local);
+		expect(valueSourceOf(child)).toBe(ValueSource.Inherited);
+		expect(valueSourceOf(grandChild)).toBe(ValueSource.Inherited);
+	});
+
+	it('resets inheriting descendants when the value is unset', () => {
+		const { root, child, grandChild } = tree();
+		root.testInherited = 'a';
+
+		const childChanges = recordChanges(child, 'testInheritedChange');
+		const grandChildChanges = recordChanges(grandChild, 'testInheritedChange');
+
+		root.testInherited = unsetValue;
+
+		expect(root.testInherited).toBeUndefined();
+		expect(child.testInherited).toBeUndefined();
+		expect(grandChild.testInherited).toBeUndefined();
+		expect(valueSourceOf(root)).toBe(ValueSource.Default);
+		expect(valueSourceOf(child)).toBe(ValueSource.Default);
+		expect(valueSourceOf(grandChild)).toBe(ValueSource.Default);
+		expect(childChanges).toEqual([undefined]);
+		expect(grandChildChanges).toEqual([undefined]);
+	});
+
+	it("resets inheriting descendants when the value is set to 'initial'", () => {
+		const { root, child, grandChild } = tree();
+		root.testInherited = 'a';
+
+		root.testInherited = <any>'initial';
+
+		expect(child.testInherited).toBeUndefined();
+		expect(grandChild.testInherited).toBeUndefined();
+	});
+
+	it('leaves a descendant that holds a local value untouched', () => {
+		const { root, child, grandChild } = tree();
+		root.testInherited = 'a';
+		child.testInherited = 'local';
+
+		root.testInherited = unsetValue;
+
+		expect(child.testInherited).toBe('local');
+		expect(valueSourceOf(child)).toBe(ValueSource.Local);
+		expect(grandChild.testInherited).toBe('local');
+		expect(valueSourceOf(grandChild)).toBe(ValueSource.Inherited);
+	});
+
+	it('propagates again after a reset', () => {
+		const { root, child, grandChild } = tree();
+		root.testInherited = 'a';
+		root.testInherited = unsetValue;
+
+		root.testInherited = 'b';
+
+		expect(child.testInherited).toBe('b');
+		expect(grandChild.testInherited).toBe('b');
+		expect(valueSourceOf(grandChild)).toBe(ValueSource.Inherited);
+	});
+});
+
+describe('bindingContext', () => {
+	it('is reset on descendants when the root unsets it', () => {
+		const root = new StackLayout();
+		const container = new StackLayout();
+		const label = new Label();
+		root.addChild(container);
+		container.addChild(label);
+
+		const context = { name: 'a' };
+		root.bindingContext = context;
+		expect(container.bindingContext).toBe(context);
+		expect(label.bindingContext).toBe(context);
+
+		const labelChanges = recordChanges(label, 'bindingContextChange');
+
+		root.bindingContext = unsetValue;
+
+		expect(root.bindingContext).toBeUndefined();
+		expect(container.bindingContext).toBeUndefined();
+		expect(label.bindingContext).toBeUndefined();
+		expect(labelChanges).toEqual([undefined]);
+	});
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

When an `InheritedProperty` (in core: `bindingContext`, `iosOverflowSafeAreaEnabled`, `iosIgnoreSafeArea`) is reset to its default on a node (`unsetValue` or `'initial'`), descendants that had *inherited* the old value keep it. The cascade's reset branch in `ui/core/properties/index.ts` calls `setFunc.call(child, unsetValue)`, but `setFunc` is the setter *factory* `(valueSource) => function(value)`, so the call only builds and discards a setter and never writes to the child.

In practice this is reached through `clearInheritedProperties()` when a subtree is detached (`ViewBase._parentChanged`) and through `Binding.updateTarget` when a `bindingContext` binding resolves to `null`/`undefined`. `InheritedCssProperty` has the correct pattern (`setDefaultFunc.call(childStyle, unsetValue)`).

## What is the new behavior?

The reset branch calls the concrete inherited setter (`setInheritedValue.call(child, unsetValue)`). Because the child's parent has just become `ValueSource.Default`, the child resolves to `defaultValue` with `ValueSource.Default`, fires its `<name>Change` event, and cascades to its own children. Children holding a **local** value are untouched, as before.

Side effect worth noting for reviewers: detaching a subtree now clears inherited view properties on all descendants (not just the removed root) and emits `bindingContextChange` on them during teardown. This matches what inherited CSS properties have always done; re-attaching re-propagates via `propagateInheritableProperties`. ListView item views receive `bindingContext` as a local value and are not affected.

Tests: `ui/core/properties/inherited-property.spec.ts` (6 cases: propagation, `unsetValue` reset, `'initial'` reset, local descendant untouched, re-propagation after reset, end-to-end `bindingContext` reset on `StackLayout`/`Label`). Three of them fail without the fix.

Found while working on the property-change `origin` change (#11412).
