### PR TITLE
fix(vite): replace the browser preload helper before esbuild minifies it

### DIFF
--- a/packages/vite/helpers/dynamic-import-plugin.spec.ts
+++ b/packages/vite/helpers/dynamic-import-plugin.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { transformDynamicImports } from './dynamic-import-plugin.js';
+import { dynamicImportPlugin, transformDynamicImports } from './dynamic-import-plugin.js';
 
 const vitePreloadHelper = `const scriptRel = /* @__PURE__ */ (function detectScriptRel() {
   const relList = typeof document !== "undefined" && document.createElement("link").relList;
@@ -36,5 +36,24 @@ describe('dynamic import plugin', () => {
 	it('leaves chunks without dynamic imports or the Vite helper unchanged', () => {
 		const source = 'export const value = 42;';
 		expect(transformDynamicImports(source)).toBe(source);
+	});
+
+	// Minified builds rename __vitePreload before generateBundle; the browser
+	// helper then survived and its window.dispatchEvent masked every dynamic
+	// import failure as "window is not defined".
+	it('replaces the helper in renderChunk as a post plugin, ahead of esbuild minification', () => {
+		const plugin = dynamicImportPlugin() as any;
+		expect(plugin.enforce).toBe('post');
+		expect(plugin.generateBundle).toBeUndefined();
+		const result = plugin.renderChunk(`${vitePreloadHelper}\nconst page = () => __vitePreload(() => import('./page.js'), []);`);
+		expect(result.code).not.toContain('document');
+		expect(result.code).toContain("import('~/page.js')");
+	});
+
+	it('returns null from renderChunk when nothing changes, including on already-transformed code', () => {
+		const plugin = dynamicImportPlugin() as any;
+		expect(plugin.renderChunk('export const value = 42;')).toBeNull();
+		const once = transformDynamicImports(`${vitePreloadHelper}\nexport const page = () => __vitePreload(() => import('./page.js'), []);`);
+		expect(plugin.renderChunk(once)).toBeNull();
 	});
 });

--- a/packages/vite/helpers/dynamic-import-plugin.ts
+++ b/packages/vite/helpers/dynamic-import-plugin.ts
@@ -62,15 +62,18 @@ export function transformDynamicImports(code: string) {
 // Fix NativeScript dynamic imports by transforming paths and simplifying __vitePreload.
 // Vite still emits its browser preload helper when modulePreload is disabled:
 // https://github.com/vitejs/vite/issues/13952
+// Runs in renderChunk as a post plugin: user post plugins precede Vite's
+// esbuild minifier, so `__vitePreload` is still named when we look for it.
 export function dynamicImportPlugin() {
 	return {
 		name: 'nativescript-dynamic-import-fix',
-		generateBundle(_options, bundle) {
-			for (const chunk of Object.values(bundle) as any) {
-				if (chunk.type === 'chunk') {
-					chunk.code = transformDynamicImports(chunk.code);
-				}
+		enforce: 'post' as const,
+		renderChunk(code: string) {
+			const transformed = transformDynamicImports(code);
+			if (transformed === code) {
+				return null;
 			}
+			return { code: transformed, map: null };
 		},
 	};
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?

`dynamicImportPlugin` replaces Vite's browser `__vitePreload` helper (which touches `document` and `window`) with a native one, but it does so from `generateBundle` using a literal regex on the identifier. With `build.minify: 'esbuild'` Vite's `vite:esbuild-transpile` plugin has already renamed `__vitePreload` in `renderChunk`, so the regex misses, the browser helper ships, and its `window.dispatchEvent` in the rejection path turns every failed dynamic import into `ReferenceError: window is not defined` with a misattributed stack. Details in #11423.

## What is the new behavior?

The transform runs in `renderChunk` as an `enforce: 'post'` plugin. User post plugins run before `buildPlugins.post` (where the esbuild minifier lives), so the helper is still named when it is replaced. `renderChunk` returns `null` when nothing changed, so untouched chunks and already-transformed code are left alone. `transformDynamicImports` is unchanged.

Specs cover the plugin shape (post + renderChunk, no generateBundle), the replacement through `renderChunk`, and the no-op/idempotent return.

Verified with a real `ns build ios` of a blank Vue app with `build.minify: 'esbuild'`: the emitted bundle contains the native helper and no `vite:preloadError` / `document.createElement("link")`; the published 8.0.5 bundle has the reverse. At runtime a deliberately failing `import()` now reports the real load error.

Fixes #11423.
