### PR TITLE
feat(core): native update scheduler and commit hook (phase 0)

### DIFF
--- a/apps/automated/src/ui/lifecycle/lifecycle-tests.ts
+++ b/apps/automated/src/ui/lifecycle/lifecycle-tests.ts
@@ -1,6 +1,7 @@
 import * as helper from '../../ui-helper';
 import * as btnCounter from './pages/button-counter';
 import * as TKUnit from '../../tk-unit';
+import { NativeUpdates } from '@nativescript/core';
 
 // Integration tests that asser sertain runtime behavior, lifecycle events atc.
 
@@ -72,6 +73,72 @@ export function test_setting_one_property_while_suspedned_does_not_call_other_pr
 
 	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'backgroundInternal.setNative at step4');
 	TKUnit.assertEqual(btn1.fontInternalSetNativeCount, 2, 'fontInternal.setNative at step4');
+}
+
+export function test_native_updates_batch_coalesces_like_batch_update() {
+	const page = helper.navigateToModule('ui/lifecycle/pages/page-one');
+	const btn1 = page.getViewById<btnCounter.Button>('btn1');
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 1, 'backgroundInternal.setNative at step1');
+	TKUnit.assertEqual(btn1.fontInternalSetNativeCount, 1, 'fontInternal.setNative at step1');
+
+	NativeUpdates.batch(() => {
+		// None
+	});
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 1, 'backgroundInternal.setNative at step2');
+	TKUnit.assertEqual(btn1.fontInternalSetNativeCount, 1, 'fontInternal.setNative at step2');
+
+	NativeUpdates.batch(() => {
+		btn1.style.borderWidth = '22';
+	});
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'backgroundInternal.setNative at step3');
+	TKUnit.assertEqual(btn1.fontInternalSetNativeCount, 1, 'fontInternal.setNative at step3');
+
+	NativeUpdates.batch(() => {
+		btn1.style.fontSize = 69;
+	});
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'backgroundInternal.setNative at step4');
+	TKUnit.assertEqual(btn1.fontInternalSetNativeCount, 2, 'fontInternal.setNative at step4');
+}
+
+export function test_flush_native_updates_pushes_what_a_batch_is_holding() {
+	const page = helper.navigateToModule('ui/lifecycle/pages/page-one');
+	const btn1 = page.getViewById<btnCounter.Button>('btn1');
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 1, 'backgroundInternal.setNative after inflation');
+
+	NativeUpdates.batch(() => {
+		btn1.style.borderWidth = '22';
+		TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 1, 'nothing is pushed while the batch is open');
+
+		TKUnit.assertTrue(btn1.flushNativeUpdates(), 'the flush should reach the native view');
+		TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'the flush pushes what is pending');
+	});
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'closing the batch does not push again');
+}
+
+export function test_flush_native_updates_force_pushes_while_unloaded() {
+	const page = helper.navigateToModule('ui/lifecycle/pages/page-one');
+	// btn1 matches no selector in page-one.css, so loading it back does not write css values.
+	const btn1 = page.getViewById<btnCounter.Button>('btn1');
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 1, 'backgroundInternal.setNative after inflation');
+
+	btn1.callUnloaded();
+	btn1.style.borderWidth = '22';
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 1, 'nothing is pushed while unloaded');
+
+	TKUnit.assertTrue(btn1.flushNativeUpdates({ force: true }), 'a forced flush should reach the existing native view');
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'the forced flush pushes what is pending');
+
+	btn1.callLoaded();
+
+	TKUnit.assertEqual(btn1.backgroundInternalSetNativeCount, 2, 'loading does not push the flushed value again');
 }
 
 //

--- a/packages/core/ui/core/native-updates/batch.ts
+++ b/packages/core/ui/core/native-updates/batch.ts
@@ -1,0 +1,117 @@
+import type { ViewBase } from '../view-base';
+import type { CssAnimationProperty, CssProperty, Property } from '../properties';
+import type { Invalidation } from './invalidation';
+
+/** A change to a node's child list. Phase 0 never records one. */
+export interface ChildMutation {
+	readonly kind: 'insert' | 'remove' | 'move';
+	readonly child: ViewBase;
+	readonly index: number;
+}
+
+export type NativeUpdateProperty = Property<any, any> | CssProperty<any, any> | CssAnimationProperty<any, any>;
+
+/** What a commit applies: a property, through its `[setNative]`, or an aggregate invalidation. */
+export type NativeUpdateEntry = NativeUpdateProperty | Invalidation;
+
+export type NativeUpdateApplier = (batch: NativeUpdateBatch, entry: NativeUpdateEntry) => void;
+
+const NO_CHILDREN: readonly ChildMutation[] = Object.freeze([]);
+
+/**
+ * Everything that is dirty on one node at commit time, in the order the commit will apply it.
+ * Handed to `ViewBase.commitNativeUpdates`, which may reorder, pre-empt or drop entries.
+ */
+export class NativeUpdateBatch {
+	/** Every value the node carries is dirty: it is being applied to a native view for the first time. */
+	public readonly isMount: boolean;
+	public readonly children: readonly ChildMutation[] = NO_CHILDREN;
+
+	private readonly _entries: NativeUpdateEntry[];
+	private readonly _handled: boolean[];
+	private readonly _apply: NativeUpdateApplier;
+	private readonly _previous: Map<NativeUpdateProperty, unknown> | undefined;
+	private _index: Map<NativeUpdateEntry, number> | undefined;
+
+	constructor(
+		public readonly node: ViewBase,
+		isMount: boolean,
+		entries: NativeUpdateEntry[],
+		previous: Map<NativeUpdateProperty, unknown> | undefined,
+		apply: NativeUpdateApplier,
+	) {
+		this.isMount = isMount;
+		this._entries = entries;
+		this._handled = new Array(entries.length).fill(false);
+		this._previous = previous;
+		this._apply = apply;
+	}
+
+	/** Everything this commit applies, in commit order; `has()` tells whether an entry is still pending. */
+	public get entries(): ReadonlyArray<NativeUpdateEntry> {
+		return this._entries;
+	}
+
+	/** Whether the entry is still waiting to be applied by this commit. */
+	public has(entry: NativeUpdateEntry): boolean {
+		const index = this.indexOf(entry);
+
+		return index >= 0 && !this._handled[index];
+	}
+
+	/** The value the property held at the last commit; `undefined` on a mount. */
+	public previous<T>(property: NativeUpdateProperty): T | undefined {
+		return this._previous?.get(property) as T | undefined;
+	}
+
+	/** Runs the entry's handler now. An entry that is not pending, or already handled, is a no-op. */
+	public apply(entry: NativeUpdateEntry): void {
+		const index = this.indexOf(entry);
+		if (index < 0 || this._handled[index]) {
+			return;
+		}
+
+		this._handled[index] = true;
+		this._apply(this, this._entries[index]);
+	}
+
+	/** Marks the entry handled without touching the native view. */
+	public skip(entry: NativeUpdateEntry): void {
+		const index = this.indexOf(entry);
+		if (index >= 0) {
+			this._handled[index] = true;
+		}
+	}
+
+	/**
+	 * Applies everything still pending, in commit order.
+	 * @private
+	 */
+	public _applyRemaining(): void {
+		const entries = this._entries;
+		const handled = this._handled;
+
+		for (let i = 0, length = entries.length; i < length; i++) {
+			// A handler may apply later entries itself, so the flag is re-read on every step.
+			if (!handled[i]) {
+				handled[i] = true;
+				this._apply(this, entries[i]);
+			}
+		}
+	}
+
+	private indexOf(entry: NativeUpdateEntry): number {
+		let index = this._index;
+		if (!index) {
+			index = this._index = new Map<NativeUpdateEntry, number>();
+			const entries = this._entries;
+			for (let i = 0, length = entries.length; i < length; i++) {
+				index.set(entries[i], i);
+			}
+		}
+
+		const found = index.get(entry);
+
+		return found === undefined ? -1 : found;
+	}
+}

--- a/packages/core/ui/core/native-updates/index.ts
+++ b/packages/core/ui/core/native-updates/index.ts
@@ -1,0 +1,4 @@
+export { Invalidation, InvalidationPhase } from './invalidation';
+export type { InvalidationOptions } from './invalidation';
+export { NativeUpdateBatch } from './batch';
+export type { ChildMutation, NativeUpdateApplier, NativeUpdateProperty, NativeUpdateEntry } from './batch';

--- a/packages/core/ui/core/native-updates/index.ts
+++ b/packages/core/ui/core/native-updates/index.ts
@@ -2,3 +2,5 @@ export { Invalidation, InvalidationPhase } from './invalidation';
 export type { InvalidationOptions } from './invalidation';
 export { NativeUpdateBatch } from './batch';
 export type { ChildMutation, NativeUpdateApplier, NativeUpdateProperty, NativeUpdateEntry } from './batch';
+export { NativeUpdates } from './scheduler';
+export type { FlushNativeUpdatesOptions, NativeUpdatesMode } from './scheduler';

--- a/packages/core/ui/core/native-updates/invalidation.ts
+++ b/packages/core/ui/core/native-updates/invalidation.ts
@@ -1,0 +1,41 @@
+/**
+ * The order a commit applies invalidations in. Phase 0 carries the phase but does not order by
+ * it yet: nothing in core declares an invalidation, so every batch is properties then aggregates.
+ */
+export enum InvalidationPhase {
+	Style,
+	Structure,
+	Mount,
+	Props,
+	Content,
+	Layout,
+	Paint,
+}
+
+export interface InvalidationOptions {
+	readonly phase?: InvalidationPhase;
+	/** The handler needs a laid out size, so a commit may have to defer it until there is one. */
+	readonly needsBounds?: boolean;
+}
+
+/**
+ * A named dirty flag several properties can share, so that one native rebuild serves all of them.
+ * A node handles it with `[invalidation.apply](batch)`, mirroring `[property.setNative](value)`.
+ */
+export class Invalidation {
+	public readonly name: string;
+	public readonly apply: symbol;
+	public readonly phase: InvalidationPhase;
+	public readonly needsBounds: boolean;
+
+	constructor(name: string, options?: InvalidationOptions) {
+		this.name = name;
+		this.apply = Symbol(`${name}:applyInvalidation`);
+		this.phase = options?.phase ?? InvalidationPhase.Props;
+		this.needsBounds = options?.needsBounds ?? false;
+	}
+
+	public toString(): string {
+		return `Invalidation(${this.name})`;
+	}
+}

--- a/packages/core/ui/core/native-updates/native-updates.spec.ts
+++ b/packages/core/ui/core/native-updates/native-updates.spec.ts
@@ -5,6 +5,7 @@ import { Style } from '../../styling/style';
 import { CssProperty, Property } from '../properties';
 import { NativeUpdateBatch } from './batch';
 import { NativeUpdates } from './scheduler';
+import { Invalidation, InvalidationPhase } from './invalidation';
 
 /** `SuspendType.Loaded`; the enum is internal but the bit is part of the field's contract. */
 const Loaded = 1 << 20;
@@ -49,6 +50,31 @@ trackNative(twoProperty, TestView);
 const threeProperty = new CssProperty<Style, string>({ name: 'three', cssName: 'three', defaultValue: 'three-default' });
 threeProperty.register(Style);
 trackNative(threeProperty, TestView);
+
+const Content = new Invalidation('content', { phase: InvalidationPhase.Content });
+
+/** Raises `Content` and has a `[setNative]` of its own. */
+const fourProperty = new Property<TestView, string>({ name: 'four', defaultValue: 'four-default', invalidates: [Content] });
+fourProperty.register(TestView);
+trackNative(fourProperty, TestView);
+
+/** Raises `Content` and nothing else: no `[setNative]` is installed for it. */
+const fiveProperty = new Property<TestView, string>({ name: 'five', defaultValue: 'five-default', invalidates: [Content] });
+fiveProperty.register(TestView);
+
+/** Raises `Content` on a class that handles neither the property nor the invalidation. */
+class BareView extends View {
+	createNativeView(): Object {
+		return {};
+	}
+}
+
+const sixProperty = new Property<BareView, string>({ name: 'six', defaultValue: 'six-default', invalidates: [Content] });
+sixProperty.register(BareView);
+
+(TestView.prototype as any)[Content.apply] = function (batch: NativeUpdateBatch) {
+	log.push(`content(${String(batch.node.constructor.name)})`);
+};
 
 function loaded<T extends TestView>(view: T): T {
 	(<any>view)._setupUI({});
@@ -384,5 +410,83 @@ describe('flushNativeUpdates', () => {
 		});
 
 		expect(log).toEqual(['one=parent', 'one=child']);
+	});
+});
+
+describe('invalidates', () => {
+	it('runs the aggregate handler after the property write', () => {
+		const view: any = loaded(new TestView());
+
+		view.four = 'a';
+
+		expect(log).toEqual(['four=a', 'content(TestView)']);
+	});
+
+	it('runs the aggregate handler for a property with no native setter of its own', () => {
+		const view: any = loaded(new TestView());
+
+		view.five = 'a';
+
+		expect(log).toEqual(['content(TestView)']);
+	});
+
+	it('runs the aggregate handler once however many properties raised it', () => {
+		const view: any = loaded(new TestView());
+
+		NativeUpdates.batch(() => {
+			view.four = 'a';
+			view.five = 'b';
+			view.one = 'c';
+		});
+
+		expect(log).toEqual(['four=a', 'one=c', 'content(TestView)']);
+	});
+
+	it('is a batch target an override can pre-empt or drop', () => {
+		const pending: boolean[] = [];
+
+		class ContentFirstView extends TestView {
+			public commitNativeUpdates(batch: NativeUpdateBatch): void {
+				pending.push(batch.has(Content));
+				batch.apply(Content);
+				batch.skip(fourProperty);
+				super.commitNativeUpdates(batch);
+			}
+		}
+		const view: any = loaded(new ContentFirstView());
+		pending.length = 0;
+
+		view.four = 'a';
+
+		expect(pending).toEqual([true]);
+		expect(log).toEqual(['content(ContentFirstView)']);
+	});
+
+	it('gives the aggregate handler the value the property held at the last commit', () => {
+		const seen: unknown[] = [];
+
+		class ContentReadingView extends TestView {}
+		(ContentReadingView.prototype as any)[Content.apply] = function (batch: NativeUpdateBatch) {
+			seen.push(batch.previous(fourProperty));
+		};
+
+		const view: any = loaded(new ContentReadingView());
+		seen.length = 0;
+
+		view.four = 'a';
+		view.four = 'b';
+
+		expect(seen).toEqual(['four-default', 'a']);
+	});
+
+	it('does nothing on a node with no handler for the invalidation', () => {
+		const view: any = new BareView();
+		view._setupUI({});
+		view.callLoaded();
+		log.length = 0;
+
+		view.six = 'a';
+
+		expect(log).toEqual([]);
 	});
 });

