### PR TITLE
fix(android): re-apply edge-to-edge system bar style on appearance change

### DIFF
--- a/packages/core/application/application.android.ts
+++ b/packages/core/application/application.android.ts
@@ -50,7 +50,7 @@ import { androidGetForegroundActivity, androidGetStartActivity, androidSetForegr
 import { getImageFetcher, getNativeApp, getRootView, initImageCache, setA11yUpdatePropertiesCallback, setApplicationPropertiesCallback, setAppMainEntry, setNativeApp, setRootView, setToggleApplicationEventListenersCallback } from './helpers-common';
 import { getNativeScriptGlobals } from '../globals/global-utils';
 import type { AndroidApplication as IAndroidApplication } from './application';
-import { enableEdgeToEdge } from '../utils/native-helper-for-android';
+import { enableEdgeToEdge, refreshEdgeToEdge } from '../utils/native-helper-for-android';
 import lazy from '../utils/lazy';
 
 declare class NativeScriptLifecycleCallbacks extends android.app.Application.ActivityLifecycleCallbacks {}
@@ -561,6 +561,8 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 		this._pendingReceiverRegistrations.length = 0;
 	}
 
+	private edgeToEdgeAppearance: 'dark' | 'light' | null = null;
+
 	onConfigurationChanged(configuration: android.content.res.Configuration): void {
 		// The application context reports the app-wide configuration, which a window on a
 		// second display or in split-screen does not necessarily share, so the primary
@@ -570,6 +572,17 @@ export class AndroidApplication extends ApplicationCommon implements IAndroidApp
 		this.setOrientation(primaryWindow?.orientation() ?? this.getOrientationValue(configuration));
 		this.setSystemAppearance(primaryWindow?.systemAppearance() ?? this.getSystemAppearanceValue(configuration));
 		this.setLayoutDirection(primaryWindow?.layoutDirection() ?? this.getLayoutDirectionValue(configuration));
+	}
+
+	protected setSystemAppearance(value: 'dark' | 'light') {
+		super.setSystemAppearance(value);
+		// The activity survives the switch (uiMode is a handled config change),
+		// so the edge-to-edge system bar style must be applied again to pick up
+		// the icon appearance for the new theme.
+		if (this.edgeToEdgeAppearance !== value) {
+			this.edgeToEdgeAppearance = value;
+			refreshEdgeToEdge(this.foregroundActivity ?? this.startActivity);
+		}
 	}
 
 	getNativeApplication() {

--- a/packages/core/utils/native-helper-for-android.ts
+++ b/packages/core/utils/native-helper-for-android.ts
@@ -310,6 +310,24 @@ interface ISystemColor {
 }
 const systemColors = new WeakMap<androidx.appcompat.app.AppCompatActivity, ISystemColor>();
 
+/**
+ * Re-applies the activity's edge-to-edge styling. The system bar icon
+ * appearance is decided from the theme at the time the style is applied, so
+ * an activity that survives a dark-mode switch keeps the old icons until this
+ * runs again.
+ */
+export function refreshEdgeToEdge(activity: androidx.appcompat.app.AppCompatActivity): void {
+	if (!activity) {
+		return;
+	}
+	const existingColors = systemColors.get(activity);
+	if (existingColors) {
+		setEnableEdgeToEdge(activity, existingColors);
+	} else {
+		enableEdgeToEdge(activity);
+	}
+}
+
 function setEnableEdgeToEdge(activity: androidx.appcompat.app.AppCompatActivity, existingColors: ISystemColor) {
 	enableEdgeToEdge(activity, {
 		statusBarLightColor: existingColors.statusBarLight,

--- a/packages/core/utils/native-helper-for-android.ts
+++ b/packages/core/utils/native-helper-for-android.ts
@@ -310,12 +310,6 @@ interface ISystemColor {
 }
 const systemColors = new WeakMap<androidx.appcompat.app.AppCompatActivity, ISystemColor>();
 
-/**
- * Re-applies the activity's edge-to-edge styling. The system bar icon
- * appearance is decided from the theme at the time the style is applied, so
- * an activity that survives a dark-mode switch keeps the old icons until this
- * runs again.
- */
 export function refreshEdgeToEdge(activity: androidx.appcompat.app.AppCompatActivity): void {
 	if (!activity) {
 		return;

--- a/packages/core/utils/native-helper.android.ts
+++ b/packages/core/utils/native-helper.android.ts
@@ -2,7 +2,7 @@ import type { IOSNativeHelper } from './native-helper.types';
 import { platformCheck } from './platform-check';
 
 // importing this helper as a separate file avoids "android" symbol clash with the global android object
-import { resources, collections, getWindow, getApplication, getCurrentActivity, getApplicationContext, getResources, getPackageName, getInputMethodManager, showSoftInput, dismissSoftInput, enableEdgeToEdge, setDarkModeHandler, setNavigationBarColor, setStatusBarColor, getIgnoreEdgeToEdgeOnOlderDevices, setIgnoreEdgeToEdgeOnOlderDevices } from './native-helper-for-android';
+import { resources, collections, getWindow, getApplication, getCurrentActivity, getApplicationContext, getResources, getPackageName, getInputMethodManager, showSoftInput, dismissSoftInput, enableEdgeToEdge, refreshEdgeToEdge, setDarkModeHandler, setNavigationBarColor, setStatusBarColor, getIgnoreEdgeToEdgeOnOlderDevices, setIgnoreEdgeToEdgeOnOlderDevices } from './native-helper-for-android';
 export { dataSerialize, dataDeserialize } from './native-helper-for-android';
 
 export { getWindow } from './native-helper-for-android';
@@ -20,6 +20,7 @@ export const android = {
 	showSoftInput,
 	dismissSoftInput,
 	enableEdgeToEdge,
+	refreshEdgeToEdge,
 	setStatusBarColor,
 	setNavigationBarColor,
 	setDarkModeHandler,

--- a/packages/core/utils/native-helper.d.ts
+++ b/packages/core/utils/native-helper.d.ts
@@ -123,6 +123,13 @@ export const android: {
 	 */
 	setStatusBarColor(options?: { activity?: androidx.appcompat.app.AppCompatActivity; lightColor?: Color; darkColor?: Color }): void;
 	/**
+	 * Re-applies the activity's edge-to-edge styling. The system bar icon
+	 * appearance is decided from the theme at the time the style is applied, so
+	 * an activity that survives a dark-mode switch keeps the old icons until this
+	 * runs again.
+	 */
+	refreshEdgeToEdge(activity: androidx.appcompat.app.AppCompatActivity): void;
+	/**
 	 * Enables edge-to-edge navigation for the provided activity.
 	 * @param activity The activity to enable edge-to-edge navigation for.
 	 * @param options Optional configuration for status and navigation bar colors.


### PR DESCRIPTION
Core enables edge-to-edge once, in onActivityCreated, with the auto system bar style. The activity survives a dark-mode switch (uiMode is a handled configuration change), so the status and navigation bar icons keep the appearance chosen for the previous theme: dark icons over the app's dark canvas after switching to night mode.

Adds `Utils.android.refreshEdgeToEdge(activity)`, which re-applies the activity's styling with any colors or handler registered through the existing setters, and call it from the Android application when the system appearance changes.