--- a/packages/core/ui/core/native-updates/native-updates.spec.ts
+++ b/packages/core/ui/core/native-updates/native-updates.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { View } from '../view';
 import { Style } from '../../styling/style';
@@ -165,6 +165,81 @@ describe('commitNativeUpdates', () => {
 		});
 
 		expect(log).toEqual(['one=a']);
+	});
+});
+
+describe('committing without a batch', () => {
+	it('builds no batch for a node whose class can neither order nor observe one', () => {
+		const plain: any = loaded(new TestView());
+		const ordered: any = loaded(new OrderedView());
+		const applyRemaining = vi.spyOn(NativeUpdateBatch.prototype, '_applyRemaining');
+
+		try {
+			plain._batchUpdate(() => {
+				plain.two = 'b';
+				plain.one = 'a';
+			});
+			NativeUpdates.batch(() => {
+				plain.one = 'c';
+			});
+			plain.callUnloaded();
+			plain.two = 'd';
+			plain.flushNativeUpdates({ force: true });
+			plain.callLoaded();
+
+			expect(log).toEqual(['two=b', 'one=a', 'one=c', 'two=d']);
+			expect(applyRemaining).not.toHaveBeenCalled();
+
+			log.length = 0;
+			ordered._batchUpdate(() => {
+				ordered.two = 'b';
+				ordered.one = 'a';
+			});
+
+			expect(log).toEqual(['commit', 'two=b', 'one=a']);
+			expect(applyRemaining).toHaveBeenCalledTimes(1);
+		} finally {
+			applyRemaining.mockRestore();
+		}
+	});
+
+	it('sweeps a mount in the same order the batch path does', () => {
+		function mounted(view: any): string[] {
+			log.length = 0;
+			view.two = 'b';
+			view.style.three = 'c';
+			view.one = 'a';
+			view._setupUI({});
+			view.callLoaded();
+
+			return log.filter((entry) => entry !== 'commit');
+		}
+
+		const withoutBatch = mounted(new TestView());
+		const withBatch = mounted(new OrderedView());
+
+		expect(withoutBatch).toEqual(['two=b', 'one=a', 'three=c']);
+		expect(withBatch).toEqual(withoutBatch);
+	});
+
+	it('sweeps a dirty set in the same order the batch path does', () => {
+		function reloaded(view: any): string[] {
+			loaded(view);
+			view.callUnloaded();
+			view.two = 'b';
+			view.style.three = 'c';
+			view.one = 'a';
+			log.length = 0;
+			view.callLoaded();
+
+			return log.filter((entry) => entry !== 'commit');
+		}
+
+		const withoutBatch = reloaded(new TestView());
+		const withBatch = reloaded(new OrderedView());
+
+		expect(withoutBatch).toEqual(['two=b', 'three=c', 'one=a']);
+		expect(withBatch).toEqual(withoutBatch);
 	});
 });
 

--- a/packages/core/ui/core/native-updates/native-updates.spec.ts
+++ b/packages/core/ui/core/native-updates/native-updates.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { View } from '../view';
+import { Style } from '../../styling/style';
+import { CssProperty, Property } from '../properties';
+import { NativeUpdateBatch } from './batch';
+
+const log: string[] = [];
+
+class TestView extends View {
+	public commits: NativeUpdateBatch[] = [];
+
+	createNativeView(): Object {
+		return {};
+	}
+
+	public _addViewToNativeVisualTree(): boolean {
+		return true;
+	}
+}
+
+/** Records the batch and applies it as the base class would. */
+class OrderedView extends TestView {
+	public commitNativeUpdates(batch: NativeUpdateBatch): void {
+		this.commits.push(batch);
+		log.push('commit');
+		super.commitNativeUpdates(batch);
+	}
+}
+
+function trackNative(property: { name: string; setNative: symbol }, target: typeof TestView): void {
+	(target.prototype as any)[property.setNative] = function (value: unknown) {
+		log.push(`${property.name}=${String(value)}`);
+	};
+}
+
+const oneProperty = new Property<TestView, string>({ name: 'one', defaultValue: 'one-default' });
+oneProperty.register(TestView);
+trackNative(oneProperty, TestView);
+
+const twoProperty = new Property<TestView, string>({ name: 'two', defaultValue: 'two-default' });
+twoProperty.register(TestView);
+trackNative(twoProperty, TestView);
+
+const threeProperty = new CssProperty<Style, string>({ name: 'three', cssName: 'three', defaultValue: 'three-default' });
+threeProperty.register(Style);
+trackNative(threeProperty, TestView);
+
+function loaded<T extends TestView>(view: T): T {
+	(<any>view)._setupUI({});
+	view.callLoaded();
+	log.length = 0;
+
+	return view;
+}
+
+beforeEach(() => {
+	log.length = 0;
+});
+
+describe('commitNativeUpdates', () => {
+	it('is not called per set on a class that does not override it', () => {
+		const view: any = loaded(new TestView());
+
+		view.one = 'a';
+
+		expect(log).toEqual(['one=a']);
+	});
+
+	it('runs once per live set on a class that overrides it', () => {
+		const view: any = loaded(new OrderedView());
+
+		view.one = 'a';
+		view.two = 'b';
+
+		expect(log).toEqual(['commit', 'one=a', 'commit', 'two=b']);
+	});
+
+	it('receives the whole dirty set of a batched update, in first-dirtied order', () => {
+		const view: any = loaded(new OrderedView());
+
+		view._batchUpdate(() => {
+			view.two = 'b';
+			view.style.three = 'c';
+			view.one = 'a';
+		});
+
+		expect(log).toEqual(['commit', 'two=b', 'three=c', 'one=a']);
+	});
+
+	it('lets an override apply a property before the rest', () => {
+		class ReorderedView extends TestView {
+			public commitNativeUpdates(batch: NativeUpdateBatch): void {
+				batch.apply(oneProperty);
+				super.commitNativeUpdates(batch);
+			}
+		}
+		const view: any = loaded(new ReorderedView());
+
+		view._batchUpdate(() => {
+			view.two = 'b';
+			view.one = 'a';
+		});
+
+		expect(log).toEqual(['one=a', 'two=b']);
+	});
+
+	it('applies a target at most once', () => {
+		class TwiceView extends TestView {
+			public commitNativeUpdates(batch: NativeUpdateBatch): void {
+				batch.apply(oneProperty);
+				batch.apply(oneProperty);
+				super.commitNativeUpdates(batch);
+			}
+		}
+		const view: any = loaded(new TwiceView());
+
+		view.one = 'a';
+
+		expect(log).toEqual(['one=a']);
+	});
+
+	it('drops a skipped target', () => {
+		class SkippingView extends TestView {
+			public commitNativeUpdates(batch: NativeUpdateBatch): void {
+				batch.skip(twoProperty);
+				super.commitNativeUpdates(batch);
+			}
+		}
+		const view: any = loaded(new SkippingView());
+
+		view._batchUpdate(() => {
+			view.one = 'a';
+			view.two = 'b';
+		});
+
+		expect(log).toEqual(['one=a']);
+	});
+});
+
+describe('the batch', () => {
+	function commitOf(view: TestView): NativeUpdateBatch {
+		return view.commits[view.commits.length - 1];
+	}
+
+	it('reports what is pending and what was handled', () => {
+		const view: any = loaded(new OrderedView());
+
+		view.one = 'a';
+
+		const batch = commitOf(view);
+		expect(batch.node).toBe(view);
+		expect(batch.has(oneProperty)).toBe(false);
+		expect(batch.has(twoProperty)).toBe(false);
+	});
+
+	it('lists everything it applies, in commit order', () => {
+		const view: any = loaded(new OrderedView());
+
+		view._batchUpdate(() => {
+			view.two = 'b';
+			view.style.three = 'c';
+			view.one = 'a';
+		});
+
+		expect(commitOf(view).entries).toEqual([twoProperty, threeProperty, oneProperty]);
+	});
+
+	it('is a mount batch on the first commit only', () => {
+		const view: any = new OrderedView();
+		view.one = 'a';
+		view._setupUI({});
+		view.callLoaded();
+
+		expect(view.commits[0].isMount).toBe(true);
+
+		view.two = 'b';
+
+		expect(commitOf(view).isMount).toBe(false);
+	});
+
+	it('carries the value each property held at the last commit', () => {
+		const view: any = loaded(new OrderedView());
+
+		view.one = 'a';
+		expect(commitOf(view).previous(oneProperty)).toBe('one-default');
+
+		view.one = 'b';
+		expect(commitOf(view).previous(oneProperty)).toBe('a');
+
+		expect(commitOf(view).previous(twoProperty)).toBeUndefined();
+	});
+
+	it('records no previous values for a node whose class does not read them', () => {
+		const view: any = loaded(new TestView());
+
+		view._batchUpdate(() => {
+			view.one = 'a';
+			view.two = 'b';
+		});
+
+		expect(view._pendingPrevious).toBeUndefined();
+
+		view.callUnloaded();
+		view.one = 'c';
+		expect(view._pendingPrevious).toBeUndefined();
+
+		view.callLoaded();
+
+		expect(log).toEqual(['one=a', 'two=b', 'one=c']);
+		expect(view._pendingPrevious).toBeUndefined();
+	});
+
+	it('has no previous values on a mount', () => {
+		const view: any = new OrderedView();
+		view.one = 'a';
+		view._setupUI({});
+		view.callLoaded();
+
+		expect(view.commits[0].previous(oneProperty)).toBeUndefined();
+	});
+
+	it('carries no child mutations in this phase', () => {
+		const view: any = loaded(new OrderedView());
+		view.one = 'a';
+
+		const { children } = commitOf(view);
+		expect(children).toEqual([]);
+		expect(Object.isFrozen(children)).toBe(true);
+	});
+});

--- a/packages/core/ui/core/native-updates/native-updates.spec.ts
+++ b/packages/core/ui/core/native-updates/native-updates.spec.ts
@@ -4,6 +4,10 @@ import { View } from '../view';
 import { Style } from '../../styling/style';
 import { CssProperty, Property } from '../properties';
 import { NativeUpdateBatch } from './batch';
+import { NativeUpdates } from './scheduler';
+
+/** `SuspendType.Loaded`; the enum is internal but the bit is part of the field's contract. */
+const Loaded = 1 << 20;
 
 const log: string[] = [];
 
@@ -144,14 +148,25 @@ describe('the batch', () => {
 	}
 
 	it('reports what is pending and what was handled', () => {
-		const view: any = loaded(new OrderedView());
+		const seen: boolean[] = [];
 
+		class ReportingView extends TestView {
+			public commitNativeUpdates(batch: NativeUpdateBatch): void {
+				this.commits.push(batch);
+				seen.push(batch.has(oneProperty), batch.has(twoProperty));
+				batch.apply(oneProperty);
+				seen.push(batch.has(oneProperty));
+				super.commitNativeUpdates(batch);
+				seen.push(batch.has(oneProperty));
+			}
+		}
+
+		const view: any = loaded(new ReportingView());
+		seen.length = 0;
 		view.one = 'a';
 
-		const batch = commitOf(view);
-		expect(batch.node).toBe(view);
-		expect(batch.has(oneProperty)).toBe(false);
-		expect(batch.has(twoProperty)).toBe(false);
+		expect(commitOf(view).node).toBe(view);
+		expect(seen).toEqual([true, false, false, false]);
 	});
 
 	it('lists everything it applies, in commit order', () => {
@@ -227,5 +242,147 @@ describe('the batch', () => {
 		const { children } = commitOf(view);
 		expect(children).toEqual([]);
 		expect(Object.isFrozen(children)).toBe(true);
+	});
+});
+
+describe('the scheduler', () => {
+	it('only implements the sync mode', () => {
+		expect(NativeUpdates.mode).toBe('sync');
+
+		NativeUpdates.mode = 'sync';
+		expect(NativeUpdates.mode).toBe('sync');
+
+		expect(() => {
+			(<any>NativeUpdates).mode = 'microtask';
+		}).toThrow(/'sync' is the only mode/);
+	});
+
+	it('coalesces the writes made to a node inside a batch', () => {
+		const view: any = loaded(new TestView());
+
+		NativeUpdates.batch(() => {
+			view.two = 'b';
+			view.one = 'a';
+			view.two = 'b2';
+
+			expect(log).toEqual([]);
+			expect(view._pendingPrevious).toBeUndefined();
+		});
+
+		expect(log).toEqual(['two=b2', 'one=a']);
+		expect(view._suspendNativeUpdatesCount).toBe(0);
+	});
+
+	it('commits touched nodes in the order they were first written to', () => {
+		const first: any = loaded(new TestView());
+		const second: any = loaded(new TestView());
+
+		NativeUpdates.batch(() => {
+			second.one = 'second';
+			first.one = 'first';
+			second.two = 'second-two';
+		});
+
+		expect(log).toEqual(['one=second', 'two=second-two', 'one=first']);
+	});
+
+	it('commits only when the outermost batch closes', () => {
+		const view: any = loaded(new TestView());
+
+		NativeUpdates.batch(() => {
+			NativeUpdates.batch(() => {
+				view.one = 'a';
+			});
+
+			expect(log).toEqual([]);
+			expect(NativeUpdates._depth).toBe(1);
+		});
+
+		expect(log).toEqual(['one=a']);
+		expect(NativeUpdates._depth).toBe(0);
+	});
+
+	it('closes the batch when the callback throws', () => {
+		const view: any = loaded(new TestView());
+
+		expect(() =>
+			NativeUpdates.batch(() => {
+				view.one = 'a';
+				throw new Error('boom');
+			}),
+		).toThrow('boom');
+
+		expect(log).toEqual(['one=a']);
+		expect(NativeUpdates._depth).toBe(0);
+	});
+
+	it('rejects an unmatched end', () => {
+		expect(() => NativeUpdates.end()).toThrow(/without a matching begin/);
+	});
+});
+
+describe('flushNativeUpdates', () => {
+	it('pushes what a batch is holding and leaves the batch open', () => {
+		const view: any = loaded(new TestView());
+
+		NativeUpdates.batch(() => {
+			view.one = 'a';
+			expect(view.flushNativeUpdates()).toBe(true);
+			expect(log).toEqual(['one=a']);
+			expect(view._suspendNativeUpdatesCount).toBe(1);
+
+			view.two = 'b';
+		});
+
+		expect(log).toEqual(['one=a', 'two=b']);
+	});
+
+	it('reports nothing to push to when the node has no native view', () => {
+		const view: any = new TestView();
+		view.one = 'a';
+
+		expect(view.flushNativeUpdates()).toBe(false);
+		expect(view.flushNativeUpdates({ force: true })).toBe(false);
+		expect(log).toEqual([]);
+	});
+
+	it('leaves an unloaded node alone without force', () => {
+		const view: any = new TestView();
+		view.one = 'a';
+		view._setupUI({});
+
+		expect(view.flushNativeUpdates()).toBe(false);
+		expect(log).toEqual([]);
+	});
+
+	it('pushes to an unloaded node with force, keeping the holds', () => {
+		const view: any = new TestView();
+		view.one = 'a';
+		view._setupUI({});
+
+		expect(view.flushNativeUpdates({ force: true })).toBe(true);
+		expect(log).toEqual(['one=a']);
+		expect(view._suspendNativeUpdatesCount).toBe(Loaded);
+
+		log.length = 0;
+		view.two = 'b';
+		view.callLoaded();
+
+		expect(log).toEqual(['two=b']);
+	});
+
+	it('flushes a subtree after each node', () => {
+		const parent: any = loaded(new TestView());
+		const child: any = loaded(new TestView());
+		parent.eachChildView = (callback: any) => callback(child);
+
+		NativeUpdates.batch(() => {
+			child.one = 'child';
+			parent.one = 'parent';
+
+			expect(NativeUpdates.flush(parent)).toBe(true);
+		});
+
+		expect(log).toEqual(['one=parent', 'one=child']);
 	});
 });

--- a/packages/core/ui/core/native-updates/scheduler.ts
+++ b/packages/core/ui/core/native-updates/scheduler.ts
@@ -1,0 +1,100 @@
+import type { ViewBase } from '../view-base';
+import { SuspendType } from '../view-base/suspend-type';
+
+export type NativeUpdatesMode = 'sync';
+
+export interface FlushNativeUpdatesOptions {
+	/** Flush the node's descendants as well, each after its own host. */
+	subtree?: boolean;
+	/** Push to a native view that already exists even while the node is not loaded. */
+	force?: boolean;
+}
+
+let depth = 0;
+
+/** The nodes an open batch is holding, in the order they were first written to. */
+const held = new Set<ViewBase>();
+
+/**
+ * Decides when native updates are committed. The only mode in this version is `'sync'`: every
+ * write commits as it is made, except inside `batch()`/`begin()`…`end()`, which coalesces the
+ * writes made to each node into one commit per node when the outermost batch closes.
+ */
+export const NativeUpdates = {
+	/** Depth of the open batches; `0` means a write commits where it is made. @private */
+	_depth: 0,
+
+	get mode(): NativeUpdatesMode {
+		return 'sync';
+	},
+
+	set mode(value: NativeUpdatesMode) {
+		if (value !== 'sync') {
+			throw new Error(`NativeUpdates.mode cannot be set to '${value}': 'sync' is the only mode this version implements.`);
+		}
+	},
+
+	/** Runs `callback` with commits coalesced per node. Nestable; only the outermost one commits. */
+	batch<T>(callback: () => T): T {
+		NativeUpdates.begin();
+		try {
+			return callback();
+		} finally {
+			NativeUpdates.end();
+		}
+	},
+
+	/** The unpaired form of `batch()`, for renderers that have their own begin/end hooks. */
+	begin(): void {
+		depth++;
+		NativeUpdates._depth = depth;
+	},
+
+	end(): void {
+		if (depth === 0) {
+			throw new Error('NativeUpdates.end() called without a matching begin().');
+		}
+
+		depth--;
+		NativeUpdates._depth = depth;
+
+		if (depth !== 0 || held.size === 0) {
+			return;
+		}
+
+		const nodes = Array.from(held);
+		held.clear();
+
+		for (let i = 0, length = nodes.length; i < length; i++) {
+			nodes[i]._resumeNativeUpdates(SuspendType.Incremental);
+		}
+	},
+
+	/**
+	 * Commits now: the node and, unless told otherwise, its subtree. Without a node, commits every
+	 * node the open batch is holding, leaving the batch open. Returns whether anything was pushed.
+	 */
+	flush(view?: ViewBase, options?: FlushNativeUpdatesOptions): boolean {
+		if (view) {
+			return view.flushNativeUpdates({ subtree: options?.subtree ?? true, force: options?.force });
+		}
+
+		let flushed = false;
+		for (const node of held) {
+			flushed = node.flushNativeUpdates(options) || flushed;
+		}
+
+		return flushed;
+	},
+
+	/**
+	 * Holds the node for the open batch the first time it is written to.
+	 * @private
+	 */
+	_hold(view: ViewBase): void {
+		if (!held.has(view)) {
+			held.add(view);
+			view._suspendNativeUpdates(SuspendType.Incremental);
+		}
+	},
+};

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -1,4 +1,6 @@
-import { ViewBase } from '../view-base';
+// Type-only on purpose: `ViewBase` imports this module back, and the cycle only holds while
+// nothing here needs `ViewBase` at runtime.
+import type { ViewBase } from '../view-base';
 import { PropertyChangeData, WrappedValue } from '../../../data/observable';
 import { Trace } from '../../../trace';
 
@@ -6,6 +8,9 @@ import { Style } from '../../styling/style';
 
 import { profile } from '../../../profiling';
 import { unsetValue, PropertyOptions, CoerciblePropertyOptions, CssPropertyOptions, ShorthandPropertyOptions, CssAnimationPropertyOptions, isCssWideKeyword, isCssUnsetValue, isResetValue } from './property-shared';
+import { Invalidation } from '../native-updates/invalidation';
+import { NativeUpdateBatch } from '../native-updates/batch';
+import type { NativeUpdateEntry } from '../native-updates/batch';
 import { calc } from '@csstools/css-calc';
 
 // Backwards compatibility
@@ -334,15 +339,25 @@ function applyNativeValue(view: ViewBase, store: any, property: NativeProperty, 
 	}
 }
 
+let defaultCommitNativeUpdates: unknown;
+
 /**
- * The single native routing point of every property setter: apply the write now, or record the
- * property as dirty while the view is holding native updates back.
+ * Registered by `ViewBase` at load. Setters compare a node's hook against it to tell whether its
+ * class takes part in commit ordering, which they cannot ask `ViewBase` for directly.
+ * @private
  */
-function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty, value: any, write: NativeWrite): void {
-	if (view._suspendNativeUpdatesCount !== 0) {
-		if (view._suspendedUpdates && view[property.setNative]) {
-			view._suspendedUpdates[property.name] = property;
-		}
+export function _setDefaultCommitNativeUpdates(commit: unknown): void {
+	defaultCommitNativeUpdates = commit;
+}
+
+/**
+ * The single native routing point of every property setter. A live view whose class takes no part
+ * in commit ordering writes straight through; anything else records the property as dirty and lets
+ * a commit apply it, right away when nothing is holding native updates back.
+ */
+function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty, value: any, write: NativeWrite, oldValue: any): void {
+	if (view._suspendNativeUpdatesCount !== 0 || view.commitNativeUpdates !== defaultCommitNativeUpdates) {
+		queueNativeUpdate(view, property, oldValue);
 
 		return;
 	}
@@ -364,6 +379,29 @@ function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty
 		view[setNative](value);
 	} else if (write !== NativeWrite.None) {
 		applyNativeValue(view, store, property, value, write);
+	}
+}
+
+function queueNativeUpdate(view: ViewBase, property: NativeProperty, oldValue: any): void {
+	const dirty = view._suspendedUpdates;
+	if (dirty && view[property.setNative]) {
+		// `NativeUpdateBatch.previous` is only reachable from a commit hook, so a node whose class
+		// does not define one records nothing.
+		if (view.commitNativeUpdates !== defaultCommitNativeUpdates) {
+			let previous = view._pendingPrevious;
+			if (!previous) {
+				previous = view._pendingPrevious = new Map();
+			}
+			if (!previous.has(property)) {
+				previous.set(property, oldValue);
+			}
+		}
+
+		dirty[property.name] = property;
+	}
+
+	if (view._suspendNativeUpdatesCount === 0) {
+		initNativeView(view);
 	}
 }
 
@@ -466,7 +504,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 					valueChanged(this, oldValue, value);
 				}
 
-				queueOrApplyNative(this, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
+				queueOrApplyNative(this, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value, oldValue);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -621,7 +659,7 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
 					valueChanged(this, oldValue, value);
 				}
 
-				queueOrApplyNative(this, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
+				queueOrApplyNative(this, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value, oldValue);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -833,7 +871,7 @@ export class CssProperty<T extends Style, U> {
 					valueChanged(this, oldValue, value);
 				}
 
-				queueOrApplyNative(view, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
+				queueOrApplyNative(view, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value, oldValue);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -891,7 +929,7 @@ export class CssProperty<T extends Style, U> {
 					valueChanged(this, oldValue, value);
 				}
 
-				queueOrApplyNative(view, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
+				queueOrApplyNative(view, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value, oldValue);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -1079,7 +1117,7 @@ export class CssAnimationProperty<T extends Style, U> implements CssAnimationPro
 					}
 
 					if (computedValueChanged || isSet !== wasSet) {
-						queueOrApplyNative(view, this, property, value, isSet ? (wasSet ? NativeWrite.ValueNoCapture : NativeWrite.Value) : wasSet ? NativeWrite.DefaultNoRelease : NativeWrite.None);
+						queueOrApplyNative(view, this, property, value, isSet ? (wasSet ? NativeWrite.ValueNoCapture : NativeWrite.Value) : wasSet ? NativeWrite.DefaultNoRelease : NativeWrite.None, oldValue);
 					}
 
 					if (computedValueChanged && this.hasListeners(eventName)) {
@@ -1250,7 +1288,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 						valueChanged(this, oldValue, value);
 					}
 
-					queueOrApplyNative(view, this, property, value, unsetNativeValue ? NativeWrite.Default : NativeWrite.Value);
+					queueOrApplyNative(view, this, property, value, unsetNativeValue ? NativeWrite.Default : NativeWrite.Value, oldValue);
 
 					if (this.hasListeners(eventName)) {
 						this.notify<PropertyChangeData>({
@@ -1425,14 +1463,80 @@ function inheritableCssPropertyValuesOn(style: Style): Array<{ property: Inherit
 
 type PropertyInterface = Property<ViewBase, any> | CssProperty<Style, any> | CssAnimationProperty<Style, any>;
 
-export const initNativeView = profile('"properties".initNativeView', function initNativeView(view: ViewBase): void {
-	if (view._suspendedUpdates) {
-		applyPendingNativeSetters(view);
+/** What a commit has to apply, in the order `ViewBase.commitNativeUpdates` will apply it. */
+function collectNativeUpdateEntries(view: ViewBase, isMount: boolean): NativeUpdateEntry[] {
+	const entries: NativeUpdateEntry[] = [];
+
+	if (isMount) {
+		let symbols = Object.getOwnPropertySymbols(view);
+		for (const symbol of symbols) {
+			const property: Property<any, any> = symbolPropertyMap[symbol];
+			if (property) {
+				entries.push(property);
+			}
+		}
+
+		symbols = Object.getOwnPropertySymbols(view.style);
+		for (const symbol of symbols) {
+			const property: CssProperty<any, any> = cssSymbolPropertyMap[symbol];
+			if (property) {
+				entries.push(property);
+			}
+		}
 	} else {
-		applyAllNativeSetters(view);
+		const suspendedUpdates = view._suspendedUpdates;
+		for (const propertyName in suspendedUpdates) {
+			if (HAS_OWN.call(suspendedUpdates, propertyName)) {
+				entries.push(<PropertyInterface>suspendedUpdates[propertyName]);
+			}
+		}
 	}
+
+	const invalidations = view._pendingInvalidations;
+	if (invalidations) {
+		for (const invalidation of invalidations) {
+			entries.push(invalidation);
+		}
+	}
+
+	return entries;
+}
+
+function applyNativeUpdate(batch: NativeUpdateBatch, entry: NativeUpdateEntry): void {
+	const view = batch.node;
+
+	if (entry instanceof Invalidation) {
+		const handler = view[entry.apply];
+		if (handler) {
+			handler.call(view, batch);
+		}
+
+		return;
+	}
+
+	if (batch.isMount) {
+		applyMountedNativeSetter(view, entry);
+	} else {
+		applyPendingNativeSetter(view, entry);
+	}
+}
+
+/**
+ * Builds the batch of everything dirty on the view and hands it to `commitNativeUpdates`.
+ * @deprecated Override `ViewBase.commitNativeUpdates` to order a class's native writes, or call
+ * `ViewBase.flushNativeUpdates` to push what is pending.
+ */
+export const initNativeView = profile('"properties".initNativeView', function initNativeView(view: ViewBase): void {
+	const isMount = view._suspendedUpdates === undefined;
+	const batch = new NativeUpdateBatch(view, isMount, collectNativeUpdateEntries(view, isMount), view._pendingPrevious, applyNativeUpdate);
+
+	// Dropped before the commit runs so that a write made from a handler queues against a fresh set.
 	// Would it be faster to delete all members of the old object?
 	view._suspendedUpdates = {};
+	view._pendingPrevious = undefined;
+	view._pendingInvalidations = undefined;
+
+	view.commitNativeUpdates(batch);
 });
 
 /**
@@ -1477,6 +1581,10 @@ function applyMountedNativeSetter(view: ViewBase, property: PropertyInterface): 
 	}
 }
 
+/**
+ * @deprecated Superseded by `ViewBase.commitNativeUpdates`, which applies the same dirty set
+ * through a `NativeUpdateBatch` the class can reorder.
+ */
 export function applyPendingNativeSetters(view: ViewBase): void {
 	// TODO: Check what happens if a view was suspended and its value was reset, or set back to default!
 	const suspendedUpdates = view._suspendedUpdates;
@@ -1486,6 +1594,9 @@ export function applyPendingNativeSetters(view: ViewBase): void {
 	}
 }
 
+/**
+ * @deprecated Superseded by `ViewBase.commitNativeUpdates` with a batch whose `isMount` is set.
+ */
 export function applyAllNativeSetters(view: ViewBase): void {
 	let symbols = Object.getOwnPropertySymbols(view);
 	for (const symbol of symbols) {

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -361,7 +361,7 @@ export function _setDefaultCommitNativeUpdates(commit: unknown): void {
  * a commit apply it, right away when nothing is holding native updates back.
  */
 function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty, value: any, write: NativeWrite, oldValue: any): void {
-	if (view._suspendNativeUpdatesCount !== 0 || scheduler._depth !== 0 || view.commitNativeUpdates !== defaultCommitNativeUpdates) {
+	if (view._suspendNativeUpdatesCount !== 0 || scheduler._depth !== 0 || view.commitNativeUpdates !== defaultCommitNativeUpdates || property.invalidates !== undefined) {
 		queueNativeUpdate(view, property, oldValue);
 
 		return;
@@ -392,11 +392,12 @@ function queueNativeUpdate(view: ViewBase, property: NativeProperty, oldValue: a
 		scheduler._hold(view);
 	}
 
+	const invalidates = property.invalidates;
 	const dirty = view._suspendedUpdates;
 	if (dirty && view[property.setNative]) {
-		// `NativeUpdateBatch.previous` is only reachable from a commit hook, so a node whose class
-		// does not define one records nothing.
-		if (view.commitNativeUpdates !== defaultCommitNativeUpdates) {
+		// `NativeUpdateBatch.previous` is only reachable from a commit hook or an aggregate
+		// handler, so a node with neither records nothing.
+		if (invalidates !== undefined || view.commitNativeUpdates !== defaultCommitNativeUpdates) {
 			let previous = view._pendingPrevious;
 			if (!previous) {
 				previous = view._pendingPrevious = new Map();
@@ -407,6 +408,17 @@ function queueNativeUpdate(view: ViewBase, property: NativeProperty, oldValue: a
 		}
 
 		dirty[property.name] = property;
+	}
+
+	if (invalidates) {
+		let pending = view._pendingInvalidations;
+		if (!pending) {
+			pending = view._pendingInvalidations = new Set();
+		}
+
+		for (let i = 0, length = invalidates.length; i < length; i++) {
+			pending.add(invalidates[i]);
+		}
 	}
 
 	if (view._suspendNativeUpdatesCount === 0) {
@@ -425,6 +437,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 
 	public readonly defaultValueKey: symbol;
 	public readonly defaultValue: U;
+	public readonly invalidates: readonly Invalidation[] | undefined;
 	public readonly nativeValueChange: (owner: T, value: U) => void;
 
 	public isStyleProperty: boolean;
@@ -453,6 +466,7 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 
 		const defaultValue: U = options.defaultValue;
 		this.defaultValue = defaultValue;
+		this.invalidates = options.invalidates;
 
 		const eventName = propertyName + 'Change';
 
@@ -787,6 +801,7 @@ export class CssProperty<T extends Style, U> {
 	public readonly sourceKey: symbol;
 	public readonly defaultValueKey: symbol;
 	public readonly defaultValue: U;
+	public readonly invalidates: readonly Invalidation[] | undefined;
 
 	public overrideHandlers: (options: CssPropertyOptions<T, U>) => void;
 
@@ -819,6 +834,7 @@ export class CssProperty<T extends Style, U> {
 
 		const defaultValue: U = options.defaultValue;
 		this.defaultValue = defaultValue;
+		this.invalidates = options.invalidates;
 
 		const eventName = propertyName + 'Change';
 		let affectsLayout: boolean = options.affectsLayout;
@@ -1013,6 +1029,7 @@ export class CssAnimationProperty<T extends Style, U> implements CssAnimationPro
 	private readonly source: symbol;
 
 	public readonly defaultValue: U;
+	public readonly invalidates: readonly Invalidation[] | undefined;
 
 	public isStyleProperty: boolean;
 
@@ -1050,6 +1067,7 @@ export class CssAnimationProperty<T extends Style, U> implements CssAnimationPro
 		this.defaultValueKey = defaultValueKey;
 
 		this.defaultValue = options.defaultValue;
+		this.invalidates = options.invalidates;
 
 		const cssValue = Symbol(cssName);
 		const styleValue = Symbol(`local:${propertyName}`);

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -283,6 +283,90 @@ function getPropertiesFromMap(map): Property<any, any>[] | CssProperty<any, any>
 	return props;
 }
 
+type NativeProperty = Property<any, any> | CssProperty<any, any> | CssAnimationProperty<any, any>;
+
+/**
+ * What a setter asks of the native view. The `store` a write is made against is where the
+ * captured native default lives: the view for view properties, the style for css ones.
+ */
+const enum NativeWrite {
+	/** Nothing to push; the write only has to be recorded while updates are suspended. */
+	None,
+	/** Push the value, capturing the native default first when nothing captured it yet. */
+	Value,
+	/** Push the value without capturing: the slot doubles as `CssAnimationProperty`'s `default:` value. */
+	ValueNoCapture,
+	/** Push the captured native default back and drop the capture. */
+	Default,
+	/** Push the captured native default back, keeping it for the same reason as `ValueNoCapture`. */
+	DefaultNoRelease,
+}
+
+function captureNativeDefault(view: ViewBase, store: any, property: NativeProperty): void {
+	const defaultValueKey = property.defaultValueKey;
+	if (!(defaultValueKey in store)) {
+		const getDefault = property.getDefault;
+		store[defaultValueKey] = view[getDefault] ? view[getDefault]() : property.defaultValue;
+	}
+}
+
+function applyNativeValue(view: ViewBase, store: any, property: NativeProperty, value: any, write: NativeWrite): void {
+	const setNative = property.setNative;
+
+	if (write === NativeWrite.Value || write === NativeWrite.ValueNoCapture) {
+		if (write === NativeWrite.Value) {
+			captureNativeDefault(view, store, property);
+		}
+
+		view[setNative](value);
+
+		return;
+	}
+
+	const defaultValueKey = property.defaultValueKey;
+	if (defaultValueKey in store) {
+		view[setNative](store[defaultValueKey]);
+		if (write === NativeWrite.Default) {
+			delete store[defaultValueKey];
+		}
+	} else {
+		view[setNative](property.defaultValue);
+	}
+}
+
+/**
+ * The single native routing point of every property setter: apply the write now, or record the
+ * property as dirty while the view is holding native updates back.
+ */
+function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty, value: any, write: NativeWrite): void {
+	if (view._suspendNativeUpdatesCount !== 0) {
+		if (view._suspendedUpdates && view[property.setNative]) {
+			view._suspendedUpdates[property.name] = property;
+		}
+
+		return;
+	}
+
+	const setNative = property.setNative;
+	if (!view[setNative]) {
+		return;
+	}
+
+	// The plain write is spelled out rather than delegated: it is the one every live set takes,
+	// and a call per set is measurable on an interpreter-only engine.
+	if (write === NativeWrite.Value) {
+		const defaultValueKey = property.defaultValueKey;
+		if (!(defaultValueKey in store)) {
+			const getDefault = property.getDefault;
+			store[defaultValueKey] = view[getDefault] ? view[getDefault]() : property.defaultValue;
+		}
+
+		view[setNative](value);
+	} else if (write !== NativeWrite.None) {
+		applyNativeValue(view, store, property, value, write);
+	}
+}
+
 export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<U>, Property<T, U> {
 	private registered: boolean;
 
@@ -374,39 +458,15 @@ export class Property<T extends ViewBase, U> implements TypedPropertyDescriptor<
 
 				if (reset) {
 					delete this[key];
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-					if (this[setNative]) {
-						if (this._suspendNativeUpdatesCount) {
-							if (this._suspendedUpdates) {
-								this._suspendedUpdates[propertyName] = property;
-							}
-						} else if (defaultValueKey in this) {
-							this[setNative](this[defaultValueKey]);
-							delete this[defaultValueKey];
-						} else {
-							this[setNative](defaultValue);
-						}
-					}
 				} else {
 					this[key] = value;
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-					if (this[setNative]) {
-						if (this._suspendNativeUpdatesCount) {
-							if (this._suspendedUpdates) {
-								this._suspendedUpdates[propertyName] = property;
-							}
-						} else {
-							if (!(defaultValueKey in this)) {
-								this[defaultValueKey] = this[getDefault] ? this[getDefault]() : defaultValue;
-							}
-							this[setNative](value);
-						}
-					}
 				}
+
+				if (valueChanged) {
+					valueChanged(this, oldValue, value);
+				}
+
+				queueOrApplyNative(this, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -490,9 +550,6 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
 
 		const propertyName = options.name;
 		const key = this.key;
-		const getDefault: symbol = this.getDefault;
-		const setNative: symbol = this.setNative;
-		const defaultValueKey = this.defaultValueKey;
 		const defaultValue: U = this.defaultValue;
 
 		const coerceKey = Symbol(propertyName + ':coerceKey');
@@ -556,41 +613,15 @@ export class CoercibleProperty<T extends ViewBase, U> extends Property<T, U> imp
 			if (wrapped || changed) {
 				if (reset) {
 					delete this[key];
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-
-					if (this[setNative]) {
-						if (this._suspendNativeUpdatesCount) {
-							if (this._suspendedUpdates) {
-								this._suspendedUpdates[propertyName] = property;
-							}
-						} else if (defaultValueKey in this) {
-							this[setNative](this[defaultValueKey]);
-							delete this[defaultValueKey];
-						} else {
-							this[setNative](defaultValue);
-						}
-					}
 				} else {
 					this[key] = value;
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-
-					if (this[setNative]) {
-						if (this._suspendNativeUpdatesCount) {
-							if (this._suspendedUpdates) {
-								this._suspendedUpdates[propertyName] = property;
-							}
-						} else {
-							if (!(defaultValueKey in this)) {
-								this[defaultValueKey] = this[getDefault] ? this[getDefault]() : defaultValue;
-							}
-							this[setNative](value);
-						}
-					}
 				}
+
+				if (valueChanged) {
+					valueChanged(this, oldValue, value);
+				}
+
+				queueOrApplyNative(this, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -794,41 +825,15 @@ export class CssProperty<T extends Style, U> {
 			if (changed) {
 				if (reset) {
 					delete this[key];
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-
-					if (view[setNative]) {
-						if (view._suspendNativeUpdatesCount) {
-							if (view._suspendedUpdates) {
-								view._suspendedUpdates[propertyName] = property;
-							}
-						} else if (defaultValueKey in this) {
-							view[setNative](this[defaultValueKey]);
-							delete this[defaultValueKey];
-						} else {
-							view[setNative](defaultValue);
-						}
-					}
 				} else {
 					this[key] = value;
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-
-					if (view[setNative]) {
-						if (view._suspendNativeUpdatesCount) {
-							if (view._suspendedUpdates) {
-								view._suspendedUpdates[propertyName] = property;
-							}
-						} else {
-							if (!(defaultValueKey in this)) {
-								this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-							}
-							view[setNative](value);
-						}
-					}
 				}
+
+				if (valueChanged) {
+					valueChanged(this, oldValue, value);
+				}
+
+				queueOrApplyNative(view, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -878,41 +883,15 @@ export class CssProperty<T extends Style, U> {
 			if (changed) {
 				if (reset) {
 					delete this[key];
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-
-					if (view[setNative]) {
-						if (view._suspendNativeUpdatesCount) {
-							if (view._suspendedUpdates) {
-								view._suspendedUpdates[propertyName] = property;
-							}
-						} else if (defaultValueKey in this) {
-							view[setNative](this[defaultValueKey]);
-							delete this[defaultValueKey];
-						} else {
-							view[setNative](defaultValue);
-						}
-					}
 				} else {
 					this[key] = value;
-					if (valueChanged) {
-						valueChanged(this, oldValue, value);
-					}
-
-					if (view[setNative]) {
-						if (view._suspendNativeUpdatesCount) {
-							if (view._suspendedUpdates) {
-								view._suspendedUpdates[propertyName] = property;
-							}
-						} else {
-							if (!(defaultValueKey in this)) {
-								this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-							}
-							view[setNative](value);
-						}
-					}
 				}
+
+				if (valueChanged) {
+					valueChanged(this, oldValue, value);
+				}
+
+				queueOrApplyNative(view, this, property, value, reset ? NativeWrite.Default : NativeWrite.Value);
 
 				if (this.hasListeners(eventName)) {
 					this.notify<PropertyChangeData>({
@@ -1034,8 +1013,7 @@ export class CssAnimationProperty<T extends Style, U> implements CssAnimationPro
 		this.source = computedSource;
 
 		this.getDefault = Symbol(propertyName + ':getDefault');
-		const getDefault = this.getDefault;
-		const setNative = (this.setNative = Symbol(propertyName + ':setNative'));
+		this.setNative = Symbol(propertyName + ':setNative');
 		const eventName = propertyName + 'Change';
 
 		const property = this;
@@ -1100,25 +1078,8 @@ export class CssAnimationProperty<T extends Style, U> implements CssAnimationPro
 						options.valueChanged(this, oldValue, value);
 					}
 
-					if (view[setNative] && (computedValueChanged || isSet !== wasSet)) {
-						if (view._suspendNativeUpdatesCount) {
-							if (view._suspendedUpdates) {
-								view._suspendedUpdates[propertyName] = property;
-							}
-						} else {
-							if (isSet) {
-								if (!wasSet && !(defaultValueKey in this)) {
-									this[defaultValueKey] = view[getDefault] ? view[getDefault]() : options.defaultValue;
-								}
-								view[setNative](value);
-							} else if (wasSet) {
-								if (defaultValueKey in this) {
-									view[setNative](this[defaultValueKey]);
-								} else {
-									view[setNative](options.defaultValue);
-								}
-							}
-						}
+					if (computedValueChanged || isSet !== wasSet) {
+						queueOrApplyNative(view, this, property, value, isSet ? (wasSet ? NativeWrite.ValueNoCapture : NativeWrite.Value) : wasSet ? NativeWrite.DefaultNoRelease : NativeWrite.None);
 					}
 
 					if (computedValueChanged && this.hasListeners(eventName)) {
@@ -1199,9 +1160,6 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 
 		const key = this.key;
 		const sourceKey = this.sourceKey;
-		const getDefault = this.getDefault;
-		const setNative = this.setNative;
-		const defaultValueKey = this.defaultValueKey;
 		const eventName = propertyName + 'Change';
 		const defaultValue: U = options.defaultValue;
 
@@ -1292,26 +1250,7 @@ export class InheritedCssProperty<T extends Style, U> extends CssProperty<T, U> 
 						valueChanged(this, oldValue, value);
 					}
 
-					if (view[setNative]) {
-						if (view._suspendNativeUpdatesCount) {
-							if (view._suspendedUpdates) {
-								view._suspendedUpdates[propertyName] = property;
-							}
-						} else if (unsetNativeValue) {
-							if (defaultValueKey in this) {
-								view[setNative](this[defaultValueKey]);
-								delete this[defaultValueKey];
-							} else {
-								view[setNative](defaultValue);
-							}
-						} else {
-							if (!(defaultValueKey in this)) {
-								this[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-							}
-
-							view[setNative](value);
-						}
-					}
+					queueOrApplyNative(view, this, property, value, unsetNativeValue ? NativeWrite.Default : NativeWrite.Value);
 
 					if (this.hasListeners(eventName)) {
 						this.notify<PropertyChangeData>({
@@ -1496,39 +1435,54 @@ export const initNativeView = profile('"properties".initNativeView', function in
 	view._suspendedUpdates = {};
 });
 
+/**
+ * One entry of `applyPendingNativeSetters`: the value is re-read from its store, so a property
+ * dirtied several times while suspended reaches native once, with the value it ended up at.
+ */
+function applyPendingNativeSetter(view: ViewBase, property: PropertyInterface): void {
+	const setNative = property.setNative;
+	if (!view[setNative]) {
+		return;
+	}
+
+	const store = property.isStyleProperty ? view.style : view;
+	if ((<any>property).isSet(store)) {
+		captureNativeDefault(view, store, property);
+		// TODO: Only if value is different from the value before the scope was created.
+		view[setNative](store[property.name]);
+	} else {
+		view[setNative](store[property.defaultValueKey]);
+	}
+}
+
+/** One entry of `applyAllNativeSetters`: every value the instance carries is dirty. */
+function applyMountedNativeSetter(view: ViewBase, property: PropertyInterface): void {
+	const setNative = property.setNative;
+
+	if (property.isStyleProperty) {
+		if (!view[setNative]) {
+			return;
+		}
+
+		const style = view.style;
+		captureNativeDefault(view, style, property);
+		view[setNative](style[property.key]);
+	} else {
+		if (!(setNative in view)) {
+			return;
+		}
+
+		captureNativeDefault(view, view, property);
+		view[setNative](view[property.key]);
+	}
+}
+
 export function applyPendingNativeSetters(view: ViewBase): void {
 	// TODO: Check what happens if a view was suspended and its value was reset, or set back to default!
 	const suspendedUpdates = view._suspendedUpdates;
 	for (const propertyName in suspendedUpdates) {
 		if (!HAS_OWN.call(suspendedUpdates, propertyName)) continue;
-		const property = <PropertyInterface>suspendedUpdates[propertyName];
-		const setNative = property.setNative;
-		if (view[setNative]) {
-			const { getDefault, isStyleProperty, defaultValueKey, defaultValue } = property;
-			let value;
-			if (isStyleProperty) {
-				const style = view.style;
-				if ((<CssProperty<Style, any> | CssAnimationProperty<Style, any>>property).isSet(view.style)) {
-					if (!(defaultValueKey in style)) {
-						style[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-					}
-					value = view.style[propertyName];
-				} else {
-					value = style[defaultValueKey];
-				}
-			} else {
-				if ((<Property<ViewBase, any>>property).isSet(view)) {
-					if (!(defaultValueKey in view)) {
-						view[defaultValueKey] = view[getDefault] ? view[getDefault]() : defaultValue;
-					}
-					value = view[propertyName];
-				} else {
-					value = view[defaultValueKey];
-				}
-			}
-			// TODO: Only if value is different from the value before the scope was created.
-			view[setNative](value);
-		}
+		applyPendingNativeSetter(view, <PropertyInterface>suspendedUpdates[propertyName]);
 	}
 }
 
@@ -1536,39 +1490,16 @@ export function applyAllNativeSetters(view: ViewBase): void {
 	let symbols = Object.getOwnPropertySymbols(view);
 	for (const symbol of symbols) {
 		const property: Property<any, any> = symbolPropertyMap[symbol];
-		if (!property) {
-			continue;
-		}
-
-		const setNative = property.setNative;
-		const getDefault = property.getDefault;
-		if (setNative in view) {
-			const defaultValueKey = property.defaultValueKey;
-			if (!(defaultValueKey in view)) {
-				view[defaultValueKey] = view[getDefault] ? view[getDefault]() : property.defaultValue;
-			}
-
-			const value = view[symbol];
-			view[setNative](value);
+		if (property) {
+			applyMountedNativeSetter(view, property);
 		}
 	}
 
-	const style = view.style;
-	symbols = Object.getOwnPropertySymbols(style);
+	symbols = Object.getOwnPropertySymbols(view.style);
 	for (const symbol of symbols) {
 		const property: CssProperty<any, any> = cssSymbolPropertyMap[symbol];
-		if (!property) {
-			continue;
-		}
-
-		if (view[property.setNative]) {
-			const defaultValueKey = property.defaultValueKey;
-			if (!(defaultValueKey in style)) {
-				style[defaultValueKey] = view[property.getDefault] ? view[property.getDefault]() : property.defaultValue;
-			}
-
-			const value = style[symbol];
-			view[property.setNative](value);
+		if (property) {
+			applyMountedNativeSetter(view, property);
 		}
 	}
 }

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -1554,7 +1554,24 @@ function applyNativeUpdate(batch: NativeUpdateBatch, entry: NativeUpdateEntry): 
  * `ViewBase.flushNativeUpdates` to push what is pending.
  */
 export const initNativeView = profile('"properties".initNativeView', function initNativeView(view: ViewBase): void {
-	const isMount = view._suspendedUpdates === undefined;
+	const dirty = view._suspendedUpdates;
+	const isMount = dirty === undefined;
+
+	if (view._pendingInvalidations === undefined && view.commitNativeUpdates === defaultCommitNativeUpdates) {
+		// Nothing on this node can reach a batch, so the sweep runs straight off the dirty set,
+		// which is dropped first as on the batch path.
+		view._suspendedUpdates = {};
+		view._pendingPrevious = undefined;
+
+		if (isMount) {
+			applyAllNativeSetters(view);
+		} else {
+			applyDirtyNativeSetters(view, dirty);
+		}
+
+		return;
+	}
+
 	const batch = new NativeUpdateBatch(view, isMount, collectNativeUpdateEntries(view, isMount), view._pendingPrevious, applyNativeUpdate);
 
 	// Dropped before the commit runs so that a write made from a handler queues against a fresh set.
@@ -1612,13 +1629,16 @@ function applyMountedNativeSetter(view: ViewBase, property: PropertyInterface): 
  * @deprecated Superseded by `ViewBase.commitNativeUpdates`, which applies the same dirty set
  * through a `NativeUpdateBatch` the class can reorder.
  */
-export function applyPendingNativeSetters(view: ViewBase): void {
+function applyDirtyNativeSetters(view: ViewBase, dirty: ViewBase['_suspendedUpdates']): void {
 	// TODO: Check what happens if a view was suspended and its value was reset, or set back to default!
-	const suspendedUpdates = view._suspendedUpdates;
-	for (const propertyName in suspendedUpdates) {
-		if (!HAS_OWN.call(suspendedUpdates, propertyName)) continue;
-		applyPendingNativeSetter(view, <PropertyInterface>suspendedUpdates[propertyName]);
+	for (const propertyName in dirty) {
+		if (!HAS_OWN.call(dirty, propertyName)) continue;
+		applyPendingNativeSetter(view, <PropertyInterface>dirty[propertyName]);
 	}
+}
+
+export function applyPendingNativeSetters(view: ViewBase): void {
+	applyDirtyNativeSetters(view, view._suspendedUpdates);
 }
 
 /**

--- a/packages/core/ui/core/properties/index.ts
+++ b/packages/core/ui/core/properties/index.ts
@@ -10,6 +10,7 @@ import { profile } from '../../../profiling';
 import { unsetValue, PropertyOptions, CoerciblePropertyOptions, CssPropertyOptions, ShorthandPropertyOptions, CssAnimationPropertyOptions, isCssWideKeyword, isCssUnsetValue, isResetValue } from './property-shared';
 import { Invalidation } from '../native-updates/invalidation';
 import { NativeUpdateBatch } from '../native-updates/batch';
+import { NativeUpdates } from '../native-updates/scheduler';
 import type { NativeUpdateEntry } from '../native-updates/batch';
 import { calc } from '@csstools/css-calc';
 
@@ -339,6 +340,10 @@ function applyNativeValue(view: ViewBase, store: any, property: NativeProperty, 
 	}
 }
 
+// Bound once: the setters read the batch depth on every write, and going through the module
+// namespace on each of them is measurable.
+const scheduler = NativeUpdates;
+
 let defaultCommitNativeUpdates: unknown;
 
 /**
@@ -356,7 +361,7 @@ export function _setDefaultCommitNativeUpdates(commit: unknown): void {
  * a commit apply it, right away when nothing is holding native updates back.
  */
 function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty, value: any, write: NativeWrite, oldValue: any): void {
-	if (view._suspendNativeUpdatesCount !== 0 || view.commitNativeUpdates !== defaultCommitNativeUpdates) {
+	if (view._suspendNativeUpdatesCount !== 0 || scheduler._depth !== 0 || view.commitNativeUpdates !== defaultCommitNativeUpdates) {
 		queueNativeUpdate(view, property, oldValue);
 
 		return;
@@ -383,6 +388,10 @@ function queueOrApplyNative(view: ViewBase, store: any, property: NativeProperty
 }
 
 function queueNativeUpdate(view: ViewBase, property: NativeProperty, oldValue: any): void {
+	if (scheduler._depth !== 0) {
+		scheduler._hold(view);
+	}
+
 	const dirty = view._suspendedUpdates;
 	if (dirty && view[property.setNative]) {
 		// `NativeUpdateBatch.previous` is only reachable from a commit hook, so a node whose class

--- a/packages/core/ui/core/properties/native-updates-commit-cost.spec.ts
+++ b/packages/core/ui/core/properties/native-updates-commit-cost.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+
+import { View } from '../view';
+import { Property } from './index';
+
+/**
+ * What a commit costs per node, where the batch is built. The numbers are printed rather than
+ * asserted - the assertion is only that every pending value arrived.
+ */
+const COMMIT_PROPERTIES = 8;
+const RELOAD_PROPERTIES = 4;
+
+let calls = 0;
+
+class TestView extends View {
+	createNativeView(): Object {
+		return {};
+	}
+
+	public _addViewToNativeVisualTree(): boolean {
+		return true;
+	}
+}
+
+const propertyNames: string[] = [];
+for (let i = 0; i < COMMIT_PROPERTIES; i++) {
+	const property = new Property<TestView, number>({ name: `commit${i}`, defaultValue: -1 });
+	property.register(TestView);
+	(TestView.prototype as any)[property.setNative] = function () {
+		calls++;
+	};
+	propertyNames.push(property.name);
+}
+
+function write(view: any, count: number, value: number): void {
+	for (let i = 0; i < count; i++) {
+		view[propertyNames[i]] = value;
+	}
+}
+
+function loadedView(): any {
+	const view: any = new TestView();
+	view._setupUI({});
+	view.callLoaded();
+
+	return view;
+}
+
+function measure(label: string, iterations: number, unit: string, callsEach: number, run: (iterations: number) => void): void {
+	run(Math.max(1, Math.round(iterations / 10)));
+
+	calls = 0;
+	const started = performance.now();
+	run(iterations);
+	const elapsed = performance.now() - started;
+
+	console.log(`commit ${label}: ${iterations} ${unit} in ${elapsed.toFixed(1)}ms (${((elapsed * 1000) / iterations).toFixed(2)}us each)`);
+	expect(calls).toBe(callsEach * iterations);
+}
+
+describe('commit cost', () => {
+	it('loads views carrying pending properties', () => {
+		measure('load', 2000, 'views', COMMIT_PROPERTIES, (iterations) => {
+			for (let i = 0; i < iterations; i++) {
+				const view: any = new TestView();
+				write(view, COMMIT_PROPERTIES, i);
+				view._setupUI({});
+				view.callLoaded();
+			}
+		});
+	});
+
+	it('reloads views written to while unloaded', () => {
+		const views: any[] = [];
+		for (let i = 0; i < 2200; i++) {
+			views.push(loadedView());
+		}
+		let next = 0;
+
+		measure('reload', 2000, 'views', RELOAD_PROPERTIES, (iterations) => {
+			for (let i = 0; i < iterations; i++) {
+				const view = views[next++ % views.length];
+				view.callUnloaded();
+				write(view, RELOAD_PROPERTIES, i);
+				view.callLoaded();
+			}
+		});
+	});
+
+	it('commits batched writes on a live view', () => {
+		const view = loadedView();
+
+		measure('_batchUpdate', 5000, 'batches', COMMIT_PROPERTIES, (iterations) => {
+			for (let i = 0; i < iterations; i++) {
+				view._batchUpdate(() => {
+					write(view, COMMIT_PROPERTIES, i);
+				});
+			}
+		});
+	});
+});

--- a/packages/core/ui/core/properties/native-updates-hot-path.spec.ts
+++ b/packages/core/ui/core/properties/native-updates-hot-path.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+import { View } from '../view';
+import { Style } from '../../styling/style';
+import { CssProperty, Property } from './index';
+
+/**
+ * Invariant I6: a set on a live view reaches `[setNative]` directly. The numbers are
+ * printed rather than asserted - the assertion is only that every set arrived.
+ */
+const ITERATIONS = 100000;
+
+let calls = 0;
+
+class TestView extends View {
+	createNativeView(): Object {
+		return {};
+	}
+
+	public _addViewToNativeVisualTree(): boolean {
+		return true;
+	}
+}
+
+const hotProperty = new Property<TestView, number>({ name: 'hot', defaultValue: -1 });
+hotProperty.register(TestView);
+(TestView.prototype as any)[hotProperty.setNative] = function () {
+	calls++;
+};
+
+const hotCssProperty = new CssProperty<Style, number>({ name: 'hotCss', cssName: 'hot-css', defaultValue: -1 });
+hotCssProperty.register(Style);
+(TestView.prototype as any)[hotCssProperty.setNative] = function () {
+	calls++;
+};
+
+function loadedView(): any {
+	const view: any = new TestView();
+	view._setupUI({});
+	view.callLoaded();
+
+	return view;
+}
+
+function measure(label: string, run: (iterations: number) => void): void {
+	run(ITERATIONS / 10);
+
+	calls = 0;
+	const started = performance.now();
+	run(ITERATIONS);
+	const elapsed = performance.now() - started;
+
+	console.log(`I6 ${label}: ${ITERATIONS} live sets in ${elapsed.toFixed(1)}ms (${((elapsed * 1e6) / ITERATIONS).toFixed(0)}ns/set)`);
+	expect(calls).toBe(ITERATIONS);
+}
+
+describe('hot path cost', () => {
+	it('applies 100k live Property sets', () => {
+		const view = loadedView();
+
+		measure('Property', (iterations) => {
+			for (let i = 0; i < iterations; i++) {
+				view.hot = i;
+			}
+		});
+	});
+
+	it('applies 100k live CssProperty sets', () => {
+		const view = loadedView();
+		const style = view.style;
+
+		measure('CssProperty', (iterations) => {
+			for (let i = 0; i < iterations; i++) {
+				style.hotCss = i;
+			}
+		});
+	});
+});

--- a/packages/core/ui/core/properties/native-updates.spec.ts
+++ b/packages/core/ui/core/properties/native-updates.spec.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { View } from '../view';
+import { Style } from '../../styling/style';
+import { CoercibleProperty, CssAnimationProperty, CssProperty, InheritedCssProperty, InheritedProperty, Property, ShorthandProperty } from './index';
+import { unsetValue } from './property-shared';
+
+/**
+ * Native writes, default captures and `<name>Change` notifications share one log so that
+ * their relative order is part of what every expectation pins down.
+ */
+const log: string[] = [];
+
+class TestView extends View {
+	public testChildren: TestView[] = [];
+
+	createNativeView(): Object {
+		return {};
+	}
+
+	public eachChildView(callback: (child: any) => boolean): void {
+		for (const child of this.testChildren) {
+			if (!callback(child)) {
+				return;
+			}
+		}
+	}
+
+	// The fake native view is a plain object, so the real subview plumbing cannot run.
+	public _addViewToNativeVisualTree(): boolean {
+		return true;
+	}
+
+	public _removeViewFromNativeVisualTree(view: any): void {
+		view._isAddedToNativeVisualTree = false;
+	}
+
+	public addTestChild(child: TestView): void {
+		this.testChildren.push(child);
+		this._addView(child);
+	}
+}
+
+interface NativeProperty {
+	name: string;
+	setNative: symbol;
+	getDefault: symbol;
+}
+
+function trackNative(property: NativeProperty, withDefault = true): void {
+	const prototype = TestView.prototype as any;
+	prototype[property.setNative] = function (value: unknown) {
+		log.push(`${property.name}=${String(value)}`);
+	};
+
+	if (withDefault) {
+		prototype[property.getDefault] = function () {
+			log.push(`${property.name}:getDefault`);
+
+			return `${property.name}-native`;
+		};
+	}
+}
+
+function trackChange(target: any, name: string): void {
+	target.on(`${name}Change`, (args: any) => {
+		log.push(`${name}Change=${String(args.value)}`);
+	});
+}
+
+const alphaProperty = new Property<TestView, string>({ name: 'alpha', defaultValue: 'alpha-default' });
+alphaProperty.register(TestView);
+trackNative(alphaProperty);
+
+const betaProperty = new Property<TestView, string>({ name: 'beta', defaultValue: 'beta-default' });
+betaProperty.register(TestView);
+trackNative(betaProperty);
+
+/** No `[getDefault]` handler: resets fall back to the property's own default value. */
+const epsilonProperty = new Property<TestView, string>({ name: 'epsilon', defaultValue: 'epsilon-default' });
+epsilonProperty.register(TestView);
+trackNative(epsilonProperty, false);
+
+const zetaProperty = new CoercibleProperty<TestView, number>({
+	name: 'zeta',
+	defaultValue: 0,
+	coerceValue: (target, value) => Math.min(value, 10),
+});
+zetaProperty.register(TestView);
+trackNative(zetaProperty);
+
+const etaProperty = new InheritedProperty<TestView, string>({ name: 'eta', defaultValue: 'eta-default' });
+etaProperty.register(TestView);
+trackNative(etaProperty);
+
+const gammaProperty = new CssProperty<Style, string>({ name: 'gamma', cssName: 'gamma', defaultValue: 'gamma-default' });
+gammaProperty.register(Style);
+trackNative(gammaProperty);
+
+const deltaProperty = new CssProperty<Style, string>({ name: 'delta', cssName: 'delta', defaultValue: 'delta-default' });
+deltaProperty.register(Style);
+trackNative(deltaProperty);
+
+const animProperty = new CssAnimationProperty<Style, string>({ name: 'anim', cssName: 'anim', defaultValue: 'anim-default' });
+animProperty.register(Style);
+trackNative(animProperty);
+
+const inhProperty = new InheritedCssProperty<Style, string>({ name: 'inh', cssName: 'inh', defaultValue: 'inh-default' });
+inhProperty.register(Style);
+trackNative(inhProperty);
+
+const gammaDeltaProperty = new ShorthandProperty<Style, string>({
+	name: 'gammaDelta',
+	cssName: 'gamma-delta',
+	getter(this: Style) {
+		return `${this.gamma} ${this.delta}`;
+	},
+	converter: (value: string) => {
+		const [gamma, delta] = String(value).split(' ');
+
+		return [
+			[gammaProperty, gamma],
+			[deltaProperty, delta],
+		];
+	},
+});
+gammaDeltaProperty.register(Style as any);
+
+/** A view with a native view, loaded, with nothing pending. */
+function loadedView(): any {
+	const view: any = new TestView();
+	view._setupUI({});
+	view.callLoaded();
+	log.length = 0;
+
+	return view;
+}
+
+beforeEach(() => {
+	log.length = 0;
+});
+
+describe('native updates on first load', () => {
+	it('applies every set property once, view properties before style properties, in insertion order', () => {
+		const view: any = new TestView();
+		view.alpha = 'a';
+		view.style.gamma = 'g';
+		view.beta = 'b';
+		view.style.delta = 'd';
+
+		expect(log).toEqual([]);
+
+		view._setupUI({});
+		view.callLoaded();
+
+		expect(log).toEqual(['alpha:getDefault', 'alpha=a', 'beta:getDefault', 'beta=b', 'gamma:getDefault', 'gamma=g', 'delta:getDefault', 'delta=d']);
+	});
+
+	it('does not apply properties that were never set', () => {
+		const view: any = new TestView();
+		view.beta = 'b';
+
+		view._setupUI({});
+		view.callLoaded();
+
+		expect(log).toEqual(['beta:getDefault', 'beta=b']);
+	});
+});
+
+describe('native updates on a live view', () => {
+	it('applies each set immediately, without collapsing A to B back to A', () => {
+		const view = loadedView();
+
+		view.alpha = 'a';
+		view.alpha = 'b';
+		view.alpha = 'a';
+
+		expect(log).toEqual(['alpha:getDefault', 'alpha=a', 'alpha=b', 'alpha=a']);
+	});
+
+	it('does not apply a set that does not change the value', () => {
+		const view = loadedView();
+
+		view.alpha = 'a';
+		log.length = 0;
+		view.alpha = 'a';
+
+		expect(log).toEqual([]);
+	});
+
+	it('applies the coerced value', () => {
+		const view = loadedView();
+
+		view.zeta = 42;
+
+		expect(log).toEqual(['zeta:getDefault', 'zeta=10']);
+	});
+});
+
+describe('batched native updates', () => {
+	it('applies one native call for repeated sets of the same property', () => {
+		const view = loadedView();
+
+		view._batchUpdate(() => {
+			view.alpha = '1';
+			view.alpha = '2';
+			view.alpha = '3';
+		});
+
+		expect(log).toEqual(['alpha:getDefault', 'alpha=3']);
+	});
+
+	it('applies one native call per property, in first-dirtied order', () => {
+		const view = loadedView();
+
+		view._batchUpdate(() => {
+			view.beta = 'b';
+			view.alpha = 'a';
+			view.beta = 'b2';
+		});
+
+		expect(log).toEqual(['beta:getDefault', 'beta=b2', 'alpha:getDefault', 'alpha=a']);
+	});
+
+	it('keeps the first-dirtied order across view and style properties', () => {
+		const view = loadedView();
+
+		view._batchUpdate(() => {
+			view.style.gamma = 'g';
+			view.alpha = 'a';
+		});
+
+		expect(log).toEqual(['gamma:getDefault', 'gamma=g', 'alpha:getDefault', 'alpha=a']);
+	});
+});
+
+describe('native updates across unload and reload', () => {
+	it('re-applies only what changed while unloaded', () => {
+		const view = loadedView();
+		view.alpha = 'a';
+		view.beta = 'b';
+		log.length = 0;
+
+		view.callUnloaded();
+		view.alpha = 'a2';
+		expect(log).toEqual([]);
+
+		view.callLoaded();
+
+		expect(log).toEqual(['alpha=a2']);
+	});
+});
+
+describe('resetting a property', () => {
+	it('pushes the captured native default back and drops the capture', () => {
+		const view = loadedView();
+		view.alpha = 'a';
+		log.length = 0;
+
+		view.alpha = unsetValue;
+		view.alpha = 'a2';
+
+		expect(log).toEqual(['alpha=alpha-native', 'alpha:getDefault', 'alpha=a2']);
+	});
+
+	it('pushes the property default when the view has no getDefault handler', () => {
+		const view = loadedView();
+		view.epsilon = 'e';
+		log.length = 0;
+
+		view.epsilon = unsetValue;
+
+		expect(log).toEqual(['epsilon=epsilon-default']);
+	});
+
+	it('pushes the captured default once when reset while suspended', () => {
+		const view = loadedView();
+		view.alpha = 'a';
+		log.length = 0;
+
+		view._batchUpdate(() => {
+			view.alpha = 'a2';
+			view.alpha = unsetValue;
+		});
+
+		expect(log).toEqual(['alpha=alpha-native']);
+	});
+
+	it('pushes an uncaptured default as undefined when reset while suspended', () => {
+		const view = loadedView();
+
+		view._batchUpdate(() => {
+			view.alpha = 'a';
+			view.alpha = unsetValue;
+		});
+
+		expect(log).toEqual(['alpha=undefined']);
+	});
+});
+
+describe('shorthand expansion', () => {
+	it('applies one native call per longhand, in converter order', () => {
+		const view = loadedView();
+
+		view.style.gammaDelta = 'g d';
+
+		expect(log).toEqual(['gamma:getDefault', 'gamma=g', 'delta:getDefault', 'delta=d']);
+	});
+});
+
+describe('css value sources', () => {
+	it('lets a local value win over a css value', () => {
+		const view = loadedView();
+
+		view.style['css:gamma'] = 'from-css';
+		view.style.gamma = 'from-local';
+		view.style['css:gamma'] = 'from-css-again';
+
+		expect(log).toEqual(['gamma:getDefault', 'gamma=from-css', 'gamma=from-local']);
+	});
+
+	it('lets a keyframe value win over a css value', () => {
+		const view = loadedView();
+
+		view.style['css:anim'] = 'from-css';
+		view.style['keyframe:anim'] = 'from-keyframe';
+		view.style['css:anim'] = 'from-css-again';
+
+		expect(log).toEqual(['anim:getDefault', 'anim=from-css', 'anim=from-keyframe']);
+	});
+
+	it('propagates an inherited css value into a loaded child', () => {
+		const parent: any = new TestView();
+		const child: any = new TestView();
+		parent.addTestChild(child);
+		parent._setupUI({});
+		parent.callLoaded();
+		log.length = 0;
+
+		parent.style.inh = 'p';
+
+		expect(log).toEqual(['inh:getDefault', 'inh=p', 'inh:getDefault', 'inh=p']);
+	});
+
+	it('propagates an inherited view value into a loaded child', () => {
+		const parent: any = new TestView();
+		const child: any = new TestView();
+		parent.addTestChild(child);
+		parent._setupUI({});
+		parent.callLoaded();
+		log.length = 0;
+
+		parent.eta = 'p';
+
+		expect(log).toEqual(['eta:getDefault', 'eta=p', 'eta:getDefault', 'eta=p']);
+	});
+});
+
+describe('change notifications', () => {
+	it('notifies after the native write on a live view', () => {
+		const view = loadedView();
+		trackChange(view, 'alpha');
+
+		view.alpha = 'a';
+
+		expect(log).toEqual(['alpha:getDefault', 'alpha=a', 'alphaChange=a']);
+	});
+
+	it('notifies before the native write while suspended', () => {
+		const view = loadedView();
+		trackChange(view, 'alpha');
+
+		view._batchUpdate(() => {
+			view.alpha = 'a';
+		});
+
+		expect(log).toEqual(['alphaChange=a', 'alpha:getDefault', 'alpha=a']);
+	});
+
+	it('notifies style property changes on the style', () => {
+		const view = loadedView();
+		trackChange(view.style, 'gamma');
+
+		view.style.gamma = 'g';
+
+		expect(log).toEqual(['gamma:getDefault', 'gamma=g', 'gammaChange=g']);
+	});
+});
+
+describe('nativeValueChange', () => {
+	it('captures the native default and notifies without writing back to native', () => {
+		const view = loadedView();
+		trackChange(view, 'alpha');
+
+		alphaProperty.nativeValueChange(view, 'from-native');
+
+		expect(log).toEqual(['alpha:getDefault', 'alphaChange=from-native']);
+		expect(view.alpha).toBe('from-native');
+	});
+});

--- a/packages/core/ui/core/properties/property-shared.ts
+++ b/packages/core/ui/core/properties/property-shared.ts
@@ -1,6 +1,8 @@
 // Shared property types, interfaces, and value helpers for properties and view-base modules.
 // Only put platform-agnostic logic here.
 
+import type { Invalidation } from '../native-updates/invalidation';
+
 /**
  * Value specifying that Property should be set to its initial value.
  */
@@ -13,6 +15,11 @@ export interface PropertyOptions<T, U> {
 	readonly equalityComparer?: (x: U, y: U) => boolean;
 	readonly valueChanged?: (target: T, oldValue: U, newValue: U) => void;
 	readonly valueConverter?: (value: string) => U;
+	/**
+	 * Aggregate invalidations this property raises, applied by the node's commit after the
+	 * property's own `[setNative]`, once per commit however many properties raised them.
+	 */
+	readonly invalidates?: readonly Invalidation[];
 }
 
 export interface CoerciblePropertyOptions<T, U> extends PropertyOptions<T, U> {
@@ -48,6 +55,8 @@ export interface CssAnimationPropertyOptions<T, U> {
 	readonly equalityComparer?: (x: U, y: U) => boolean;
 	readonly valueChanged?: (target: T, oldValue: U, newValue: U) => void;
 	readonly valueConverter?: (value: string) => U;
+	/** @see PropertyOptions.invalidates */
+	readonly invalidates?: readonly Invalidation[];
 }
 
 export function isCssUnsetValue(value: any): boolean {

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -4,6 +4,8 @@ import { CoreTypes, Trace } from '../../styling/styling-shared';
 import { Property, CssProperty, CssAnimationProperty, InheritedProperty, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView, _setDefaultCommitNativeUpdates } from '../properties';
 import type { NativeUpdateBatch, NativeUpdateProperty } from '../native-updates/batch';
 import type { Invalidation } from '../native-updates/invalidation';
+import type { FlushNativeUpdatesOptions } from '../native-updates/scheduler';
+import { SuspendType } from './suspend-type';
 import { CSSUtils } from '../../../css/system-classes';
 import { Source } from '../../../utils/debug-source';
 import { Binding } from '../bindable';
@@ -287,20 +289,6 @@ enum Flags {
 	superOnUnloadedCalled = 'Unloaded',
 }
 
-enum SuspendType {
-	Incremental = 0,
-	Loaded = 1 << 20,
-	NativeView = 1 << 21,
-	UISetup = 1 << 22,
-	IncrementalCountMask = ~((1 << 20) + (1 << 21) + (1 << 22)),
-}
-
-namespace SuspendType {
-	export function toString(type: SuspendType): string {
-		return (type ? 'suspended' : 'resumed') + '(' + 'Incremental: ' + (type & SuspendType.IncrementalCountMask) + ', ' + 'Loaded: ' + !(type & SuspendType.Loaded) + ', ' + 'NativeView: ' + !(type & SuspendType.NativeView) + ', ' + 'UISetup: ' + !(type & SuspendType.UISetup) + ')';
-	}
-}
-
 const DEFAULT_VIEW_PADDINGS: Map<string, any> = new Map();
 
 /**
@@ -450,6 +438,9 @@ export abstract class ViewBase extends Observable {
 	 * Native setters that had to execute while there was no native view,
 	 * or the view was detached from the visual tree etc. will accumulate in this object,
 	 * and will be applied when all prerequisites are met.
+	 *
+	 * @deprecated The dirty set behind `NativeUpdateBatch`; read it from the batch a commit is
+	 * given rather than from here.
 	 * @private
 	 */
 	public _suspendedUpdates: {
@@ -793,6 +784,10 @@ export abstract class ViewBase extends Observable {
 		// Overridden
 	}
 
+	/**
+	 * @deprecated Use `NativeUpdates.batch()` to coalesce writes across nodes, or `_batchUpdate`
+	 * for a single one.
+	 */
 	public _suspendNativeUpdates(type: SuspendType): void {
 		if (type) {
 			this._suspendNativeUpdatesCount = this._suspendNativeUpdatesCount | type;
@@ -800,6 +795,9 @@ export abstract class ViewBase extends Observable {
 			this._suspendNativeUpdatesCount++;
 		}
 	}
+	/**
+	 * @deprecated The counterpart of `_suspendNativeUpdates`; see the note there.
+	 */
 	public _resumeNativeUpdates(type: SuspendType): void {
 		if (type) {
 			this._suspendNativeUpdatesCount = this._suspendNativeUpdatesCount & ~type;
@@ -1476,6 +1474,47 @@ export abstract class ViewBase extends Observable {
 	 */
 	public commitNativeUpdates(batch: NativeUpdateBatch): void {
 		batch._applyRemaining();
+	}
+
+	/**
+	 * Pushes whatever is pending on this node to its native view now, and returns whether it
+	 * could. In `sync` mode nothing is normally pending, so this only has work to do inside a
+	 * batch, or with `force`.
+	 *
+	 * `force` pushes to a native view that already exists even though the node is not loaded yet
+	 * - Android builds native views at `onCreate`, one lifecycle step before load - and leaves
+	 * the holds themselves in place. Values pushed this way are not pushed again on load.
+	 */
+	public flushNativeUpdates(options?: FlushNativeUpdatesOptions): boolean {
+		let flushed = false;
+
+		if (this.nativeViewProtected) {
+			const holds = this._suspendNativeUpdatesCount;
+			// Anything outside the incremental count is a reason the node is not ready for native
+			// writes at all, which only `force` overrides.
+			if (holds === 0) {
+				flushed = true;
+			} else if (options?.force || (holds & ~SuspendType.IncrementalCountMask) === 0) {
+				this._suspendNativeUpdatesCount = 0;
+				try {
+					this.onResumeNativeUpdates();
+				} finally {
+					this._suspendNativeUpdatesCount = holds;
+				}
+
+				flushed = true;
+			}
+		}
+
+		if (options?.subtree) {
+			this.eachChild((child) => {
+				child.flushNativeUpdates(options);
+
+				return true;
+			});
+		}
+
+		return flushed;
 	}
 
 	/**

--- a/packages/core/ui/core/view-base/index.ts
+++ b/packages/core/ui/core/view-base/index.ts
@@ -1,7 +1,9 @@
 import { AlignSelf, FlexGrow, FlexShrink, FlexWrapBefore, Order } from '../../layouts/flexbox-layout';
 import { Page } from '../../page';
 import { CoreTypes, Trace } from '../../styling/styling-shared';
-import { Property, CssProperty, CssAnimationProperty, InheritedProperty, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView } from '../properties';
+import { Property, CssProperty, CssAnimationProperty, InheritedProperty, clearInheritedProperties, propagateInheritableProperties, propagateInheritableCssProperties, initNativeView, _setDefaultCommitNativeUpdates } from '../properties';
+import type { NativeUpdateBatch, NativeUpdateProperty } from '../native-updates/batch';
+import type { Invalidation } from '../native-updates/invalidation';
 import { CSSUtils } from '../../../css/system-classes';
 import { Source } from '../../../utils/debug-source';
 import { Binding } from '../bindable';
@@ -453,6 +455,17 @@ export abstract class ViewBase extends Observable {
 	public _suspendedUpdates: {
 		[propertyName: string]: Property<ViewBase, any> | CssProperty<Style, any> | CssAnimationProperty<Style, any>;
 	};
+	/**
+	 * The value each dirty property held at the last commit, behind `NativeUpdateBatch.previous`.
+	 * Only recorded for a node whose class can read it back, and dropped by the commit.
+	 * @private
+	 */
+	public _pendingPrevious: Map<NativeUpdateProperty, unknown>;
+	/**
+	 * Aggregate invalidations raised since the last commit by properties declaring `invalidates`.
+	 * @private
+	 */
+	public _pendingInvalidations: Set<Invalidation>;
 	//@endprivate
 	/**
 	 * Determines the depth of suspended updates.
@@ -1454,6 +1467,21 @@ export abstract class ViewBase extends Observable {
 		}
 	}
 
+	/**
+	 * Applies a batch of pending native updates. Override to apply what this class needs in the
+	 * order it needs, then call `super` to apply everything still pending in the batch.
+	 *
+	 * Overriding opts the class out of the setter fast path: every write then reaches native
+	 * through a commit rather than straight from the setter.
+	 */
+	public commitNativeUpdates(batch: NativeUpdateBatch): void {
+		batch._applyRemaining();
+	}
+
+	/**
+	 * @deprecated Override `commitNativeUpdates` instead; this only builds the batch and hands
+	 * it over. Existing overrides keep working as long as they call `super`.
+	 */
 	public onResumeNativeUpdates(): void {
 		// Apply native setters...
 		initNativeView(this, undefined, undefined);
@@ -1588,6 +1616,7 @@ ViewBase.prototype.recycleNativeView = 'never';
 ViewBase.prototype.reusable = false;
 
 ViewBase.prototype._suspendNativeUpdatesCount = SuspendType.Loaded | SuspendType.NativeView | SuspendType.UISetup;
+_setDefaultCommitNativeUpdates(ViewBase.prototype.commitNativeUpdates);
 
 export const bindingContextProperty = new InheritedProperty<ViewBase, any>({
 	name: 'bindingContext',

--- a/packages/core/ui/core/view-base/lifecycle.spec.ts
+++ b/packages/core/ui/core/view-base/lifecycle.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { View } from '../view';
+import { Style } from '../../styling/style';
+import { CssProperty, Property, applyAllNativeSetters, applyPendingNativeSetters, initNativeView } from '../properties';
+
+/** `SuspendType` is module-private; the bits are part of the public field's contract. */
+const Loaded = 1 << 20;
+const NativeView = 1 << 21;
+const UISetup = 1 << 22;
+
+const log: string[] = [];
+
+class TestView extends View {
+	public testChildren: TestView[] = [];
+	public resumeCount = 0;
+
+	createNativeView(): Object {
+		return {};
+	}
+
+	public eachChildView(callback: (child: any) => boolean): void {
+		for (const child of this.testChildren) {
+			if (!callback(child)) {
+				return;
+			}
+		}
+	}
+
+	public _addViewToNativeVisualTree(): boolean {
+		return true;
+	}
+
+	public _removeViewFromNativeVisualTree(view: any): void {
+		view._isAddedToNativeVisualTree = false;
+	}
+
+	public addTestChild(child: TestView): void {
+		this.testChildren.push(child);
+		this._addView(child);
+	}
+
+	public onResumeNativeUpdates(): void {
+		this.resumeCount++;
+		super.onResumeNativeUpdates();
+	}
+}
+
+function trackNative(property: { name: string; setNative: symbol }): void {
+	(TestView.prototype as any)[property.setNative] = function (value: unknown) {
+		log.push(`${property.name}=${String(value)}`);
+	};
+}
+
+const oneProperty = new Property<TestView, string>({ name: 'one', defaultValue: 'one-default' });
+oneProperty.register(TestView);
+trackNative(oneProperty);
+
+const twoProperty = new Property<TestView, string>({ name: 'two', defaultValue: 'two-default' });
+twoProperty.register(TestView);
+trackNative(twoProperty);
+
+const threeProperty = new CssProperty<Style, string>({ name: 'three', cssName: 'three', defaultValue: 'three-default' });
+threeProperty.register(Style);
+trackNative(threeProperty);
+
+beforeEach(() => {
+	log.length = 0;
+});
+
+describe('suspend state through the view lifecycle', () => {
+	it('starts held by Loaded, NativeView and UISetup', () => {
+		const view: any = new TestView();
+
+		expect(view._suspendNativeUpdatesCount).toBe(Loaded | NativeView | UISetup);
+		expect(view._suspendedUpdates).toBeUndefined();
+	});
+
+	it('releases NativeView and UISetup on _setupUI, and Loaded on load', () => {
+		const view: any = new TestView();
+
+		view._setupUI({});
+		expect(view._suspendNativeUpdatesCount).toBe(Loaded);
+		expect(view.resumeCount).toBe(0);
+
+		view.callLoaded();
+		expect(view._suspendNativeUpdatesCount).toBe(0);
+		expect(view.resumeCount).toBe(1);
+	});
+
+	it('takes the Loaded hold back on unload', () => {
+		const view: any = new TestView();
+		view._setupUI({});
+		view.callLoaded();
+
+		view.callUnloaded();
+		expect(view._suspendNativeUpdatesCount).toBe(Loaded);
+
+		view.callLoaded();
+		expect(view._suspendNativeUpdatesCount).toBe(0);
+		expect(view.resumeCount).toBe(2);
+	});
+
+	it('counts nested _batchUpdate holds', () => {
+		const view: any = new TestView();
+		view._setupUI({});
+		view.callLoaded();
+
+		view._batchUpdate(() => {
+			expect(view._suspendNativeUpdatesCount).toBe(1);
+			view._batchUpdate(() => {
+				expect(view._suspendNativeUpdatesCount).toBe(2);
+			});
+			expect(view._suspendNativeUpdatesCount).toBe(1);
+		});
+
+		expect(view._suspendNativeUpdatesCount).toBe(0);
+		expect(view.resumeCount).toBe(2);
+	});
+
+	it('rejects an unbalanced resume', () => {
+		const view: any = new TestView();
+		view._setupUI({});
+		view.callLoaded();
+
+		expect(() => view._resumeNativeUpdates(0)).toThrow();
+	});
+});
+
+describe('the dirty set', () => {
+	it('is undefined until the first commit, then an empty bag', () => {
+		const view: any = new TestView();
+		view.one = 'a';
+
+		expect(view._suspendedUpdates).toBeUndefined();
+
+		view._setupUI({});
+		expect(view._suspendedUpdates).toBeUndefined();
+
+		view.callLoaded();
+		expect(view._suspendedUpdates).toEqual({});
+	});
+
+	it('records first-dirtied order while suspended and is emptied by the commit', () => {
+		const view: any = new TestView();
+		view._setupUI({});
+		view.callLoaded();
+		log.length = 0;
+
+		view.callUnloaded();
+		view.two = 'b';
+		view.style.three = 'c';
+		view.one = 'a';
+		view.two = 'b2';
+
+		expect(Object.keys(view._suspendedUpdates)).toEqual(['two', 'three', 'one']);
+
+		view.callLoaded();
+
+		expect(log).toEqual(['two=b2', 'three=c', 'one=a']);
+		expect(view._suspendedUpdates).toEqual({});
+	});
+
+	it('goes back to a full sweep when a new native view is set', () => {
+		const view: any = new TestView();
+		view.one = 'a';
+		view.style.three = 'c';
+		view._setupUI({});
+		view.callLoaded();
+		log.length = 0;
+
+		view.setNativeView({});
+
+		expect(log).toEqual(['one=a', 'three=c']);
+		expect(view._suspendNativeUpdatesCount).toBe(0);
+	});
+});
+
+describe('setup order in a subtree', () => {
+	it('sets up and loads children after their parent', () => {
+		const parent: any = new TestView();
+		const child: any = new TestView();
+		parent.one = 'p';
+		child.one = 'c';
+		parent.addTestChild(child);
+
+		parent._setupUI({});
+		expect(log).toEqual([]);
+
+		parent.callLoaded();
+
+		expect(log).toEqual(['one=p', 'one=c']);
+		expect(child._suspendNativeUpdatesCount).toBe(0);
+	});
+});
+
+describe('the property application entry points', () => {
+	it('applyAllNativeSetters walks view symbols before style symbols', () => {
+		const view: any = new TestView();
+		view.style.three = 'c';
+		view.one = 'a';
+		view._setupUI({});
+		view.callLoaded();
+		log.length = 0;
+
+		applyAllNativeSetters(view);
+
+		expect(log).toEqual(['one=a', 'three=c']);
+	});
+
+	it('applyPendingNativeSetters walks the dirty set in first-dirtied order', () => {
+		const view: any = new TestView();
+		view._setupUI({});
+		view.callLoaded();
+		view.callUnloaded();
+		view.two = 'b';
+		view.one = 'a';
+		log.length = 0;
+
+		applyPendingNativeSetters(view);
+
+		expect(log).toEqual(['two=b', 'one=a']);
+	});
+
+	it('initNativeView commits and clears the dirty set', () => {
+		const view: any = new TestView();
+		view._setupUI({});
+		view.callLoaded();
+		view.callUnloaded();
+		view.one = 'a';
+		log.length = 0;
+
+		initNativeView(view);
+
+		expect(log).toEqual(['one=a']);
+		expect(view._suspendedUpdates).toEqual({});
+	});
+});

--- a/packages/core/ui/core/view-base/suspend-type.ts
+++ b/packages/core/ui/core/view-base/suspend-type.ts
@@ -1,0 +1,17 @@
+/**
+ * What is holding a node's native updates back: three latched reasons plus a count of the
+ * incremental holds, all in one bitfield (`ViewBase._suspendNativeUpdatesCount`).
+ */
+export enum SuspendType {
+	Incremental = 0,
+	Loaded = 1 << 20,
+	NativeView = 1 << 21,
+	UISetup = 1 << 22,
+	IncrementalCountMask = ~((1 << 20) + (1 << 21) + (1 << 22)),
+}
+
+export namespace SuspendType {
+	export function toString(type: SuspendType): string {
+		return (type ? 'suspended' : 'resumed') + '(' + 'Incremental: ' + (type & SuspendType.IncrementalCountMask) + ', ' + 'Loaded: ' + !(type & SuspendType.Loaded) + ', ' + 'NativeView: ' + !(type & SuspendType.NativeView) + ', ' + 'UISetup: ' + !(type & SuspendType.UISetup) + ')';
+	}
+}

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -20,6 +20,8 @@ export type { Template, KeyedTemplate, AddArrayFromBuilder, AddChildFromBuilder,
 export type { ShownModallyData, Size, AndroidOverflowInsetData } from './core/view/view-interfaces';
 export { Property, CoercibleProperty, InheritedProperty, CssProperty, InheritedCssProperty, ShorthandProperty, CssAnimationProperty, makeParser, makeValidator } from './core/properties';
 export { unsetValue } from './core/properties/property-shared';
+export { Invalidation, InvalidationPhase, NativeUpdateBatch, NativeUpdates } from './core/native-updates';
+export type { ChildMutation, FlushNativeUpdatesOptions, InvalidationOptions, NativeUpdatesMode, NativeUpdateEntry } from './core/native-updates';
 export { addWeakEventListener, removeWeakEventListener } from './core/weak-event-listener';
 export { DatePicker } from './date-picker';
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

A property setter *is* the native call. Each `Property`/`CssProperty`/`CssAnimationProperty`/`InheritedCssProperty` setter carries its own copy of the "suspended → record in `_suspendedUpdates`, else `[setNative](value)`" block (six copies). The first native pass happens at `onLoaded` in the order properties were first *set* on that instance; afterwards every set is one synchronous native call. There is no way for a widget to see "these properties changed together", no previous committed value, no public batching primitive (`_batchUpdate` is private and per node), and no way for a flavor to coalesce writes across nodes.

## What is the new behavior?

Phase 0 of the native-updates redesign: **additive plumbing with no behavior change**. The new API is implemented on top of the existing storage (`_suspendNativeUpdatesCount` as the holds, `_suspendedUpdates` as the dirty set), so every existing code path produces the same native calls, in the same order, with the same `<name>Change` timing. Six commits, each green on its own; review commit by commit:

1. `test(core): add native-update oracle specs` — golden `[setNative]`/`<name>Change` sequences for every setter kind, load/unload/reload, batch, reset, shorthand, inheritance, keyframes. These specs are byte-identical from commit 1 to HEAD and pass at every commit.
2. `refactor(core): unify native property routing` — the six copies collapse into one routing function; `applyPendingNativeSetters`/`applyAllNativeSetters` share the default-capture helper.
3. `feat(core): add commitNativeUpdates hook and NativeUpdateBatch` — `ViewBase.commitNativeUpdates(batch)` is the ordering hook (override, apply what the class cares about, `super` applies the rest). `onResumeNativeUpdates` → `initNativeView` builds the batch and calls it. `NativeUpdateBatch`: `entries/has/apply/skip/previous/isMount/children` (an entry is a property or an aggregate `Invalidation`; the name avoids "target", which means a view elsewhere in core). Previous values are recorded only for nodes that can read them back (a class overriding the hook, or a property declaring `invalidates`), so default nodes allocate nothing extra in a batch or across unload/reload.
4. `feat(core): add NativeUpdates scheduler and flushNativeUpdates` — `NativeUpdates.batch()/begin()/end()/flush()` coalesce writes per node across nodes (implemented as `_batchUpdate` semantics per touched node); `mode` is `'sync'` only. `ViewBase.flushNativeUpdates({ subtree, force })`; `force` pushes to an existing native view while the node is not loaded and leaves the holds in place.
5. `feat(core): add invalidates option to properties` — `PropertyOptions.invalidates?: Invalidation[]` on every property kind; a node handles an aggregate with `[invalidation.apply](batch)`. No core property declares one yet.
6. `perf(core): commit without a batch for nodes that cannot observe one` — a node whose class uses the default hook and has no pending aggregate invalidation cannot observe a `NativeUpdateBatch`, so its commit runs the existing sweeps directly (same order) instead of building one.

**Fast path.** A live set on a class that does not override `commitNativeUpdates`, with no aggregate invalidations and no open batch, still calls `[setNative]` straight from the setter with no allocation.

**Legacy surface kept** (names, types, exports, semantics): `_suspendNativeUpdatesCount`, `_suspendedUpdates`, `SuspendType` (moved to `view-base/suspend-type.ts`, still internal), `_batchUpdate`, `_suspendNativeUpdates`, `_resumeNativeUpdates`, `onResumeNativeUpdates`, `initNativeView`, `applyPendingNativeSetters`, `applyAllNativeSetters`, `affectsLayout` timing.

### Points for reviewers

- **Cost, measured jitless (`VITEST_NO_OPT=1`, interpreter-only like iOS) with a no-op `setNative`, medians.** Live setter: roughly +40–60 ns per set from collapsing six inlined copies into one routing call (JIT: within noise); a real native write is microseconds, so the relative impact in apps is far smaller. Commit path (per view, µs), base → without commit 6 → with commit 6:

  | scenario | base | c5 | c6 |
  |---|---|---|---|
  | load: construct + 8 props + `_setupUI` + `callLoaded` | 7.8 | 10.2 | 9.4 |
  | reload: unload + 4 props + load | 4.3 | 5.7 | 5.0 |
  | `_batchUpdate`, 8 props, live view | 3.44 | 5.20 | 4.12 |

  The residual over base is two helper calls per property in the sweep; inlining the default-capture into those helpers would recover most of it at the cost of duplicating it, deliberately not done in Phase 0. The setter numbers live in `native-updates-hot-path.spec.ts`, the commit-path ones in `native-updates-commit-cost.spec.ts`; both print on every run.
- **`invalidates` is additive**: a property that declares it still runs its own `[setNative]`, then the aggregates. Whether aggregates should *replace* the property's own setter is a Phase 1 decision.
- **Dirty state is cleared before the commit runs**, so a write made from a handler queues against a fresh set (previously the set was replaced after the sweep). Only observable if a `setNative` handler runs `_batchUpdate` on the same node mid-sweep.
- **`Property.set` with an override present** routes through the commit and uses pending semantics (value re-read at commit). Only affects classes that opt in.
- **Device tests** (`apps/automated/src/ui/lifecycle/lifecycle-tests.ts`: `NativeUpdates.batch` equals `_batchUpdate` counts, flush inside a batch, forced flush while unloaded) are added but were not run here. The existing lifecycle suite there asserts exact `setNative` counts through XML inflation, `_batchUpdate`, navigation and CSS class changes and is the production check for "same native calls". To run on iOS and Android before undrafting.

Tests: 485 → 557 passing (`npx vitest run` in `packages/core`), no pre-existing failures. Typecheck: `npx tsc -p packages/core/tsconfig.lib.json --noEmit` clean.

Related: #11412 (`origin` on `PropertyChangeData`, independent), #11413 (`InheritedProperty` reset cascade fix, found on the way).
